### PR TITLE
Using rebased M2Crypto fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - echo "The next command shows that Python's platform.linux_distribution() returns a incorrect distro:"
-  - python -c "import platform; print('linux_distribution()=%s' % repr(platform.linux_distribution()))"
-  - echo "The next command shows the site packages directory for the system Python:"
-  - python -c "import pip, os; print(os.path.dirname(os.path.dirname(pip.__file__)))"
+  - python -c "import platform; print('Demonstration of incorrect distro being returned: platform.linux_distribution()=%s' % repr(platform.linux_distribution()))"
+  - python -c "import pip, os; print('Site-packages directory of system Python: %s' % os.path.dirname(os.path.dirname(pip.__file__)))"
   - pip list
   - pip install --upgrade pip
+  - pip uninstall pbr
   - make develop
   - pip list
   - make check

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,15 @@ import os
 import shutil
 from distutils.errors import DistutilsSetupError
 
+# Workaround for Python 2.6 issue https://bugs.python.org/issue15881
+# This causes this module to be referenced and prevents the premature
+# unloading and subsequent garbage collection causing the error.
+if sys.version_info[0:2] == (2, 6):
+    try:
+        import multiprocessing
+    except ImportError:
+        pass
+
 import os_setup
 from os_setup import shell, shell_check, import_setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ def main():
         # fixes for installation issues. This only seems to work if no version
         # is specified in its install_requires entry.
         'dependency_links': [
-            "git+https://github.com/pywbem/m2crypto@amfix2#egg=M2Crypto"
+            "git+https://github.com/pywbem/m2crypto@amfix_rebased#egg=M2Crypto"
         ],
         'install_requires': [
             # These dependencies will be installed as a site package.


### PR DESCRIPTION
This is to test the rebased fixes in PyWBEM's fork of M2Crypto.
There is only one fix remaining that was found to be required.

These fixes only affect installability of PyBEM, so testing with

    python setup.py install_os

should be sufficient.

The counter-test by using the upstream M2Crypto version on RedHat based distros, to verify that  the original problem still exists, would also be good. To test that, change the following in PyWBEM's setup.py:

             'dependency_links': [
    -            "git+https://github.com/pywbem/m2crypto@amfix_rebased#egg=M2Crypto"
    +            "git+https://gitlab.com/m2crypto/m2crypto#egg=M2Crypto"
             ],
