### PR TITLE
Pylintfixes4 misc fixes to reduce pylint count

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -670,10 +670,12 @@ class CIMClassName(object):
 # pylint: disable=too-many-statements,too-many-instance-attributes
 class CIMProperty(object):
     """
-    A CIM property.
+    Defines a CIM property including cim type, value, and possibly
+    qualifiers.
 
-    The property can be used in a CIM instance (as part of a `CIMInstance`
-    object) or in a CIM class (as part of a `CIMClass` object).
+    The property can be used in a CIM instance (as part of a 
+    `CIMInstance` object) or in a CIM class (as part of a 
+    `CIMClass` object).
 
     For properties in CIM instances:
 
@@ -1276,12 +1278,15 @@ class CIMInstanceName(object):
         self.keybindings[key] = value
 
     def __len__(self):
+        """Return number of keybindings"""
         return len(self.keybindings)
 
     def has_key(self, key):
+        """Return boolean. True if `key` is in keybindings"""
         return self.keybindings.has_key(key)
 
     def keys(self):
+        """Return list of keys in keybindings"""
         return self.keybindings.keys()
 
     def values(self):
@@ -1304,8 +1309,8 @@ class CIMInstanceName(object):
 
     def get(self, key, default=None):
         """
-        Get the value of a specific key property, or the specified default
-        value if a key binding with that name does not exist.
+        Get the value of a specific key property, or the specified
+        default value if a key binding with that name does not exist.
         """
         return self.keybindings.get(key, default)
 
@@ -1370,7 +1375,8 @@ class CIMInstanceName(object):
                     value = str(key_bind[1])
                 elif isinstance(key_bind[1], basestring):
                     _type = 'string'
-                    value = key_bind[1].decode('utf-8') if isinstance(key_bind[1], str) \
+                    value = key_bind[1].decode('utf-8') \
+                                if isinstance(key_bind[1], str) \
                                                   else key_bind[1]
                 else:
                     raise TypeError('Invalid keybinding type for keybinding '\
@@ -1691,7 +1697,7 @@ class CIMInstance(object):
             """ Return a string representing the MOF definition of
                 a single property defined by the type and value
                 arguments.
-                :param: type_  TODO
+                :param type_:  CIMType of the property
                 :param value: value corresponsing to this type
             """
             if value is None:
@@ -1711,7 +1717,9 @@ class CIMInstance(object):
 
         ret_str = 'instance of %s {\n' % self.classname
         for prop in self.properties.values():
-            ret_str += '\t%s = %s;\n' % (prop.name, _prop2mof(prop.type, prop.value))
+            ret_str += '\t%s = %s;\n' % (prop.name,
+                                         _prop2mof(prop.type,
+                                                   prop.value))
         ret_str += '};\n'
 
         return ret_str
@@ -1719,7 +1727,8 @@ class CIMInstance(object):
 
 class CIMClass(object):
     """
-    A CIM class.
+    Create an instance of CIMClass, a CIM class with classname,
+    properties, methods, qualifiers, and superclass name.
 
     :Ivariables:
 
@@ -1733,9 +1742,9 @@ class CIMClass(object):
         """
         Initialize the `CIMClass` object.
 
-        Initialize instance variables containing the arguments provided for
-        the CIMClass including classname, properties, class qualifiers,
-        methods, and the superclass
+        Initialize instance variables containing the arguments provided
+        for the CIMClass including classname, properties, class
+        qualifiers, methods, and the superclass
         """
         self.classname = classname
         self.properties = NocaseDict(properties)
@@ -1789,7 +1798,7 @@ class CIMClass(object):
             superclass=self.superclass)
 
     def tomof(self):
-        """ Return string with MOF of the CIMClass"""
+        """ Return string with MOF representation of the CIMClass"""
 
         # Class definition
 
@@ -2145,6 +2154,8 @@ class CIMQualifier(object):
         if isinstance(self.value, list):
             value = cim_xml.VALUE_ARRAY([cim_xml.VALUE(v) for v in self.value])
         elif self.value is not None:
