### PR TITLE
Moved definition of package version into a single place: pywbem/_version.py

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,8 +20,8 @@
 # Name of this Python package
 package_name := pywbem
 
-# Package version as specified in pywbem/__init__.py
-package_specified_version := $(shell sh -c "grep -E '^ *__version__ *= ' pywbem/__init__.py |sed -r 's/__version__ *= *\x27(.*)\x27.*/\1/'")
+# Package version as specified in pywbem/_version.py
+package_specified_version := $(shell sh -c "grep -E '^ *__version__ *= ' pywbem/_version.py |sed -r 's/__version__ *= *\x27(.*)\x27.*/\1/'")
 
 # Normalized package version (as normalized by setup.py during building)
 package_version := $(shell sh -c "echo $(package_specified_version) |sed 's/[.-]\?\(rc[0-9]\+\)$$/\1/' |sed 's/[.]\?dev[0-9]\*$$/\.dev0/'")
@@ -58,6 +58,7 @@ moftab_dependent_files := \
 # Note: Should not include the modules in doc_exclude_patterns
 doc_dependent_files := \
     $(package_name)/__init__.py \
+    $(package_name)/_version.py \
     $(package_name)/cim_obj.py \
     $(package_name)/cim_operations.py \
     $(package_name)/cim_constants.py \

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -194,15 +194,7 @@ from .cim_operations import *
 from .cim_obj import *
 from .tupleparse import *
 from .cim_http import *
-
-# Version of the pywbem package
-# !!! Keep in sync with version stated in module docstring, above !!!
-# !!! Keep in sync with version in ../setup.py !!!
-# Possible formats are:
-#   M.N.Udev   : During development of future M.N.U release
-#   M.N.UrcX   : Release candidate X of future M.N.U release
-#   M.N.U      : The final M.N.U release
-__version__ = '0.9.0.dev0'
+from ._version import __version__
 
 if sys.version_info < (2, 6, 0):
     raise RuntimeError('PyWBEM requires Python 2.6.0 or higher')

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -1,0 +1,28 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+# There are submodules, but clients shouldn't need to know about them.
+# Importing just this module is enough.
+# These are explicitly safe for 'import *'
+
+
+# Version of the pywbem package
+# Possible formats are:
+#   M.N.U.dev0  : During development of future M.N.U release
+#   M.N.U.rcX   : Release candidate X of future M.N.U release
+#   M.N.U       : The final M.N.U release
+__version__ = '0.9.0.dev0'
+

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,15 @@ if sys.version_info[0:2] == (2, 6):
 import os_setup
 from os_setup import shell, shell_check, import_setuptools
 
-# Package version - Keep in sync with pywbem/__init__.py!
-_version = '0.9.0.dev0'  # pylint: disable=invalid-name
+
+def package_version(filename, varname):
+    """Return package version string by reading `filename` and retrieving its
+       module-global variable `varnam`."""
+    _locals = {}
+    with open(filename) as fp:
+        exec(fp.read(), None, _locals)
+    return _locals[varname]
+
 
 def install_swig(installer, dry_run, verbose):
     """Custom installer function for `os_setup` module.
@@ -312,6 +319,8 @@ def main():
     py_version_m_n = "%s.%s" % (sys.version_info[0], sys.version_info[1])
     py_version_m = "%s" % sys.version_info[0]
 
+    pkg_version = package_version("pywbem/_version.py", "__version__")
+
     args = {
         'name': 'pywbem',
         'author': 'Tim Potter',
@@ -322,7 +331,7 @@ def main():
         'long_description': __doc__,
         'platforms': ['any'],
         'url': 'http://pywbem.github.io/pywbem/',
-        'version': _version,
+        'version': pkg_version,
         'license': 'LGPL version 2.1, or (at your option) any later version',
         'distclass': os_setup.OsDistribution,
         'cmdclass': {


### PR DESCRIPTION
This reduces the two definitions to one, in order to simplify the version definition (for this git repo; the pywbem.github.io repo will be dealt with separately).

The new place is a new file `pywbem/_version.py`, which gets:
- imported into by `pywbem/__init__.py` for pywbem users (a new import).
- read as Python code without importing by `setup.py` (new code in setup.py).

Already existing usages of the version, just to be complete:
- grepped for `__version__` by makefile, and then used in various ways, e.g. for distribution directory and file name (that existed before, and was just adjusted to use the new file).
- used by the Epydoc-built documentation (that existed before and did not needed to be adjusted).

