### PR TITLE
Setup: Multiple version requirements & verbosity control

### DIFF
--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -1,3 +1,0 @@
-# Requirements for development mode
-astroid>=1.2,<1.3
-pylint>=1.1,<1.4

--- a/src/makefile
+++ b/src/makefile
@@ -103,7 +103,6 @@ help:
 develop:
 	sudo python setup.py develop_os
 	python setup.py develop
-	pip install -r dev-requirements.txt
 	@echo '$@ done.'
 
 build: $(dist_file)

--- a/src/os_setup.py
+++ b/src/os_setup.py
@@ -60,6 +60,7 @@ Syntax for the new attributes of the `setup()` function:
               'redhat': [                   # distribution name
                   "python-devel",           # a package without version req.
                   "openssl-devel>=1.0.1",   # a package with version requirement
+                  "pylint>=1.3,<1.4",       # a package with multiple version requirements
                   install_swig,             # a custom function
                   . . .
               ],
@@ -71,7 +72,7 @@ Syntax for the new attributes of the `setup()` function:
 
   The syntax for version requirements is:
 
-      <op><version>
+      <op><version>[,<op><version>[,...]]
 
   Where:
   * <op> - the comparison operator, one of '<', '<=', '=', '>=', '>'.
@@ -98,6 +99,12 @@ Syntax for the new attributes of the `setup()` function:
       should be done, vs. the real action. This is controlled by the
       `-n`, `--dry-run` command line option of the `setup.py` script.
 
+    * `command.verbose` - a boolean flag indicating whether to be verbose
+      vs. quiet when printing messages. Verbose mode is on by default, or
+      when the `-v`, `--verbose` command line option of the `setup.py` script is
+      specified. Verbose mode is off when the `-q`, `--quiet` command line
+      option of the `setup.py` script is specified.
+
 * `develop_requires`
 
   This attribute has the same syntax as the `install_requires` attribute
@@ -111,6 +118,7 @@ Syntax for the new attributes of the `setup()` function:
       develop_requires = [
           "httpretty",                  # a package without version requirement
           "epydoc>=3.0.1",              # a package with version requirement
+          "pylint>=1.3,<1.4",           # a package with multiple version requirements
           patch_epydoc,                 # a custom function
           . . .
       ]
@@ -323,22 +331,12 @@ class BaseOsCommand(Command):
                 if isinstance(req, types.FunctionType):
                     req(self)
                 else: # requirements string
-                    req = req.strip()
-                    print "Processing OS-level package requirement: %s" % req
-                    r = r'^([a-zA-Z0-9_\.\-\+]+)( *(<|<=|=|>|>=) *'\
-                        r'([0-9a-zA-Z_\.\-\+]+))?$'
-                    m = re.match(r, req)
-                    if m is not None:
-                        pkg_name = m.group(1)
-                        version_req = m.group(2)
-                        self.installer.ensure_installed(pkg_name, version_req,
-                                                        self.dry_run)
-                    else:
-                        raise DistutilsSetupError(
-                            "OS-level package requirement for platform '%s' "\
-                            "has invalid syntax: %r" %\
-                            (self.installer.platform, req)
-                        )
+                    if self.verbose:
+                        print "Processing OS-level package requirement: %s" %\
+                              req
+                    pkg_name, version_reqs = self.installer.parse_pkg_req(req)
+                    self.installer.ensure_installed(pkg_name, version_reqs,
+                                                    self.dry_run, self.verbose)
 
 class install_os(BaseOsCommand): # pylint: disable=invalid-name
     """Setuptools/distutils command class for installing OS-level packages
@@ -360,8 +358,9 @@ class install_os(BaseOsCommand): # pylint: disable=invalid-name
         command.
         """
 
-        print "install_os: Installing prerequisite OS-level packages for "\
-              "platform '%s'" % self.installer.platform
+        if self.verbose:
+            print "install_os: Installing prerequisite OS-level packages for "\
+                  "platform '%s'" % self.installer.platform
 
         self.run_os(self.distribution.install_os_requires)
 