+            # pylint: disable=redefined-variable-type
+            # used as VALUE.ARRAY and the as VALUE
             value = cim_xml.VALUE(self.value)
 
         return cim_xml.QUALIFIER(self.name,
@@ -2415,9 +2426,10 @@ def tocimobj(type_, value):
     def partition(str_arg, seq):
         """ partition(str_arg, sep) -> (head, sep, tail)
 
-        Searches for the separator sep in str_arg, and returns the part before it,
-        the separator itself, and the part after it.  If the separator is not
-        found, returns str_arg and two empty strings.
+        Searches for the separator sep in str_arg, and returns the,
+        part before it the separator itself, and the part after it.
+        If the separator is not found, returns str_arg and two empty
+        strings.
         """
         try:
             return str_arg.partition(seq)

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -673,8 +673,8 @@ class CIMProperty(object):
     Defines a CIM property including cim type, value, and possibly
     qualifiers.
 
-    The property can be used in a CIM instance (as part of a 
-    `CIMInstance` object) or in a CIM class (as part of a 
+    The property can be used in a CIM instance (as part of a
+    `CIMInstance` object) or in a CIM class (as part of a
     `CIMClass` object).
 
     For properties in CIM instances:

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -674,7 +674,8 @@ class WBEMConnection(object):
             raise CIMError(code, 'Error code %s' % tup_tree[1]['CODE'])
 
         if tup_tree[0] != 'IRETURNVALUE':
-            raise ParseError('Expecting IRETURNVALUE element, got %s' % tup_tree[0])
+            raise ParseError('Expecting IRETURNVALUE element, got %s' \
+                             % tup_tree[0])
 
         return tup_tree
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -34,8 +34,8 @@ operation.
 import string
 import re
 from types import StringTypes
-from xml.dom import minidom
 from datetime import datetime, timedelta
+from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 
 from pywbem import cim_obj, cim_xml, cim_http, cim_types, tupletree, tupleparse
@@ -605,8 +605,8 @@ class WBEMConnection(object):
             msg = str(exc)
             parsing_error = True
         except ExpatError as exc:
-            # This is raised e.g. when XML numeric entity references of invalid
-            # XML characters are used (e.g. '&#0;').
+            # This is raised e.g. when XML numeric entity references of
+            # invalid XML characters are used (e.g. '&#0;').
             # str(exc) is: "{message}, line {X}, offset {Y}"
             parsed_line = str(reply_xml).splitlines()[exc.lineno-1]
             msg = "ExpatError %s: %s: %r" % (str(exc.code), str(exc),
@@ -678,6 +678,7 @@ class WBEMConnection(object):
 
         return tt
 
+    # pylint: disable=invalid-name
     def methodcall(self, methodname, localobject, Params=None, **params):
         """
         Perform an extrinsic method call (= CIM method invocation).
@@ -741,8 +742,12 @@ class WBEMConnection(object):
             if isinstance(obj, (cim_types.CIMType, bool, StringTypes)):
                 return cim_xml.VALUE(cim_types.atomic_to_cim_xml(obj))
             if isinstance(obj, (CIMClassName, CIMInstanceName)):
+                # Note: Because CIMDateTime is an obj but tested above
+                # pylint: disable=no-member
                 return cim_xml.VALUE_REFERENCE(obj.tocimxml())
             if isinstance(obj, (CIMClass, CIMInstance)):
+                # Note: Because CIMDateTime is an obj but tested above
+                # pylint: disable=no-member
                 return cim_xml.VALUE(obj.tocimxml().toxml())
             if isinstance(obj, list):
                 if obj and isinstance(obj[0], (CIMClassName, CIMInstanceName)):
@@ -1332,7 +1337,7 @@ class WBEMConnection(object):
     # Schema management API
     #
 
-    def _map_classname_param(self, params):
+    def _map_classname_param(self, params): # pylint: disable=no-self-use
         """Convert string ClassName parameter to a CIMClassName."""
 
         if params.has_key('ClassName') and \
@@ -1673,7 +1678,7 @@ class WBEMConnection(object):
     # Association provider API
     #
 
-    def _add_objectname_param(self, params, object_):
+    def _add_objectname_param(self, params, object_): # pylint: disable=no-self-use
         """Add an object name (either a class name or an instance
         name) to a dictionary of parameter names."""
 
@@ -1688,7 +1693,7 @@ class WBEMConnection(object):
 
         return params
 
-    def _map_association_params(self, params):
+    def _map_association_params(self, params): # pylint: disable=no-self-use
         """Convert various convenience parameters and types into their
         correct form for passing to the imethodcall() function."""
 
@@ -2207,14 +2212,13 @@ class WBEMConnection(object):
             namespace,
             **params)
 
-        qualifiers = []
 
         if result is not None:
-            names = result[2]
+            qualifiers = result[2]
         else:
-            names = []
+            qualifiers = []
 
-        return names
+        return qualifiers
 
     def GetQualifier(self, QualifierName, namespace=None, **params):
         # pylint: disable=invalid-name
@@ -2251,6 +2255,7 @@ class WBEMConnection(object):
         if namespace is None:
             namespace = self.default_namespace
 
+        #pylint: disable=unused-variable
         result = self.imethodcall(
             'SetQualifier',
             namespace,
@@ -2268,25 +2273,25 @@ class WBEMConnection(object):
         if namespace is None:
             namespace = self.default_namespace
 
-        result = self.imethodcall(
+        unused_result = self.imethodcall(
             'DeleteQualifier',
             namespace,
             QualifierName=QualifierName,
             **params)
 
-def is_subclass(ch, ns, super, sub):
+def is_subclass(ch, ns, super_class, sub):
     """Determine if one class is a subclass of another
 
     Keyword Arguments:
     ch -- A CIMOMHandle.  Either a pycimmb.CIMOMHandle or a
         pywbem.WBEMConnection.
     ns -- Namespace.
-    super -- A string containing the super class name.
+    super-class -- A string containing the super class name.
     sub -- The subclass.  This can either be a string or a pywbem.CIMClass.
 
     """
 
-    lsuper = super.lower()
+    lsuper = super_class.lower()
     if isinstance(sub, CIMClass):
         subname = sub.classname
         subclass = sub
@@ -2314,14 +2319,26 @@ def is_subclass(ch, ns, super, sub):
     return False
 
 def PegasusUDSConnection(creds=None, **kwargs):
+    """ Pegasus specific Unix Domain Socket call. Specific because
+        of the location of the file name
+    """
+
     # pylint: disable=invalid-name
     return WBEMConnection('/var/run/tog-pegasus/cimxml.socket', creds, **kwargs)
 
 def SFCBUDSConnection(creds=None, **kwargs):
+    """ SFCB specific Unix Domain Socket call. Specific because
+        of the location of the file name
+    """
+
     # pylint: disable=invalid-name
     return WBEMConnection('/tmp/sfcbHttpSocket', creds, **kwargs)
 
 def OpenWBEMUDSConnection(creds=None, **kwargs):
+    """ Pegasus specific Unix Domain Socket call. Specific because
+        of the location of the file name
+    """
+
     # pylint: disable=invalid-name
     return WBEMConnection('/tmp/OW@LCL@APIIPC_72859_Xq47Bf_P9r761-5_J-7_Q',
                           creds, **kwargs)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -637,46 +637,46 @@ class WBEMConnection(object):
 
         # Parse response
 
-        tt = tupleparse.parse_cim(tupletree.dom_to_tupletree(reply_dom))
+        tup_tree = tupleparse.parse_cim(tupletree.dom_to_tupletree(reply_dom))
 
-        if tt[0] != 'CIM':
-            raise ParseError('Expecting CIM element, got %s' % tt[0])
-        tt = tt[2]
+        if tup_tree[0] != 'CIM':
+            raise ParseError('Expecting CIM element, got %s' % tup_tree[0])
+        tup_tree = tup_tree[2]
 
-        if tt[0] != 'MESSAGE':
-            raise ParseError('Expecting MESSAGE element, got %s' % tt[0])
-        tt = tt[2]
+        if tup_tree[0] != 'MESSAGE':
+            raise ParseError('Expecting MESSAGE element, got %s' % tup_tree[0])
+        tup_tree = tup_tree[2]
 
-        if len(tt) != 1 or tt[0][0] != 'SIMPLERSP':
+        if len(tup_tree) != 1 or tup_tree[0][0] != 'SIMPLERSP':
             raise ParseError('Expecting one SIMPLERSP element')
-        tt = tt[0][2]
+        tup_tree = tup_tree[0][2]
 
-        if tt[0] != 'IMETHODRESPONSE':
+        if tup_tree[0] != 'IMETHODRESPONSE':
             raise ParseError('Expecting IMETHODRESPONSE element, got %s' %\
-                             tt[0])
+                             tup_tree[0])
 
-        if tt[1]['NAME'] != methodname:
+        if tup_tree[1]['NAME'] != methodname:
             raise ParseError('Expecting attribute NAME=%s, got %s' %\
-                             (methodname, tt[1]['NAME']))
-        tt = tt[2]
+                             (methodname, tup_tree[1]['NAME']))
+        tup_tree = tup_tree[2]
 
         # At this point we either have a IRETURNVALUE, ERROR element
         # or None if there was no child nodes of the IMETHODRESPONSE
         # element.
 
-        if tt is None:
+        if tup_tree is None:
             return None
 
-        if tt[0] == 'ERROR':
-            code = int(tt[1]['CODE'])
-            if tt[1].has_key('DESCRIPTION'):
-                raise CIMError(code, tt[1]['DESCRIPTION'])
-            raise CIMError(code, 'Error code %s' % tt[1]['CODE'])
+        if tup_tree[0] == 'ERROR':
+            code = int(tup_tree[1]['CODE'])
+            if tup_tree[1].has_key('DESCRIPTION'):
+                raise CIMError(code, tup_tree[1]['DESCRIPTION'])
+            raise CIMError(code, 'Error code %s' % tup_tree[1]['CODE'])
 
-        if tt[0] != 'IRETURNVALUE':
-            raise ParseError('Expecting IRETURNVALUE element, got %s' % tt[0])
+        if tup_tree[0] != 'IRETURNVALUE':
+            raise ParseError('Expecting IRETURNVALUE element, got %s' % tup_tree[0])
 
-        return tt
+        return tup_tree
 
     # pylint: disable=invalid-name
     def methodcall(self, methodname, localobject, Params=None, **params):
@@ -2197,11 +2197,32 @@ class WBEMConnection(object):
     def EnumerateQualifiers(self, namespace=None, **params):
         # pylint: disable=invalid-name
         """
-        Enumerate qualifier types.
+        Enumerate qualifier declarations for a namespace.
 
-        Returns a list of `CIMQualifier` objects.
+        This method performs the GetQualifier CIM-XML operation.
+        If the operation succeeds, this method returns.
+        Otherwise, this method raises an exception.
+        Returns a `CIMQualifier` object.
 
-        TODO Complete this description.
+        TODO This method is UNSUPPORTED right now. Test and verify description.
+
+        :Parameters:
+
+          Qualifier : string
+              Name of the qualifier to be invoked deleted.
+
+          namespace : string
+              Optional: Name of the namespace in which the class is to be
+              created. The value `None` causes the default namespace of the
+              connection to be used.
+
+        :Returns:
+
+            A list of`CIMQualifierDeclaration` object that is a
+            representation of the retrieved qualifier declarations.
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
         """
 
         if namespace is None:
@@ -2223,11 +2244,32 @@ class WBEMConnection(object):
     def GetQualifier(self, QualifierName, namespace=None, **params):
         # pylint: disable=invalid-name
         """
-        Retrieve a qualifier type.
+        Retrieve a qualifier declaration.
 
+        This method performs the GetQualifier CIM-XML operation.
+        If the operation succeeds, this method returns.
+        Otherwise, this method raises an exception.
         Returns a `CIMQualifier` object.
 
-        TODO Complete this description.
+        TODO This method is UNSUPPORTED right now. Test and verify description.
+
+        :Parameters:
+
+          Qualifier : string
+              Name of the qualifier to be invoked deleted.
+
+          namespace : string
+              Optional: Name of the namespace in which the class is to be
+              created. The value `None` causes the default namespace of the
+              connection to be used.
+
+        :Returns:
+
+            A `CIMQualifierDeclaration` object that is a representation
+            of the retrieved qualifier declaration.
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
         """
 
         if namespace is None:
@@ -2247,9 +2289,27 @@ class WBEMConnection(object):
     def SetQualifier(self, QualifierDeclaration, namespace=None, **params):
         # pylint: disable=invalid-name
         """
-        Create or modify a qualifier type.
+        Create or modify a qualifier declaration.
 
-        TODO Complete this description.
+        This method performs the SetQualifier CIM-XML operation.
+        If the operation succeeds, this method returns.
+        Otherwise, this method raises an exception.
+
+        TODO This method is UNSUPPORTED right now. Test and verify description.
+
+        :Parameters:
+
+          QualifierDeclaration : CIMQualifierDeclaration object
+              Definition of the qualifier to be created or modified.
+
+          namespace : string
+              Optional: Name of the namespace in which the class is to be
+              created. The value `None` causes the default namespace of the
+              connection to be used.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
         """
 
         if namespace is None:
@@ -2265,9 +2325,27 @@ class WBEMConnection(object):
     def DeleteQualifier(self, QualifierName, namespace=None, **params):
         # pylint: disable=invalid-name
         """
-        Delete a qualifier type.
+        Delete a qualifier declaration.
 
-        TODO Complete this description.
+        This method performs the DeleteQualifier CIM-XML operation.
+        If the operation succeeds, this method returns.
+        Otherwise, this method raises an exception.
+
+        TODO This method is UNSUPPORTED right now. Test and verify description.
+
+        :Parameters:
+
+          Qualifier : string
+              Name of the qualifier to be deleted.
+
+          namespace : string
+              Optional: Name of the namespace in which the class is to be
+              created. The value `None` causes the default namespace of the
+              connection to be used.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
         """
 
         if namespace is None:
@@ -2280,7 +2358,7 @@ class WBEMConnection(object):
             **params)
 
 def is_subclass(ch, ns, super_class, sub):
-    """Determine if one class is a subclass of another
+    """Determine if one class is a subclass of another class.
 
     Keyword Arguments:
     ch -- A CIMOMHandle.  Either a pycimmb.CIMOMHandle or a
@@ -2324,7 +2402,8 @@ def PegasusUDSConnection(creds=None, **kwargs):
     """
 
     # pylint: disable=invalid-name
-    return WBEMConnection('/var/run/tog-pegasus/cimxml.socket', creds, **kwargs)
+    return WBEMConnection('/var/run/tog-pegasus/cimxml.socket', creds,
+                          **kwargs)
 
 def SFCBUDSConnection(creds=None, **kwargs):
     """ SFCB specific Unix Domain Socket call. Specific because

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -20,8 +20,8 @@
 # Author: Bart Whiteley <bwhiteley@suse.de>
 #
 
-# TODO: Sort this issue out and see if we need to fix KS_TODO. These
-# two issues are found repeatedly in this file.
+# TODO:2/16:ks: Sort this issue out and see if we need to fix.
+# These two issues are found repeatedly in this file so pylint disabled.
 # pylint: disable=non-parent-init-called,super-init-not-called
 """
 
@@ -175,8 +175,9 @@ def _pcdata_nodes(pcdata):
             nodelist.append(node)
 
     else:
-
-        # The following automatically uses XML entity references for escaping.
+        # The following automatically uses XML entity references
+        # for escaping.
+        # pylint: disable=redefined-variable-type
         node = _text(pcdata)
 
         nodelist.append(node)

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -21,12 +21,12 @@
 
 """CIM/XML Parser. Parses the CIM/XML Elements defined in the DMTF
    specification DSP0201.
-   
+
    WARNING: Many of the parsing functions defined in this file must
    keep the exact name (i.e. those prepended by parse_) since the
    parser uses the names to call the function from the parse_any(...)
    function substituting _ for the "." in the element names.
-   
+
    These functions raise ParseError exception if there are any
    errors in the parsing and terminate the parsing.
 """
@@ -76,14 +76,14 @@ def _get_end_event(parser, tagName):
         raise ParseError(
             'Expecting %s end tag, got %s %s' % (tagName, event, node.tagName))
 
-def _is_start(event, node, tagName):
+def _is_start(event, node, tagName):  # pylint: disable=invalid-name
     """Return true if (event, node) is a start event for tagname."""
-    
+
     return event == pulldom.START_ELEMENT and node.tagName == tagName
 
-def _is_end(event, node, tagName):
+def _is_end(event, node, tagName): # pylint: disable=invalid-name
     """Return true if (event, node) is an end event for tagname."""
-    
+
     return event == pulldom.END_ELEMENT and node.tagName == tagName
 
 # <!-- ************************************************** -->
@@ -132,7 +132,7 @@ def _is_end(event, node, tagName):
 
 # <!ELEMENT VALUE (#PCDATA)>
 
-def parse_value(parser, event, node):
+def parse_value(parser, event, node): # pylint: disable=unused-argument
     """ Parse CIM/XML VALUE element and return the value"""
     value = ''
 
@@ -151,7 +151,7 @@ def parse_value(parser, event, node):
 
 # <!ELEMENT VALUE.ARRAY (VALUE*)>
 
-def parse_value_array(parser, event, node):
+def parse_value_array(parser, event, node): # pylint: disable=invalid-name
     """ Parse CIM/XML VALUE.ARRAY element and return the value array"""
 
     value_array = []
@@ -187,6 +187,8 @@ def parse_value_reference(parser, event, node):
     """
 
     (next_event, next_node) = parser.next()
+    
+    TODO: 2/16:ks : functions parse_classpath, parse_localclasspath, parseclassname do not exist.
 
     if _is_start(next_event, next_node, 'CLASSPATH'):
         result = parse_classpath(parser, next_event, next_node)

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -191,7 +191,7 @@ def parse_value_reference(parser, event, node): #pylint: disable=unused-argument
     (next_event, next_node) = parser.next()
 
     #TODO:2/16:ks: Some functions below do not exist: i.e. class stuff broken.
-    #TODO: parse_classpath, parse_localclasspath, parseclassname.
+    #TODO: parse_classpath, parse_localclasspath, parse_classname.
 
     if _is_start(next_event, next_node, 'CLASSPATH'):
         result = parse_classpath(parser, next_event, next_node)

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -19,6 +19,19 @@
 # Author: Tim Potter <tpot@hp.com>
 #
 
+"""CIM/XML Parser. Parses the CIM/XML Elements defined in the DMTF
+   specification DSP0201.
+   
+   WARNING: Many of the parsing functions defined in this file must
+   keep the exact name (i.e. those prepended by parse_) since the
+   parser uses the names to call the function from the parse_any(...)
+   function substituting _ for the "." in the element names.
+   
+   These functions raise ParseError exception if there are any
+   errors in the parsing and terminate the parsing.
+"""
+
+import sys
 import string
 from xml.dom import pulldom
 
@@ -38,7 +51,7 @@ class ParseError(Exception):
 #
 
 def _get_required_attribute(node, attr):
-    """Return an attribute by name.  Throw an exception if not present."""
+    """Return an attribute by name.  Raise ParseError if not present."""
 
     if not node.hasAttribute(attr):
         raise ParseError(
@@ -55,7 +68,7 @@ def _get_attribute(node, attr):
     return None
 
 def _get_end_event(parser, tagName):
-    """Check that the next event is the end of a particular tag."""
+    """Check that the next event is the end of a particular XML tag."""
 
     (event, node) = parser.next()
 
@@ -65,10 +78,12 @@ def _get_end_event(parser, tagName):
 
 def _is_start(event, node, tagName):
     """Return true if (event, node) is a start event for tagname."""
+    
     return event == pulldom.START_ELEMENT and node.tagName == tagName
 
 def _is_end(event, node, tagName):
     """Return true if (event, node) is an end event for tagname."""
+    
     return event == pulldom.END_ELEMENT and node.tagName == tagName
 
 # <!-- ************************************************** -->
@@ -118,7 +133,7 @@ def _is_end(event, node, tagName):
 # <!ELEMENT VALUE (#PCDATA)>
 
 def parse_value(parser, event, node):
-
+    """ Parse CIM/XML VALUE element and return the value"""
     value = ''
 
     (next_event, next_node) = parser.next()
@@ -137,6 +152,7 @@ def parse_value(parser, event, node):
 # <!ELEMENT VALUE.ARRAY (VALUE*)>
 
 def parse_value_array(parser, event, node):
+    """ Parse CIM/XML VALUE.ARRAY element and return the value array"""
 
     value_array = []
 
@@ -161,9 +177,14 @@ def parse_value_array(parser, event, node):
     return value_array
 
 # <!ELEMENT VALUE.REFERENCE (CLASSPATH | LOCALCLASSPATH | CLASSNAME |
-#                            INSTANCEPATH | LOCALINSTANCEPATH | INSTANCENAME)>
+#                            INSTANCEPATH | LOCALINSTANCEPATH |
+#                            INSTANCENAME)>
 
 def parse_value_reference(parser, event, node):
+    """Parse CIM/XML VALUE.REFERENCE element and call function
+       for the child ELEMENT. Return the result of that element
+       parser call.
+    """
 
     (next_event, next_node) = parser.next()
 
@@ -403,6 +424,7 @@ def parse_instancename(parser, event, node):
 # >
 
 def parse_keybinding(parser, event, node):
+    """Parse CIM/XML KEYBINDING element and return name, value tuple"""
 
     name = _get_required_attribute(node, 'NAME')
 
@@ -413,7 +435,8 @@ def parse_keybinding(parser, event, node):
         result = (name, keyvalue)
 
     elif _is_start(next_event, next_node, 'VALUE.REFERENCE'):
-        value_reference = parse_value_reference(parser, next_event, next_node)
+        value_reference = parse_value_reference(parser,
+                                                next_event, next_node)
         result = (name, value_reference)
 
     else:
@@ -430,8 +453,13 @@ def parse_keybinding(parser, event, node):
 # >
 
 def parse_keyvalue(parser, event, node):
+    """Parse CIM/CML KEYVALUE element and return key value based on
+       VALUETYPE  or TYPE (future) information
+    """
 
     valuetype = _get_required_attribute(node, 'VALUETYPE')
+    # TODO: feb 2015: ks : Why is type attribute not used? why get
+    # if not used? Think this should be used if exists.
     type = _get_attribute(node, 'TYPE')
 
     (next_event, next_node) = parser.next()
@@ -469,7 +497,8 @@ def parse_keyvalue(parser, event, node):
 
             # XXX: Would like to use long() here, but that tends to cause
             # trouble when it's written back out as '2L'
-
+            # pylint: disable redefined-variable-type
+            # Redefined from bool to int
             value = int(value.strip(), 0)
 
         except ValueError:
@@ -502,6 +531,7 @@ def parse_keyvalue(parser, event, node):
 # >
 
 def parse_instance(parser, event, node):
+    """Parse CIM/XML INSTANCE Element and return CIMInstance"""
 
     classname = _get_required_attribute(node, 'CLASSNAME')
 
@@ -569,9 +599,11 @@ def parse_instance(parser, event, node):
 # >
 
 def parse_qualifier(parser, event, node):
+    """Parse CIM/XML QUALIFIER element and return CIMQualifier"""
 
     name = _get_required_attribute(node, 'NAME')
     type = _get_required_attribute(node, 'TYPE')
+    # TODO: Feb 2016: ks : Why is propagated not used?
     propagated = _get_attribute(node, 'PROPAGATED')
 
     (next_event, next_node) = parser.next()
@@ -582,6 +614,8 @@ def parse_qualifier(parser, event, node):
     if _is_start(next_event, next_node, 'VALUE'):
         value = parse_value(parser, next_event, next_node)
     elif _is_start(next_event, next_node, 'VALUE.ARRAY'):
+        #pylint: disable=redefined-variable-type
+        # redefined from str to list.
         value = parse_value_array(parser, next_event, next_node)
     else:
         raise ParseError('Expecting (VALUE | VALUE.ARRAY)')
@@ -602,6 +636,7 @@ def parse_qualifier(parser, event, node):
 # >
 
 def parse_property(parser, event, node):
+    """Parse CIM/XML PROPERTY Element and return CIMProperty"""
 
     name = _get_required_attribute(node, 'NAME')
     type = _get_required_attribute(node, 'TYPE')
@@ -658,6 +693,7 @@ def parse_property(parser, event, node):
 # >
 
 def parse_property_array(parser, event, node):
+    """Parse CIM/XML PROPERTY.ARRAY element and return CIMProperty"""
 
     name = _get_required_attribute(node, 'NAME')
     type = _get_required_attribute(node, 'TYPE')
@@ -666,6 +702,7 @@ def parse_property_array(parser, event, node):
     class_origin = _get_attribute(node, 'CLASSORIGIN')
     propagated = _get_attribute(node, 'PROPAGATED')
 
+    ## TODO: Jan 2016: ks The qualifier processing could be common
     qualifiers = []
     value = None
 
@@ -714,6 +751,9 @@ def parse_property_array(parser, event, node):
 # >
 
 def parse_property_reference(parser, event, node):
+    """Parse CIM/XML PROPERTY.REFERENCE ELEMENT and return
+       CIMProperty
+    """
 
     name = _get_required_attribute(node, 'NAME')
 
@@ -938,7 +978,10 @@ def make_parser(stream_or_string):
         return pulldom.parse(stream_or_string)
 
 def parse_any(stream_or_string):
-    """Parse any XML string or stream."""
+    """Parse any XML string or stream. This function fabricates
+       the names of the parser functions by prepending parse_ to
+       the node name and then calling that function.
+    """
 
     parser = make_parser(stream_or_string)
 
@@ -962,5 +1005,4 @@ def parse_any(stream_or_string):
 # Test harness
 
 if __name__ == '__main__':
-    import sys
     print parse_any(sys.stdin)

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -696,7 +696,7 @@ def parse_property(parser, event, node): #pylint: disable=unused-argument
 
     return CIMProperty(
         name,
-        cim_obj.tocimobj(type, value),
+        cim_obj.tocimobj(cim_type, value),
         type=cim_type,
         class_origin=class_origin,
         propagated=propagated,

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -151,7 +151,8 @@ def parse_value(parser, event, node): # pylint: disable=unused-argument
 
 # <!ELEMENT VALUE.ARRAY (VALUE*)>
 
-def parse_value_array(parser, event, node): # pylint: disable=invalid-name
+def parse_value_array(parser, event, node): #pylint: disable=unused-argument
+     # pylint: disable=invalid-name
     """ Parse CIM/XML VALUE.ARRAY element and return the value array"""
 
     value_array = []
@@ -180,15 +181,17 @@ def parse_value_array(parser, event, node): # pylint: disable=invalid-name
 #                            INSTANCEPATH | LOCALINSTANCEPATH |
 #                            INSTANCENAME)>
 
-def parse_value_reference(parser, event, node):
+def parse_value_reference(parser, event, node): #pylint: disable=unused-argument
+
     """Parse CIM/XML VALUE.REFERENCE element and call function
        for the child ELEMENT. Return the result of that element
        parser call.
     """
 
     (next_event, next_node) = parser.next()
-    
-    TODO: 2/16:ks : functions parse_classpath, parse_localclasspath, parseclassname do not exist.
+
+    #TODO:2/16:ks: Some functions below do not exist: i.e. class stuff broken.
+    #TODO: parse_classpath, parse_localclasspath, parseclassname.
 
     if _is_start(next_event, next_node, 'CLASSPATH'):
         result = parse_classpath(parser, next_event, next_node)
@@ -232,7 +235,8 @@ def parse_value_reference(parser, event, node):
 
 # <!ELEMENT NAMESPACEPATH (HOST, LOCALNAMESPACEPATH)>
 
-def parse_namespacepath(parser, event, node):
+def parse_namespacepath(parser, event, node): #pylint: disable=unused-argument
+
 
     (next_event, next_node) = parser.next()
 
@@ -258,6 +262,7 @@ def parse_namespacepath(parser, event, node):
 # <!ELEMENT LOCALNAMESPACEPATH (NAMESPACE+)>
 
 def parse_localnamespacepath(parser, event, node):
+     #pylint: disable=unused-argument
 
     (next_event, next_node) = parser.next()
 
@@ -286,6 +291,7 @@ def parse_localnamespacepath(parser, event, node):
 # <!ELEMENT HOST (#PCDATA)>
 
 def parse_host(parser, event, node):
+     #pylint: disable=unused-argument
 
     host = ''
 
@@ -308,7 +314,10 @@ def parse_host(parser, event, node):
 # >
 
 def parse_namespace(parser, event, node):
-
+     #pylint: disable=unused-argument
+    """Parse the CIM/XML NAMESPACE element and return the value
+       of the CIMName attribute
+    """
     name = _get_required_attribute(node, 'NAME')
 
     (next_event, next_node) = parser.next()
@@ -330,6 +339,13 @@ def parse_namespace(parser, event, node):
 # <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
 
 def parse_instancepath(parser, event, node):
+     #pylint: disable=unused-argument
+    """Parse the CIM/XML INSTANCEPATH element and return an
+       instancname
+
+       <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
+
+    """
 
     (next_event, next_node) = parser.next()
 
@@ -354,6 +370,7 @@ def parse_instancepath(parser, event, node):
 # <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
 
 def parse_localinstancepath(parser, event, node):
+     #pylint: disable=unused-argument
 
     (next_event, next_node) = parser.next()
 
@@ -378,7 +395,7 @@ def parse_localinstancepath(parser, event, node):
 #       %ClassName;
 # >
 
-def parse_instancename(parser, event, node):
+def parse_instancename(parser, event, node): #pylint: disable=unused-argument
 
     classname = _get_required_attribute(node, 'CLASSNAME')
     keybindings = []
@@ -425,7 +442,7 @@ def parse_instancename(parser, event, node):
 #       %CIMName;
 # >
 
-def parse_keybinding(parser, event, node):
+def parse_keybinding(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML KEYBINDING element and return name, value tuple"""
 
     name = _get_required_attribute(node, 'NAME')
@@ -454,15 +471,15 @@ def parse_keybinding(parser, event, node):
 #       %CIMType;              #IMPLIED
 # >
 
-def parse_keyvalue(parser, event, node):
+def parse_keyvalue(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/CML KEYVALUE element and return key value based on
        VALUETYPE  or TYPE (future) information
     """
 
     valuetype = _get_required_attribute(node, 'VALUETYPE')
-    # TODO: feb 2015: ks : Why is type attribute not used? why get
-    # if not used? Think this should be used if exists.
-    type = _get_attribute(node, 'TYPE')
+    # TODO:2/16:ks: Why is type attribute not used? Why get
+    # if not used? This was late extension to allow real types.
+    cim_type = _get_attribute(node, 'TYPE')
 
     (next_event, next_node) = parser.next()
 
@@ -501,6 +518,7 @@ def parse_keyvalue(parser, event, node):
             # trouble when it's written back out as '2L'
             # pylint: disable redefined-variable-type
             # Redefined from bool to int
+            # pylint: disable=redefined-variable-type
             value = int(value.strip(), 0)
 
         except ValueError:
@@ -532,7 +550,7 @@ def parse_keyvalue(parser, event, node):
 #       xml:lang   NMTOKEN      #IMPLIED
 # >
 
-def parse_instance(parser, event, node):
+def parse_instance(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML INSTANCE Element and return CIMInstance"""
 
     classname = _get_required_attribute(node, 'CLASSNAME')
@@ -600,18 +618,18 @@ def parse_instance(parser, event, node):
 #       xml:lang   NMTOKEN     #IMPLIED
 # >
 
-def parse_qualifier(parser, event, node):
+def parse_qualifier(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML QUALIFIER element and return CIMQualifier"""
 
     name = _get_required_attribute(node, 'NAME')
-    type = _get_required_attribute(node, 'TYPE')
+    cim_type = _get_required_attribute(node, 'TYPE')
     # TODO: Feb 2016: ks : Why is propagated not used?
     propagated = _get_attribute(node, 'PROPAGATED')
 
     (next_event, next_node) = parser.next()
 
     if _is_end(next_event, next_node, 'QUALIFIER'):
-        return CIMQualifier(name, None, type=type)
+        return CIMQualifier(name, None, type=cim_type)
 
     if _is_start(next_event, next_node, 'VALUE'):
         value = parse_value(parser, next_event, next_node)
@@ -622,7 +640,7 @@ def parse_qualifier(parser, event, node):
     else:
         raise ParseError('Expecting (VALUE | VALUE.ARRAY)')
 
-    result = CIMQualifier(name, cim_obj.tocimobj(type, value))
+    result = CIMQualifier(name, cim_obj.tocimobj(cim_type, value))
 
     _get_end_event(parser, 'QUALIFIER')
 
@@ -637,11 +655,11 @@ def parse_qualifier(parser, event, node):
 #       xml:lang   NMTOKEN     #IMPLIED
 # >
 
-def parse_property(parser, event, node):
+def parse_property(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML PROPERTY Element and return CIMProperty"""
 
     name = _get_required_attribute(node, 'NAME')
-    type = _get_required_attribute(node, 'TYPE')
+    cim_type = _get_required_attribute(node, 'TYPE')
 
     class_origin = _get_attribute(node, 'CLASSORIGIN')
     propagated = _get_attribute(node, 'PROPAGATED')
@@ -679,7 +697,7 @@ def parse_property(parser, event, node):
     return CIMProperty(
         name,
         cim_obj.tocimobj(type, value),
-        type=type,
+        type=cim_type,
         class_origin=class_origin,
         propagated=propagated,
         qualifiers=dict([(x.name, x) for x in qualifiers]))
@@ -694,12 +712,13 @@ def parse_property(parser, event, node):
 #       xml:lang   NMTOKEN     #IMPLIED
 # >
 
-def parse_property_array(parser, event, node):
+def parse_property_array(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML PROPERTY.ARRAY element and return CIMProperty"""
 
     name = _get_required_attribute(node, 'NAME')
-    type = _get_required_attribute(node, 'TYPE')
+    cim_type = _get_required_attribute(node, 'TYPE')
 
+    #TODO: 2/16:ks: array_size here is unused
     array_size = _get_attribute(node, 'ARRAYSIZE')
     class_origin = _get_attribute(node, 'CLASSORIGIN')
     propagated = _get_attribute(node, 'PROPAGATED')
@@ -738,7 +757,7 @@ def parse_property_array(parser, event, node):
     return CIMProperty(
         name,
         cim_obj.tocimobj(type, value),
-        type=type,
+        type=cim_type,
         class_origin=class_origin,
         propagated=propagated,
         is_array=True,
@@ -752,7 +771,7 @@ def parse_property_array(parser, event, node):
 #       %Propagated;
 # >
 
-def parse_property_reference(parser, event, node):
+def parse_property_reference(parser, event, node): #pylint: disable=unused-argument
     """Parse CIM/XML PROPERTY.REFERENCE ELEMENT and return
        CIMProperty
     """

--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -339,7 +339,7 @@ def parse_namespace(parser, event, node):
 # <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
 
 def parse_instancepath(parser, event, node):
-     #pylint: disable=unused-argument
+    #pylint: disable=unused-argument
     """Parse the CIM/XML INSTANCEPATH element and return an
        instancname
 

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -446,6 +446,9 @@ def parse_value_namedobject(tup_tree):
         _object = parse_class(k[0])
     elif len(k) == 2:
         path = parse_instancename(kids(tup_tree)[0])
+
+        # pylint: disable=redefined-variable-type
+        # redefines _object from pywbem.cim_obj.CIMClass to ...CIMInstance
         _object = parse_instance(kids(tup_tree)[1])
 
         _object.path = path
@@ -455,7 +458,7 @@ def parse_value_namedobject(tup_tree):
 
     return (name(tup_tree), attrs(tup_tree), _object)
 
-#pylint: disable=invalid-function-name
+# pylint: disable=invalid-name
 def parse_value_objectwithlocalpath(tup_tree):
     """
     <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH, CLASS) |
@@ -473,6 +476,8 @@ def parse_value_objectwithlocalpath(tup_tree):
                    parse_class(kids(tup_tree)[1]))
     else:
         path = parse_localinstancepath(kids(tup_tree)[0])
+        # pylint: disable=redefined-variable-type
+        # redefines _object from tuple to CIMInstance
         _object = parse_instance(kids(tup_tree)[1])
         _object.path = path
 
@@ -492,10 +497,11 @@ def parse_value_objectwithpath(tup_tree):
         raise ParseError('Expecting two elements, got %s' % k)
 
     if name(k[0]) == 'CLASSPATH':
-        _object = (parse_classpath(k[0]),
-                   parse_class(k[1]))
+        _object = (parse_classpath(k[0]), parse_class(k[1]))
     else:
         path = parse_instancepath(k[0])
+        # pylint: disable=redefined-variable-type
+        # redefines _object from tuple to CIMInstance
         _object = parse_instance(k[1])
         _object.path = path
 
@@ -595,7 +601,7 @@ def parse_localclasspath(tup_tree):
 
 def parse_classname(tup_tree):
     """Parse a CLASSNAME element and return a CIMClassName.
-    
+
            <!ELEMENT CLASSNAME EMPTY>
            <!ATTLIST CLASSNAME
                %CIMName;>
@@ -606,7 +612,7 @@ def parse_classname(tup_tree):
 
 def parse_instancepath(tup_tree):
     """Parse a INSTANCEPATH element returning the instance name.
-    
+
           <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
     """
 
@@ -626,7 +632,7 @@ def parse_instancepath(tup_tree):
 
 def parse_localinstancepath(tup_tree):
     """Parse a LOCALINSTANCEPATH element:
-    
+
            <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
     """
 
@@ -1502,7 +1508,7 @@ def parse_any(tup_tree):
     """Parse a fragment of XML. This function drives the rest of
        the parser by calling 'parse_*' functions based on the name
        of the element being parsed.
-       
+
        It builds parser function name from incoming name in tup_tree
        prepended with 'parse_' and calls that function.
 
@@ -1541,7 +1547,8 @@ def parse_embeddedObject(val): # pylint: disable=invalid-name
 
 
 def unpack_value(tup_tree):
-    """Find VALUE or VALUE.ARRAY under TT and convert to a Python value.
+    """Find VALUE or VALUE.ARRAY under tup_tree and convert to a
+    Python value.
 
     Looks at the TYPE of the node to work out how to decode it.
     Handles nodes with no value (e.g. in CLASS.)

--- a/pywbem/tupletree.py
+++ b/pywbem/tupletree.py
@@ -85,8 +85,7 @@ def dom_to_tupletree(node):
         attr_node = node.attributes.item(i)
         attrs[attr_node.nodeName] = attr_node.nodeValue
 
-    # XXX: Cannot yet handle comments, cdata, processing instructions and
-    # other XML batshit.
+    # XXX: Cannot handle comments, cdata, processing instructions, etc.
 
     # it's so easy in retrospect!
     return (name, attrs, contents, None)

--- a/testsuite/test_cim_xml.py
+++ b/testsuite/test_cim_xml.py
@@ -47,18 +47,18 @@ def validate_xml(data, dtd_directory=None):
 
 # Test data to save typing
 
-def LOCALNAMESPACEPATH():
+def LOCALNAMESPACEPATH():   # pylint: disable=invalid-name
     return cim_xml.LOCALNAMESPACEPATH([cim_xml.NAMESPACE('root'),
                                        cim_xml.NAMESPACE('cimv2')])
 
-def NAMESPACEPATH():
+def NAMESPACEPATH():   # pylint: disable=invalid-name
     return cim_xml.NAMESPACEPATH(
         cim_xml.HOST('leonardo'), LOCALNAMESPACEPATH())
 
-def CLASSNAME():
+def CLASSNAME():  # pylint: disable=invalid-name
     return cim_xml.CLASSNAME('CIM_Foo')
 
-def INSTANCENAME():
+def INSTANCENAME():  # pylint: disable=invalid-name
     return cim_xml.INSTANCENAME(
         'CIM_Pet',
         [cim_xml.KEYBINDING('type', cim_xml.KEYVALUE('dog', 'string')),
@@ -101,6 +101,7 @@ class CIMXMLTest(unittest.TestCase):
                                      act_xml_str)
 
 
+# pylint: disable=too-few-public-methods
 class UnimplementedTest(object):
     def test_all(self):
         raise AssertionError('Unimplemented test')
@@ -134,11 +135,13 @@ class CIM(CIMXMLTest):
 #     3.2.2.5. QUALIFIER.DECLARATION
 #     3.2.2.6. SCOPE
 
+# pylint: disable=too-few-public-methods
 class Declaration(UnimplementedTest):
     """
     <!ELEMENT DECLARATION  (DECLGROUP|DECLGROUP.WITHNAME|DECLGROUP.WITHPATH)+>
     """
 
+# pylint: disable=too-few-public-methods
 class DeclGroup(UnimplementedTest):
     """
     <!ELEMENT DECLGROUP  ((LOCALNAMESPACEPATH|NAMESPACEPATH)?,
@@ -147,18 +150,21 @@ class DeclGroup(UnimplementedTest):
 
     pass
 
+# pylint: disable=too-few-public-methods
 class DeclGroupWithName(UnimplementedTest):
     """
     <!ELEMENT DECLGROUP.WITHNAME  ((LOCALNAMESPACEPATH|NAMESPACEPATH)?,
                                    QUALIFIER.DECLARATION*,VALUE.NAMEDOBJECT*)>
     """
 
+# pylint: disable=too-few-public-methods
 class DeclGroupWithPath(UnimplementedTest):
     """
     <!ELEMENT DECLGROUP.WITHPATH  (VALUE.OBJECTWITHPATH|
                                    VALUE.OBJECTWITHLOCALPATH)*>
     """
 
+# pylint: disable=too-few-public-methods
 class QualifierDeclaration(UnimplementedTest):
     """
     <!ELEMENT QUALIFIER.DECLARATION (SCOPE?, (VALUE | VALUE.ARRAY)?)>
@@ -434,6 +440,7 @@ class ValueObjectWithLocalPath(CIMXMLTest):
                 INSTANCENAME()),
             cim_xml.INSTANCE('CIM_Pet', [])))
 
+# pylint: disable=too-few-public-methods
 class ValueNull(UnimplementedTest):
     """
     <!ELEMENT VALUE.NULL EMPTY>
@@ -1718,6 +1725,7 @@ class IReturnValue(CIMXMLTest):
                 INSTANCENAME(),
                 cim_xml.INSTANCE('CIM_Pet', []))))
 
+# pylint: disable=too-few-public-methods
 class ResponseDestination(UnimplementedTest):
     """
     The RESPONSEDESTINATION element contains an instance that
@@ -1725,7 +1733,7 @@ class ResponseDestination(UnimplementedTest):
 
     <!ELEMENT RESPONSEDESTINATON (INSTANCE)>
     """
-
+# pylint: disable=too-few-public-methods
 class SimpleReqAck(UnimplementedTest):
     """
 

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -106,8 +106,8 @@ def tc_hasattr(dict_, key):
     return key in dict_
 
 class Callback(object):
-    """A class with static methods that are HTTPretty callback functions for
-    raising expected exceptions at the socket level."""
+    """A class with static methods that are HTTPretty callback functions
+    for raising expected exceptions at the socket level."""
 
     @staticmethod
     def socket_ssl(request, uri, headers):
@@ -189,7 +189,7 @@ class ClientTest(unittest.TestCase):
         """
 
         print "" # We are in the middle of test runner output
-        
+
         # We need to work with absolute file paths, because this test may be
         # run from a different directory.
         for basefn in os.listdir(TESTCASE_DIR):
@@ -300,15 +300,15 @@ class ClientTest(unittest.TestCase):
             http_request = httpretty.last_request()
             exp_verb = tc_getattr(tc_name, exp_http_request, "verb")
             self.assertEqual(http_request.method, exp_verb,
-                              "verb in HTTP request")
+                             "verb in HTTP request")
             exp_headers = tc_getattr(tc_name, exp_http_request, "headers", {})
             for header_name in exp_headers:
                 self.assertEqual(http_request.headers[header_name],
-                                  exp_headers[header_name],
-                                  "headers in HTTP request")
+                                 exp_headers[header_name],
+                                 "headers in HTTP request")
             exp_data = tc_getattr(tc_name, exp_http_request, "data", None)
             self.assertXMLEqual(http_request.body, exp_data,
-                                  "data in HTTP request")
+                                "data in HTTP request")
 
         # Validate PyWBEM result
 
@@ -335,14 +335,14 @@ class ClientTest(unittest.TestCase):
                                      "but no exception was actually raised." %\
                                      exp_exception)
             self.assertEqual(raised_exception.__class__.__name__,
-                              exp_exception, "expected PyWBEM exception name")
+                             exp_exception, "expected PyWBEM exception name")
         elif exp_cim_status != 0:
             if raised_exception is None:
                 raise AssertionError("CIMError exception was expected to be "\
                                      "raised, but no exception was actually "
                                      "raised.")
             self.assertEqual(raised_exception.__class__.__name__, "CIMError",
-                              "expected PyWBEM exception name")
+                             "expected PyWBEM exception name")
         else:
             if raised_exception is not None:
                 raise AssertionError("No exception was expected to be raised, "\

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 #
-# Test XML parsing routines.
-#
-# These tests check that we don't lose any information by converting
-# an object to XML then parsing it again.  The round trip should
-# produce an object that is identical to the one we started with.
-#
 
+"""
+Test XML parsing routines.
+
+These tests check that we don't lose any information by converting
+an object to XML then parsing it again.  The round trip should
+produce an object that is identical to the one we started with.
+"""
 import unittest
 import pytest
 
@@ -55,8 +56,8 @@ class ParseCIMInstanceName(TupleTest):
         self._run_single(CIMInstanceName('CIM_Foo'))
 
         self._run_single(CIMInstanceName('CIM_Foo',
-                                  {'Name': 'Foo',
-                                   'Chicken': 'Ham'}))
+                                         {'Name': 'Foo',
+                                          'Chicken': 'Ham'}))
 
         self._run_single(
             CIMInstanceName('CIM_Foo', {'Name': 'Foo',
@@ -94,6 +95,7 @@ class ParseCIMInstance(TupleTest):
                         path=CIMInstanceName('CIM_Foo',
                                              {'InstanceID': '1234'})))
 
+# TODO: 2/8/16: ks: Create test for more complete class
 class ParseCIMClass(TupleTest):
     """Test parsing of CIMClass objects."""
 
@@ -150,6 +152,7 @@ class ParseCIMClass(TupleTest):
                        }
             ))
 
