### PR TITLE
pylint cleanup of wbemcli, test_cim_http, test_cim_xml

### DIFF
--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -68,10 +68,15 @@ import pywbem
 
 __all__ = []
 
+# Connection global variable. Set by remote_connection and use
+# by all functions that execute operations.
 _CONN = None
 
 def remote_connection(argv, opts):
-    """Initiate a remote connection, via PyWBEM."""
+    """Initiate a remote connection, via PyWBEM. Arguments for
+       the request are part of the command line arguments and include
+       user name, password, namespace, etc.
+    """
 
     global _CONN     # pylint: disable=global-statement
 
@@ -105,21 +110,27 @@ def remote_connection(argv, opts):
 #
 # Create some convenient global functions to reduce typing
 #
-
+# The following pylint disable is because many of the functions
+# in this file use CamelCase specifically to maintain equivalence to
+# the client functions in other languages. Do not change these names.
+# pylint: disable=invalid-name
 def EnumerateInstanceNames(classname, namespace=None):
     """Enumerate the names of the instances of a CIM Class (including the
     names of any subclasses) in the target namespace."""
 
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
 
     return _CONN.EnumerateInstanceNames(classname, namespace=namespace)
 
+# pylint: disable=too-many-arguments
 def EnumerateInstances(classname, namespace=None, LocalOnly=True,
                        DeepInheritance=True, IncludeQualifiers=False,
                        IncludeClassOrigin=False):
     """Enumerate instances of a CIM Class (includeing the instances of
     any subclasses in the target namespace."""
 
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
 
     return _CONN.EnumerateInstances(classname,
@@ -132,8 +143,21 @@ def EnumerateInstances(classname, namespace=None, LocalOnly=True,
 def GetInstance(instancename, LocalOnly=True, IncludeQualifiers=False,
                 IncludeClassOrigin=False):
     """Return a single CIM instance corresponding to the instance name
-    given."""
+    given.
 
+    :param instancename: ObjectPath defining the instance.
+    :param LocalOnly: Optional argument defining whether the
+       only the properties defined in this instance are returned.
+       Default= true. DEPRECATED
+    :param IncludeQualifier: Optional argument defining whether
+        qualifiers are included. Default false. DEPRECATED
+    :param IncludeClassOrigin: Optional argument defining wheteher
+        class origin information is cinclude in the response. Default
+        is False.
+    :return: Dictionary containing the retrieved instance
+    :raises:
+    """
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
 
     return _CONN.GetInstance(instancename,
@@ -142,81 +166,137 @@ def GetInstance(instancename, LocalOnly=True, IncludeQualifiers=False,
                              IncludeClassOrigin=IncludeClassOrigin)
 
 def DeleteInstance(instancename):
-    """Delete a single CIM instance."""
+    """Delete a single CIM instance.
 
+       :param instancename: CIMObjectPath defining the instance
+       :return:
+    """
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
 
     return _CONN.DeleteInstance(instancename)
-
+# TODO all of the following functions simply use args and kwargs
+# This makes sorting out arguments difficult for the user.
 def ModifyInstance(*args, **kwargs):
+    """Modify an existing instance"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.ModifyInstance(*args, **kwargs)
 
 def CreateInstance(*args, **kwargs):
+    """Create a new instance for an existing class"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.CreateInstance(*args, **kwargs)
 
 def InvokeMethod(*args, **kwargs):
+    """Invoke a method"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.InvokeMethod(*args, **kwargs)
 
 def AssociatorNames(*args, **kwargs):
+    """Return associator names for the source class or instance"""
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.AssociatorNames(*args, **kwargs)
 
 def Associators(*args, **kwargs):
+    """Return associators for the source class or instance"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.Associators(*args, **kwargs)
 
 def ReferenceNames(*args, **kwargs):
+    """Return the refernence names for the target class or instance"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.ReferenceNames(*args, **kwargs)
 
 def References(*args, **kwargs):
+    """Return the instances or classes for the target instance or class"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.References(*args, **kwargs)
 
 def EnumerateClassNames(*args, **kwargs):
+    "Enumerate the class names in the namespace"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.EnumerateClassNames(*args, **kwargs)
 
 def EnumerateClasses(*args, **kwargs):
+    """Enumerate the classes defined by the input arguments"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.EnumerateClasses(*args, **kwargs)
 
 def GetClass(*args, **kwargs):
+    """ Get the class defined by the inputs"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.GetClass(*args, **kwargs)
 
 def DeleteClass(*args, **kwargs):
+    """Delete the class defined by the input. """
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.DeleteClass(*args, **kwargs)
 
 def ModifyClass(*args, **kwargs):
+    """Modify the class defined by the input arguments"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.ModifyClass(*args, **kwargs)
 
 def CreateClass(*args, **kwargs):
+    """Create a class from the input arguments"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.CreateClass(*args, **kwargs)
 
 def EnumerateQualifiers(*args, **kwargs):
+    """Return the qualifier types that exist in the defined namespace"""
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.EnumerateQualifiers(*args, **kwargs)
 
 def GetQualifier(*args, **kwargs):
+    """Return the qualifier type defined by the input argument"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.GetQualifier(*args, **kwargs)
 
 def SetQualifier(*args, **kwargs):
+    """Create a new qualifier type from the input arguments"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.SetQualifier(*args, **kwargs)
 
 def DeleteQualifier(*args, **kwargs):
+    """Delete a qualifier type"""
+
+    # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement
     return _CONN.DeleteQualifier(*args, **kwargs)
 
 # Aliases for global functions above
+
 
 ein = EnumerateInstanceNames
 ei = EnumerateInstances
@@ -248,7 +328,7 @@ dq = DeleteQualifier
 def get_banner():
     """Return a banner message for the interactive console."""
 
-    global _CONN     # pylint: disable=global-statement
+    global _CONN     # pylint: disable=global-statement,global-variable-not-assigned
 
     result = ''
 

--- a/testsuite/test_cim_http.py
+++ b/testsuite/test_cim_http.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-#
-# Exercise routines in cim_http.
-#
+
+"""Exercise routines in cim_http"""
 
 import unittest
 import pytest
@@ -9,7 +8,7 @@ import pytest
 from pywbem import cim_http
 
 
-class Parse_url(unittest.TestCase):
+class Parse_url(unittest.TestCase):  # pylint: disable=invalid-name
     """
     Test the parse_url() function.
     """
@@ -22,14 +21,14 @@ class Parse_url(unittest.TestCase):
         host, port, ssl = cim_http.parse_url(url)
 
         self.assertEqual(host, exp_host,
-                          "Unexpected host: %r, expected: %r" %\
-                          (host, exp_host))
+                         "Unexpected host: %r, expected: %r" %\
+                         (host, exp_host))
         self.assertEqual(port, exp_port,
-                          "Unexpected port: %r, expected: %r" %\
-                          (port, exp_port))
+                         "Unexpected port: %r, expected: %r" %\
+                         (port, exp_port))
         self.assertEqual(ssl, exp_ssl,
-                          "Unexpected ssl: %r, expected: %r" %\
-                          (ssl, exp_ssl))
+                         "Unexpected ssl: %r, expected: %r" %\
+                         (ssl, exp_ssl))
 
 
     def test_all(self):
@@ -43,157 +42,157 @@ class Parse_url(unittest.TestCase):
         default_ssl = False
 
         self._run_single("http://my.host.com",
-                            "my.host.com",
-                            default_port_http,
-                            False)
+                         "my.host.com",
+                         default_port_http,
+                         False)
 
         self._run_single("https://my.host.com/",
-                            "my.host.com",
-                            default_port_https,
-                            True)
+                         "my.host.com",
+                         default_port_https,
+                         True)
 
         self._run_single("my.host.com",
-                            "my.host.com",
-                            default_port_http,
-                            default_ssl)
+                         "my.host.com",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("http.com",
-                            "http.com",
-                            default_port_http,
-                            default_ssl)
+                         "http.com",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("http.com/",
-                            "http.com",
-                            default_port_http,
-                            default_ssl)
+                         "http.com",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("http.com/path.segment.com",
-                            "http.com",
-                            default_port_http,
-                            default_ssl)
+                         "http.com",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("http.com//path.segment.com",
-                            "http.com",
-                            default_port_http,
-                            default_ssl)
+                         "http.com",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("http://my.host.com:1234",
-                            "my.host.com",
-                            1234,
-                            False)
+                         "my.host.com",
+                         1234,
+                         False)
 
         self._run_single("http://my.host.com:1234/",
-                            "my.host.com",
-                            1234,
-                            False)
+                         "my.host.com",
+                         1234,
+                         False)
 
         self._run_single("http://my.host.com:1234/path/segment",
-                            "my.host.com",
-                            1234,
-                            False)
+                         "my.host.com",
+                         1234,
+                         False)
 
         self._run_single("http://9.10.11.12:1234",
-                            "9.10.11.12",
-                            1234,
-                            False)
+                         "9.10.11.12",
+                         1234,
+                         False)
 
         self._run_single("my.host.com:1234",
-                            "my.host.com",
-                            1234,
-                            default_ssl)
+                         "my.host.com",
+                         1234,
+                         default_ssl)
 
         self._run_single("my.host.com:1234/",
-                            "my.host.com",
-                            1234,
-                            default_ssl)
+                         "my.host.com",
+                         1234,
+                         default_ssl)
 
         self._run_single("9.10.11.12/",
-                            "9.10.11.12",
-                            default_port_http,
-                            default_ssl)
+                         "9.10.11.12",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("HTTP://my.host.com",
-                            "my.host.com",
-                            default_port_http,
-                            False)
+                         "my.host.com",
+                         default_port_http,
+                         False)
 
         self._run_single("HTTPS://my.host.com",
-                            "my.host.com",
-                            default_port_https,
-                            True)
+                         "my.host.com",
+                         default_port_https,
+                         True)
 
         self._run_single("http://[2001:db8::7348]",
-                            "2001:db8::7348",
-                            default_port_http,
-                            False)
+                         "2001:db8::7348",
+                         default_port_http,
+                         False)
 
         self._run_single("http://[2001:db8::7348-1]",
-                            "2001:db8::7348%1",
-                            default_port_http,
-                            False)
+                         "2001:db8::7348%1",
+                         default_port_http,
+                         False)
 
         self._run_single("http://[2001:db8::7348-eth1]",
-                            "2001:db8::7348%eth1",
-                            default_port_http,
-                            False)
+                         "2001:db8::7348%eth1",
+                         default_port_http,
+                         False)
 
         # Toleration of (incorrect) IPv6 URI format supported by PyWBEM:
         # Must specify port; zone index must be specified with % if used
 
         self._run_single("http://2001:db8::7348:1234",
-                            "2001:db8::7348",
-                            1234,
-                            False)
+                         "2001:db8::7348",
+                         1234,
+                         False)
 
         self._run_single("http://2001:db8::7348%eth0:1234",
-                            "2001:db8::7348%eth0",
-                            1234,
-                            False)
+                         "2001:db8::7348%eth0",
+                         1234,
+                         False)
 
         self._run_single("http://2001:db8::7348%1:1234",
-                            "2001:db8::7348%1",
-                            1234,
-                            False)
+                         "2001:db8::7348%1",
+                         1234,
+                         False)
 
         self._run_single("https://[2001:db8::7348]/",
-                            "2001:db8::7348",
-                            default_port_https,
-                            True)
+                         "2001:db8::7348",
+                         default_port_https,
+                         True)
 
         self._run_single("http://[2001:db8::7348]:1234",
-                            "2001:db8::7348",
-                            1234,
-                            False)
+                         "2001:db8::7348",
+                         1234,
+                         False)
 
         self._run_single("https://[::ffff.9.10.11.12]:1234/",
-                            "::ffff.9.10.11.12",
-                            1234,
-                            True)
+                         "::ffff.9.10.11.12",
+                         1234,
+                         True)
 
         self._run_single("https://[::ffff.9.10.11.12-0]:1234/",
-                            "::ffff.9.10.11.12%0",
-                            1234,
-                            True)
+                         "::ffff.9.10.11.12%0",
+                         1234,
+                         True)
 
         self._run_single("https://[::ffff.9.10.11.12-eth0]:1234/",
-                            "::ffff.9.10.11.12%eth0",
-                            1234,
-                            True)
+                         "::ffff.9.10.11.12%eth0",
+                         1234,
+                         True)
 
         self._run_single("[2001:db8::7348]",
-                            "2001:db8::7348",
-                            default_port_http,
-                            default_ssl)
+                         "2001:db8::7348",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("[2001:db8::7348]/",
-                            "2001:db8::7348",
-                            default_port_http,
-                            default_ssl)
+                         "2001:db8::7348",
+                         default_port_http,
+                         default_ssl)
 
         self._run_single("[2001:db8::7348]/-eth0",
-                            "2001:db8::7348",
-                            default_port_http,
-                            default_ssl)
+                         "2001:db8::7348",
+                         default_port_http,
+                         default_ssl)
 
 
 if __name__ == '__main__':

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -12,6 +12,9 @@ picked up here.
 Note that class `NocaseDict` is tested in test_nocasedict.py.
 """
 
+# Allows use of lots of single character variable names.
+# pylint: disable=invalid-name,missing-docstring,too-many-statements
+# pylint: disable=too-many-lines
 import re
 import inspect
 import os.path
@@ -134,7 +137,7 @@ class DictTest(unittest.TestCase):
 
         items = obj.items()
         self.assertTrue(('Chicken', 'Ham') in items and
-                     ('Beans', 42) in items)
+                        ('Beans', 42) in items)
         self.assertEqual(len(items), 2)
 
         # Test iterkeys
@@ -153,7 +156,7 @@ class DictTest(unittest.TestCase):
 
         items = list(obj.iteritems())
         self.assertTrue(('Chicken', 'Ham') in items and
-                     ('Beans', 42) in items)
+                        ('Beans', 42) in items)
         self.assertEqual(len(items), 2)
 
         # Test in
