### PR TITLE
Clean up pylint for selected modules

### DIFF
--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -24,6 +24,8 @@
 
 # CIMError error code constants
 
+# pylint: disable=bad-whitespace
+
 CIM_ERR_FAILED                       = 1  # A general error occurred
 CIM_ERR_ACCESS_DENIED                = 2  # Resource not available
 CIM_ERR_INVALID_NAMESPACE            = 3  # The target namespace does not exist

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -515,22 +515,28 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
 
             client.putrequest('POST', '/cimom')
 
-            client.putheader('Content-type', 'application/xml; charset="utf-8"')
+            client.putheader('Content-type',
+                             'application/xml; charset="utf-8"')
             client.putheader('Content-length', str(len(data)))
             if local_auth_header is not None:
                 client.putheader(*local_auth_header)
             elif creds is not None:
+                #pylint: disable=line-too-long
                 client.putheader('Authorization', 'Basic %s' %
                                  base64.encodestring('%s:%s' %
-                                                     (creds[0], creds[1])).replace('\n', ''))
+                                                     (creds[0],
+                                                      creds[1])).replace('\n', ''))
             elif locallogin is not None:
-                client.putheader('PegasusAuthorization', 'Local "%s"' % locallogin)
+                client.putheader('PegasusAuthorization',
+                                 'Local "%s"' % locallogin)
 
             for hdr in headers:
                 if isinstance(hdr, unicode):
                     hdr = hdr.encode('utf-8')
-                hdr_pieces = map(lambda x: string.strip(x), string.split(hdr, ":", 1))
-                client.putheader(urllib.quote(hdr_pieces[0]), urllib.quote(hdr_pieces[1]))
+                hdr_pieces = map(lambda x: string.strip(x),
+                                 string.split(hdr, ":", 1))
+                client.putheader(urllib.quote(hdr_pieces[0]),
+                                 urllib.quote(hdr_pieces[1]))
 
             try:
                 # See RFC 2616 section 8.2.2
@@ -573,7 +579,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                                     raise ConnectionError(
                                         "OWLocal authorization for OpenWbem "\
                                         "server not supported on %s platform "\
-                                        "due to missing os.getuid()" %\
+                                        "due to missing os.getuid()" % \
                                         platform.system())
                                 local_auth_header = ('Authorization',
                                                      'OWLocal uid="%d"' % uid)
@@ -581,11 +587,14 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                             else:
                                 try:
                                     nonce_idx = auth_chal.index('nonce=')
-                                    nonce_begin = auth_chal.index('"', nonce_idx)
-                                    nonce_end = auth_chal.index('"', nonce_begin+1)
+                                    nonce_begin = auth_chal.index('"',
+                                                                  nonce_idx)
+                                    nonce_end = auth_chal.index('"',
+                                                                nonce_begin+1)
                                     nonce = auth_chal[nonce_begin+1:nonce_end]
                                     cookie_idx = auth_chal.index('cookiefile=')