+# TODO extend to all property data types
 class ParseCIMProperty(TupleTest):
     """Test parsing of CIMProperty objects."""
 
@@ -162,21 +165,24 @@ class ParseCIMProperty(TupleTest):
         self._run_single(CIMProperty('Foo', '', type='string'))
         self._run_single(CIMProperty('Foo', None, type='string'))
         self._run_single(CIMProperty('Age', None, type='uint16',
-                              qualifiers={'Key': CIMQualifier('Key', True)}))
+                                     qualifiers={'Key': CIMQualifier('Key',
+                                                                     True)}))
 
         # Property arrays
 
         self._run_single(CIMProperty('Foo', ['a', 'b', 'c']))
         self._run_single(CIMProperty('Foo', None, type='string', is_array=True))
         self._run_single(CIMProperty('Foo', [Uint8(x) for x in [1, 2, 3]],
-                              qualifiers={'Key': CIMQualifier('Key', True)}))
+                                     qualifiers={'Key': CIMQualifier('Key',
+                                                                     True)}))
 
         # Reference properties
 
         self._run_single(CIMProperty('Foo', None, type='reference'))
         self._run_single(CIMProperty('Foo', CIMInstanceName('CIM_Foo')))
         self._run_single(CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
-                              qualifiers={'Key': CIMQualifier('Key', True)}))
+                                     qualifiers={'Key': CIMQualifier('Key',
+                                                                     True)}))
 
         # EmbeddedObject properties
 