@@ -392,8 +391,9 @@ class develop_os(BaseOsCommand): # pylint: disable=invalid-name
         command.
         """
 
-        print "develop_os: Installing prerequisite OS-level packages for "\
-              "platform '%s'" % self.installer.platform
+        if self.verbose:
+            print "develop_os: Installing prerequisite OS-level packages for "\
+                  "platform '%s'" % self.installer.platform
 
         self.run_os(self.distribution.install_os_requires)
         self.run_os(self.distribution.develop_os_requires)
@@ -423,18 +423,19 @@ class develop(_develop): # pylint: disable=invalid-name
 
         _develop.run(self)
 
-        print "develop: Installing prerequisite Python packages"
+        if self.verbose:
+            print "develop: Installing prerequisite Python packages"
 
         req_list = self.distribution.develop_requires
         for req in req_list:
             if isinstance(req, types.FunctionType):
                 req(self)
             else: # requirements string
-                req = req.strip()
-                print "Processing Python package requirement: %s" % req
-                pkg_name, version_req = self.installer.parse_pkg_req(req)
-                self.installer.ensure_installed(
-                    pkg_name, version_req, self.dry_run)
+                if self.verbose:
+                    print "Processing Python package requirement: %s" % req
+                pkg_name, version_reqs = self.installer.parse_pkg_req(req)
+                self.installer.ensure_installed(pkg_name, version_reqs,
+                                                self.dry_run, self.verbose)
 
         if len(self.installer.errors) > 0:
             self.installer.print_errors()
@@ -508,29 +509,33 @@ class BaseInstaller(object):
 
         self.userid = getpass.getuser()
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
         """Interface definition: Install an OS-level or Python package,
-        optionally applying  a version requirement.
+        optionally applying a version requirement.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         raise NotImplementedError
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Interface definition: Test whether an OS-level or Python package
         is installed, and optionally satisfies a version requirement.
 
         Parameters:
         * pkg_name (string): Name of the Python package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * If a package version that satisfies the requirement is installed, its
@@ -538,7 +543,7 @@ class BaseInstaller(object):
         """
         raise NotImplementedError
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Interface definition: Test whether an OS-level or Python package
         is available in the repos (for OS-level packages) or on Pypi (for
         Python packages), and optionally satisfies a version requirement.
@@ -547,24 +552,28 @@ class BaseInstaller(object):
 
         Parameters:
         * pkg_name (string): Name of the Python package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
         """
         raise NotImplementedError
 
-    def ensure_installed(self, pkg_name, version_req=None, dry_run=False):
+    def ensure_installed(self, pkg_name, version_reqs=None, dry_run=False,
+                         verbose=True):
         """Interface definition: Ensure that an OS-level or Python package
         is installed, and optionally satisfies a version requirement.
 
         Parameters:
         * pkg_name (string): Name of the Python package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
@@ -577,75 +586,100 @@ class BaseInstaller(object):
         Python packages.
 
         Parameters:
-        * pkg_req: A string specifying the package requirement (e.g. 'abc>=1.0')
+        * pkg_req: A string specifying the package requirement
+          (e.g. 'abc >=1.0,<3.0', or 'def 1.0')
 
         Returns:
         * tuple of:
-          - A string specifying the package name (e.g. 'abc')
-          - A string specifying the version requirement (e.g. '>=1.0'). Empty
-            string, if no version requirement was specified.
+          - A string specifying the package name (e.g. 'abc' or 'def')
+          - A list with zero or more strings, each specifying a version
+            requirement (e.g. ('>=1.0', '<3.0') or ('=1.0',)). If no
+            comparison operator was specified, the default operator '=' is
+            added, so that each list entry is of the form <op><version>.
         """
-        r = r'^([0-9a-zA-Z_\.\-\+]+)( *(<|<=|=||>|>=) *'\
-            r'([0-9a-zA-Z_\.\-\+]+))?$'
+        r = r'^([a-zA-Z0-9_\.\-\+]+)'\
+            r'((?: *(?:<|<=|=| |!=|>|>=)[0-9a-zA-Z_\.\-\+]+)'\
+            r'(?: *, *(?:<|<=|=||!=|>|>=)[0-9a-zA-Z_\.\-\+]+)*)?$'
         m = re.match(r, pkg_req)
         if m is not None:
             pkg_name = m.group(1)
-            pkg_version_req = m.group(2)
-            return pkg_name, pkg_version_req
+            req_string = m.group(2)
+            req_list = []
+            if req_string is not None:
+                for req in req_string.split(','):
+                    req = req.strip()
+                    if len(req) == 0:
+                        continue # ignore empty requirements
+                    if req[0] not in "<=>!":
+                        req = '=' + req # add default operator
+                    req_list.append(req)
+            return pkg_name, req_list
         else:
             raise DistutilsSetupError(
                 "Package requirement has an invalid syntax: %r" % pkg_req
             )
 
