### PR TITLE
Fixed pycmp_0.7.0.sh script by installing twisted package.

### DIFF
--- a/tools/pycmp_0.7.0.sh
+++ b/tools/pycmp_0.7.0.sh
@@ -33,6 +33,9 @@ mv $tmpdir/pywbem-${version}/*.py $tmpdir/pywbem/
 rm $tmpdir/pywbem/setup.py   # not part of the package
 rm $tmpdir/pywbem/wbemcli.py # cannot be imported, in 0.7.0
 
+# twisted is needed for pywbem/twisted_client.py
+pip install twisted
+
 $pycmp -e $tmpdir/pywbem pywbem >$reportfile
 
 echo "Success: Generated report: $reportfile"


### PR DESCRIPTION
This should fix the problem that Karl reported in PR #83.
The `pycmp_*.sh` shell script now installs the "twisted" Python package before invoking the `pycmp.py` script.