@@ -172,7 +175,7 @@ class DictTest(unittest.TestCase):
             default_value = 'NoValue'
             invalid_propname = 'Cheepy'
             self.assertEqual(obj.get(invalid_propname, default_value),
-                              default_value)
+                             default_value)
         except Exception as exc:
             self.fail('%s thrown in exception-free get() when accessing '
                       'undefined key %s\n'\
@@ -312,7 +315,7 @@ class CopyCIMInstanceName(unittest.TestCase, CIMObjectMixin):
         c.namespace = None
 
         self.assertCIMInstanceName(i, 'CIM_Foo', {'InstanceID': '1234'},
-                         'woot.com', 'root/cimv2')
+                                   'woot.com', 'root/cimv2')
 
 class CIMInstanceNameAttrs(unittest.TestCase, CIMObjectMixin):
     """
@@ -330,7 +333,7 @@ class CIMInstanceNameAttrs(unittest.TestCase, CIMObjectMixin):
                               host='woot.com')
 
         self.assertCIMInstanceName(obj, 'CIM_Foo', kb,
-                         'woot.com', 'root/cimv2')
+                                   'woot.com', 'root/cimv2')
 
         kb = {'InstanceID': '5678'}
 
@@ -340,7 +343,7 @@ class CIMInstanceNameAttrs(unittest.TestCase, CIMObjectMixin):
         obj.namespace = 'root/interop'
 
         self.assertCIMInstanceName(obj, 'CIM_Bar', kb,
-                         'woom.com', 'root/interop')
+                                   'woom.com', 'root/interop')
 
 class CIMInstanceNameDict(DictTest):
     """