-    def version_matches_req(self, version, version_req=None):
-        """Test whether a version matches a version requirement.
+    def version_matches_req(self, version, req_list=None):
+        """Test whether a version matches all version requirements in a list.
+        This can be used for OS-level packages and for Python packages.
 
         Parameters:
         * version: A string specifying the version to be tested
           (e.g. '1.0.1-rc1')
-        * version_req: A string specifying a version requirement (e.g. '>=1.0')
+        * req_list: A list of zero or more version requirements, each being
+          a string of the form <op><version> (e.g. '>=1.0').
         """
-        if version_req:
-            version_info = version.split(".")
-            version_req = version_req.strip()
-            m = re.match(
-                r'^(<|<=|=||>|>=) *([0-9a-zA-Z_\.\-\+]+)$',
-                version_req)
-            if m is not None:
-                req_op = m.group(1)
-                req_version = m.group(2)
-                req_version_info = req_version.split(".")
-                if req_op == '<':
-                    return version_info < req_version_info
-                elif req_op == '<=':
-                    return version_info <= req_version_info
-                elif req_op == '=' or req_op == '':
-                    return version_info == req_version_info
-                elif req_op == '>':
-                    return version_info > req_version_info
-                elif req_op == '>=':
-                    return version_info >= req_version_info
-                else:
-                    raise DistutilsSetupError(
-                        "Version requirement has an invalid syntax: %r" %\
-                        version_req
-                    )
+        if not req_list:
+            return True # no requirement -> version always matches
+
+        version_info = version.split(".")
+        for req_string in req_list:
+            m = re.match(r'^(<|<=|=|!=|>|>=)([0-9a-zA-Z_\.\-\+]+)$',
+                         req_string)
+            if m is None:
+                raise DistutilsSetupError(
+                    "Version requirement has an invalid syntax: %r" %\
+                    req_string
+                )
+            req_op = m.group(1)
+            req_version_info = m.group(2).split(".")
+            if req_op == '<':
+                if not version_info < req_version_info:
+                    return False
+            elif req_op == '<=':
+                if not version_info <= req_version_info:
+                    return False
+            elif req_op == '=':
+                if not version_info == req_version_info:
+                    return False
+            elif req_op == '!=':
+                if not version_info != req_version_info:
+                    return False
+            elif req_op == '>':
+                if not version_info > req_version_info:
+                    return False
+            elif req_op == '>=':
+                if not version_info >= req_version_info:
+                    return False
             else:
                 raise DistutilsSetupError(
                     "Version requirement has an invalid syntax: %r" %\
-                    version_req
+                    req_string
                 )
-        else:
-            return True # no requirement -> version always matches
+        return True
 
-    def record_error(self, pkg_name, version_req, msg_id):
+    def pkg_req(self, pkg_name, version_reqs):
+        """Return a string from package name and list of version requirements.
+        """
+        return "%s %s" % (pkg_name, ", ".join(version_reqs))
+
+    def record_error(self, pkg_name, version_reqs, msg_id):
         """Record an error. Errors will be queued and at the end will cause
         a DistutilsSetupError to be raised.
         """
         if msg_id not in self.errors:
             self.errors[msg_id] = list()
-        pkg_req = pkg_name + (version_req or "")
-        self.errors[msg_id].append(pkg_req)
+        self.errors[msg_id].append(self.pkg_req(pkg_name, version_reqs))
 
     def print_errors(self):
         for msg_id in self.errors:
@@ -678,20 +712,22 @@ class PythonInstaller(BaseInstaller):
     def __init__(self):
         BaseInstaller.__init__(self)
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
-        """Install a Python package, optionally applying  a version
-        requirement.
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
+        """Install a Python package, optionally ensuring that the specified
+        version requirements are satisfied.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
-        pkg_req = pkg_name + (version_req or "")
+        pkg_req = self.pkg_req(pkg_name, version_reqs)
         if dry_run:
             print "Dry-running: pip install %s" % pkg_req
             return 0
@@ -704,14 +740,16 @@ class PythonInstaller(BaseInstaller):
                 )
             return rc
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether a Python package is installed, and optionally satisfies
-        a version requirement.
+        the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is installed.
@@ -719,38 +757,36 @@ class PythonInstaller(BaseInstaller):
         cmd = "pip show %s" % pkg_name
         rc, out, _ = shell(cmd)
         if rc != 0:
-            print "Package is not installed: %s" % pkg_name
+            if verbose:
+                print "Package is not installed: %s" % pkg_name
             return False
         lines = out.splitlines()
         version_line = [line for line in lines
                         if line.startswith("Version:")][0]
         version = version_line.split()[1]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
             if version_sufficient:
                 print "Installed package version is sufficient: "\
-                    "%s %s" % (pkg_name, version)
+                      "%s %s" % (pkg_name, version)
             else:
                 print "Installed package version is not sufficient: "\
-                    "%s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            print "Installed package version is sufficient: "\
-                "%s %s" % (pkg_name, version)
-            return True
+                      "%s %s" % (pkg_name, version)
+        return version_sufficient
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether a Python package is available on Pypi, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
         It does not matter for this function whether the package is already
         installed.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
@@ -764,46 +800,46 @@ class PythonInstaller(BaseInstaller):
         hits = pip.commands.search.transform_hits(pypi_hits)
         for hit in hits:
             if hit['name'] == pkg_name:
-                if version_req is None:
-                    if display:
-                        print "Package version(s) available in Pypi are "\
-                              "sufficient: %s %s" %\
-                              (pkg_name, repr(hit['versions']))
-                    return True
+                if not version_reqs:
+                    versions = hit['versions']
                 else:
+                    versions = []
                     for _version in hit['versions']:
-                        version_sufficient = self.version_matches_req(
-                            _version, version_req)
-                        if version_sufficient:
-                            version = _version
-                            break
-                    if display:
-                        if version_sufficient:
-                            print "Package version available in Pypi is "\
-                                  "sufficient: %s %s" % (pkg_name, version)
-                        else:
-                            print "Package version available in Pypi is "\
-                                  "not sufficient: %s %s" % (pkg_name, version)
-                    return version_sufficient
-        if display:
+                        if self.version_matches_req(_version, version_reqs):
+                            versions.append(_version)
+                sufficient = len(versions) > 0
+                if verbose:
+                    if sufficient:
+                        print "The following package versions available in "\
+                              "Pypi are sufficient: %s %s" %\
+                              (pkg_name, ", ".join(versions))
+                    else:
+                        print "None of the package versions available in Pypi "\
+                              "is sufficient: %s %s" %\
+                              (pkg_name, ", ".join(hit['versions']))
+                return sufficient
+        if verbose:
             print "Package is not available in Pypi: %s" % pkg_name
         return False
 
-    def ensure_installed(self, pkg_name, version_req=None, dry_run=False):
+    def ensure_installed(self, pkg_name, version_reqs=None, dry_run=False,
+                         verbose=True):
         """Ensure that a Python package is installed, and optionally satisfies