-                                    cookie_begin = auth_chal.index('"', cookie_idx)
+                                    cookie_begin = auth_chal.index('"',
+                                                                   cookie_idx)
                                     cookie_end = auth_chal.index(
                                         '"', cookie_begin+1)
                                     cookie_file = auth_chal[

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -250,7 +250,7 @@ def get_default_ca_certs():
 def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                  verify_callback=None, ca_certs=None,
                  no_verification=False, timeout=None):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,unused-argument
     # pylint: disable=too-many-locals
     """
     Send an HTTP or HTTPS request to a WBEM server and return the response.

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -342,54 +342,12 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
             self.sock.sendall(strng)
 
     class HTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
-        """
-        Execute client connection without ssl using httplib.
-
-            :Parameters:
-
-             host : `unicode` or UTF-8 encoded `str`
-                   Name or IP address of host
-
-              port : TODO
-                   port of host or None if default to be used
-
-              strict : TODO
-
-              timeout : timeout in seconds for connection
-
-            :Returns:  TODO
-
-            :Raises:   TODO
-         """
+        """ Execute client connection without ssl using httplib. """
         def __init__(self, host, port=None, strict=None, timeout=None):
             httplib.HTTPConnection.__init__(self, host, port, strict, timeout)
 
     class HTTPSConnection(HTTPBaseConnection, httplib.HTTPSConnection):
-        """
-        Execute client connection with ssl using httplib.
-
-            :Parameters:
-
-             host : `unicode` or UTF-8 encoded `str`
-                   Name or IP address of host
-
-              port : TODO
-                   port of host or None if default to be used
-
-              key_file :
-
-              cert_file :
-
-              strict : TODO
-
-              verify_callback : TODO
-
-              timeout : timeout in seconds for connection
-
-            :Returns:  TODO
-
-            :Raises:   TODO
-        """
+        """ Execute client connection with ssl using httplib."""
         # pylint: disable=R0913,too-many-arguments
         def __init__(self, host, port=None, key_file=None, cert_file=None,
                      strict=None, ca_certs=None, verify_callback=None,
@@ -401,7 +359,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
 
         def connect(self):
             # pylint: disable=too-many-branches
-            "Connect to a host on a given (SSL) port."
+            """Connect to a host on a given (SSL) port."""
 
             # Calling httplib.HTTPSConnection.connect(self) does not work
             # because of its ssl.wrap_socket() call. So we copy the code of
@@ -469,19 +427,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                     "SSL error %s: %s" % (str(arg.__class__), arg))
 
     class FileHTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
-        """
-        Execute client connection to TODO.
-
-            :Parameters:
-
-             uds_path :  Path to the server
-
-            :Returns:  TODO
-
-            :Raises:   TODO
-        """
-
-
+        """Execute client connection based on a unix domain socket. """
 
         def __init__(self, uds_path):
             httplib.HTTPConnection.__init__(self, 'localhost')

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -69,7 +69,7 @@ class TimeoutError(Error):
     """This exception is raised when the client times out."""
     pass
 
-class HTTPTimeout(object):
+class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
     """HTTP timeout class that is a context manager (for use by 'with'
     statement).
 
@@ -183,10 +183,10 @@ def parse_url(url):
     default_ssl = False             # default SSL use (for no or unknown scheme)
 
     # Look for scheme.
-    m = re.match(r"^(https?)://(.*)$", url, re.I)
-    if m:
-        _scheme = m.group(1).lower()
-        hostport = m.group(2)
+    matches = re.match(r"^(https?)://(.*)$", url, re.I)
+    if matches:
+        _scheme = matches.group(1).lower()
+        hostport = matches.group(2)
         ssl = (_scheme == 'https')
     else:
         # The URL specified no scheme (or a scheme other than the expected
@@ -197,17 +197,17 @@ def parse_url(url):
     # Remove trailing path segments, if any.
     # Having URL components other than just slashes (e.g. '#' or '?') is not
     # allowed (but we don't check).
-    m = hostport.find("/")
-    if m >= 0:
-        hostport = hostport[0:m]
+    result = hostport.find("/")
+    if result >= 0:
+        hostport = hostport[0:result]
 
     # Look for port.
     # This regexp also works for (colon-separated) IPv6 addresses, because they
     # must be bracketed in a URL.
-    m = re.search(r":([0-9]+)$", hostport)
-    if m:
-        host = hostport[0:m.start(0)]
-        port = int(m.group(1))
+    matches = re.search(r":([0-9]+)$", hostport)
+    if matches:
+        host = hostport[0:matches.start(0)]
+        port = int(matches.group(1))
     else:
         host = hostport
         port = default_port_https if ssl else default_port_http
@@ -219,13 +219,13 @@ def parse_url(url):
     # Note on the regexp below: The first group needs the '?' after '.+' to
     # become non-greedy; in greedy mode, the optional second group would never
     # be matched.
-    m = re.match(r"^\[(.+?)(?:-(.+))?\]$", host)
-    if m:
+    matches = re.match(r"^\[(.+?)(?:-(.+))?\]$", host)
+    if matches:
         # It is an IPv6 address