@@ -185,7 +191,7 @@ class ParseCIMProperty(TupleTest):
         self._run_single(CIMProperty('Foo', inst))
         self._run_single(CIMProperty('Foo', [inst]))
 
-
+# TODO: Feb/16: ks: Extend for all data types
 class ParseCIMParameter(TupleTest):
     """Test parsing of CIMParameter objects."""
 
@@ -196,45 +202,53 @@ class ParseCIMParameter(TupleTest):
         self._run_single(CIMParameter('Param', 'string'))
 
         self._run_single(CIMParameter('Param', 'string',
-                               qualifiers={'Key': CIMQualifier('Key', True)}))
+                                      qualifiers={'Key': CIMQualifier('Key',
+                                                                      True)}))
 
         # Reference parameters
 
         self._run_single(CIMParameter('RefParam', 'reference'))
 
         self._run_single(CIMParameter('RefParam', 'reference',
-                               reference_class='CIM_Foo'))
+                                      reference_class='CIM_Foo'))
 
         self._run_single(CIMParameter('RefParam', 'reference',
-                               reference_class='CIM_Foo',
-                               qualifiers={'Key': CIMQualifier('Key', True)}))
+                                      reference_class='CIM_Foo',
+                                      qualifiers={'Key': CIMQualifier('Key',
+                                                                      True)}))
 
         # Array parameters
 
         self._run_single(CIMParameter('Array', 'string', is_array=True))
 
         self._run_single(CIMParameter('Array', 'string', is_array=True,
-                               array_size=10))
+                                      array_size=10))
 
         self._run_single(CIMParameter('Array', 'string', is_array=True,
-                               array_size=10,
-                               qualifiers={'Key': CIMQualifier('Key', True)}))
+                                      array_size=10,
+                                      qualifiers={'Key': CIMQualifier('Key',
+                                                                      True)}))
 
         # Reference array parameters
 