-        a version requirement.
+        the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
-        if not self.is_installed(pkg_name, version_req):
-            self.install(pkg_name, version_req, dry_run)
+        if not self.is_installed(pkg_name, version_reqs, verbose):
+            self.install(pkg_name, version_reqs, dry_run, verbose)
 
 class OSInstaller(BaseInstaller):
     """Base class for installing OS-level packages."""
@@ -847,82 +883,88 @@ class OSInstaller(BaseInstaller):
             authorized = True
         return authorized
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
-        """Install an OS-level package, optionally applying a version
-        requirement.
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
+        """Install an OS-level package, optionally ensuring that the specified
+        version requirements are satisfied.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         # The real code is in the subclass. If this code gets control, this
         # platform is not supported.
-        self.record_error(pkg_name, version_req,
+        self.record_error(pkg_name, version_reqs,
                           self.MSG_PLATFORM_NOT_SUPPORTED)
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is installed, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is installed.
         """
         # The real code is in the subclass. If this code gets control, there
         # is no subclass that handles this platform.
-        self.record_error(pkg_name, version_req,
+        self.record_error(pkg_name, version_reqs,
                           self.MSG_PLATFORM_NOT_SUPPORTED)
         return False
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is available in the repos, and
-        optionally satisfies a version requirement.
+        optionally satisfies the specified version requirements.
         It does not matter for this function whether the package is already
         installed.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
         """
         # The real code is in the subclass. If this code gets control, there
         # is no subclass that handles this platform.
-        self.record_error(pkg_name, version_req,
+        self.record_error(pkg_name, version_reqs,
                           self.MSG_PLATFORM_NOT_SUPPORTED)
         return False
 
-    def ensure_installed(self, pkg_name, version_req=None, dry_run=False):
+    def ensure_installed(self, pkg_name, version_reqs=None, dry_run=False,
+                         verbose=True):
         """Ensure that an OS-level package is installed, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         if not self.supported():
-            self.record_error(pkg_name, version_req,
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_PLATFORM_NOT_SUPPORTED)
             return
-        if not self.is_installed(pkg_name, version_req):
-            self.install(pkg_name, version_req, dry_run)
+        if not self.is_installed(pkg_name, version_reqs, verbose):
+            self.install(pkg_name, version_reqs, dry_run, verbose)
 
 class YumInstaller(OSInstaller):
     """Installer for yum (or dnf) tool (e.g. RHEL, CentOS, Fedora).
@@ -936,24 +978,26 @@ class YumInstaller(OSInstaller):
         else:
             self.installer_cmd = "yum"
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
-        """Install an OS-level package, optionally applying a version
-        requirement.
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
+        """Install an OS-level package, optionally ensuring that the specified
+        version requirements are satisfied.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         if not self.authorized():
-            self.record_error(pkg_name, version_req,
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_USER_NOT_AUTHORIZED)
-        elif not self.is_available(pkg_name, version_req, display=False):
-            self.record_error(pkg_name, version_req,
+        elif not self.is_available(pkg_name, version_reqs, verbose):
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_PKG_NOT_IN_REPOS)
         else:
             cmd = "sudo %s install -y %s" %\
@@ -964,14 +1008,16 @@ class YumInstaller(OSInstaller):
                 print "Running: %s" % cmd
                 shell_check(cmd, display=True)
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is installed, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is installed.
@@ -979,7 +1025,8 @@ class YumInstaller(OSInstaller):
         cmd = "%s list installed %s" % (self.installer_cmd, pkg_name)
         rc, out, err = shell(cmd)
         if rc != 0:
-            print "Package is not installed: %s" % pkg_name
+            if verbose:
+                print "Package is not installed: %s" % pkg_name
             return False
         info = out.splitlines()[-1].strip("\n").split()
         if not info[0].startswith(pkg_name+"."):
@@ -987,32 +1034,29 @@ class YumInstaller(OSInstaller):
                 "Unexpected output from command '%s':\n%s%s" %\
                 (cmd, out, err))
         version = info[1].split("-")[0]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
             if version_sufficient:
-                print "Installed package version is sufficient: "\
-                    "%s %s" % (pkg_name, version)
+                print "Installed package version is sufficient: %s %s" %\
+                      (pkg_name, version)
             else:
-                print "Installed package version is not sufficient: "\
-                    "%s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            print "Installed package version is sufficient: "\
-                "%s %s" % (pkg_name, version)
-            return True
+                print "Installed package version is not sufficient: %s %s" %\
+                      (pkg_name, version)
+        return version_sufficient
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is available in the repos, and
-        optionally satisfies a version requirement.
+        optionally satisfies the specified version requirements.
         It does not matter for this function whether the package is already
         installed.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
@@ -1020,7 +1064,7 @@ class YumInstaller(OSInstaller):
         cmd = "%s list %s" % (self.installer_cmd, pkg_name)
         rc, out, err = shell(cmd)
         if rc != 0:
-            if display:
+            if verbose:
                 print "Package is not available in repositories: %s" %\
                     pkg_name
             return False
@@ -1030,22 +1074,16 @@ class YumInstaller(OSInstaller):
                 "Unexpected output from command '%s':\n%s%s" %\
                 (cmd, out, err))
         version = info[1].split("-")[0]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