@@ -364,26 +367,26 @@ class CIMInstanceNameEquality(unittest.TestCase):
         # Basic equality tests
 
         self.assertEqual(CIMInstanceName('CIM_Foo'),
-                          CIMInstanceName('CIM_Foo'))
+                         CIMInstanceName('CIM_Foo'))
 
         self.assertNotEqual(CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}),
-                             CIMInstanceName('CIM_Foo'))
+                            CIMInstanceName('CIM_Foo'))
 
         self.assertEqual(CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}),
-                          CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}))
+                         CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}))
 
         # Class name should be case insensitive
 
         self.assertEqual(CIMInstanceName('CIM_Foo'),
-                          CIMInstanceName('ciM_foO'))
+                         CIMInstanceName('ciM_foO'))
 
         # Key bindings should be case insensitive
 
         self.assertEqual(CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}),
-                          CIMInstanceName('CIM_Foo', {'cheepy': 'Birds'}))
+                         CIMInstanceName('CIM_Foo', {'cheepy': 'Birds'}))
 
         self.assertNotEqual(CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}),
-                             CIMInstanceName('CIM_Foo', {'cheepy': 'birds'}))
+                            CIMInstanceName('CIM_Foo', {'cheepy': 'birds'}))
 
         # Test a bunch of different key binding types
 