-        self._run_single(CIMParameter('RefArray', 'reference', is_array=True))
+        self._run_single(CIMParameter('RefArray', 'reference',
+                                      is_array=True))
 
-        self._run_single(CIMParameter('RefArray', 'reference', is_array=True,
-                               reference_class='CIM_Foo'))
+        self._run_single(CIMParameter('RefArray', 'reference',
+                                      is_array=True,
+                                      reference_class='CIM_Foo'))
 
-        self._run_single(CIMParameter('RefArray', 'reference', is_array=True,
-                               reference_class='CIM_Foo',
-                               array_size=10))
+        self._run_single(CIMParameter('RefArray', 'reference',
+                                      is_array=True,
+                                      reference_class='CIM_Foo',
+                                      array_size=10))
 
-        self._run_single(CIMParameter('RefArray', 'reference', is_array=True,
-                               reference_class='CIM_Foo',
-                               array_size=10,
-                               qualifiers={'Key': CIMQualifier('Key', True)}))
+        self._run_single(CIMParameter('RefArray', 'reference',
+                                      is_array=True,
+                                      reference_class='CIM_Foo',
+                                      array_size=10,
+                                      qualifiers={'Key': CIMQualifier('Key',
+                                                                      True)}))
 
 
 class ParseXMLKeyValue(RawXMLTest):

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -152,7 +152,7 @@ class ParseCIMClass(TupleTest):
                        }
             ))
 