-            if display:
-                if version_sufficient:
-                    print "Package version available in repositories is "\
-                        "sufficient: %s %s" % (pkg_name, version)
-                else:
-                    print "Package version available in repositories is "\
-                        "not sufficient: %s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            if display:
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
+            if version_sufficient:
                 print "Package version available in repositories is "\
-                    "sufficient: %s %s" % (pkg_name, version)
-            return True
+                      "sufficient: %s %s" % (pkg_name, version)
+            else:
+                print "Package version available in repositories is "\
+                      "not sufficient: %s %s" % (pkg_name, version)
+        return version_sufficient
 
 class AptInstaller(OSInstaller):
     """Installer for apt tool (e.g. Debian, Ubuntu)."""
@@ -1053,24 +1091,26 @@ class AptInstaller(OSInstaller):
     def __init__(self):
         OSInstaller.__init__(self)
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
-        """Install an OS-level package, optionally applying a version
-        requirement.
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
+        """Install an OS-level package, optionally ensuring that the specified
+        version requirements are satisfied.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         if not self.authorized():
-            self.record_error(pkg_name, version_req,
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_USER_NOT_AUTHORIZED)
-        elif not self.is_available(pkg_name, version_req, display=False):
-            self.record_error(pkg_name, version_req,
+        elif not self.is_available(pkg_name, version_reqs, verbose):
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_PKG_NOT_IN_REPOS)
         else:
             cmd = "sudo apt-get install -y %s" % pkg_name