-        host = m.group(1)
-        if m.group(2) != None:
+        host = matches.group(1)
+        if matches.group(2) != None:
             # The zone index is present
-            host += "%" + m.group(2)
+            host += "%" + matches.group(2)
 
     return host, port, ssl
 
@@ -246,9 +246,12 @@ def get_default_ca_certs():
             get_default_ca_certs._path = None
     return get_default_ca_certs._path
 
+# pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                  verify_callback=None, ca_certs=None,
                  no_verification=False, timeout=None):
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-locals
     """
     Send an HTTP or HTTPS request to a WBEM server and return the response.
 
@@ -318,9 +321,12 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
       :raise TimeoutError:
     """
 
-    class HTTPBaseConnection:
-        # pylint: disable=old-style-class
-        def send(self, str):
+    class HTTPBaseConnection:        # pylint: disable=no-init
+        """ Common base for specific connection classes. Implements
+            the send method
+        """
+        # pylint: disable=old-style-class,too-few-public-methods
+        def send(self, strng):
             """ Same as httplib.HTTPConnection.send(), except we don't
             check for sigpipe and close the connection.  If the connection
             gets closed, getresponse() fails.
@@ -332,14 +338,59 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                 else:
                     raise httplib.NotConnected()
             if self.debuglevel > 0:
-                print "send:", repr(str)
-            self.sock.sendall(str)
+                print "send:", repr(strng)
+            self.sock.sendall(strng)
 
     class HTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
+        """
+        Execute client connection without ssl using httplib.
+
+            :Parameters:
+
+             host : `unicode` or UTF-8 encoded `str`
+                   Name or IP address of host
+
+              port : TODO
+                   port of host or None if default to be used
+
+              strict : TODO
+
+              timeout : timeout in seconds for connection
+
+            :Returns:  TODO
+
+            :Raises:   TODO
+         """
         def __init__(self, host, port=None, strict=None, timeout=None):
             httplib.HTTPConnection.__init__(self, host, port, strict, timeout)
 
     class HTTPSConnection(HTTPBaseConnection, httplib.HTTPSConnection):
+        """
+        Execute client connection with ssl using httplib.
+
+            :Parameters:
+
+             host : `unicode` or UTF-8 encoded `str`
+                   Name or IP address of host
+
+              port : TODO
+                   port of host or None if default to be used
+
+              key_file :
+
+              cert_file :
+
+              strict : TODO
+
+              verify_callback : TODO
+
+              timeout : timeout in seconds for connection
+
+            :Returns:  TODO
+
+            :Raises:   TODO
+        """
+        # pylint: disable=R0913,too-many-arguments
         def __init__(self, host, port=None, key_file=None, cert_file=None,
                      strict=None, ca_certs=None, verify_callback=None,
                      timeout=None):
@@ -349,6 +400,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
             self.verify_callback = verify_callback
 
         def connect(self):
+            # pylint: disable=too-many-branches
             "Connect to a host on a given (SSL) port."
 
             # Calling httplib.HTTPSConnection.connect(self) does not work
@@ -417,6 +469,19 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                     "SSL error %s: %s" % (str(arg.__class__), arg))
 
     class FileHTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
+        """
+        Execute client connection to TODO.
+
+            :Parameters:
+
+             uds_path :  Path to the server
+
+            :Returns:  TODO
+
+            :Raises:   TODO
+        """
+
+
 
         def __init__(self, uds_path):
             httplib.HTTPConnection.__init__(self, 'localhost')
@@ -441,9 +506,9 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
         cert_file = x509.get('cert_file')
         key_file = x509.get('key_file')
 
-    numTries = 0
-    localAuthHeader = None
-    tryLimit = 5
+    num_tries = 0
+    local_auth_header = None
+    try_limit = 5
 
     # Make sure the data argument is converted to a UTF-8 encoded str object.
     # This is important because according to RFC2616, the Content-Length HTTP
@@ -461,27 +526,27 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
 
     local = False
     if use_ssl:
-        h = HTTPSConnection(host,
-                            port=port,
-                            key_file=key_file,
-                            cert_file=cert_file,
-                            ca_certs=ca_certs,
-                            verify_callback=verify_callback,
-                            timeout=timeout)
+        client = HTTPSConnection(host,
+                                 port=port,
+                                 key_file=key_file,
+                                 cert_file=cert_file,
+                                 ca_certs=ca_certs,
+                                 verify_callback=verify_callback,
+                                 timeout=timeout)
     else:
         if url.startswith('http'):
-            h = HTTPConnection(host,
-                               port=port,
-                               timeout=timeout)
+            client = HTTPConnection(host,  # pylint: disable=redefined-variable-type
+                                    port=port,
+                                    timeout=timeout)
         else:
             if url.startswith('file:'):
                 url_ = url[5:]
             else:
                 url_ = url
             try:
-                s = os.stat(url_)
-                if S_ISSOCK(s.st_mode):
-                    h = FileHTTPConnection(url_)
+                status = os.stat(url_)
+                if S_ISSOCK(status.st_mode):
+                    client = FileHTTPConnection(url_)
                     local = True
                 else:
                     raise ConnectionError('File URL is not a socket: %s' % url)
@@ -497,30 +562,29 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
         except (KeyError, ImportError):
             locallogin = None
 
-    with HTTPTimeout(timeout, h):
+    with HTTPTimeout(timeout, client):
 
-        while numTries < tryLimit:
-            numTries = numTries + 1
+        while num_tries < try_limit:
+            num_tries = num_tries + 1
 
-            h.putrequest('POST', '/cimom')
+            client.putrequest('POST', '/cimom')
 
-            h.putheader('Content-type', 'application/xml; charset="utf-8"')
-            h.putheader('Content-length', str(len(data)))
-            if localAuthHeader is not None:
-                h.putheader(*localAuthHeader)
+            client.putheader('Content-type', 'application/xml; charset="utf-8"')
+            client.putheader('Content-length', str(len(data)))
+            if local_auth_header is not None:
+                client.putheader(*local_auth_header)
             elif creds is not None:
-                h.putheader('Authorization', 'Basic %s' %
-                            base64.encodestring(
-                                '%s:%s' %
-                                (creds[0], creds[1])).replace('\n', ''))
+                client.putheader('Authorization', 'Basic %s' %
+                                 base64.encodestring('%s:%s' %
+                                                     (creds[0], creds[1])).replace('\n', ''))
             elif locallogin is not None:
-                h.putheader('PegasusAuthorization', 'Local "%s"' % locallogin)
+                client.putheader('PegasusAuthorization', 'Local "%s"' % locallogin)
 
             for hdr in headers:
                 if isinstance(hdr, unicode):
                     hdr = hdr.encode('utf-8')
-                s = map(lambda x: string.strip(x), string.split(hdr, ":", 1))
-                h.putheader(urllib.quote(s[0]), urllib.quote(s[1]))
+                hdr_pieces = map(lambda x: string.strip(x), string.split(hdr, ":", 1))
+                client.putheader(urllib.quote(hdr_pieces[0]), urllib.quote(hdr_pieces[1]))
 
             try:
                 # See RFC 2616 section 8.2.2
@@ -539,24 +603,24 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                 try:
                     # endheaders() is the first method in this sequence that
                     # actually sends something to the server.
-                    h.endheaders()
-                    h.send(data)
+                    client.endheaders()
+                    client.send(data)
                 except socket.error as exc:
                     # TODO: Verify these errno numbers on Windows vs. Linux
                     if exc[0] != 104 and exc[0] != 32:
                         raise ConnectionError("Socket error: %s" % exc)
 
-                response = h.getresponse()
+                response = client.getresponse()
 
                 if response.status != 200:
                     if response.status == 401:
-                        if numTries >= tryLimit:
+                        if num_tries >= try_limit:
                             raise AuthError(response.reason)
                         if not local:
                             raise AuthError(response.reason)
-                        authChal = response.getheader('WWW-Authenticate', '')
+                        auth_chal = response.getheader('WWW-Authenticate', '')
                         if 'openwbem' in response.getheader('Server', ''):
-                            if 'OWLocal' not in authChal:
+                            if 'OWLocal' not in auth_chal:
                                 try:
                                     uid = os.getuid()
                                 except AttributeError:
@@ -565,42 +629,42 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                                         "server not supported on %s platform "\
                                         "due to missing os.getuid()" %\
                                         platform.system())
-                                localAuthHeader = ('Authorization',
-                                                   'OWLocal uid="%d"' % uid)
+                                local_auth_header = ('Authorization',
+                                                     'OWLocal uid="%d"' % uid)
                                 continue
                             else:
                                 try:
-                                    nonceIdx = authChal.index('nonce=')
-                                    nonceBegin = authChal.index('"', nonceIdx)
-                                    nonceEnd = authChal.index('"', nonceBegin+1)
-                                    nonce = authChal[nonceBegin+1:nonceEnd]
-                                    cookieIdx = authChal.index('cookiefile=')
-                                    cookieBegin = authChal.index('"', cookieIdx)
-                                    cookieEnd = authChal.index(
-                                        '"', cookieBegin+1)
-                                    cookieFile = authChal[
-                                        cookieBegin+1:cookieEnd]
-                                    f = open(cookieFile, 'r')
-                                    cookie = f.read().strip()
-                                    f.close()
-                                    localAuthHeader = (
+                                    nonce_idx = auth_chal.index('nonce=')
+                                    nonce_begin = auth_chal.index('"', nonce_idx)
+                                    nonce_end = auth_chal.index('"', nonce_begin+1)
+                                    nonce = auth_chal[nonce_begin+1:nonce_end]
+                                    cookie_idx = auth_chal.index('cookiefile=')
+                                    cookie_begin = auth_chal.index('"', cookie_idx)
+                                    cookie_end = auth_chal.index(
+                                        '"', cookie_begin+1)
+                                    cookie_file = auth_chal[
+                                        cookie_begin+1:cookie_end]
+                                    file_hndl = open(cookie_file, 'r')
+                                    cookie = file_hndl.read().strip()
+                                    file_hndl.close()
+                                    local_auth_header = (
                                         'Authorization',
                                         'OWLocal nonce="%s", cookie="%s"' % \
                                         (nonce, cookie))
                                     continue
-                                except:
-                                    localAuthHeader = None
+                                except:    #pylint: disable=bare-except
+                                    local_auth_header = None
                                     continue
-                        elif 'Local' in authChal:
+                        elif 'Local' in auth_chal:
                             try:
-                                beg = authChal.index('"') + 1
-                                end = authChal.rindex('"')
+                                beg = auth_chal.index('"') + 1
+                                end = auth_chal.rindex('"')
                                 if end > beg:
-                                    _file = authChal[beg:end]
-                                    fo = open(_file, 'r')
-                                    cookie = fo.read().strip()
-                                    fo.close()
-                                    localAuthHeader = (
+                                    _file = auth_chal[beg:end]
+                                    file_hndl = open(_file, 'r')
+                                    cookie = file_hndl.read().strip()
+                                    file_hndl.close()
+                                    local_auth_header = (
                                         'PegasusAuthorization',
                                         'Local "%s:%s:%s"' % \
                                         (locallogin, _file, cookie))

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -101,7 +101,7 @@ class MinutesFromUTC(tzinfo):
         """
         return timedelta(0)
 