@@ -402,20 +405,20 @@ class CIMInstanceNameEquality(unittest.TestCase):
         # Test that key binding types are not confused in comparisons
 
         self.assertNotEqual(CIMInstanceName('CIM_Foo', {'Foo': '42'}),
-                             CIMInstanceName('CIM_Foo', {'Foo': 42}))
+                            CIMInstanceName('CIM_Foo', {'Foo': 42}))
 
         self.assertNotEqual(CIMInstanceName('CIM_Foo', {'Bar': True}),
-                             CIMInstanceName('CIM_Foo', {'Bar': 'TRUE'}))
+                            CIMInstanceName('CIM_Foo', {'Bar': 'TRUE'}))
 
         # Host name should be case insensitive
 
         self.assertEqual(CIMInstanceName('CIM_Foo', host='woot.com'),
-                          CIMInstanceName('CIM_Foo', host='Woot.Com'))
+                         CIMInstanceName('CIM_Foo', host='Woot.Com'))
 
         # Namespace should be case insensitive
 
         self.assertEqual(CIMInstanceName('CIM_Foo', namespace='root/cimv2'),
-                          CIMInstanceName('CIM_Foo', namespace='Root/CIMv2'))
+                         CIMInstanceName('CIM_Foo', namespace='Root/CIMv2'))
 
 class CIMInstanceNameCompare(unittest.TestCase):
     """
@@ -490,7 +493,7 @@ class CIMInstanceNameString(unittest.TestCase, RegexpMixin):
                               namespace='root/InterOp')
 
         self.assertEqual(str(obj),
-                          '//woot.com/root/InterOp:CIM_Foo.InstanceID="1234"')
+                         '//woot.com/root/InterOp:CIM_Foo.InstanceID="1234"')
 
 class CIMInstanceNameToXML(ValidateTest):
     """
@@ -863,43 +866,43 @@ class CIMInstanceEquality(unittest.TestCase):
         # Basic equality tests
 
         self.assertEqual(CIMInstance('CIM_Foo'),
-                          CIMInstance('CIM_Foo'))
+                         CIMInstance('CIM_Foo'))
 
         self.assertNotEqual(CIMInstance('CIM_Foo', {'Cheepy': 'Birds'}),
-                             CIMInstance('CIM_Foo'))
+                            CIMInstance('CIM_Foo'))
 
         # Classname should be case insensitive
 
         self.assertEqual(CIMInstance('CIM_Foo'),
-                          CIMInstance('cim_foo'))
+                         CIMInstance('cim_foo'))
 
         # NocaseDict should implement case insensitive keybinding names
 
         self.assertEqual(CIMInstance('CIM_Foo', {'Cheepy': 'Birds'}),
-                          CIMInstance('CIM_Foo', {'cheepy': 'Birds'}))
+                         CIMInstance('CIM_Foo', {'cheepy': 'Birds'}))
 
         self.assertNotEqual(CIMInstance('CIM_Foo', {'Cheepy': 'Birds'}),
-                             CIMInstance('CIM_Foo', {'cheepy': 'birds'}))
+                            CIMInstance('CIM_Foo', {'cheepy': 'birds'}))
 
         # Qualifiers
 
         self.assertNotEqual(CIMInstance('CIM_Foo'),
-                             CIMInstance('CIM_Foo',
-                                         qualifiers={'Key':
-                                                     CIMQualifier('Key',
-                                                                  True)}))
+                            CIMInstance('CIM_Foo',
+                                        qualifiers={'Key':
+                                                    CIMQualifier('Key',
+                                                                 True)}))
 
         # Path
 
         self.assertNotEqual(CIMInstance('CIM_Foo'),
-                             CIMInstance('CIM_Foo', {'Cheepy': 'Birds'}))
+                            CIMInstance('CIM_Foo', {'Cheepy': 'Birds'}))
 
         # Reference properties
 
         self.assertEqual(CIMInstance('CIM_Foo',
-                                      {'Ref1': CIMInstanceName('CIM_Bar')}),
-                          CIMInstance('CIM_Foo',
-                                      {'Ref1': CIMInstanceName('CIM_Bar')}))
+                                     {'Ref1': CIMInstanceName('CIM_Bar')}),
+                         CIMInstance('CIM_Foo',
+                                     {'Ref1': CIMInstanceName('CIM_Bar')}))
 
         # Null properties
 
@@ -1345,32 +1348,39 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
                                 seconds=55, microseconds=654321)
         cim_datetime_1 = '12345678224455.654321:000'
 