@@ -1080,14 +1120,16 @@ class AptInstaller(OSInstaller):
                 print "Running: %s" % cmd
                 shell_check(cmd, display=True)
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is installed, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is installed.
@@ -1109,22 +1151,18 @@ class AptInstaller(OSInstaller):
         if ":" in version:
             version = version.split(":")[1]
             # TODO: Add support for epoch number in the version
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
             if version_sufficient:
-                print "Installed package version is sufficient: "\
-                    "%s %s" % (pkg_name, version)
+                print "Installed package version is sufficient: %s %s" %\
+                      (pkg_name, version)
             else:
-                print "Installed package version is not sufficient: "\
-                    "%s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            print "Installed package version is sufficient: "\
-                "%s %s" % (pkg_name, version)
-            return True
+                print "Installed package version is not sufficient: %s %s" %\
+                      (pkg_name, version)
+        return version_sufficient
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is available in the repos, and
         optionally satisfies a version requirement.
         It does not matter for this function whether the package is already
@@ -1132,9 +1170,10 @@ class AptInstaller(OSInstaller):
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
@@ -1142,7 +1181,7 @@ class AptInstaller(OSInstaller):
         cmd = "apt show %s" % pkg_name
         rc, out, _ = shell(cmd)
         if rc != 0:
-            if display:
+            if verbose:
                 print "Package is not available in repositories: %s" %\
                     pkg_name
             return False
@@ -1150,22 +1189,16 @@ class AptInstaller(OSInstaller):
         version_line = [line for line in lines
                         if line.startswith("Version:")][0]
         version = version_line.split()[1].split("-")[0]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
-            if display:
-                if version_sufficient:
-                    print "Package version available in repositories is "\
-                        "sufficient: %s %s" % (pkg_name, version)
-                else:
-                    print "Package version available in repositories is "\
-                        "not sufficient: %s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            if display:
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
+            if version_sufficient:
                 print "Package version available in repositories is "\
-                    "sufficient: %s %s" % (pkg_name, version)
-            return True
+                      "sufficient: %s %s" % (pkg_name, version)
+            else:
+                print "Package version available in repositories is "\
+                      "not sufficient: %s %s" % (pkg_name, version)
+        return version_sufficient
 
 class ZypperInstaller(OSInstaller):
     """Installer for zypper tool (e.g. SLES, openSUSE)."""
@@ -1173,24 +1206,26 @@ class ZypperInstaller(OSInstaller):
     def __init__(self):
         OSInstaller.__init__(self)
 
