### PR TITLE
Fixes #60: Add support for measuring and reporting test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ MANIFEST
 parser.out
 moflog.txt
 pylint_done
+.coverage
 /build/
 /build_doc/
 /dist/

--- a/coveragerc
+++ b/coveragerc
@@ -1,0 +1,25 @@
+# Config file for Python "coverage" package.
+#
+# For documentation, see:
+# http://coverage.readthedocs.org/en/latest/config.html
+
+[run]
+
+# TODO: For now, measure just statement coverage.
+#       Once we get better, enable this.
+branch = False
+
+# Don't measure source files we don't own or that
+# are not used in the PyWBEM Client.
+omit =
+    pywbem/lex.py
+    pywbem/yacc.py
+    pywbem/cim_provider*.py
+    pywbem/twisted_client.py
+
+[report]
+
+# TODO: For now, don't include missing lines.
+#       Once we get better, enable this.
+show_missing = False
+

--- a/makefile
+++ b/makefile
@@ -185,7 +185,7 @@ clobber: clean
 clean:
 	find . -name "*.pyc" -delete
 	sh -c "find . -name \"__pycache__\" |xargs rm -Rf"
-	rm -f MANIFEST parser.out $(package_name)/parser.out $(test_tmp_file) $(package_name)/mofparsetab.py $(package_name)/moflextab.py
+	rm -f MANIFEST parser.out .coverage $(package_name)/parser.out $(test_tmp_file) $(package_name)/mofparsetab.py $(package_name)/moflextab.py
 	rm -Rf build tmp_install testtmp testsuite/testtmp .cache $(package_name).egg-info
 	@echo '$@ done.'
 
@@ -247,8 +247,8 @@ pylint.log: $(pylint_rc_file) setup.py os_setup.py $(package_name)/*.py testsuit
 	-bash -c "set -o pipefail; PYTHONPATH=. pylint --rcfile=$(pylint_rc_file) --ignore=moflextab.py,mofparsetab.py,yacc.py,lex.py,twisted_client.py,cim_provider.py,cim_provider2.py --output-format=text setup.py os_setup.py $(package_name) testsuite/test*.py testsuite/validate.py 2>&1 |tee pylint.tmp.log"
 	mv -f pylint.tmp.log pylint.log
 
-$(test_log_file): $(package_name)/*.py testsuite/*.py
+$(test_log_file): $(package_name)/*.py testsuite/*.py coveragerc
 	rm -f $(test_log_file)
-	bash -c "set -o pipefail; PYTHONPATH=. py.test --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
+	bash -c "set -o pipefail; PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
 	mv -f $(test_tmp_file) $(test_log_file)
 

--- a/setup.py
+++ b/setup.py
@@ -363,6 +363,7 @@ def main():
         'develop_requires' : [
             # Python prereqs for 'develop' command. Handled by os_setup module.
             "pytest>=2.4",
+            "pytest-cov",
             # Epydoc does not support Python 3.
             "epydoc==3.0.1" if sys.version_info[0] == 2 else None,
             patch_epydoc if sys.version_info[0] == 2 else None,


### PR DESCRIPTION
This uses the Python "coverage" package, and its py.test plugin "pytest-cov".
The setup script was updated to automatically install it in development mode.
The coverage report is part of the stdout when running py.test, e.g. with `make test`.