-class CIMType(object):
+class CIMType(object):       # pylint: disable=too-few-public-methods
     """Base type for numeric and datetime CIM types."""
 
 class CIMDateTime(CIMType):
@@ -141,17 +141,17 @@ class CIMDateTime(CIMType):
             date_pattern = re.compile(
                 r'^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.' \
                 r'(\d{6})([+|-])(\d{3})')
-            s = date_pattern.search(dtarg)
-            if s is not None:
-                g = s.groups()
-                offset = int(g[8])
-                if g[7] == '-':
+            srch_result = date_pattern.search(dtarg)
+            if srch_result is not None:
+                parts = srch_result.groups()
+                offset = int(parts[8])
+                if parts[7] == '-':
                     offset = -offset
                 try:
-                    self.__datetime = datetime(int(g[0]), int(g[1]),
-                                               int(g[2]), int(g[3]),
-                                               int(g[4]), int(g[5]),
-                                               int(g[6]),
+                    self.__datetime = datetime(int(parts[0]), int(parts[1]),
+                                               int(parts[2]), int(parts[3]),
+                                               int(parts[4]), int(parts[5]),
+                                               int(parts[6]),
                                                MinutesFromUTC(offset))
                 except ValueError as exc:
                     raise ValueError('dtarg argument "%s" has invalid field '\
@@ -160,16 +160,16 @@ class CIMDateTime(CIMType):
             else:
                 tv_pattern = re.compile(
                     r'^(\d{8})(\d{2})(\d{2})(\d{2})\.(\d{6})(:)(000)')
-                s = tv_pattern.search(dtarg)
-                if s is not None:
-                    g = s.groups()
+                srch_result = tv_pattern.search(dtarg)
+                if srch_result is not None:
+                    parts = srch_result.groups()
                     # Because the input values are limited by the matched
                     # pattern, timedelta() never throws any exception.
-                    self.__timedelta = timedelta(days=int(g[0]),
-                                                 hours=int(g[1]),
-                                                 minutes=int(g[2]),
-                                                 seconds=int(g[3]),
-                                                 microseconds=int(g[4]))
+                    self.__timedelta = timedelta(days=int(parts[0]),
+                                                 hours=int(parts[1]),
+                                                 minutes=int(parts[2]),
+                                                 seconds=int(parts[3]),
+                                                 microseconds=int(parts[4]))
                 else:
                     raise ValueError('dtarg argument "%s" has an invalid CIM '\
                                      'datetime format' % dtarg)
@@ -275,6 +275,7 @@ class CIMDateTime(CIMType):
 
     @classmethod
     def fromtimestamp(cls, ts, tzi=None):
+        # pylint: disable=invalid-name
         """
         Factory method that returns a new `CIMDateTime` object from a POSIX
         timestamp value and optional timezone information.
@@ -509,6 +510,7 @@ def atomic_to_cim_xml(obj):
         A unicode string in CIM-XML value format representing the CIM typed
         value. For a value of `None`, `None` is returned.
     """
+    # pylint: disable=too-many-return-statements
     if isinstance(obj, bool):
         if obj:
             return u"true"

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -20,6 +20,9 @@
 # Author: Bart Whiteley <bwhiteley@suse.de>
 #
 
+# TODO: Sort this issue out and see if we need to fix KS_TODO. These
+# two issues are found repeatedly in this file.
+# pylint: disable=non-parent-init-called,super-init-not-called
 """
 
 Functions to create XML documens and elements conforming to the DMTF
@@ -1069,7 +1072,7 @@ class PARAMETER_REFARRAY(CIMElement):
             self.setAttribute('ARRAYSIZE', str(array_size))
         self.appendChildren(qualifiers)
 
-class TABLECELL_DECLARATION(CIMElement):
+class TABLECELL_DECLARATION(CIMElement): #pylint: disable=invalid-name
     # pylint: disable=invalid-name
     """
     The TABLECELL.DECLARATION element describes a TABLECELL that is


### PR DESCRIPTION
Cleaned up cim_constants.py, cim_http.py and cim_types.py.  Note that this does not remove all pylint issues but significantly reduces the number for these modules.

The end result is:

cim_constants                          0
cim_types                                 0
pywbem.cim_http               Total: 24
---------------------------------------
(protected-access)                   3
(line-too-long)                          7
(unnecessary-lambda)            1
(no-member)                          5
(fixme)                                    2
(not-an-iterable)                     1
(redefined-variable-type)        1
(deprecated-lambda)              1
(bad-builtin)                            1
(dangerous-default-value)      1
(using-constant-test)               1
---------------------------------------