-        # This test failed in the old constructor implementation, because the
-        # timedelta object was not converted to a CIMDateTime object.
+        # This test failed in the old constructor implementation, because
+        # the timedelta object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', timedelta_1)
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         # This test failed in the old constructor implementation, because the
         # timedelta object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', timedelta_1, 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(timedelta_1))
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(timedelta_1), 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         # This test failed in the old constructor implementation, because the
         # datetime formatted string was not converted to a CIMDateTime object.
         p = CIMProperty('Age', cim_datetime_1, 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(cim_datetime_1))
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(cim_datetime_1), 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_1),
+                               'datetime')
 
         datetime_2 = datetime(year=2014, month=9, day=24, hour=19, minute=30,
                               second=40, microsecond=654321,
@@ -1380,90 +1390,109 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # This test failed in the old constructor implementation, because the
         # datetime object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', datetime_2)
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         # This test failed in the old constructor implementation, because the
         # datetime object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', datetime_2, 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(datetime_2))
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(datetime_2), 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         # This test failed in the old constructor implementation, because the
         # datetime formatted string was not converted to a CIMDateTime object.
         p = CIMProperty('Age', cim_datetime_2, 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(cim_datetime_2))
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         p = CIMProperty('Age', CIMDateTime(cim_datetime_2), 'datetime')
-        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2), 'datetime')
+        self.assertCIMProperty(p, 'Age', CIMDateTime(cim_datetime_2),
+                               'datetime')
 
         # Reference properties
 
         p = CIMProperty('Foo', None, 'reference')
-        self.assertCIMProperty(p, 'Foo', None, 'reference', reference_class=None)
+        self.assertCIMProperty(p, 'Foo', None, 'reference',
+                               reference_class=None)
 
         # This test failed in the old constructor implementation, because the
         # reference_class argument was required to be provided for references.
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'))
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo')
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo')
 
         # This test failed in the old constructor implementation, because the
         # reference_class argument was required to be provided for references.
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'), 'reference')
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo')
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo')
 
         # This test failed in the old constructor implementation, because the
         # reference_class argument was required to be provided for references.
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
                         qualifiers=quals)
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo', qualifiers=quals)
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo', qualifiers=quals)
 
         # This test failed in the old constructor implementation, because the
         # reference_class argument was required to be provided for references.
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'), 'reference',
                         qualifiers=quals)
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo', qualifiers=quals)
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo', qualifiers=quals)
 
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
                         reference_class='CIM_Foo')
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo')
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo')
 
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'), 'reference',
                         reference_class='CIM_Foo')
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo')
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo')
 
         p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
                         reference_class='CIM_Foo', qualifiers=quals)
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo', qualifiers=quals)
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo', qualifiers=quals)
 
-        p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'), 'reference',
+        p = CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
+                        'reference',
                         reference_class='CIM_Foo', qualifiers=quals)
-        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'), 'reference',
-                         reference_class='CIM_Foo', qualifiers=quals)
+        self.assertCIMProperty(p, 'Foo', CIMInstanceName('CIM_Foo'),
+                               'reference',
+                               reference_class='CIM_Foo', qualifiers=quals)
 
         # Initialization to CIM embedded object / instance
 
         # This test failed in the old constructor implementation, because the
         # type argument was required to be provided for embedded objects.
         p = CIMProperty('Bar', None, embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', None, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', None, 'string',
+                               embedded_object='object')
 
         p = CIMProperty('Bar', None, 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', None, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', None, 'string',
+                               embedded_object='object')
 
         ec = CIMClass('CIM_Bar')
 
@@ -1474,13 +1503,16 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # embedded_object attribute was not implied from the value argument if
         # the type argument was also provided.
         p = CIMProperty('Bar', ec, 'string')
-        self.assertCIMProperty(p, 'Bar', ec, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', ec, 'string',
+                               embedded_object='object')
 
         p = CIMProperty('Bar', ec, embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', ec, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', ec, 'string',
+                               embedded_object='object')
 
         p = CIMProperty('Bar', ec, 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', ec, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', ec, 'string',
+                               embedded_object='object')
 
         ei = CIMInstance('CIM_Bar')
 
@@ -1491,22 +1523,27 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='object')
 
         p = CIMProperty('Bar', ei, 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='object')
+        self.assertCIMProperty(p, 'Bar', ei, 'string',
+                               embedded_object='object')
 
         p = CIMProperty('Bar', ei)
-        self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='instance')
+        self.assertCIMProperty(p, 'Bar', ei, 'string',
+                               embedded_object='instance')
 
         # This test failed in the old constructor implementation, because the
         # embedded_object attribute was not implied from the value argument if
         # the type argument was also provided.
         p = CIMProperty('Bar', ei, 'string')
-        self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='instance')
+        self.assertCIMProperty(p, 'Bar', ei, 'string',
+                               embedded_object='instance')
 
         p = CIMProperty('Bar', ei, embedded_object='instance')
-        self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='instance')
+        self.assertCIMProperty(p, 'Bar', ei, 'string',
+                               embedded_object='instance')
 
         p = CIMProperty('Bar', ei, 'string', embedded_object='instance')
-        self.assertCIMProperty(p, 'Bar', ei, 'string', embedded_object='instance')
+        self.assertCIMProperty(p, 'Bar', ei, 'string',
+                               embedded_object='instance')
 
         # Check that initialization with Null without specifying a type is
         # rejected