-# TODO extend to all property data types
+# TODO: Feb/16: ks: extend to all property data types
 class ParseCIMProperty(TupleTest):
     """Test parsing of CIMProperty objects."""
 


### PR DESCRIPTION
Number of mostly cleanup including adding some docstrings, rename some variables, bunch of
disables, etc.  Did some changes to the testsuite also primarily multiple line alignment.

Passed tests locally.  Note that count is down to 599 and I added at least 10 new TODOs

Summary with this change is as follows:
 Count of messages per module summary
======================================
pywbem.mof_compiler                240
test_nocasedict                     44
pywbem.cim_obj                      33
test_cim_obj                        32
pywbem.tupleparse                   32
pywbem.cim_xml                      29
test_mof_compiler                   29
test_cim_xml                        27
test_cimxmlparse                    24
test_client                         22
pywbem.cimxml_parse                 21
pywbem.cim_http                     17
test_tupleparse                     15
pywbem.cim_operations               12
os_setup                            11
setup                                5
pywbem.wbemcli                       2
pywbem.tupletree                     1
test_cim_http                        1
                                     0
======================================

Count by message type
Message Type                 Msg Count
======================================
(missing-docstring)                146
(using-constant-test)                2
(broad-except)                       2
(dangerous-default-value)           33
(bad-builtin)                       10
(undefined-variable)                 3
(attribute-defined-outside-init)       4
(cell-var-from-loop)                 1
(unused-import)                      9
(unused-argument)                   11
(deprecated-lambda)                  9
(redefined-variable-type)            8
(redefined-builtin)                  6
(unused-variable)                    8
(not-an-iterable)                    1
(cyclic-import)                      1
(fixme)                             86
(no-self-use)                       27
(no-member)                         14
(unnecessary-lambda)                 2
(bad-continuation)                  11
(bad-inline-option)                  4
(line-too-long)                      2
(protected-access)                   5
(invalid-name)                     194
======================================
Total                              599