-    def install(self, pkg_name, version_req=None, dry_run=False):
-        """Install an OS-level package, optionally applying a version
-        requirement.
+    def install(self, pkg_name, version_reqs=None, dry_run=False, verbose=True):
+        """Install an OS-level package, optionally ensuring that the specified
+        version requirements are satisfied.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Raises:
         * If installation fails, raises a DistutilsSetupError exception.
         """
         if not self.authorized():
-            self.record_error(pkg_name, version_req,
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_USER_NOT_AUTHORIZED)
-        elif not self.is_available(pkg_name, version_req, display=False):
-            self.record_error(pkg_name, version_req,
+        elif not self.is_available(pkg_name, version_reqs, verbose):
+            self.record_error(pkg_name, version_reqs,
                               self.MSG_PKG_NOT_IN_REPOS)
         else:
             cmd = "sudo yum zypper -y %s" % pkg_name
@@ -1200,14 +1235,16 @@ class ZypperInstaller(OSInstaller):
                 print "Running: %s" % cmd
                 shell_check(cmd, display=True)
 
-    def is_installed(self, pkg_name, version_req=None):
+    def is_installed(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is installed, and optionally
-        satisfies a version requirement.
+        satisfies the specified version requirements.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is installed.
@@ -1215,7 +1252,8 @@ class ZypperInstaller(OSInstaller):
         cmd = "zypper info %s" % pkg_name
         rc, out, err = shell(cmd)
         if rc != 0:
-            print "Package is not installed: %s" % pkg_name
+            if verbose:
+                print "Package is not installed: %s" % pkg_name
             return False
         info = out.splitlines()[-1].strip("\n").split()
         if not info[0].startswith(pkg_name+"."):
@@ -1223,32 +1261,29 @@ class ZypperInstaller(OSInstaller):
                 "Unexpected output from command '%s':\n%s%s" %\
                 (cmd, out, err))
         version = info[1].split("-")[0]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
             if version_sufficient:
-                print "Installed package version is sufficient: "\
-                    "%s %s" % (pkg_name, version)
+                print "Installed package version is sufficient: %s %s" %\
+                      (pkg_name, version)
             else:
-                print "Installed package version is not sufficient: "\
-                    "%s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            print "Installed package version is sufficient: "\
-                "%s %s" % (pkg_name, version)
-            return True
+                print "Installed package version is not sufficient: %s %s" %\
+                      (pkg_name, version)
+        return version_sufficient
 
-    def is_available(self, pkg_name, version_req=None, display=True):
+    def is_available(self, pkg_name, version_reqs=None, verbose=True):
         """Test whether an OS-level package is available in the repos, and
-        optionally satisfies a version requirement.
+        optionally satisfies the specified version requirements.
         It does not matter for this function whether the package is already
         installed.
 
         Parameters:
         * pkg_name (string): Name of the package.
-        * version_req (string): Version requirement for the package
-          (e.g. '>=3.0').
-        * display (boolean): Print messages.
+        * version_reqs (list): List of zero or more strings that are version
+          requirements for the package (e.g. ('>=3.0', '!=3.5')).
+        * verbose (boolean): Verbose mode. In verbose mode, all messages are
+          printed. In quiet mode, only the most important messages are printed.
 
         Returns:
         * Boolean indicating whether the package is available for installation.
@@ -1259,28 +1294,22 @@ class ZypperInstaller(OSInstaller):
         lines = out.splitlines()
         version_lines = [line for line in lines if line.startswith("Version:")]
         if len(version_lines) == 0:
-            if display:
+            if verbose:
                 print "Package is not available in repositories: %s" %\
                     pkg_name
             return False
         version_line = version_lines[0]
         version = version_line.split()[1].split("-")[0]
-        if version_req is not None:
-            version_sufficient = self.version_matches_req(
-                version, version_req)
-            if display:
-                if version_sufficient:
-                    print "Package version available in repositories is "\
-                        "sufficient: %s %s" % (pkg_name, version)
-                else:
-                    print "Package version available in repositories is "\
-                        "not sufficient: %s %s" % (pkg_name, version)
-            return version_sufficient
-        else:
-            if display:
+        version_sufficient = self.version_matches_req(version, version_reqs) \
+                             if version_reqs else True
+        if verbose:
+            if version_sufficient:
                 print "Package version available in repositories is "\
-                    "sufficient: %s %s" % (pkg_name, version)
-            return True
+                      "sufficient: %s %s" % (pkg_name, version)
+            else:
+                print "Package version available in repositories is "\
+                      "not sufficient: %s %s" % (pkg_name, version)
+        return version_sufficient
 
 def shell(command, display=False):
     """Execute a shell command and return its return code, stdout and stderr.


### PR DESCRIPTION
This merge request:
* Adds support for specifying multiple version requirements for OS-level and Python packages in the setup script.
* Utilizes this new ability for specifying the version requirements for Pylint and its Astroid library.
* Adds support for specifying the verbosity of messages during setup, via the standard setup.py command line options for verbosity (-q, -v and their long versions).

It has been tested on RHEL 6.7 at this point with some manually created scenarios, and on the Travis CI (with its default scenario of most packages not being installed).

Please review.