@@ -1548,19 +1585,19 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
 
         p = CIMProperty('Foo', [Uint8(x) for x in [1, 2, 3]])
         self.assertCIMProperty(p, 'Foo', [Uint8(x) for x in [1, 2, 3]],
-                         'uint8', is_array=True)
+                               'uint8', is_array=True)
 
         p = CIMProperty('Foo', [Uint8(x) for x in [1, 2, 3]], is_array=True)
         self.assertCIMProperty(p, 'Foo', [Uint8(x) for x in [1, 2, 3]],
-                         'uint8', is_array=True)
+                               'uint8', is_array=True)
 
         p = CIMProperty('Foo', [Uint8(x) for x in [1, 2, 3]], type='uint8')
         self.assertCIMProperty(p, 'Foo', [Uint8(x) for x in [1, 2, 3]],
-                         'uint8', is_array=True)
+                               'uint8', is_array=True)
 
         p = CIMProperty('Foo', [Uint8(x) for x in [1, 2, 3]], qualifiers=quals)
         self.assertCIMProperty(p, 'Foo', [Uint8(x) for x in [1, 2, 3]],
-                         'uint8', is_array=True, qualifiers=quals)
+                               'uint8', is_array=True, qualifiers=quals)
 
         # Arrays of CIM boolean type
 
@@ -1568,7 +1605,8 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         self.assertCIMProperty(p, 'Aged', [True], 'boolean', is_array=True)
 
         p = CIMProperty('Aged', [False, True], 'boolean')
-        self.assertCIMProperty(p, 'Aged', [False, True], 'boolean', is_array=True)
+        self.assertCIMProperty(p, 'Aged', [False, True], 'boolean',
+                               is_array=True)
 
         p = CIMProperty('Aged', [None], 'boolean')
         self.assertCIMProperty(p, 'Aged', [None], 'boolean', is_array=True)
@@ -1585,36 +1623,36 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # This test failed in the old constructor implementation, because the
         # timedelta object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [timedelta_1])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # timedelta object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [timedelta_1], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(timedelta_1)])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(timedelta_1)], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # datetime formatted string was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [cim_datetime_1], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(cim_datetime_1)])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(cim_datetime_1)], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_1)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [None], 'datetime')
         self.assertCIMProperty(p, 'Age', [None], 'datetime', is_array=True)
@@ -1627,36 +1665,36 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # This test failed in the old constructor implementation, because the
         # datetime object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [datetime_2])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # datetime object was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [datetime_2], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(datetime_2)])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(datetime_2)], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # datetime formatted string was not converted to a CIMDateTime object.
         p = CIMProperty('Age', [cim_datetime_2], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(cim_datetime_2)])
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         p = CIMProperty('Age', [CIMDateTime(cim_datetime_2)], 'datetime')
-        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)], 'datetime',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Age', [CIMDateTime(cim_datetime_2)],
+                               'datetime', is_array=True)
 
         # Arrays of reference properties are not allowed in CIM v2.
 
@@ -1666,44 +1704,52 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # first array element was used for defaulting the type, without
         # checking for None.
         p = CIMProperty('Bar', [None], embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [None], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [None], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [None], 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [None], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [None], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
-        # This test failed in the old constructor implementation, because the
-        # type of the empty array could not be defaulted from the
+        # This test failed in the old constructor implementation, because
+        # the type of the empty array could not be defaulted from the
         # embedded_object argument.
         p = CIMProperty('Bar', [], embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [], 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         ec = CIMClass('CIM_Bar')
 
         p = CIMProperty('Bar', [ec])
-        self.assertCIMProperty(p, 'Bar', [ec], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ec], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # embedded_object attribute was not implied from the value argument if
         # the type argument was also provided.
         p = CIMProperty('Bar', [ec], 'string')
-        self.assertCIMProperty(p, 'Bar', [ec], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ec], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ec], embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [ec], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ec], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ec], 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [ec], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ec], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         ei = CIMInstance('CIM_Bar')
 
@@ -1711,31 +1757,37 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
         # embedded_object argument value of 'object' was changed to 'instance'
         # when a CIMInstance typed value was provided.
         p = CIMProperty('Bar', [ei], embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ei], 'string', embedded_object='object')
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='object',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='object',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ei])
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='instance',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='instance',
+                               is_array=True)
 
         # This test failed in the old constructor implementation, because the
         # embedded_object attribute was not implied from the value argument if
         # the type argument was also provided.
         p = CIMProperty('Bar', [ei], 'string')
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='instance',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='instance',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ei], embedded_object='instance')
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='instance',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='instance',
+                               is_array=True)
 
         p = CIMProperty('Bar', [ei], 'string', embedded_object='instance')
-        self.assertCIMProperty(p, 'Bar', [ei], 'string', embedded_object='instance',
-                         is_array=True)
+        self.assertCIMProperty(p, 'Bar', [ei], 'string',
+                               embedded_object='instance',
+                               is_array=True)
 
         # Check that initialization with array being Null, array being empty,
         # or first array element being Null without specifying a type is
@@ -1783,7 +1835,8 @@ class CopyCIMProperty(unittest.TestCase, CIMObjectMixin):
         c.value = '1234'
         c.qualifiers = {'Key': CIMQualifier('Value', True)}
 
-        self.assertCIMProperty(p, 'Spotty', 'Foot', type_='string', qualifiers={})
+        self.assertCIMProperty(p, 'Spotty', 'Foot', type_='string',
+                               qualifiers={})
 
 class CIMPropertyAttrs(unittest.TestCase, CIMObjectMixin):
 
@@ -1807,7 +1860,7 @@ class CIMPropertyAttrs(unittest.TestCase, CIMObjectMixin):
         v = CIMInstanceName('CIM_Bar')
         obj = CIMProperty('Foo', v)
         self.assertCIMProperty(obj, 'Foo', v, type_='reference',
-                         reference_class='CIM_Bar')
+                               reference_class='CIM_Bar')
 
 class CIMPropertyEquality(unittest.TestCase):
 
