### PR TITLE
Fixes #77: Removed unnecessary functions in cim_obj/cim_types from external API

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -51,7 +51,7 @@ from .cim_types import _CIMComparisonMixin, type_from_name, \
         
 __all__ = ['CIMClassName', 'CIMProperty', 'CIMInstanceName', 'CIMInstance',
            'CIMClass', 'CIMMethod', 'CIMParameter', 'CIMQualifier',
-           'CIMQualifierDeclaration', 'tocimxml', 'tocimobj']
+           'CIMQualifierDeclaration']
 
 # pylint: disable=too-many-lines
 class NocaseDict(object):

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -51,7 +51,7 @@ from .cim_types import _CIMComparisonMixin, type_from_name, \
         
 __all__ = ['CIMClassName', 'CIMProperty', 'CIMInstanceName', 'CIMInstance',
            'CIMClass', 'CIMMethod', 'CIMParameter', 'CIMQualifier',
-           'CIMQualifierDeclaration']
+           'CIMQualifierDeclaration', 'tocimxml', 'tocimobj']
 
 # pylint: disable=too-many-lines
 class NocaseDict(object):

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -76,8 +76,7 @@ else:
 
 __all__ = ['MinutesFromUTC', 'CIMType', 'CIMDateTime', 'CIMInt', 'Uint8',
            'Sint8', 'Uint16', 'Sint16', 'Uint32', 'Sint32', 'Uint64', 'Sint64',
-           'CIMFloat', 'Real32', 'Real64', 'cimtype', 'type_from_name',
-           'atomic_to_cim_xml']
+           'CIMFloat', 'Real32', 'Real64']
 
 class _CIMComparisonMixin(object):
     """Mixin class providing default implementations for rich comparison


### PR DESCRIPTION
The following functions have been removed from the external API (i.e. they have been removed from `__all__`):

    pywbem.cim_obj.tocimobj
    pywbem.cim_obj.tocimxml
    pywbem.cim_types.atomic_to_cim_xml
    pywbem.cim_types.cimtype
    pywbem.cim_types.type_from_name

None of them should be needed by normal client code. For example, client code should not have to deal with CIM-XML representations.

Note that most CIM object classes have a `tomof()` method.