### PR TITLE
Fixes #71: Two classes ParseError defined

### DIFF
--- a/pywbem/cimxml_parse.py
+++ b/pywbem/cimxml_parse.py
@@ -35,16 +35,17 @@
 from xml.dom import pulldom
 import six
 
-from pywbem import cim_obj
-from pywbem.cim_obj import CIMInstance, CIMInstanceName, CIMQualifier, \
-                           CIMProperty
+from . import cim_obj
+from .cim_obj import CIMInstance, CIMInstanceName, CIMQualifier, \
+                     CIMProperty
+from .tupleparse import ParseError
 
 __all__ = ['ParseError', 'make_parser', 'parse_any']
 
-class ParseError(Exception):
-    """This exception is raised when there is a validation error detected
-    by the parser."""
-    pass
+#class ParseError(Exception):
+#    """This exception is raised when there is a validation error detected
+#    by the parser."""
+#    pass
 
 #
 # Helper functions


### PR DESCRIPTION
Replaced the definition of class `ParseError` in sub-module `cimxml_parse.py` by an import of `ParseError` from `tupleparse`.