@@ -1816,25 +1869,25 @@ class CIMPropertyEquality(unittest.TestCase):
         # Compare single-valued properties
 
         self.assertEqual(CIMProperty('Spotty', None, 'string'),
-                          CIMProperty('Spotty', None, 'string'))
+                         CIMProperty('Spotty', None, 'string'))
 
         self.assertNotEqual(CIMProperty('Spotty', '', 'string'),
-                             CIMProperty('Spotty', None, 'string'))
+                            CIMProperty('Spotty', None, 'string'))
 
         self.assertEqual(CIMProperty('Spotty', 'Foot'),
-                          CIMProperty('Spotty', 'Foot'))
+                         CIMProperty('Spotty', 'Foot'))
 
         self.assertNotEqual(CIMProperty('Spotty', 'Foot'),
-                             CIMProperty('Spotty', Uint32(42)))
+                            CIMProperty('Spotty', Uint32(42)))
 
         self.assertEqual(CIMProperty('Spotty', 'Foot'),
-                          CIMProperty('spotty', 'Foot'))
+                         CIMProperty('spotty', 'Foot'))
 
         self.assertNotEqual(CIMProperty('Spotty', 'Foot'),
-                             CIMProperty('Spotty', 'Foot',
-                                         qualifiers={'Key':
-                                                     CIMQualifier('Key',
-                                                                  True)}))
+                            CIMProperty('Spotty', 'Foot',
+                                        qualifiers={'Key':
+                                                    CIMQualifier('Key',
+                                                                 True)}))
 
         # Compare property arrays
 
@@ -2004,16 +2057,16 @@ class CIMQualifierEquality(unittest.TestCase):
     def test_all(self):
 
         self.assertEqual(CIMQualifier('Spotty', 'Foot'),
-                          CIMQualifier('Spotty', 'Foot'))
+                         CIMQualifier('Spotty', 'Foot'))
 
         self.assertEqual(CIMQualifier('Spotty', 'Foot'),
-                          CIMQualifier('spotty', 'Foot'))
+                         CIMQualifier('spotty', 'Foot'))
 
         self.assertNotEqual(CIMQualifier('Spotty', 'Foot'),
-                             CIMQualifier('Spotty', 'foot'))
+                            CIMQualifier('Spotty', 'foot'))
 
         self.assertNotEqual(CIMQualifier('Null', None, type='string'),
-                             CIMQualifier('Null', ''))
+                            CIMQualifier('Null', ''))
 
 class CIMQualifierCompare(unittest.TestCase):
 
@@ -2122,7 +2175,7 @@ class CIMClassEquality(unittest.TestCase):
         self.assertEqual(CIMClass('CIM_Foo'), CIMClass('cim_foo'))
 
         self.assertNotEqual(CIMClass('CIM_Foo', superclass='CIM_Bar'),
-                             CIMClass('CIM_Foo'))
+                            CIMClass('CIM_Foo'))
 
         properties = {'InstanceID':
                       CIMProperty('InstanceID', None,
@@ -2133,16 +2186,16 @@ class CIMClassEquality(unittest.TestCase):
         qualifiers = {'Key': CIMQualifier('Key', True)}
 
         self.assertNotEqual(CIMClass('CIM_Foo'),
-                             CIMClass('CIM_Foo', properties=properties))
+                            CIMClass('CIM_Foo', properties=properties))
 
         self.assertNotEqual(CIMClass('CIM_Foo'),
-                             CIMClass('CIM_Foo', methods=methods))
+                            CIMClass('CIM_Foo', methods=methods))
 
         self.assertNotEqual(CIMClass('CIM_Foo'),
-                             CIMClass('CIM_Foo', qualifiers=qualifiers))
+                            CIMClass('CIM_Foo', qualifiers=qualifiers))
 
         self.assertEqual(CIMClass('CIM_Foo', superclass='CIM_Bar'),
-                          CIMClass('CIM_Foo', superclass='cim_bar'))
+                         CIMClass('CIM_Foo', superclass='cim_bar'))
 
 class CIMClassCompare(unittest.TestCase):
 
@@ -2258,15 +2311,15 @@ class CIMMethodEquality(unittest.TestCase):
     def test_all(self):
 
         self.assertEqual(CIMMethod('FooMethod', 'uint32'),
-                          CIMMethod('FooMethod', 'uint32'))
+                         CIMMethod('FooMethod', 'uint32'))
 
         self.assertEqual(CIMMethod('FooMethod', 'uint32'),
-                          CIMMethod('fooMethod', 'uint32'))
+                         CIMMethod('fooMethod', 'uint32'))
 
         self.assertNotEqual(CIMMethod('FooMethod', 'uint32'),
-                             CIMMethod('FooMethod', 'uint32',
-                                       qualifiers={'Key': CIMQualifier('Key',
-                                                                       True)}))
+                            CIMMethod('FooMethod', 'uint32',
+                                      qualifiers={'Key': CIMQualifier('Key',
+                                                                      True)}))
 
 class CIMMethodCompare(unittest.TestCase):
 
@@ -2412,19 +2465,19 @@ class CIMParameterEquality(unittest.TestCase):
         # Single-valued parameters
 
         self.assertEqual(CIMParameter('Param1', 'uint32'),
-                          CIMParameter('Param1', 'uint32'))
+                         CIMParameter('Param1', 'uint32'))
 
         self.assertEqual(CIMParameter('Param1', 'uint32'),
-                          CIMParameter('param1', 'uint32'))
+                         CIMParameter('param1', 'uint32'))
 
         self.assertNotEqual(CIMParameter('Param1', 'uint32'),
-                             CIMParameter('param1', 'string'))
+                            CIMParameter('param1', 'string'))
 
         self.assertNotEqual(CIMParameter('Param1', 'uint32'),
-                             CIMParameter('param1', 'uint32',
-                                          qualifiers={'Key':
-                                                      CIMQualifier('Key',
-                                                                   True)}))
+                            CIMParameter('param1', 'uint32',
+                                         qualifiers={'Key':
+                                                     CIMQualifier('Key',
+                                                                  True)}))
 
         # Array parameters
 
@@ -2453,65 +2506,66 @@ class CIMParameterEquality(unittest.TestCase):
         # Reference parameters
 
         self.assertEqual(CIMParameter('RefParam', 'reference',
-                                       reference_class='CIM_Foo'),
-                          CIMParameter('RefParam', 'reference',
-                                       reference_class='CIM_Foo'))
+                                      reference_class='CIM_Foo'),
+                         CIMParameter('RefParam', 'reference',
+                                      reference_class='CIM_Foo'))
 
         self.assertEqual(CIMParameter('RefParam', 'reference',
-                                       reference_class='CIM_Foo'),
-                          CIMParameter('refParam', 'reference',
-                                       reference_class='CIM_Foo'))
+                                      reference_class='CIM_Foo'),
+                         CIMParameter('refParam', 'reference',
+                                      reference_class='CIM_Foo'))
 
         self.assertEqual(CIMParameter('RefParam', 'reference',
-                                       reference_class='CIM_Foo'),
-                          CIMParameter('refParam', 'reference',
-                                       reference_class='CIM_foo'))
+                                      reference_class='CIM_Foo'),
+                         CIMParameter('refParam', 'reference',
+                                      reference_class='CIM_foo'))
 
         self.assertNotEqual(CIMParameter('RefParam', 'reference',
-                                          reference_class='CIM_Foo'),
-                             CIMParameter('RefParam', 'reference',
-                                          reference_class='CIM_Bar'))
+                                         reference_class='CIM_Foo'),
+                            CIMParameter('RefParam', 'reference',
+                                         reference_class='CIM_Bar'))
 
         self.assertNotEqual(CIMParameter('RefParam', 'reference',
-                                          reference_class='CIM_Foo'),
-                             CIMParameter('RefParam', 'reference',
-                                          reference_class='CIM_Foo',
-                                          qualifiers=
-                                          {'Key': CIMQualifier('Key', True)}))
+                                         reference_class='CIM_Foo'),
+                            CIMParameter('RefParam', 'reference',
+                                         reference_class='CIM_Foo',
+                                         qualifiers=
+                                         {'Key': CIMQualifier('Key',
+                                                              True)}))
 
         # Reference array parameters
 
         self.assertEqual(CIMParameter('ArrayParam', 'reference',
-                                       reference_class='CIM_Foo',
-                                       is_array=True),
-                          CIMParameter('ArrayParam', 'reference',
-                                       reference_class='CIM_Foo',
-                                       is_array=True))
+                                      reference_class='CIM_Foo',
+                                      is_array=True),
+                         CIMParameter('ArrayParam', 'reference',
+                                      reference_class='CIM_Foo',
+                                      is_array=True))
 
         self.assertEqual(CIMParameter('ArrayParam', 'reference',
-                                       reference_class='CIM_Foo',
-                                       is_array=True),
-                          CIMParameter('arrayparam', 'reference',
-                                       reference_class='CIM_Foo',
-                                       is_array=True))
+                                      reference_class='CIM_Foo',
+                                      is_array=True),
+                         CIMParameter('arrayparam', 'reference',
+                                      reference_class='CIM_Foo',
+                                      is_array=True))
 
         self.assertNotEqual(CIMParameter('ArrayParam', 'reference',
-                                          reference_class='CIM_Foo',
-                                          is_array=True),
-                             CIMParameter('arrayParam', 'reference',
-                                          reference_class='CIM_foo',
-                                          is_array=True,
-                                          array_size=10))
+                                         reference_class='CIM_Foo',
+                                         is_array=True),
+                            CIMParameter('arrayParam', 'reference',
+                                         reference_class='CIM_foo',
+                                         is_array=True,
+                                         array_size=10))
 
         self.assertNotEqual(CIMParameter('ArrayParam', 'reference',
-                                          reference_class='CIM_Foo',
-                                          is_array=True),
-                             CIMParameter('ArrayParam', 'reference',
-                                          reference_class='CIM_Foo',
-                                          is_array=True,
-                                          qualifiers={'Key':
-                                                      CIMQualifier('Key',
-                                                                   True)}))
+                                         reference_class='CIM_Foo',
+                                         is_array=True),
+                            CIMParameter('ArrayParam', 'reference',
+                                         reference_class='CIM_Foo',
+                                         is_array=True,
+                                         qualifiers={'Key':
+                                                     CIMQualifier('Key',
+                                                                  True)}))
 
 class CIMParameterCompare(unittest.TestCase):
 


### PR DESCRIPTION
Cleaned up wbemcli to better understand it.  Note that this is really incomplete in that the doc strings are minimal but there are other issues behind that.  Primarily pylints and docstrings.

Cleaned up the test_* simply because there were so many trivial issues, primarly formatting, etc. No code changes at all. I did pylint disable invalid_names which seemed logical since a lot of the variables are single character and these are test programs.