### PR TITLE
Resolved Epydoc warnings and improved docstrings.

### DIFF
--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -66,7 +66,8 @@ of this package.
 
 The Epydoc documentation tool that is used to produce these web pages does
 not list all symbols that are folded into the package namespace, unfortunately
-(as you can see, it lists only the variables, not including `__version__`).
+(as you can see, it lists only the variables, not including
+`pywbem.__version__`).
 It does however honor the ``__all__`` variable defining the exported symbols
 in each sub-module, and shows only those exported symbols in the documentation
 that is generated for the sub-modules. In other words, the symbols that

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -88,7 +88,9 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
     statement).
 
     Usage:
+
       ::
+
         with HTTPTimeout(timeout, http_conn):
             ... operations using http_conn ...
 
@@ -330,10 +332,9 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
       The CIM-XML formatted response data from the WBEM server, as a `unicode`
       object.
 
-    :Raises:
-      :raise AuthError:
-      :raise ConnectionError:
-      :raise TimeoutError:
+    :Raises AuthError:
+    :Raises ConnectionError:
+    :Raises TimeoutError:
     """
 
     class HTTPBaseConnection:        # pylint: disable=no-init

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2710,16 +2710,16 @@ def tocimxml(value):
                      (value, builtin_type(value)))
 
 #pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
-def tocimobj(type_name, value):
+def tocimobj(type_, value):
     """Return a CIM object representing the value and
     type.
 
     :Parameters:
 
-      type_name : string
+      type_ : string
         The CIM type name for the CIM object. See `cim_types` for a table with
         valid CIM type names and their corresponding Python types.
-        If the value is a list, type_name must specify the CIM type name of
+        If the value is a list, type_ must specify the CIM type name of
         an item in the list.
 
       value : see description
@@ -2734,20 +2734,20 @@ def tocimobj(type_name, value):
     :Raises ValueError: The value is not suitable for the type name.
     """
 
-    if value is None or type_name is None:
+    if value is None or type_ is None:
         return None
 
-    if type_name != 'string' and isinstance(value, six.string_types) and not value:
+    if type_ != 'string' and isinstance(value, six.string_types) and not value:
         return None
 
     # Lists of values
 
     if isinstance(value, list):
-        return [tocimobj(type_name, x) for x in value]
+        return [tocimobj(type_, x) for x in value]
 
     # Boolean type
 
-    if type_name == 'boolean':
+    if type_ == 'boolean':
         if isinstance(value, bool):
             return value
         elif isinstance(value, six.string_types):
@@ -2759,51 +2759,51 @@ def tocimobj(type_name, value):
 
     # String type
 
-    if type_name == 'string':
+    if type_ == 'string':
         return value
 
     # Integer types
 
-    if type_name == 'uint8':
+    if type_ == 'uint8':
         return Uint8(value)
 
-    if type_name == 'sint8':
+    if type_ == 'sint8':
         return Sint8(value)
 
-    if type_name == 'uint16':
+    if type_ == 'uint16':
         return Uint16(value)
 
-    if type_name == 'sint16':
+    if type_ == 'sint16':
         return Sint16(value)
 
-    if type_name == 'uint32':
+    if type_ == 'uint32':
         return Uint32(value)
 
-    if type_name == 'sint32':
+    if type_ == 'sint32':
         return Sint32(value)
 
-    if type_name == 'uint64':
+    if type_ == 'uint64':
         return Uint64(value)
 
-    if type_name == 'sint64':
+    if type_ == 'sint64':
         return Sint64(value)
 
     # Real types
 
-    if type_name == 'real32':
+    if type_ == 'real32':
         return Real32(value)
 
-    if type_name == 'real64':
+    if type_ == 'real64':
         return Real64(value)
 
     # Char16
 
-    if type_name == 'char16':
+    if type_ == 'char16':
         raise ValueError('CIMType char16 not handled')
 
     # Datetime
 
-    if type_name == 'datetime':
+    if type_ == 'datetime':
         return CIMDateTime(value)
 
     # REF
@@ -2824,7 +2824,7 @@ def tocimobj(type_name, value):
                 return (str_arg, '', '')
             return (str_arg[:idx], seq, str_arg[idx+len(seq):])
 
-    if type_name == 'reference': # pylint: disable=too-many-nested-blocks
+    if type_ == 'reference': # pylint: disable=too-many-nested-blocks
         # pylint: disable=too-many-return-statements,too-many-branches
         # TODO doesn't handle double-quoting, as in refs to refs.  Example:
         # r'ex_composedof.composer="ex_sampleClass.label1=9921,' +
@@ -2892,7 +2892,7 @@ def tocimobj(type_name, value):
         else:
             raise ValueError('Invalid reference value: "%s"' % value)
 
-    raise ValueError('Invalid CIM type name: "%s"' % type_name)
+    raise ValueError('Invalid CIM type name: "%s"' % type_)
 
 
 def byname(nlist):

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -295,7 +295,8 @@ class NocaseDict(object):
     # Other stuff
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `NocaseDict` object that is
+        suitable for debugging."""
 
         items = ', '.join([('%r: %r' % (key, value))
                            for key, value in sorted(self.iteritems())])
@@ -661,13 +662,12 @@ class CIMClassName(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
     def __init__(self, classname, host=None, namespace=None):
-        """
-        Initialize the `CIMClassName` object.
+        """Initialize the `CIMClassName` object.
 
         :Parameters:
 
@@ -690,9 +690,8 @@ class CIMClassName(_CIMComparisonMixin):
 
             Default: `None`.
 
-        :Raises:
-          :raise TypeError:
-          :raise ValueError:
+        :Raises TypeError:
+        :Raises ValueError:
         """
 
         # Make sure we process Unicode strings
@@ -714,7 +713,7 @@ class CIMClassName(_CIMComparisonMixin):
         self.namespace = namespace
 
     def copy(self):
-        """Return a copy the CIMClassName object"""
+        """Return a copy the `CIMClassName` object"""
 
         return CIMClassName(self.classname, host=self.host,
                             namespace=self.namespace)
@@ -741,7 +740,8 @@ class CIMClassName(_CIMComparisonMixin):
                 cmpname(self.classname, other.classname))
 
     def __str__(self):
-        """Return the WBEM URI representation of the CIM class path."""
+        """Return the WBEM URI of the CIM class path represented by the
+        `CIMClassName` object."""
 
         ret_str = ''
 
@@ -756,7 +756,8 @@ class CIMClassName(_CIMComparisonMixin):
         return ret_str
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMClassName` object that is
+        suitable for debugging."""
 
         return '%s(classname=%r, namespace=%r, ' \
                'host=%r)' % \
@@ -764,9 +765,10 @@ class CIMClassName(_CIMComparisonMixin):
                 self.host)
 
     def tocimxml(self):
-        """
-        Convert the CIMClassName object to CIM/XML consistent with
-        DMTF DSP-0200 format and return the resulting XML
+        """Return the CIM-XML representation of the `CIMClassName` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
 
         classname = cim_xml.CLASSNAME(self.classname)
@@ -825,10 +827,9 @@ class CIMProperty(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
-
 
     # pylint: disable=too-many-statements
     def __init__(self, name, value, type=None,
@@ -852,14 +853,14 @@ class CIMProperty(_CIMComparisonMixin):
           name : Unicode string or UTF-8 encoded byte string
             Name of the property. Must not be `None`.
 
-          value
+          value :
             Value of the property (interpreted as actual value when the
             property object is used in an instance, and as default value when
             it is used in a class).
             For valid types for CIM values, see `cim_types`.
 
           type : Unicode string or UTF-8 encoded byte string
-            Name of the CIM type of the property (e.g. `'uint8'`).
+            Name of the CIM type of the property (e.g. ``uint8``).
             `None` means that the argument is unspecified, causing the
             corresponding instance variable to be inferred. An exception is
             raised if it cannot be inferred.
@@ -870,18 +871,18 @@ class CIMProperty(_CIMComparisonMixin):
             the class hierarchy of the class owning the property).
             `None` means that class origin information is not available.
 
-          array_size : `int`
+          array_size : int
             The size of the array property, for fixed-size arrays.
             `None` means that the array property has variable size.
 
           propagated : Unicode string or UTF-8 encoded byte string
             The CIM *propagated* attribute of the property (the effective value
-            of the `Propagated` qualifier of the property, which is a string
+            of the ``Propagated`` qualifier of the property, which is a string
             that specifies the name of the source property from which the
             property value should be propagated).
             `None` means that propagation information is not available.
 
-          is_array : `bool`
+          is_array : bool
             A boolean indicating whether the property is an array (`True`) or a
             scalar (`False`).
             `None` means that the argument is unspecified, causing the
@@ -906,16 +907,17 @@ class CIMProperty(_CIMComparisonMixin):
             A string value indicating the kind of
             embedded object represented by the property value. The following
             values are defined for this argument:
-            `'instance'`: The property is declared with the
-            `EmbeddedInstance` qualifier, indicating that the property
-            value is an embedded instance of a known class name (or Null).
-            `'object'`: The property is declared with the
-            `EmbeddedObject` qualifier, indicating that the property
-            value is an embedded object (instance or class) of which the
-            class name is not known (or Null).
-            `None` means that the argument is unspecified, causing the
-            corresponding instance variable to be inferred. An exception is
-            raised if it cannot be inferred.
+
+            * ``"instance"``: The property is declared with the
+              ``EmbeddedInstance`` qualifier, indicating that the property
+              value is an embedded instance of a known class name (or Null).
+            * ``"object"``: The property is declared with the
+              ``EmbeddedObject`` qualifier, indicating that the property
+              value is an embedded object (instance or class) of which the
+              class name is not known (or Null).
+            * `None`: The argument is unspecified, causing the
+              corresponding instance variable to be inferred. An exception is
+              raised if it cannot be inferred.
 
         Examples:
 
@@ -931,8 +933,7 @@ class CIMProperty(_CIMComparisonMixin):
             -> a reference property
           * `CIMProperty("MyEmbObj", CIMClass(...))`
             -> an embedded object property containing a class
-          * `CIMProperty("MyEmbObj", CIMInstance(...),
-            embedded_object='object')`
+          * `CIMProperty("MyEmbObj",CIMInstance(...),embedded_object="object")`
             -> an embedded object property containing an instance
           * `CIMProperty("MyEmbInst", CIMInstance(...))`
             -> an embedded instance property
@@ -942,14 +943,13 @@ class CIMProperty(_CIMComparisonMixin):
             -> a uint8 property that is Null
           * `CIMProperty("MyRef", None, reference_class="MyClass")`
             -> a reference property that is Null
-          * `CIMProperty("MyEmbObj", None, embedded_object='object')`
+          * `CIMProperty("MyEmbObj", None, embedded_object="object")`
             -> an embedded object property that is Null
-          * `CIMProperty("MyEmbInst", None, embedded_object='instance')`
+          * `CIMProperty("MyEmbInst", None, embedded_object="instance")`
             -> an embedded instance property that is Null
 
-        :Raises:
-          :raise TypeError:
-          :raise ValueError:
+        :Raises TypeError:
+        :Raises ValueError:
         """
 
         type_ = type  # Minimize usage of the builtin 'type'
@@ -1161,7 +1161,7 @@ class CIMProperty(_CIMComparisonMixin):
         self.embedded_object = embedded_object
 
     def copy(self):
-        """ Return a copy of the CIMProperty object"""
+        """ Return a copy of the `CIMProperty` object"""
 
         return CIMProperty(self.name,
                            self.value,
@@ -1174,7 +1174,8 @@ class CIMProperty(_CIMComparisonMixin):
                            qualifiers=self.qualifiers.copy())
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMProperty` object
+        for human consumption."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'reference_class=%r, embedded_object=%r, ' \
@@ -1184,7 +1185,8 @@ class CIMProperty(_CIMComparisonMixin):
                 self.is_array)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMProperty` object
+        that is suitable for debugging."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'reference_class=%r, embedded_object=%r, ' \
@@ -1198,8 +1200,10 @@ class CIMProperty(_CIMComparisonMixin):
                 self.qualifiers)
 
     def tocimxml(self):
-        """ Return the string with CIM/XML form of the CIMProperty object using
-            the representation defined in DSP0200
+        """Return the CIM-XML representation of the `CIMProperty` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
 
         if self.is_array:
@@ -1298,7 +1302,7 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
@@ -1340,9 +1344,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
             Default: `None`.
 
-        :Raises:
-          :raise TypeError:
-          :raise ValueError:
+        :Raises TypeError:
+        :Raises ValueError:
         """
 
         # Make sure we process Unicode strings
@@ -1359,7 +1362,9 @@ class CIMInstanceName(_CIMComparisonMixin):
         self.namespace = namespace
 
     def copy(self):
-        """ Return a copy of the CIMInstanceName object """
+        """
+        Return a copy of the `CIMInstanceName` object.
+        """
 
         result = CIMInstanceName(self.classname)
         result.keybindings = self.keybindings.copy()
@@ -1392,7 +1397,8 @@ class CIMInstanceName(_CIMComparisonMixin):
                 cmpitem(self.keybindings, other.keybindings))
 
     def __str__(self):
-        """Return the WBEM URI representation of the CIM instance path."""
+        """Return the WBEM URI of the CIM instance path represented by the
+        `CIMInstanceName` object."""
 
         ret_str = ''
 
@@ -1421,7 +1427,8 @@ class CIMInstanceName(_CIMComparisonMixin):
         return ret_str[:-1]
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMInstanceName` object
+        that is suitable for debugging."""
 
         return '%s(classname=%r, keybindings=%r, ' \
                'namespace=%r, host=%r)' % \
@@ -1483,8 +1490,11 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     # pylint: disable=too-many-branches
     def tocimxml(self):
-        """Generate a CIM-XML representation of the instance name (class name
-        and key bindings)."""
+        """Return the CIM-XML representation of the `CIMInstanceName` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
+        """
 
         if isinstance(self.keybindings, str):
 
@@ -1597,7 +1607,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
@@ -1640,9 +1650,8 @@ class CIMInstance(_CIMComparisonMixin):
             Optional: List of property names for use by some operations on this
             object.
 
-        :Raises:
-          :raise TypeError:
-          :raise ValueError:
+        :Raises TypeError:
+        :Raises ValueError:
         """
 
         self.classname = _ensure_unicode(classname)
@@ -1713,7 +1722,7 @@ class CIMInstance(_CIMComparisonMixin):
             prop.value = tocimobj(prop.type, value)
 
     def copy(self):
-        """ Return copy of the CIMInstance object"""
+        """Return copy of the `CIMInstance` object."""
 
         result = CIMInstance(self.classname)
         result.properties = self.properties.copy()
@@ -1746,13 +1755,15 @@ class CIMInstance(_CIMComparisonMixin):
                 cmpitem(self.qualifiers, other.qualifiers))
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMInstance` object
+        for human consumption."""
 
         return '%s(classname=%r, path=%r, ...)' % \
                (self.__class__.__name__, self.classname, self.path)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMInstance` object
+        that is suitable for debugging."""
 
         return '%s(classname=%r, path=%r, ' \
                'properties=%r, property_list=%r' \
@@ -1846,7 +1857,10 @@ class CIMInstance(_CIMComparisonMixin):
         return default if prop is None else prop.value
 
     def tocimxml(self):
-        """ Return string with CIM/XML representing this CIMInstance.
+        """Return the CIM-XML representation of the `CIMInstance` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
 
         props = []
@@ -1881,7 +1895,7 @@ class CIMInstance(_CIMComparisonMixin):
             """ Return a string representing the MOF definition of
                 a single property defined by the type and value
                 arguments.
-                :param type_:  CIMType of the property
+                :param type_: `CIMType` of the property
                 :param value: value corresponsing to this type
             """
             if value is None:
@@ -1919,13 +1933,12 @@ class CIMInstance(_CIMComparisonMixin):
 
 
 class CIMClass(_CIMComparisonMixin):
-    """
-    Create an instance of CIMClass, a CIM class with classname,
+    """Create an instance of CIMClass, a CIM class with classname,
     properties, methods, qualifiers, and superclass name.
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
@@ -1936,7 +1949,7 @@ class CIMClass(_CIMComparisonMixin):
         Initialize the `CIMClass` object.
 
         Initialize instance variables containing the arguments provided
-        for the CIMClass including classname, properties, class
+        for the `CIMClass` including classname, properties, class
         qualifiers, methods, and the superclass
         """
         self.classname = _ensure_unicode(classname)
@@ -1946,7 +1959,7 @@ class CIMClass(_CIMComparisonMixin):
         self.qualifiers = NocaseDict(qualifiers)
 
     def copy(self):
-        """ Return a copy of the CIMClass object"""
+        """ Return a copy of the `CIMClass` object"""
         result = CIMClass(self.classname)
         result.properties = self.properties.copy()
         result.methods = self.methods.copy()
@@ -1956,13 +1969,15 @@ class CIMClass(_CIMComparisonMixin):
         return result
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMClass` object
+        for human consumption."""
 
         return '%s(classname=%r, ...)' % \
                (self.__class__.__name__, self.classname)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMClass` object
+        that is suitable for debugging."""
 
         return '%s(classname=%r, superclass=%r, ' \
                'properties=%r, methods=%r, qualifiers=%r)' % \
@@ -1995,7 +2010,11 @@ class CIMClass(_CIMComparisonMixin):
                 cmpitem(self.methods, other.methods))
 
     def tocimxml(self):
-        """ Return string with CIM/XML representation of the CIMClass"""
+        """Return the CIM-XML representation of the `CIMClass` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
+        """
 
         return cim_xml.CLASS(
             self.classname,
@@ -2049,7 +2068,7 @@ class CIMMethod(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
@@ -2069,7 +2088,7 @@ class CIMMethod(_CIMComparisonMixin):
         self.qualifiers = NocaseDict(qualifiers)
 
     def copy(self):
-        """ Return copy of the CIMMethod object"""
+        """ Return copy of the `CIMMethod` object"""
 
         result = CIMMethod(self.name,
                            return_type=self.return_type,
@@ -2082,8 +2101,10 @@ class CIMMethod(_CIMComparisonMixin):
         return result
 
     def tocimxml(self):
-        """ Return string containing CIM/XML representation of CIMMethod
-            object
+        """Return the CIM-XML representation of the `CIMMethod` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
 
         return cim_xml.METHOD(
@@ -2095,13 +2116,15 @@ class CIMMethod(_CIMComparisonMixin):
             qualifiers=[q.tocimxml() for q in self.qualifiers.values()])
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMMethod` object
+        for human consumption."""
 
         return '%s(name=%r, return_type=%r, ...)' % \
                (self.__class__.__name__, self.name, self.return_type)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMMethod` object
+        that is suitable for debugging."""
 
         return '%s(name=%r, return_type=%r, ' \
                'class_origin=%r, propagated=%r, ' \
@@ -2136,7 +2159,7 @@ class CIMMethod(_CIMComparisonMixin):
                 cmpitem(self.propagated, other.propagated))
 
     def tomof(self):
-        """ Return string MOF representation of the CIMMethod object"""
+        """ Return string MOF representation of the `CIMMethod` object"""
         ret_str = ''
 
         ret_str += '      %s\n' % (_makequalifiers(self.qualifiers, 7))
@@ -2159,9 +2182,10 @@ class CIMParameter(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
+
     # pylint: disable=too-many-arguments
     def __init__(self, name, type, reference_class=None, is_array=None,
                  array_size=None, qualifiers=None, value=None):
@@ -2183,7 +2207,7 @@ class CIMParameter(_CIMComparisonMixin):
         self.value = _ensure_unicode(value)
 
     def copy(self):
-        """ return copy of the CIMParameter object"""
+        """ return copy of the `CIMParameter` object"""
         result = CIMParameter(self.name,
                               self.type,
                               reference_class=self.reference_class,
@@ -2196,7 +2220,8 @@ class CIMParameter(_CIMComparisonMixin):
         return result
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMParameter` object
+        for human consumption."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'reference_class=%r, ' \
@@ -2206,7 +2231,8 @@ class CIMParameter(_CIMComparisonMixin):
                 self.is_array)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMParameter` object
+        that is suitable for debugging."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'reference_class=%r, ' \
@@ -2244,8 +2270,10 @@ class CIMParameter(_CIMComparisonMixin):
                 cmpitem(self.value, other.value))
 
     def tocimxml(self):
-        """ Return String containing CIM/XML representation of
-            the CIMParameter
+        """Return the CIM-XML representation of the `CIMParameter` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
 
         if self.type == 'reference':
@@ -2315,9 +2343,10 @@ class CIMQualifier(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
+
     #pylint: disable=too-many-arguments
     def __init__(self, name, value, type=None, propagated=None,
                  overridable=None, tosubclass=None, toinstance=None,
@@ -2379,7 +2408,7 @@ class CIMQualifier(_CIMComparisonMixin):
         self.value = value
 
     def copy(self):
-        """ Return copy of CIMQualifier object"""
+        """ Return copy of `CIMQualifier` object"""
 
         return CIMQualifier(self.name,
                             self.value,
@@ -2391,13 +2420,15 @@ class CIMQualifier(_CIMComparisonMixin):
                             translatable=self.translatable)
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the `CIMQualifier` object
+        for human consumption."""
 
         return "%s(name=%r, value=%r, type=%r, ...)" % \
                (self.__class__.__name__, self.name, self.value, self.type)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMQualifier` object
+        that is suitable for debugging."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'tosubclass=%r, overridable=%r, translatable=%r, ' \
@@ -2434,7 +2465,12 @@ class CIMQualifier(_CIMComparisonMixin):
                 cmpitem(self.translatable, other.translatable))
 
     def tocimxml(self):
-        """ Return CIM/XML string representing CIMQualifier"""
+        """Return the CIM-XML representation of the `CIMQualifier` object,
+        as an object of an appropriate subclass of `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
+        """
+
         value = None
 
         if isinstance(self.value, list):
@@ -2454,7 +2490,7 @@ class CIMQualifier(_CIMComparisonMixin):
                                  translatable=self.translatable)
 
     def tomof(self, indent=7):
-        """ Return string representing CIMQualifier in MOF format"""
+        """ Return string representing `CIMQualifier` in MOF format"""
 
         def valstr(value):
             """ Return string representing value argument."""
@@ -2477,7 +2513,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
     """
 
@@ -2523,7 +2559,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
                                        translatable=self.translatable)
 
     def __str__(self):
-        """Return a short string representation for human consumption."""
+        """Return a short string representation of the
+        `CIMQualifierDeclaration` object for human consumption."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'is_array=%r, ...)' % \
@@ -2531,7 +2568,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
                 self.is_array)
 
     def __repr__(self):
-        """Return a string representation suitable for debugging."""
+        """Return a string representation of the `CIMQualifierDeclaration`
+        object that is suitable for debugging."""
 
         return '%s(name=%r, value=%r, type=%r, ' \
                'is_array=%r, array_size=%r, ' \
@@ -2543,8 +2581,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
                 self.translatable, self.toinstance)
 
     def _cmp(self, other):
-        """
-        Comparator function for two `CIMQualifierDeclaration` objects.
+        """Comparator function for two `CIMQualifierDeclaration` objects.
 
         The comparison is based on the `name`, `type`, `value`, `is_array`,
         `array_size`, `scopes`, `overridable`, `tosubclass`, `toinstance`,
@@ -2552,8 +2589,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
         The `name` attribute is compared case-insensitively.
 
-        Raises `TypeError', if the `other` object is not a
-        `CIMQualifierDeclaration` object.
+        :Raises TypeError: `other` is not a `CIMQualifierDeclaration` object.
         """
         if self is other:
             return 0
@@ -2572,10 +2608,13 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
                 cmpitem(self.translatable, other.translatable))
 
     def tocimxml(self):
+        """Return the CIM-XML representation of the `CIMQualifierDeclaration`
+        object, as an object of an appropriate subclass of
+        `xml.dom.minidom.Element`.
+
+        The returned CIM-XML representation is consistent with DMTF DSP0201.
         """
-        Return string with CIM/XML representation of CIMQualifierDeclaration
-        based on DMTF DSP0200 representation
-        """
+
         return cim_xml.QUALIFIER_DECLARATION(self.name,
                                              self.type,
                                              self.value,
@@ -2624,8 +2663,21 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         return mof
 
 def tocimxml(value):
-    """Convert an arbitrary object to CIM xml.  Works with cim_obj
-    objects and builtin types."""
+    """Return the CIM-XML representation of the value, consistent with
+    DMTF DSP0201.
+
+    :Parameters:
+
+      value : see description
+        The value to be converted to CIM-XML. Must be a either a CIM
+        object (see `cim_obj` module) or a CIM typed value (see `cim_types`
+        module).
+
+    :Returns:
+
+      CIM-XML representation of the value, as an object of an appropriate
+      subclass of `xml.dom.minidom.Element`.
+    """
 
     # Python cim_obj object
 
@@ -2658,28 +2710,44 @@ def tocimxml(value):
                      (value, builtin_type(value)))
 
 #pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
-def tocimobj(type_, value):
-    """Convert a CIM type and a string value into an appropriate
-       CIM builtin type.
-       :return: value converted from value argument using type
-       argument.
-       :exception: ValueError if type and value string do not match
+def tocimobj(type_name, value):
+    """Return a CIM object representing the value and
+    type.
+
+    :Parameters:
+
+      type_name : string
+        The CIM type name for the CIM object. See `cim_types` for a table with
+        valid CIM type names and their corresponding Python types.
+        If the value is a list, type_name must specify the CIM type name of
+        an item in the list.
+
+      value : see description
+        The value to be represented as a CIM object. Its Python type must be
+        valid for the specified type parameter.
+
+    :Returns:
+
+      CIM object representing the value and type, as an object of an appropriate
+      Python object as defined in `cim_types`.
+
+    :Raises ValueError: The value is not suitable for the type name.
     """
 
-    if value is None or type_ is None:
+    if value is None or type_name is None:
         return None
 
-    if type_ != 'string' and isinstance(value, six.string_types) and not value:
+    if type_name != 'string' and isinstance(value, six.string_types) and not value:
         return None
 
     # Lists of values
 
     if isinstance(value, list):
-        return [tocimobj(type_, x) for x in value]
+        return [tocimobj(type_name, x) for x in value]
 
     # Boolean type
 
-    if type_ == 'boolean':
+    if type_name == 'boolean':
         if isinstance(value, bool):
             return value
         elif isinstance(value, six.string_types):
@@ -2691,51 +2759,51 @@ def tocimobj(type_, value):
 
     # String type
 
-    if type_ == 'string':
+    if type_name == 'string':
         return value
 
     # Integer types
 
-    if type_ == 'uint8':
+    if type_name == 'uint8':
         return Uint8(value)
 
-    if type_ == 'sint8':
+    if type_name == 'sint8':
         return Sint8(value)
 
-    if type_ == 'uint16':
+    if type_name == 'uint16':
         return Uint16(value)
 
-    if type_ == 'sint16':
+    if type_name == 'sint16':
         return Sint16(value)
 
-    if type_ == 'uint32':
+    if type_name == 'uint32':
         return Uint32(value)
 
-    if type_ == 'sint32':
+    if type_name == 'sint32':
         return Sint32(value)
 
-    if type_ == 'uint64':
+    if type_name == 'uint64':
         return Uint64(value)
 
-    if type_ == 'sint64':
+    if type_name == 'sint64':
         return Sint64(value)
 
     # Real types
 
-    if type_ == 'real32':
+    if type_name == 'real32':
         return Real32(value)
 
-    if type_ == 'real64':
+    if type_name == 'real64':
         return Real64(value)
 
     # Char16
 
-    if type_ == 'char16':
+    if type_name == 'char16':
         raise ValueError('CIMType char16 not handled')
 
     # Datetime
 
-    if type_ == 'datetime':
+    if type_name == 'datetime':
         return CIMDateTime(value)
 
     # REF
@@ -2756,7 +2824,7 @@ def tocimobj(type_, value):
                 return (str_arg, '', '')
             return (str_arg[:idx], seq, str_arg[idx+len(seq):])
 
-    if type_ == 'reference': # pylint: disable=too-many-nested-blocks
+    if type_name == 'reference': # pylint: disable=too-many-nested-blocks
         # pylint: disable=too-many-return-statements,too-many-branches
         # TODO doesn't handle double-quoting, as in refs to refs.  Example:
         # r'ex_composedof.composer="ex_sampleClass.label1=9921,' +
@@ -2824,7 +2892,7 @@ def tocimobj(type_, value):
         else:
             raise ValueError('Invalid reference value: "%s"' % value)
 
-    raise ValueError('Invalid CIM type: "%s"' % type_)
+    raise ValueError('Invalid CIM type name: "%s"' % type_name)
 
 
 def byname(nlist):

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -103,9 +103,9 @@ def check_utf8_xml_chars(utf8_xml, meaning):
 
     :Exceptions:
 
-      `TypeError`, if invoked with incorrect Python object type for `utf8_xml`.
+      `TypeError` : Invoked with incorrect Python object type for `utf8_xml`.
 
-      `pywbem.ParseError`, if `utf8_xml` contains Bytes that are invalid UTF-8
+      `pywbem.ParseError` : `utf8_xml` contains Bytes that are invalid UTF-8
       sequences (incorrectly encoded or ill-formed) or invalid XML characters.
 
     Notes on Unicode support in Python:
@@ -162,10 +162,10 @@ def check_utf8_xml_chars(utf8_xml, meaning):
 
     (1) The legal XML characters are defined in W3C XML 1.0 (Fith Edition):
 
-        ::
+          ::
 
-          Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] |
-                   [#x10000-#x10FFFF]
+            Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] |
+                     [#x10000-#x10FFFF]
 
         These are the code points of Unicode characters using a non-surrogate
         representation.
@@ -334,7 +334,7 @@ class WBEMConnection(object):
 
     :Ivariables:
 
-      ...
+      ... : ...
         All parameters of `__init__` are set as instance variables.
 
       debug : `bool`
@@ -520,9 +520,9 @@ class WBEMConnection(object):
 
     def __repr__(self):
         """
-        Return a representation of the connection object with all instance
-        variables (except for the password in the credentials), suitable for
-        debugging.
+        Return a representation of the `WBEMConnection` object with all
+        instance variables (except for the password in the credentials)
+        that is suitable for debugging.
         """
 
         if isinstance(self.creds, tuple):
@@ -1690,6 +1690,7 @@ class WBEMConnection(object):
 
         :Exceptions:
 
+          ... : ...
             See the list of exceptions described in `WBEMConnection`.
         """
 
@@ -2380,13 +2381,20 @@ class WBEMConnection(object):
 def is_subclass(ch, ns, super_class, sub):
     """Determine if one class is a subclass of another class.
 
-    Keyword Arguments:
-    ch -- A CIMOMHandle.  Either a pycimmb.CIMOMHandle or a
-        pywbem.WBEMConnection.
-    ns -- Namespace.
-    super-class -- A string containing the super class name.
-    sub -- The subclass.  This can either be a string or a pywbem.CIMClass.
+    :Parameters:
 
+      ch : ...
+        A CIMOMHandle.  Either a pycimmb.CIMOMHandle or a
+        pywbem.WBEMConnection.
+
+      ns : string
+        Namespace.
+
+      super_class : string
+        Super class name.
+
+      sub : ...
+        The subclass.  This can either be a string or a pywbem.CIMClass.
     """
 
     lsuper = super_class.lower()

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -220,6 +220,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
 
           dtarg
             The input object, as one of the following types:
+
             * A Unicode string or UTF-8 encoded byte string will be interpreted
               as CIM datetime format (see DSP0004) and will result in a point
               in time or a time interval.
@@ -228,9 +229,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
             * A `datetime.timedelta` object will result in a time interval.
             * Another `CIMDateTime` object will be copied.
 
-        :Raises:
-          :raise ValueError:
-          :raise TypeError:
+        :Raises ValueError:
+        :Raises TypeError:
         """
         from .cim_obj import _ensure_unicode # defer due to cyclic deps.
         self.cimtype = 'datetime'
@@ -355,8 +355,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         The optional timezone information is used to convert the CIM datetime
         value into the desired timezone. That does not change the point in time
         that is represented by the value, but it changes the value of the
-        `hhmmss` components of the CIM datetime value to compensate for changes
-        in the timezone offset component.
+        ``hhmmss`` components of the CIM datetime value to compensate for
+        changes in the timezone offset component.
 
         :Parameters:
 
@@ -387,8 +387,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         The optional timezone information is used to convert the CIM datetime
         value into the desired timezone. That does not change the point in time
         that is represented by the value, but it changes the value of the
-        `hhmmss` components of the CIM datetime value to compensate for changes
-        in the timezone offset component.
+        ``hhmmss`` components of the CIM datetime value to compensate for
+        changes in the timezone offset component.
 
         :Parameters:
 
@@ -522,13 +522,8 @@ def cimtype(obj):
 
         The CIM type name of the value, as a string.
 
-    :Raises:
-
-        :raise TypeError:
-            Type is not a CIM type.
-
-        :raise ValueError:
-            Cannot determine CIM type from empty array.
+    :Raises TypeError: Type is not a CIM type.
+    :Raises ValueError: Cannot determine CIM type from empty array.
     """
     if isinstance(obj, CIMType):
         return obj.cimtype
@@ -584,10 +579,7 @@ def type_from_name(type_name):
         The Python type object for the CIM type (e.g. `Uint8` or
         `CIMInstanceName`).
 
-    :Raises:
-
-      :raise ValueError:
-        Unknown CIM type name.
+    :Raises ValueError: Unknown CIM type name.
     """
     if type_name == 'reference':
         # move import to run time to avoid circular imports

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -204,10 +204,12 @@ class CIM(CIMElement):
     mapping), or it contains a DECLARATION element used to declare a
     set of CIM objects.
 
-    <!ELEMENT CIM (MESSAGE | DECLARATION)>
-    <!ATTLIST CIM
-        CIMVERSION CDATA #REQUIRED
-        DTDVERSION CDATA #REQUIRED>
+      ::
+
+        <!ELEMENT CIM (MESSAGE | DECLARATION)>
+        <!ATTLIST CIM
+            CIMVERSION CDATA #REQUIRED
+            DTDVERSION CDATA #REQUIRED>
     """
 
     def __init__(self, data, cim_version, dtd_version):
@@ -224,8 +226,10 @@ class DECLARATION(CIMElement):
     of CIM objects.  These are partitioned into logical declaration
     subsets.
 
-    <!ELEMENT DECLARATION (DECLGROUP | DECLGROUP.WITHNAME |
-                           DECLGROUP.WITHPATH)+>
+      ::
+
+        <!ELEMENT DECLARATION (DECLGROUP | DECLGROUP.WITHNAME |
+                               DECLGROUP.WITHPATH)+>
     """
 
     def __init__(self, data):
@@ -240,8 +244,10 @@ class DECLGROUP(CIMElement):
     defines the common namespace in which all objects within the group
     are declared.
 
-    <!ELEMENT DECLGROUP ((LOCALNAMESPACEPATH | NAMESPACEPATH)?,
-                         QUALIFIER.DECLARATION*, VALUE.OBJECT*)>
+      ::
+
+        <!ELEMENT DECLGROUP ((LOCALNAMESPACEPATH | NAMESPACEPATH)?,
+                             QUALIFIER.DECLARATION*, VALUE.OBJECT*)>
     """
 
     def __init__(self, data):
@@ -257,7 +263,9 @@ class DECLGROUP_WITHNAME(CIMElement):
     defines the common namespace in which all objects within the group
     are declared.
 
-    <!ELEMENT DECLGROUP.WITHNAME ((LOCALNAMESPACEPATH | NAMESPACEPATH)?,
+      ::
+
+        <!ELEMENT DECLGROUP.WITHNAME ((LOCALNAMESPACEPATH | NAMESPACEPATH)?,
                                    QUALIFIER.DECLARATION*, VALUE.NAMEDOBJECT*)>
     """
 
@@ -272,8 +280,10 @@ class DECLGROUP_WITHPATH(CIMElement):
     and Instance declarations.  Each object is declared with its own
     independent naming and location information.
 
-    <!ELEMENT DECLGROUP.WITHPATH  (VALUE.OBJECTWITHPATH |
-                                   VALUE.OBJECTWITHLOCALPATH)*>
+      ::
+
+        <!ELEMENT DECLGROUP.WITHPATH (VALUE.OBJECTWITHPATH |
+                                      VALUE.OBJECTWITHLOCALPATH)*>
     """
 
     def __init__(self, data):
@@ -286,13 +296,15 @@ class QUALIFIER_DECLARATION(CIMElement):
     The QUALIFIER.DECLARATION element defines a single CIM Qualifier
     declaration.
 
-    <!ELEMENT QUALIFIER.DECLARATION (SCOPE?, (VALUE | VALUE.ARRAY)?)>
-    <!ATTLIST QUALIFIER.DECLARATION
-         %CIMName;
-         %CIMType;               #REQUIRED
-         ISARRAY    (true|false) #IMPLIED
-         %ArraySize;
-         %QualifierFlavor;>
+      ::
+
+        <!ELEMENT QUALIFIER.DECLARATION (SCOPE?, (VALUE | VALUE.ARRAY)?)>
+        <!ATTLIST QUALIFIER.DECLARATION
+             %CIMName;
+             %CIMType;               #REQUIRED
+             ISARRAY    (true|false) #IMPLIED
+             %ArraySize;
+             %QualifierFlavor;>
     """
 
     def __init__(self, name, type_, value, is_array=None,
@@ -332,15 +344,17 @@ class SCOPE(CIMElement):
     the case that there are restrictions on the scope of the Qualifier
     declaration.
 
-    <!ELEMENT SCOPE EMPTY>
-    <!ATTLIST SCOPE
-         CLASS        (true|false)      'false'
-         ASSOCIATION  (true|false)      'false'
-         REFERENCE    (true|false)      'false'
-         PROPERTY     (true|false)      'false'
-         METHOD       (true|false)      'false'
-         PARAMETER    (true|false)      'false'
-         INDICATION   (true|false)      'false'>
+      ::
+
+        <!ELEMENT SCOPE EMPTY>
+        <!ATTLIST SCOPE
+             CLASS        (true|false)      'false'
+             ASSOCIATION  (true|false)      'false'
+             REFERENCE    (true|false)      'false'
+             PROPERTY     (true|false)      'false'
+             METHOD       (true|false)      'false'
+             PARAMETER    (true|false)      'false'
+             INDICATION   (true|false)      'false'>
     """
 
     def __init__(self, scopes=None):
@@ -366,7 +380,9 @@ class VALUE(CIMElement):
     non-reference) CIM Property value, CIM Qualifier value, or a CIM
     Method Parameter value.
 
-    <!ELEMENT VALUE (#PCDATA)>
+      ::
+
+        <!ELEMENT VALUE (#PCDATA)>
     """
 
     def __init__(self, pcdata):
@@ -380,7 +396,9 @@ class VALUE_ARRAY(CIMElement):
     The VALUE.ARRAY element is used to represent the value of a CIM
     Property or Qualifier that has an array type.
 
-    <!ELEMENT VALUE.ARRAY (VALUE*)>
+      ::
+
+        <!ELEMENT VALUE.ARRAY (VALUE*)>
     """
 
     def __init__(self, values):
@@ -393,9 +411,11 @@ class VALUE_REFERENCE(CIMElement):
     The VALUE.REFERENCE element is used to define a single CIM
     reference Property value.
 
-    <!ELEMENT VALUE.REFERENCE (CLASSPATH | LOCALCLASSPATH | CLASSNAME |
-                               INSTANCEPATH | LOCALINSTANCEPATH |
-                               INSTANCENAME)>
+      ::
+
+        <!ELEMENT VALUE.REFERENCE (CLASSPATH | LOCALCLASSPATH | CLASSNAME |
+                                   INSTANCEPATH | LOCALINSTANCEPATH |
+                                   INSTANCENAME)>
     """
 
     def __init__(self, data):
@@ -408,7 +428,9 @@ class VALUE_REFARRAY(CIMElement):
     The VALUE.REFARRAY element is used to represent the value of an
     array of CIM references.
 
-    <!ELEMENT VALUE.REFARRAY (VALUE.REFERENCE*)>
+      ::
+
+        <!ELEMENT VALUE.REFARRAY (VALUE.REFERENCE*)>
     """
 
     def __init__(self, data):
@@ -421,7 +443,9 @@ class VALUE_OBJECT(CIMElement):
     The VALUE.OBJECT element is used to define a value which is
     comprised of a single CIM Class or Instance definition.
 
-    <!ELEMENT VALUE.OBJECT (CLASS | INSTANCE)>
+      ::
+
+        <!ELEMENT VALUE.OBJECT (CLASS | INSTANCE)>
     """
 
     def __init__(self, data):
@@ -434,7 +458,9 @@ class VALUE_NAMEDINSTANCE(CIMElement):
     The VALUE.NAMEDINSTANCE element is used to define a value which
     is comprised of a single named CIM Instance definition.
 
-    <!ELEMENT VALUE.NAMEDINSTANCE (INSTANCENAME, INSTANCE)>
+      ::
+
+        <!ELEMENT VALUE.NAMEDINSTANCE (INSTANCENAME, INSTANCE)>
     """
 
     def __init__(self, instancename, instance):
@@ -448,7 +474,9 @@ class VALUE_NAMEDOBJECT(CIMElement):
     The VALUE.NAMEDOBJECT element is used to define a value which
     is comprised of a single named CIM Class or Instance definition.
 
-    <!ELEMENT VALUE.NAMEDOBJECT (CLASS | (INSTANCENAME, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.NAMEDOBJECT (CLASS | (INSTANCENAME, INSTANCE))>
     """
 
     def __init__(self, data):
@@ -466,8 +494,10 @@ class VALUE_OBJECTWITHLOCALPATH(CIMElement):
     definition with additional information that defines the local path
     to that Object.
 
-    <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH, CLASS) |
-                                         (LOCALINSTANCEPATH, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH, CLASS) |
+                                             (LOCALINSTANCEPATH, INSTANCE))>
     """
 
     def __init__(self, data1, data2):
@@ -483,8 +513,10 @@ class VALUE_OBJECTWITHPATH(CIMElement):
     definition with additional information that defines the absolute
     path to that Object.
 
-    <!ELEMENT VALUE.OBJECTWITHPATH ((CLASSPATH, CLASS) |
-                                    (INSTANCEPATH, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.OBJECTWITHPATH ((CLASSPATH, CLASS) |
+                                        (INSTANCEPATH, INSTANCE))>
     """
 
     def __init__(self, data1, data2):
@@ -498,7 +530,9 @@ class VALUE_NULL(CIMElement):
     The VALUE.NULL element is used to represent a TABLECELL that has
     no assigned value.
 
-    <!ELEMENT VALUE.NULL EMPTY>
+      ::
+
+        <!ELEMENT VALUE.NULL EMPTY>
     """
 
     def __init__(self):
@@ -512,7 +546,9 @@ class NAMESPACEPATH(CIMElement):
     The NAMESPACEPATH element is used to define a Namespace Path. It
     consists of a HOST element and a LOCALNAMESPACE element.
 
-    <!ELEMENT NAMESPACEPATH (HOST, LOCALNAMESPACEPATH)>
+      ::
+
+        <!ELEMENT NAMESPACEPATH (HOST, LOCALNAMESPACEPATH)>
     """
 
     def __init__(self, host, localnamespacepath):
@@ -527,7 +563,9 @@ class LOCALNAMESPACEPATH(CIMElement):
     path (one without a Host component). It consists of one or more
     NAMESPACE elements (one for each namespace in the path).
 
-    <!ELEMENT LOCALNAMESPACEPATH (NAMESPACE+)>
+      ::
+
+        <!ELEMENT LOCALNAMESPACEPATH (NAMESPACE+)>
     """
 
     def __init__(self, namespaces):
@@ -541,7 +579,9 @@ class HOST(CIMElement):
     content MUST specify a legal value for a hostname in accordance
     with the CIM specification.
 
-    <!ELEMENT HOST (#PCDATA)>
+      ::
+
+        <!ELEMENT HOST (#PCDATA)>
     """
 
     def __init__(self, pcdata):
@@ -554,9 +594,11 @@ class NAMESPACE(CIMElement):
     The NAMESPACE element is used to define a single Namespace
     component of a Namespace path.
 
-    <!ELEMENT NAMESPACE EMPTY>
-    <!ATTLIST NAMESPACE
-        %CIMName;>
+      ::
+
+        <!ELEMENT NAMESPACE EMPTY>
+        <!ATTLIST NAMESPACE
+            %CIMName;>
     """
 
     def __init__(self, name):
@@ -569,7 +611,9 @@ class CLASSPATH(CIMElement):
     The CLASSPATH element defines the absolute path to a CIM Class. It
     is formed from a namespace path and Class name.
 
-    <!ELEMENT CLASSPATH (NAMESPACEPATH, CLASSNAME)>
+      ::
+
+        <!ELEMENT CLASSPATH (NAMESPACEPATH, CLASSNAME)>
     """
 
     def __init__(self, namespacepath, classname):
@@ -584,7 +628,9 @@ class LOCALCLASSPATH(CIMElement):
     The LOCALCLASSPATH element defines the a local path to a CIM
     Class. It is formed from a local namespace path and Class name.
 
-    <!ELEMENT LOCALCLASSPATH (LOCALNAMESPACEPATH, CLASSNAME)>
+      ::
+
+        <!ELEMENT LOCALCLASSPATH (LOCALNAMESPACEPATH, CLASSNAME)>
     """
 
     def __init__(self, localnamespacepath, classname):
@@ -597,9 +643,11 @@ class CLASSNAME(CIMElement):
     """
     The CLASSNAME element defines the qualifying name of a CIM Class.
 
-    <!ELEMENT CLASSNAME EMPTY>
-    <!ATTLIST CLASSNAME
-        %CIMName;>
+      ::
+
+        <!ELEMENT CLASSNAME EMPTY>
+        <!ATTLIST CLASSNAME
+            %CIMName;>
     """
 
     def __init__(self, classname):
@@ -613,7 +661,9 @@ class INSTANCEPATH(CIMElement):
     Instance. It is comprised of a Namespace path and an Instance Name
     (model path).
 
-    <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
+      ::
+
+        <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
     """
 
     def __init__(self, namespacepath, instancename):
@@ -628,7 +678,9 @@ class LOCALINSTANCEPATH(CIMElement):
     Instance. It is comprised of a local Namespace path and an
     Instance Name (model path).
 
-    <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
+      ::
+
+        <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
     """
 
     def __init__(self, localpath, instancename):
@@ -655,9 +707,11 @@ class INSTANCENAME(CIMElement):
     If there are no key-bindings specified, the instance is assumed to
     be a singleton instance of a keyless Class.
 
-    <!ELEMENT INSTANCENAME (KEYBINDING* | KEYVALUE? | VALUE.REFERENCE?)>
-    <!ATTLIST INSTANCENAME
-        %ClassName;>
+      ::
+
+        <!ELEMENT INSTANCENAME (KEYBINDING* | KEYVALUE? | VALUE.REFERENCE?)>
+        <!ATTLIST INSTANCENAME
+            %ClassName;>
     """
 
     def __init__(self, classname, data):
@@ -675,7 +729,9 @@ class OBJECTPATH(CIMElement):
     The OBJECTPATH element is used to define a full path to a single
     CIM Object (Class or Instance).
 
-    <!ELEMENT OBJECTPATH (INSTANCEPATH | CLASSPATH)>
+      ::
+
+        <!ELEMENT OBJECTPATH (INSTANCEPATH | CLASSPATH)>
     """
 
     def __init__(self, data):
@@ -687,9 +743,11 @@ class KEYBINDING(CIMElement):
     """
     The KEYBINDING element defines a single key property value binding.
 
-    <!ELEMENT KEYBINDING (KEYVALUE | VALUE.REFERENCE)>
-    <!ATTLIST KEYBINDING
-        %CIMName;>
+      ::
+
+        <!ELEMENT KEYBINDING (KEYVALUE | VALUE.REFERENCE)>
+        <!ATTLIST KEYBINDING
+            %CIMName;>
     """
 
     def __init__(self, name, data):
@@ -703,10 +761,12 @@ class KEYVALUE(CIMElement):
     The KEYVALUE element defines a single property key value when the
     key property is a non-reference type.
 
-    <!ELEMENT KEYVALUE (#PCDATA)>
-    <!ATTLIST KEYVALUE
-        VALUETYPE    (string|boolean|numeric)  'string'
-        %CIMType;    #IMPLIED>
+      ::
+
+        <!ELEMENT KEYVALUE (#PCDATA)>
+        <!ATTLIST KEYVALUE
+            VALUETYPE    (string|boolean|numeric)  'string'
+            %CIMType;    #IMPLIED>
     """
 
     def __init__(self, data, value_type=None, cim_type=None):
@@ -730,11 +790,13 @@ class CLASS(CIMElement):
     """
     The CLASS element defines a single CIM Class.
 
-    <!ELEMENT CLASS (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
-                     PROPERTY.REFERENCE)*, METHOD*)>
-    <!ATTLIST CLASS
-        %CIMName;
-        %SuperClass;>
+      ::
+
+        <!ELEMENT CLASS (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
+                         PROPERTY.REFERENCE)*, METHOD*)>
+        <!ATTLIST CLASS
+            %CIMName;
+            %SuperClass;>
     """
 
     def __init__(self, classname, properties=None, methods=None,
@@ -756,11 +818,13 @@ class INSTANCE(CIMElement):
     """
     The INSTANCE element defines a single CIM Instance of a CIM Class.
 
-    <!ELEMENT INSTANCE (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
-                                     PROPERTY.REFERENCE)*)>
-    <!ATTLIST INSTANCE
-         %ClassName;
-         xml:lang   NMTOKEN  #IMPLIED>
+      ::
+
+        <!ELEMENT INSTANCE (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
+                                         PROPERTY.REFERENCE)*)>
+        <!ATTLIST INSTANCE
+            %ClassName;
+            xml:lang   NMTOKEN  #IMPLIED>
     """
     def __init__(self, classname, properties=None, qualifiers=None,
                  xml_lang=None):
@@ -786,13 +850,15 @@ class QUALIFIER(CIMElement):
     If the Qualifier has no assigned value then the VALUE element MUST
     be absent.
 
-    <!ELEMENT QUALIFIER ((VALUE | VALUE.ARRAY)?)>
-    <!ATTLIST QUALIFIER
-        %CIMName;
-        %CIMType;               #REQUIRED
-        %Propagated;
-        %QualifierFlavor;
-        xml:lang  NMTOKEN  #IMPLIED>
+      ::
+
+        <!ELEMENT QUALIFIER ((VALUE | VALUE.ARRAY)?)>
+        <!ATTLIST QUALIFIER
+            %CIMName;
+            %CIMType;               #REQUIRED
+            %Propagated;
+            %QualifierFlavor;
+            xml:lang  NMTOKEN  #IMPLIED>
     """
 
     def __init__(self, name, type_, value=None, propagated=None,
@@ -833,13 +899,15 @@ class PROPERTY(CIMElement):
     CIM Reference Properties are described using the
     PROPERTY.REFERENCE element.
 
-    <!ELEMENT PROPERTY (QUALIFIER*, VALUE?)>
-    <!ATTLIST PROPERTY
-        %CIMName;
-        %ClassOrigin;
-        %Propagated;
-        %CIMType;           #REQUIRED
-        xml:lang   NMTOKEN  #IMPLIED>
+      ::
+
+        <!ELEMENT PROPERTY (QUALIFIER*, VALUE?)>
+        <!ATTLIST PROPERTY
+            %CIMName;
+            %ClassOrigin;
+            %Propagated;
+            %CIMType;           #REQUIRED
+            xml:lang   NMTOKEN  #IMPLIED>
     """
 
     def __init__(self, name, type_, value=None, class_origin=None,
@@ -892,14 +960,16 @@ class PROPERTY_ARRAY(CIMElement):
     There is no element to model a Property that contains an array of
     references as this is not a valid Property type according to CIM.
 
-    <!ELEMENT PROPERTY.ARRAY (QUALIFIER*, VALUE.ARRAY?)>
-    <!ATTLIST PROPERTY.ARRAY
-       %CIMName;
-       %CIMType;           #REQUIRED
-       %ArraySize;
-       %ClassOrigin;
-       %Propagated;
-       xml:lang   NMTOKEN  #IMPLIED>
+      ::
+
+        <!ELEMENT PROPERTY.ARRAY (QUALIFIER*, VALUE.ARRAY?)>
+        <!ATTLIST PROPERTY.ARRAY
+            %CIMName;
+            %CIMType;           #REQUIRED
+            %ArraySize;
+            %ClassOrigin;
+            %Propagated;
+            xml:lang   NMTOKEN  #IMPLIED>
     """
 
     def __init__(self, name, type_, value_array=None, array_size=None,
@@ -935,12 +1005,14 @@ class PROPERTY_REFERENCE(CIMElement):
     XML Linking is currently only at Working Draft status no explicit
     dependencies have been made at this point.
 
-    <!ELEMENT PROPERTY.REFERENCE (QUALIFIER*, VALUE.REFERENCE?)>
-    <!ATTLIST PROPERTY.REFERENCE
-        %CIMName;
-        %ReferenceClass;
-        %ClassOrigin;
-        %Propagated;>
+      ::
+
+        <!ELEMENT PROPERTY.REFERENCE (QUALIFIER*, VALUE.REFERENCE?)>
+        <!ATTLIST PROPERTY.REFERENCE
+            %CIMName;
+            %ReferenceClass;
+            %ClassOrigin;
+            %Propagated;>
     """
 
     def __init__(self, name, value_reference=None, reference_class=None,
@@ -969,13 +1041,15 @@ class METHOD(CIMElement):
     The order of the PARAMETER, PARAMETER.REFERENCE, PARAMETER.ARRAY
     and PARAMETER.REFARRAY subelements is not significant.
 
-    <!ELEMENT METHOD (QUALIFIER*, (PARAMETER | PARAMETER.REFERENCE |
+      ::
+
+        <!ELEMENT METHOD (QUALIFIER*, (PARAMETER | PARAMETER.REFERENCE |
                                    PARAMETER.ARRAY | PARAMETER.REFARRAY)*)>
-    <!ATTLIST METHOD
-        %CIMName;
-        %CIMType;          #IMPLIED
-        %ClassOrigin;
-        %Propagated;>
+        <!ATTLIST METHOD
+            %CIMName;
+            %CIMType;          #IMPLIED
+            %ClassOrigin;
+            %Propagated;>
     """
 
     def __init__(self, name, parameters=None, return_type=None,
@@ -1005,10 +1079,12 @@ class PARAMETER(CIMElement):
     Parameter to a CIM Method. The parameter MAY have zero or more
     Qualifiers.
 
-    <!ELEMENT PARAMETER (QUALIFIER*)>
-    <!ATTLIST PARAMETER
-        %CIMName;
-        %CIMType;      #REQUIRED>
+      ::
+
+        <!ELEMENT PARAMETER (QUALIFIER*)>
+        <!ATTLIST PARAMETER
+            %CIMName;
+            %CIMType;      #REQUIRED>
     """
 
     def __init__(self, name, type_, qualifiers=None):
@@ -1025,10 +1101,12 @@ class PARAMETER_REFERENCE(CIMElement):
     Parameter to a CIM Method. The parameter MAY have zero or more
     Qualifiers.
 
-    <!ELEMENT PARAMETER.REFERENCE (QUALIFIER*)>
-    <!ATTLIST PARAMETER.REFERENCE
-        %CIMName;
-        %ReferenceClass;>
+      ::
+
+        <!ELEMENT PARAMETER.REFERENCE (QUALIFIER*)>
+        <!ATTLIST PARAMETER.REFERENCE
+            %CIMName;
+            %ReferenceClass;>
     """
 
     def __init__(self, name, reference_class=None, qualifiers=None):
@@ -1045,11 +1123,13 @@ class PARAMETER_ARRAY(CIMElement):
     Method that has an array type. The parameter MAY have zero or more
     Qualifiers.
 
-    <!ELEMENT PARAMETER.ARRAY (QUALIFIER*)>
-    <!ATTLIST PARAMETER.ARRAY
-        %CIMName;
-        %CIMType;           #REQUIRED
-        %ArraySize;>
+      ::
+
+        <!ELEMENT PARAMETER.ARRAY (QUALIFIER*)>
+        <!ATTLIST PARAMETER.ARRAY
+            %CIMName;
+            %CIMType;           #REQUIRED
+            %ArraySize;>
     """
 
     def __init__(self, name, type_, array_size=None, qualifiers=None):
@@ -1068,11 +1148,13 @@ class PARAMETER_REFARRAY(CIMElement):
     Method that has an array of references type. The parameter MAY
     have zero or more Qualifiers.
 
-    <!ELEMENT PARAMETER.REFARRAY (QUALIFIER*)>
-    <!ATTLIST PARAMETER.REFARRAY
-        %CIMName;
-        %ReferenceClass;
-        %ArraySize;>
+      ::
+
+        <!ELEMENT PARAMETER.REFARRAY (QUALIFIER*)>
+        <!ATTLIST PARAMETER.REFARRAY
+            %CIMName;
+            %ReferenceClass;
+            %ArraySize;>
     """
 
     def __init__(self, name, reference_class=None, array_size=None,
@@ -1091,45 +1173,48 @@ class TABLECELL_DECLARATION(CIMElement): #pylint: disable=invalid-name
     The TABLECELL.DECLARATION element describes a TABLECELL that is
     not a reference or an array of references.
 
+      ::
 
-    <!ELEMENT TABLECELL.DECLARATION EMPTY>
-    <!ATTLIST TABLECELL.DECLARATION
-        %CIMName;
-        %CIMType;                    #REQUIRED
-        ISARRAY         (true|false) "false"
-        %ARRAYSIZE;
-        CELLPOS          CDATA       #REQUIRED
-        SORTPOS          CDATA       #IMPLIED
-        SORTDIR        (ASC|DESC)    #IMPLIED>
+        <!ELEMENT TABLECELL.DECLARATION EMPTY>
+        <!ATTLIST TABLECELL.DECLARATION
+            %CIMName;
+            %CIMType;                    #REQUIRED
+            ISARRAY         (true|false) "false"
+            %ARRAYSIZE;
+            CELLPOS          CDATA       #REQUIRED
+            SORTPOS          CDATA       #IMPLIED
+            SORTDIR        (ASC|DESC)    #IMPLIED>
     """
 
 class TABLECELL_REFERENCE(CIMElement):
     # pylint: disable=invalid-name
     """
-
     The TABLECELL.REFERENCE element defines a TABLECELL that contains
     reference or reference array values.
 
-    <!ELEMENT TABLECELL.REFERENCE EMPTY>
-    <!ATTLIST TABLECELL.REFERENCE
-        %CIMName;
-        %ReferenceClass;             #REQUIRED
-        ISARRAY        (true|false)  "false"
-        %ARRAYSIZE;
-        CELLPOS         CDATA        #REQUIRED
-        SORTPOS          CDATA       #IMPLIED
-        SORTDIR         (ASC|DESC)   #IMPLIED>
+      ::
+
+        <!ELEMENT TABLECELL.REFERENCE EMPTY>
+        <!ATTLIST TABLECELL.REFERENCE
+            %CIMName;
+            %ReferenceClass;             #REQUIRED
+            ISARRAY        (true|false)  "false"
+            %ARRAYSIZE;
+            CELLPOS         CDATA        #REQUIRED
+            SORTPOS          CDATA       #IMPLIED
+            SORTDIR         (ASC|DESC)   #IMPLIED>
      """
 
 class TABLEROW_DECLARATION(CIMElement):
     # pylint: disable=invalid-name
     """
-
     The TABLEROW.DECLARATION element contains a definition for each
     TABLECELL in the TABLEROW.
 
-    <!ELEMENT TABLEROW.DECLARATION (TABLECELL.DECLARATION
-                                    | TABLECELL.REFERENCE)*>
+      ::
+
+        <!ELEMENT TABLEROW.DECLARATION (TABLECELL.DECLARATION
+                                        | TABLECELL.REFERENCE)*>
     """
 
 class TABLE(CIMElement):
@@ -1139,19 +1224,22 @@ class TABLE(CIMElement):
     element consists of a TABLEROW.DECLARATION followed by 0 or more
     rows.
 
-    <!ELEMENT TABLE(TABLEROW.DECLARATION,(TABLEROW)*)>
+      ::
+
+        <!ELEMENT TABLE(TABLEROW.DECLARATION,(TABLEROW)*)>
     """
 
 class TABLEROW(CIMElement):
     # pylint: disable=invalid-name
     """
-
     The TABLEROW element defines the values for a single row of a
     table.  A value for each cell of the row MUST be specified.  If a
     value has no assigned value, the VALUE.NULL element MUST be used.
 
-    <!ELEMENT TABLEROW (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
-                        VALUE.REFARRAY | VALUE.NULL)*>
+      ::
+
+        <!ELEMENT TABLEROW (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
+                            VALUE.REFARRAY | VALUE.NULL)*>
     """
 
 # Message elements
@@ -1163,12 +1251,14 @@ class MESSAGE(CIMElement):
     used as the basis for CIM Operation Messages and CIM Export
     Messages.
 
-    <!ELEMENT MESSAGE (SIMPLEREQ | MULTIREQ | SIMPLERSP | MULTIRSP |
-                       SIMPLEEXPREQ | MULTIEXPREQ | SIMPLEEXPRSP |
-                       MULTIEXPRSP)>
-    <!ATTLIST MESSAGE
-	ID CDATA #REQUIRED
-	PROTOCOLVERSION CDATA #REQUIRED>
+      ::
+
+        <!ELEMENT MESSAGE (SIMPLEREQ | MULTIREQ | SIMPLERSP | MULTIRSP |
+                           SIMPLEEXPREQ | MULTIEXPREQ | SIMPLEEXPRSP |
+                           MULTIEXPRSP)>
+        <!ATTLIST MESSAGE
+            ID CDATA #REQUIRED
+            PROTOCOLVERSION CDATA #REQUIRED>
     """
 
     def __init__(self, data, message_id, protocol_version):
@@ -1184,7 +1274,9 @@ class MULTIREQ(CIMElement):
     contains two or more subelements defining the SIMPLEREQ elements
     that make up this multiple request.
 
-    <!ELEMENT MULTIREQ (SIMPLEREQ, SIMPLEREQ+)>
+      ::
+
+        <!ELEMENT MULTIREQ (SIMPLEREQ, SIMPLEREQ+)>
     """
 
     def __init__(self, data):
@@ -1198,7 +1290,9 @@ class MULTIEXPREQ(CIMElement):
     contains two or more subelements defining the SIMPLEEXPREQ
     elements that make up this multiple request.
 
-    <!ELEMENT MULTIEXPREQ (SIMPLEEXPREQ, SIMPLEEXPREQ+)>
+      ::
+
+        <!ELEMENT MULTIEXPREQ (SIMPLEEXPREQ, SIMPLEEXPREQ+)>
     """
 
     def __init__(self, data):
@@ -1212,7 +1306,9 @@ class SIMPLEREQ(CIMElement):
     contains either a METHODCALL (extrinsic method) element or an
     IMETHODCALL (intrinsic method) element.
 
-    <!ELEMENT SIMPLEREQ (IMETHODCALL | METHODCALL)>
+      ::
+
+        <!ELEMENT SIMPLEREQ (IMETHODCALL | METHODCALL)>
     """
 
     def __init__(self, data):
@@ -1225,7 +1321,9 @@ class SIMPLEEXPREQ(CIMElement):
     The SIMPLEEXPREQ element defines a Simple CIM Export request.  It
     contains an EXPMETHODCALL (export method).
 
-    <!ELEMENT SIMPLEEXPREQ (EXPMETHODCALL)>
+      ::
+
+        <!ELEMENT SIMPLEEXPREQ (EXPMETHODCALL)>
     """
 
     def __init__(self, data):
@@ -1242,10 +1340,12 @@ class IMETHODCALL(CIMElement):
     specified, the intrinsic method call MUST be interpreted as an
     asynchronous method call.
 
-    <!ELEMENT IMETHODCALL (LOCALNAMESPACEPATH, IPARAMVALUE*,
-                           RESPONSEDESTINATION?)>
-    <!ATTLIST IMETHODCALL
-	%CIMName;>
+      ::
+
+        <!ELEMENT IMETHODCALL (LOCALNAMESPACEPATH, IPARAMVALUE*,
+                               RESPONSEDESTINATION?)>
+        <!ATTLIST IMETHODCALL
+            %CIMName;>
     """
 
     def __init__(self, name, localnamespacepath, iparamvalues=None,
@@ -1267,10 +1367,12 @@ class METHODCALL(CIMElement):
     RESPONSEDESTINATION element is specified, the method call MUST be
     interpreted as an asynchronous method call.
 
-    <!ELEMENT METHODCALL ((LOCALINSTANCEPATH | LOCALCLASSPATH), PARAMVALUE*,
-                          RESPONSEDESTINATION?)>
-    <!ATTLIST METHODCALL
-	%CIMName;>
+      ::
+
+        <!ELEMENT METHODCALL ((LOCALINSTANCEPATH | LOCALCLASSPATH), PARAMVALUE*,
+                              RESPONSEDESTINATION?)>
+        <!ATTLIST METHODCALL
+            %CIMName;>
     """
 
     def __init__(self, name, localpath, paramvalues=None,
@@ -1289,9 +1391,11 @@ class EXPMETHODCALL(CIMElement):
     invocation.  It specifies zero or more  <EXPPARAMVALUE>
     subelements as the parameter values to be passed to the method.
 
-    <!ELEMENT EXPMETHODCALL (EXPPARAMVALUE*)>
-    <!ATTLIST EXPMETHODCALL
-	%CIMName;>
+      ::
+
+        <!ELEMENT EXPMETHODCALL (EXPPARAMVALUE*)>
+        <!ATTLIST EXPMETHODCALL
+            %CIMName;>
     """
 
     def __init__(self, name, params=None):
@@ -1307,11 +1411,13 @@ class PARAMVALUE(CIMElement):
     parameter value. If no subelement is present this indicates that
     no value has been supplied for this parameter.
 
-    <!ELEMENT PARAMVALUE (VALUE | VALUE.REFERENCE | VALUE.ARRAY |
-                          VALUE.REFARRAY)?>
-    <!ATTLIST PARAMVALUE
-	%CIMName;
-        %ParamType;    #IMPLIED>
+      ::
+
+        <!ELEMENT PARAMVALUE (VALUE | VALUE.REFERENCE | VALUE.ARRAY |
+                              VALUE.REFARRAY)?>
+        <!ATTLIST PARAMVALUE
+            %CIMName;
+            %ParamType;    #IMPLIED>
     """
 
     def __init__(self, name, data=None, paramtype=None,
@@ -1330,11 +1436,14 @@ class IPARAMVALUE(CIMElement):
     parameter value. If no subelement is present this indicates that
     no value has been supplied for this parameter.
 
-    <!ELEMENT IPARAMVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
-                           INSTANCENAME | CLASSNAME | QUALIFIER.DECLARATION |
-                           CLASS | INSTANCE | VALUE.NAMEDINSTANCE)?>
-    <!ATTLIST IPARAMVALUE
-	%CIMName;>
+      ::
+
+        <!ELEMENT IPARAMVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
+                               INSTANCENAME | CLASSNAME |
+                               QUALIFIER.DECLARATION |
+                               CLASS | INSTANCE | VALUE.NAMEDINSTANCE)?>
+        <!ATTLIST IPARAMVALUE
+            %CIMName;>
     """
 
     def __init__(self, name, data=None):
@@ -1349,11 +1458,13 @@ class EXPPARAMVALUE(CIMElement):
     parameter value.  If no subelement is present this indicates that
     no value has been supplied for this parameter.
 
-    <!ELEMENT EXPPARAMVALUE (INSTANCE? | VALUE? | METHODRESPONSE? |
-                             IMETHODRESPONSE?)>
-    <!ATTLIST EXPPARAMVALUE
-	%CIMName;
-        %ParamType;  #IMPLIED>
+      ::
+
+        <!ELEMENT EXPPARAMVALUE (INSTANCE? | VALUE? | METHODRESPONSE? |
+                                 IMETHODRESPONSE?)>
+        <!ATTLIST EXPPARAMVALUE
+            %CIMName;
+            %ParamType;  #IMPLIED>
     """
 
     def __init__(self, name, data=None, param_type=None):
@@ -1369,7 +1480,9 @@ class MULTIRSP(CIMElement):
     It contains two or more subelements defining the SIMPLERSP
     elements that make up this multiple response.
 
-    <!ELEMENT MULTIRSP (SIMPLERSP, SIMPLERSP+)>
+      ::
+
+        <!ELEMENT MULTIRSP (SIMPLERSP, SIMPLERSP+)>
     """
 
     def __init__(self, data):
@@ -1383,7 +1496,9 @@ class MULTIEXPRSP(CIMElement):
     It contains two or more subelements defining the SIMPLEEXPRSP
     elements that make up this multiple response.
 
-    <!ELEMENT MULTIEXPRSP (SIMPLEEXPRSP, SIMPLEEXPRSP+)>
+      ::
+
+        <!ELEMENT MULTIEXPRSP (SIMPLEEXPRSP, SIMPLEEXPRSP+)>
     """
 
     def __init__(self, data):
@@ -1398,7 +1513,9 @@ class SIMPLERSP(CIMElement):
     IMETHODRESPONSE (for intrinsic methods) or a SIMPLEREQACK
     subelement.
 
-    <!ELEMENT SIMPLERSP (METHODRESPONSE | IMETHODRESPONSE | SIMPLEREQACK)>
+      ::
+
+        <!ELEMENT SIMPLERSP (METHODRESPONSE | IMETHODRESPONSE | SIMPLEREQACK)>
     """
 
     def __init__(self, data):
@@ -1412,7 +1529,9 @@ class SIMPLEEXPRSP(CIMElement):
     contains either a EXPMETHODRESPONSE (for export methods)
     subelement.
 
-    <!ELEMENT SIMPLEEXPRSP (EXPMETHODRESPONSE)>
+      ::
+
+        <!ELEMENT SIMPLEEXPRSP (EXPMETHODRESPONSE)>
     """
 
     def __init__(self, data):
@@ -1428,9 +1547,11 @@ class METHODRESPONSE(CIMElement):
     executing), or a combination of an optional return value and zero
     or more out parameter values.
 
-    <!ELEMENT METHODRESPONSE (ERROR | (RETURNVALUE?, PARAMVALUE*))>
-    <!ATTLIST METHODRESPONSE
-	%CIMName;>
+      ::
+
+        <!ELEMENT METHODRESPONSE (ERROR | (RETURNVALUE?, PARAMVALUE*))>
+        <!ATTLIST METHODRESPONSE
+            %CIMName;>
     """
 
     def __init__(self, name, data=None):
@@ -1450,9 +1571,11 @@ class EXPMETHODRESPONSE(CIMElement):
     report a fundamental error which prevented the method from
     executing), or an optional return value.
 
-    <!ELEMENT EXPMETHODRESPONSE (ERROR | IRETURNVALUE?)>
-    <!ATTLIST EXPMETHODRESPONSE
-	%CIMName;>
+      ::
+
+        <!ELEMENT EXPMETHODRESPONSE (ERROR | IRETURNVALUE?)>
+        <!ATTLIST EXPMETHODRESPONSE
+            %CIMName;>
     """
 
     def __init__(self, name, data=None):
@@ -1468,9 +1591,11 @@ class IMETHODRESPONSE(CIMElement):
     report a fundamental error which prevented the method from
     executing), or an optional return value.
 
-    <!ELEMENT IMETHODRESPONSE (ERROR | IRETURNVALUE?)>
-    <!ATTLIST IMETHODRESPONSE
-	%CIMName;>
+      ::
+
+        <!ELEMENT IMETHODRESPONSE (ERROR | IRETURNVALUE?)>
+        <!ATTLIST IMETHODRESPONSE
+            %CIMName;>
     """
 
     def __init__(self, name, data=None):
@@ -1486,10 +1611,12 @@ class ERROR(CIMElement):
     status code, an optional description and zero or more instances
     containing detailed information about the error.
 
-    <!ELEMENT ERROR (INSTANCE*)>
-    <!ATTLIST ERROR
-	CODE CDATA #REQUIRED
-	DESCRIPTION CDATA #IMPLIED>
+      ::
+
+        <!ELEMENT ERROR (INSTANCE*)>
+        <!ATTLIST ERROR
+            CODE CDATA #REQUIRED
+            DESCRIPTION CDATA #IMPLIED>
     """
 
     def __init__(self, code, description=None, instances=None):
@@ -1505,9 +1632,11 @@ class RETURNVALUE(CIMElement):
     The RETURNVALUE element specifies the value returned from an
     extrinsic method call.
 
-    <!ELEMENT RETURNVALUE (VALUE | VALUE.REFERENCE)>
-    <!ATTLIST RETURNVALUE
-        %ParamType;     #IMPLIED>
+      ::
+
+        <!ELEMENT RETURNVALUE (VALUE | VALUE.REFERENCE)>
+        <!ATTLIST RETURNVALUE
+            %ParamType;     #IMPLIED>
     """
 
     def __init__(self, data, param_type=None):
@@ -1521,12 +1650,14 @@ class IRETURNVALUE(CIMElement):
     The IRETURNVALUE element specifies the value returned from an
     intrinsic method call.
 
-    <!ELEMENT IRETURNVALUE (CLASSNAME* | INSTANCENAME* | VALUE* |
-                            VALUE.OBJECTWITHPATH* |
-                            VALUE.OBJECTWITHLOCALPATH* | VALUE.OBJECT* |
-                            OBJECTPATH* | QUALIFIER.DECLARATION* |
-                            VALUE.ARRAY? | VALUE.REFERENCE? | CLASS* |
-                            INSTANCE* | VALUE.NAMEDINSTANCE*)>
+      ::
+
+        <!ELEMENT IRETURNVALUE (CLASSNAME* | INSTANCENAME* | VALUE* |
+                                VALUE.OBJECTWITHPATH* |
+                                VALUE.OBJECTWITHLOCALPATH* | VALUE.OBJECT* |
+                                OBJECTPATH* | QUALIFIER.DECLARATION* |
+                                VALUE.ARRAY? | VALUE.REFERENCE? | CLASS* |
+                                INSTANCE* | VALUE.NAMEDINSTANCE*)>
     """
 
     def __init__(self, data):
@@ -1539,7 +1670,9 @@ class RESPONSEDESTINATION(CIMElement):
     The RESPONSEDESTINATION element contains an instance that
     describes the desired destination for the response.
 
-    <!ELEMENT RESPONSEDESTINATON (INSTANCE)>
+      ::
+
+        <!ELEMENT RESPONSEDESTINATON (INSTANCE)>
     """
 
     def __init__(self, data):
@@ -1554,9 +1687,11 @@ class SIMPLEREQACK(CIMElement):
     to report a fundamental error which prevented the asynchronous
     request from being initiated.
 
-    <!ELEMENT SIMPLEREQACK (ERROR?)>
-    <!ATTLIST SIMPLEREQACK
-        INSTANCEID CDATA     #REQUIRED>
+      ::
+
+        <!ELEMENT SIMPLEREQACK (ERROR?)>
+        <!ATTLIST SIMPLEREQACK
+            INSTANCEID CDATA     #REQUIRED>
     """
 
     def __init__(self, instanceid, data):

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -1422,9 +1422,9 @@ def _get_error_context(input_, token):
     lines.append(pointline + pointer)
     return lines
 
-def _print_logger(str_):
-    """Print the str_ argument to stdout"""
-    print(str_)
+def _print_logger(msg):
+    """Print the msg argument to stdout."""
+    print(msg)
 
 
 class MOFWBEMConnection(object):
@@ -1432,6 +1432,7 @@ class MOFWBEMConnection(object):
        implement all of the WBEM Operations, just the subset
        required by the compiler
     """
+
     def __init__(self, conn=None):
         """Define the connection for the connection"""
         self.conn = conn
@@ -1644,11 +1645,14 @@ class MOFCompiler(object):
                  log_func=_print_logger):
         """Initialize the compiler.
 
-        Keyword arguments:
-        handle -- A WBEMConnection or similar object.  The following
+        :Parameters:
+
+          handle : WBEMConnection
+            A WBEMConnection or similar object.  The following
             attributes and methods need to be present, corresponding to the
-            the attributes and methods on pywbem.WBEMConnection having
+            the attributes and methods on `WBEMConnection` having
             the same names:
+            
             - default_namespace
             - EnumerateInstanceNames()
             - CreateClass()
@@ -1660,11 +1664,16 @@ class MOFCompiler(object):
             - DeleteQualifier()
             - EnumerateQualifiers()
             - SetQualifier()
-        search_paths -- A list of file system paths specifying where
-            missing schema elements should be looked for. `None` is considered
-            the same as an empty list.
-        verbose -- True if extra messages should be printed.
-        log_func -- A callable that takes a single string argument.
+
+          search_paths : list
+            A list of file system paths specifying where missing schema
+            elements should be looked for.
+
+          verbose : bool
+            True if extra messages should be printed.
+
+          log_func : callable
+            A callable that takes a single string argument.
             The default logger prints to stdout.
         """
 
@@ -1684,12 +1693,16 @@ class MOFCompiler(object):
     def compile_string(self, mof, ns, filename=None):
         """Compile a string of MOF.
 
-        Arguments:
-        mof -- The string of MOF
-        ns -- The CIM namespace
+        :Parameters:
 
-        Keyword arguments:
-        filename -- The name of the file that the MOF was read from.  This
+          mof : string
+            The string of MOF
+
+          ns : string
+            The CIM namespace
+
+          filename : string
+            The name of the file that the MOF was read from.  This
             is used in status and error messages.
         """
 

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -304,10 +304,12 @@ def notimplemented(tup_tree):
 def parse_cim(tup_tree):
     """Parse the top level element of CIM/XML message
 
-           <!ELEMENT CIM (MESSAGE | DECLARATION)>
-           <!ATTLIST CIM
-               CIMVERSION CDATA #REQUIRED
-               DTDVERSION CDATA #REQUIRED>
+      ::
+
+        <!ELEMENT CIM (MESSAGE | DECLARATION)>
+        <!ATTLIST CIM
+            CIMVERSION CDATA #REQUIRED
+            DTDVERSION CDATA #REQUIRED>
     """
 
     check_node(tup_tree, 'CIM', ['CIMVERSION', 'DTDVERSION'])
@@ -327,8 +329,10 @@ def parse_cim(tup_tree):
 
 def parse_declaration(tup_tree):
     """
-    <!ELEMENT DECLARATION ( DECLGROUP | DECLGROUP.WITHNAME |
-                            DECLGROUP.WITHPATH )+>
+      ::
+
+        <!ELEMENT DECLARATION ( DECLGROUP | DECLGROUP.WITHNAME |
+                                DECLGROUP.WITHPATH )+>
 
     Note: We only support the DECLGROUP child, at this point.
     """
@@ -342,8 +346,10 @@ def parse_declaration(tup_tree):
 
 def parse_declgroup(tup_tree):
     """
-    <!ELEMENT DECLGROUP ( (LOCALNAMESPACEPATH|NAMESPACEPATH)?,
-                          QUALIFIER.DECLARATION*, VALUE.OBJECT* )>
+      ::
+
+        <!ELEMENT DECLGROUP ( (LOCALNAMESPACEPATH|NAMESPACEPATH)?,
+                              QUALIFIER.DECLARATION*, VALUE.OBJECT* )>
 
     Note: We only support the QUALIFIER.DECLARATION and VALUE.OBJECT
           children, and with a multiplicity of 1, at this point.
@@ -361,16 +367,26 @@ def parse_declgroup(tup_tree):
 #
 
 def parse_value(tup_tree):
-    '''Return VALUE contents as a string'''
-    ## <!ELEMENT VALUE (#PCDATA)>
+    """Return VALUE contents as a string
+    
+      ::
+
+        <!ELEMENT VALUE (#PCDATA)>
+    """
+
     check_node(tup_tree, 'VALUE', [], [], [], True)
 
     return pcdata(tup_tree)
 
 
 def parse_value_array(tup_tree):
-    """Return list of strings."""
-    ## <!ELEMENT VALUE.ARRAY (VALUE*)>
+    """Return list of strings.
+
+      ::
+
+        <!ELEMENT VALUE.ARRAY (VALUE*)>
+    """
+
     check_node(tup_tree, 'VALUE.ARRAY', [], [], ['VALUE'])
 
     return list_of_same(tup_tree, ['VALUE'])
@@ -378,9 +394,11 @@ def parse_value_array(tup_tree):
 
 def parse_value_reference(tup_tree):
     """
-    <!ELEMENT VALUE.REFERENCE (CLASSPATH | LOCALCLASSPATH | CLASSNAME |
-                               INSTANCEPATH | LOCALINSTANCEPATH |
-                               INSTANCENAME)>
+      ::
+
+        <!ELEMENT VALUE.REFERENCE (CLASSPATH | LOCALCLASSPATH | CLASSNAME |
+                                   INSTANCEPATH | LOCALINSTANCEPATH |
+                                   INSTANCENAME)>
     """
 
     check_node(tup_tree, 'VALUE.REFERENCE', [])
@@ -396,7 +414,9 @@ def parse_value_reference(tup_tree):
 
 def parse_value_refarray(tup_tree):
     """
-    <!ELEMENT VALUE.REFARRAY (VALUE.REFERENCE*)>
+      ::
+
+        <!ELEMENT VALUE.REFARRAY (VALUE.REFERENCE*)>
     """
 
     check_node(tup_tree, 'VALUE.REFARRAY')
@@ -409,7 +429,9 @@ def parse_value_refarray(tup_tree):
 
 def parse_value_object(tup_tree):
     """
-    <!ELEMENT VALUE.OBJECT (CLASS | INSTANCE)>
+      ::
+
+        <!ELEMENT VALUE.OBJECT (CLASS | INSTANCE)>
     """
 
     check_node(tup_tree, 'VALUE.OBJECT')
@@ -421,7 +443,9 @@ def parse_value_object(tup_tree):
 
 def parse_value_namedinstance(tup_tree):
     """
-    <!ELEMENT VALUE.NAMEDINSTANCE (INSTANCENAME, INSTANCE)>
+      ::
+
+        <!ELEMENT VALUE.NAMEDINSTANCE (INSTANCENAME, INSTANCE)>
     """
 
     check_node(tup_tree, 'VALUE.NAMEDINSTANCE')
@@ -440,7 +464,9 @@ def parse_value_namedinstance(tup_tree):
 
 def parse_value_namedobject(tup_tree):
     """
-    <!ELEMENT VALUE.NAMEDOBJECT (CLASS | (INSTANCENAME, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.NAMEDOBJECT (CLASS | (INSTANCENAME, INSTANCE))>
     """
 
     check_node(tup_tree, 'VALUE.NAMEDOBJECT')
@@ -465,8 +491,10 @@ def parse_value_namedobject(tup_tree):
 # pylint: disable=invalid-name
 def parse_value_objectwithlocalpath(tup_tree):
     """
-    <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH, CLASS) |
-                                         (LOCALINSTANCEPATH, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH, CLASS) |
+                                             (LOCALINSTANCEPATH, INSTANCE))>
     """
 
     check_node(tup_tree, 'VALUE.OBJECTWITHLOCALPATH')
@@ -489,8 +517,10 @@ def parse_value_objectwithlocalpath(tup_tree):
 
 def parse_value_objectwithpath(tup_tree):
     """
-    <!ELEMENT VALUE.OBJECTWITHPATH ((CLASSPATH, CLASS) |
-                                    (INSTANCEPATH, INSTANCE))>
+      ::
+
+        <!ELEMENT VALUE.OBJECTWITHPATH ((CLASSPATH, CLASS) |
+                                        (INSTANCEPATH, INSTANCE))>
     """
 
     check_node(tup_tree, 'VALUE.OBJECTWITHPATH')
@@ -517,7 +547,9 @@ def parse_value_objectwithpath(tup_tree):
 
 def parse_namespacepath(tup_tree):
     """
-    <!ELEMENT NAMESPACEPATH (HOST, LOCALNAMESPACEPATH)>
+      ::
+
+        <!ELEMENT NAMESPACEPATH (HOST, LOCALNAMESPACEPATH)>
     """
 
     check_node(tup_tree, 'NAMESPACEPATH')
@@ -534,7 +566,9 @@ def parse_namespacepath(tup_tree):
 
 def parse_localnamespacepath(tup_tree):
     """
-    <!ELEMENT LOCALNAMESPACEPATH (NAMESPACE+)>
+      ::
+
+        <!ELEMENT LOCALNAMESPACEPATH (NAMESPACE+)>
     """
 
     check_node(tup_tree, 'LOCALNAMESPACEPATH', [], [], ['NAMESPACE'])
@@ -549,7 +583,9 @@ def parse_localnamespacepath(tup_tree):
 
 def parse_host(tup_tree):
     """
-    <!ELEMENT HOST (#PCDATA)>
+      ::
+
+        <!ELEMENT HOST (#PCDATA)>
     """
 
     check_node(tup_tree, 'HOST', allow_pcdata=True)
@@ -559,9 +595,12 @@ def parse_host(tup_tree):
 
 def parse_namespace(tup_tree):
     """Parse NAMESPACE element for namespace name
-    <!ELEMENT NAMESPACE EMPTY>
-    <!ATTLIST NAMESPACE
-        %CIMName;>
+
+      ::
+
+        <!ELEMENT NAMESPACE EMPTY>
+        <!ATTLIST NAMESPACE
+            %CIMName;>
     """
 
     check_node(tup_tree, 'NAMESPACE', ['NAME'], [], [])
@@ -571,7 +610,9 @@ def parse_namespace(tup_tree):
 
 def parse_classpath(tup_tree):
     """
-    <!ELEMENT CLASSPATH (NAMESPACEPATH, CLASSNAME)>
+      ::
+
+        <!ELEMENT CLASSPATH (NAMESPACEPATH, CLASSNAME)>
     """
 
     check_node(tup_tree, 'CLASSPATH')
@@ -589,7 +630,9 @@ def parse_classpath(tup_tree):
 
 def parse_localclasspath(tup_tree):
     """
-    <!ELEMENT LOCALCLASSPATH (LOCALNAMESPACEPATH, CLASSNAME)>
+      ::
+
+        <!ELEMENT LOCALCLASSPATH (LOCALNAMESPACEPATH, CLASSNAME)>
     """
 
     check_node(tup_tree, 'LOCALCLASSPATH')
@@ -606,10 +649,13 @@ def parse_localclasspath(tup_tree):
 def parse_classname(tup_tree):
     """Parse a CLASSNAME element and return a CIMClassName.
 
-           <!ELEMENT CLASSNAME EMPTY>
-           <!ATTLIST CLASSNAME
-               %CIMName;>
+      ::
+
+        <!ELEMENT CLASSNAME EMPTY>
+        <!ATTLIST CLASSNAME
+            %CIMName;>
     """
+
     check_node(tup_tree, 'CLASSNAME', ['NAME'], [], [])
     return CIMClassName(attrs(tup_tree)['NAME'])
 
@@ -617,7 +663,9 @@ def parse_classname(tup_tree):
 def parse_instancepath(tup_tree):
     """Parse a INSTANCEPATH element returning the instance name.
 
-          <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
+      ::
+
+        <!ELEMENT INSTANCEPATH (NAMESPACEPATH, INSTANCENAME)>
     """
 
     check_node(tup_tree, 'INSTANCEPATH')
@@ -637,7 +685,9 @@ def parse_instancepath(tup_tree):
 def parse_localinstancepath(tup_tree):
     """Parse a LOCALINSTANCEPATH element:
 
-           <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
+      ::
+
+        <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH, INSTANCENAME)>
     """
 
     check_node(tup_tree, 'LOCALINSTANCEPATH')
@@ -654,10 +704,14 @@ def parse_localinstancepath(tup_tree):
     return instancename
 
 def parse_instancename(tup_tree):
-    """Parse XML INSTANCENAME into CIMInstanceName object."""
+    """Parse XML INSTANCENAME into CIMInstanceName object.
 
-    ## <!ELEMENT INSTANCENAME (KEYBINDING* | KEYVALUE? | VALUE.REFERENCE?)>
-    ## <!ATTLIST INSTANCENAME %ClassName;>
+      ::
+
+        <!ELEMENT INSTANCENAME (KEYBINDING* | KEYVALUE? | VALUE.REFERENCE?)>
+        <!ATTLIST INSTANCENAME %ClassName;>
+    """
+
 
     check_node(tup_tree, 'INSTANCENAME', ['CLASSNAME'])
 
@@ -691,7 +745,9 @@ def parse_instancename(tup_tree):
 
 def parse_objectpath(tup_tree):
     """
-    <!ELEMENT OBJECTPATH (INSTANCEPATH | CLASSPATH)>
+      ::
+
+        <!ELEMENT OBJECTPATH (INSTANCEPATH | CLASSPATH)>
     """
 
     check_node(tup_tree, 'OBJECTPATH')
@@ -703,11 +759,14 @@ def parse_objectpath(tup_tree):
 
 
 def parse_keybinding(tup_tree):
-    ##<!ELEMENT KEYBINDING (KEYVALUE | VALUE.REFERENCE)>
-    ##<!ATTLIST KEYBINDING
-    ##  %CIMName;>
+    """Returns one-item dictionary from name to Python value.
 
-    """Returns one-item dictionary from name to Python value."""
+      ::
+
+        <!ELEMENT KEYBINDING (KEYVALUE | VALUE.REFERENCE)>
+        <!ATTLIST KEYBINDING
+            %CIMName;>
+    """
 
     check_node(tup_tree, 'KEYBINDING', ['NAME'])
 
@@ -717,13 +776,15 @@ def parse_keybinding(tup_tree):
 
 
 def parse_keyvalue(tup_tree):
-    ##<!ELEMENT KEYVALUE (#PCDATA)>
-    ##<!ATTLIST KEYVALUE
-    ##          VALUETYPE (string | boolean | numeric) "string"
-    ##          %CIMType;              #IMPLIED>
+    """Parse VALUETYPE into Python primitive value.
 
+      ::
 
-    """Parse VALUETYPE into Python primitive value"""
+        <!ELEMENT KEYVALUE (#PCDATA)>
+        <!ATTLIST KEYVALUE
+            VALUETYPE (string | boolean | numeric) "string"
+            %CIMType;              #IMPLIED>
+    """
 
     check_node(tup_tree, 'KEYVALUE', ['VALUETYPE'], ['TYPE'], [], True)
 
@@ -763,12 +824,15 @@ def parse_keyvalue(tup_tree):
 def parse_class(tup_tree):
     """Parse CLASS element returning a CIMClass if the parse
        was successful.
+
+      ::
+
+        <!ELEMENT CLASS (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
+                                      PROPERTY.REFERENCE)*, METHOD*)>
+        <!ATTLIST CLASS
+            %CIMName;
+            %SuperClass;>
     """
-    ## <!ELEMENT CLASS (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
-    ##                               PROPERTY.REFERENCE)*, METHOD*)>
-    ## <!ATTLIST CLASS
-    ##     %CIMName;
-    ##     %SuperClass;>
 
     # Doesn't check ordering of elements, but it's not very important
     check_node(tup_tree, 'CLASS', ['NAME'], ['SUPERCLASS'],
@@ -797,12 +861,15 @@ def parse_instance(tup_tree):
     """Return a CIMInstance.
 
     The instance contains the properties, qualifiers and classname for
-    the instance"""
+    the instance.
 
-    ##<!ELEMENT INSTANCE (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
-    ##                                 PROPERTY.REFERENCE)*)>
-    ##<!ATTLIST INSTANCE
-    ##  %ClassName;>
+      ::
+
+        <!ELEMENT INSTANCE (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
+                                         PROPERTY.REFERENCE)*)>
+        <!ATTLIST INSTANCE
+            %ClassName;>
+    """
 
     check_node(tup_tree, 'INSTANCE', ['CLASSNAME'],
                ['QUALIFIER', 'PROPERTY', 'PROPERTY.ARRAY',
@@ -826,30 +893,39 @@ def parse_instance(tup_tree):
     return obj
 
 def parse_scope(tup_tree):
-    """Parse SCOPE element."""
-    # <!ELEMENT SCOPE EMPTY>
-    # <!ATTLIST SCOPE
-    #   CLASS (true | false) "false"
-    #   ASSOCIATION (true | false) "false"
-    #   REFERENCE (true | false) "false"
-    #   PROPERTY (true | false) "false"
-    #   METHOD (true | false) "false"
-    #   PARAMETER (true | false) "false"
-    #   INDICATION (true | false) "false"
+    """Parse SCOPE element.
+
+      ::
+
+        <!ELEMENT SCOPE EMPTY>
+        <!ATTLIST SCOPE
+            CLASS (true | false) "false"
+            ASSOCIATION (true | false) "false"
+            REFERENCE (true | false) "false"
+            PROPERTY (true | false) "false"
+            METHOD (true | false) "false"
+            PARAMETER (true | false) "false"
+            INDICATION (true | false) "false"
+    """
+
     check_node(tup_tree, 'SCOPE', [],
                ['CLASS', 'ASSOCIATION', 'REFERENCE', 'PROPERTY', 'METHOD',
                 'PARAMETER', 'INDICATION'], [])
     return dict([(k, v.lower() == 'true') for k, v in attrs(tup_tree).items()])
 
 def parse_qualifier_declaration(tup_tree):
-    """Parse QUALIFIER.DECLARATION element"""
-    ## <!ELEMENT QUALIFIER.DECLARATION (SCOPE?, (VALUE | VALUE.ARRAY)?)>
-    ## <!ATTLIST QUALIFIER.DECLARATION
-    ##     %CIMName;
-    ##     %CIMType;               #REQUIRED
-    ##     ISARRAY    (true|false) #IMPLIED
-    ##     %ArraySize;
-    ##     %QualifierFlavor;>
+    """Parse QUALIFIER.DECLARATION element.
+
+      ::
+
+        <!ELEMENT QUALIFIER.DECLARATION (SCOPE?, (VALUE | VALUE.ARRAY)?)>
+        <!ATTLIST QUALIFIER.DECLARATION
+            %CIMName;
+            %CIMType;               #REQUIRED
+            ISARRAY    (true|false) #IMPLIED
+            %ArraySize;
+            %QualifierFlavor;>
+    """
 
     check_node(tup_tree, 'QUALIFIER.DECLARATION',
                ['NAME', 'TYPE'],
@@ -893,12 +969,16 @@ def parse_qualifier_declaration(tup_tree):
 
 
 def parse_qualifier(tup_tree):
-    """Parse QUALIFIER element returning CIMQualifier"""
-    ## <!ELEMENT QUALIFIER (VALUE | VALUE.ARRAY)>
-    ## <!ATTLIST QUALIFIER %CIMName;
-    ##      %CIMType;              #REQUIRED
-    ##      %Propagated;
-    ##      %QualifierFlavor;>
+    """Parse QUALIFIER element returning CIMQualifier.
+
+      ::
+
+        <!ELEMENT QUALIFIER (VALUE | VALUE.ARRAY)>
+        <!ATTLIST QUALIFIER %CIMName;
+            %CIMType;              #REQUIRED
+            %Propagated;
+            %QualifierFlavor;>
+    """
 
     check_node(tup_tree, 'QUALIFIER', ['NAME', 'TYPE'],
                ['OVERRIDABLE', 'TOSUBCLASS', 'TOINSTANCE',
@@ -930,14 +1010,17 @@ def parse_qualifier(tup_tree):
 def parse_property(tup_tree):
     """Parse PROPERTY into a CIMProperty object.
 
-    VAL is just the pcdata of the enclosed VALUE node."""
+    VAL is just the pcdata of the enclosed VALUE node.
 
-    ## <!ELEMENT PROPERTY (QUALIFIER*, VALUE?)>
-    ## <!ATTLIST PROPERTY %CIMName;
-    ##      %ClassOrigin;
-    ##      %Propagated;
-    ##      %CIMType;              #REQUIRED>
-    ##      %EMBEDDEDOBJECT
+      ::
+
+        <!ELEMENT PROPERTY (QUALIFIER*, VALUE?)>
+        <!ATTLIST PROPERTY %CIMName;
+            %ClassOrigin;
+            %Propagated;
+            %CIMType;              #REQUIRED>
+            %EMBEDDEDOBJECT
+    """
 
     ## TODO: Parse this into NAME, VALUE, where the value contains
     ## magic fields for the qualifiers and the propagated flag.
@@ -979,12 +1062,14 @@ def parse_property(tup_tree):
 
 def parse_property_array(tup_tree):
     """
-    <!ELEMENT PROPERTY.ARRAY (QUALIFIER*, VALUE.ARRAY?)>
-    <!ATTLIST PROPERTY.ARRAY %CIMName;
-         %CIMType;              #REQUIRED
-         %ArraySize;
-         %ClassOrigin;
-         %Propagated;>
+      ::
+
+        <!ELEMENT PROPERTY.ARRAY (QUALIFIER*, VALUE.ARRAY?)>
+        <!ATTLIST PROPERTY.ARRAY %CIMName;
+            %CIMType;              #REQUIRED
+            %ArraySize;
+            %ClassOrigin;
+            %Propagated;>
     """
 
     check_node(tup_tree, 'PROPERTY.ARRAY', ['NAME', 'TYPE'],
@@ -1022,12 +1107,14 @@ def parse_property_array(tup_tree):
 
 def parse_property_reference(tup_tree):
     """
-    <!ELEMENT PROPERTY.REFERENCE (QUALIFIER*, (VALUE.REFERENCE)?)>
-    <!ATTLIST PROPERTY.REFERENCE
-        %CIMName;
-        %ReferenceClass;
-        %ClassOrigin;
-        %Propagated;>
+      ::
+
+        <!ELEMENT PROPERTY.REFERENCE (QUALIFIER*, (VALUE.REFERENCE)?)>
+        <!ATTLIST PROPERTY.REFERENCE
+            %CIMName;
+            %ReferenceClass;
+            %ClassOrigin;
+            %Propagated;>
     """
 
     check_node(tup_tree, 'PROPERTY.REFERENCE', ['NAME'],
@@ -1062,12 +1149,14 @@ def parse_property_reference(tup_tree):
 
 def parse_method(tup_tree):
     """
-    <!ELEMENT METHOD (QUALIFIER*, (PARAMETER | PARAMETER.REFERENCE |
-                                   PARAMETER.ARRAY | PARAMETER.REFARRAY)*)>
-    <!ATTLIST METHOD %CIMName;
-         %CIMType;              #IMPLIED
-         %ClassOrigin;
-         %Propagated;>
+      ::
+
+        <!ELEMENT METHOD (QUALIFIER*, (PARAMETER | PARAMETER.REFERENCE |
+                                       PARAMETER.ARRAY | PARAMETER.REFARRAY)*)>
+        <!ATTLIST METHOD %CIMName;
+            %CIMType;              #IMPLIED
+            %ClassOrigin;
+            %Propagated;>
     """
 
     check_node(tup_tree, 'METHOD', ['NAME'],
@@ -1094,10 +1183,12 @@ def parse_method(tup_tree):
 
 def parse_parameter(tup_tree):
     """
-    <!ELEMENT PARAMETER (QUALIFIER*)>
-    <!ATTLIST PARAMETER
-         %CIMName;
-         %CIMType;              #REQUIRED>
+      ::
+
+        <!ELEMENT PARAMETER (QUALIFIER*)>
+        <!ATTLIST PARAMETER
+            %CIMName;
+            %CIMType;              #REQUIRED>
     """
 
     check_node(tup_tree, 'PARAMETER', ['NAME', 'TYPE'], [])
@@ -1113,10 +1204,12 @@ def parse_parameter(tup_tree):
 
 def parse_parameter_reference(tup_tree):
     """
-    <!ELEMENT PARAMETER.REFERENCE (QUALIFIER*)>
-    <!ATTLIST PARAMETER.REFERENCE
-        %CIMName;
-        %ReferenceClass;>
+      ::
+
+        <!ELEMENT PARAMETER.REFERENCE (QUALIFIER*)>
+        <!ATTLIST PARAMETER.REFERENCE
+            %CIMName;
+            %ReferenceClass;>
     """
 
     check_node(tup_tree, 'PARAMETER.REFERENCE', ['NAME'], ['REFERENCECLASS'])
@@ -1135,11 +1228,13 @@ def parse_parameter_reference(tup_tree):
 
 def parse_parameter_array(tup_tree):
     """
-    <!ELEMENT PARAMETER.ARRAY (QUALIFIER*)>
-    <!ATTLIST PARAMETER.ARRAY
-         %CIMName;
-         %CIMType;              #REQUIRED
-         %ArraySize;>
+      ::
+
+        <!ELEMENT PARAMETER.ARRAY (QUALIFIER*)>
+        <!ATTLIST PARAMETER.ARRAY
+            %CIMName;
+            %CIMType;              #REQUIRED
+            %ArraySize;>
     """
 
     check_node(tup_tree, 'PARAMETER.ARRAY', ['NAME', 'TYPE'],
@@ -1164,11 +1259,13 @@ def parse_parameter_array(tup_tree):
 
 def parse_parameter_refarray(tup_tree):
     """
-    <!ELEMENT PARAMETER.REFARRAY (QUALIFIER*)>
-    <!ATTLIST PARAMETER.REFARRAY
-        %CIMName;
-        %ReferenceClass;
-        %ArraySize;>
+      ::
+
+        <!ELEMENT PARAMETER.REFARRAY (QUALIFIER*)>
+        <!ATTLIST PARAMETER.REFARRAY
+            %CIMName;
+            %ReferenceClass;
+            %ArraySize;>
     """
 
     check_node(tup_tree, 'PARAMETER.REFARRAY', ['NAME'],
@@ -1197,10 +1294,12 @@ def parse_parameter_refarray(tup_tree):
 
 def parse_message(tup_tree):
     """
-    <!ELEMENT MESSAGE (SIMPLEREQ | MULTIREQ | SIMPLERSP | MULTIRSP)>
-    <!ATTLIST MESSAGE
-        ID CDATA #REQUIRED
-        PROTOCOLVERSION CDATA #REQUIRED>
+      ::
+
+        <!ELEMENT MESSAGE (SIMPLEREQ | MULTIREQ | SIMPLERSP | MULTIRSP)>
+        <!ATTLIST MESSAGE
+            ID CDATA #REQUIRED
+            PROTOCOLVERSION CDATA #REQUIRED>
     """
 
     check_node(tup_tree, 'MESSAGE', ['ID', 'PROTOCOLVERSION'])
@@ -1229,7 +1328,9 @@ def parse_multiexpreq(tup_tree):   #pylint: disable=unused-argument
 
 def parse_simpleexpreq(tup_tree):
     """
-    <!ELEMENT SIMPLEEXPREQ (EXPMETHODCALL)>
+      ::
+
+        <!ELEMENT SIMPLEEXPREQ (EXPMETHODCALL)>
     """
 
     child = one_child(tup_tree, ['EXPMETHODCALL'])
@@ -1238,7 +1339,9 @@ def parse_simpleexpreq(tup_tree):
 
 def parse_simplereq(tup_tree):
     """
-    <!ELEMENT SIMPLEREQ (IMETHODCALL | METHODCALL)>
+      ::
+
+        <!ELEMENT SIMPLEREQ (IMETHODCALL | METHODCALL)>
     """
 
     check_node(tup_tree, 'SIMPLEREQ')
@@ -1250,9 +1353,11 @@ def parse_simplereq(tup_tree):
 
 def parse_imethodcall(tup_tree):
     """
-    <!ELEMENT IMETHODCALL (LOCALNAMESPACEPATH, IPARAMVALUE*)>
-    <!ATTLIST IMETHODCALL
-        %CIMName;>
+      ::
+
+        <!ELEMENT IMETHODCALL (LOCALNAMESPACEPATH, IPARAMVALUE*)>
+        <!ATTLIST IMETHODCALL
+            %CIMName;>
     """
 
     check_node(tup_tree, 'IMETHODCALL', ['NAME'])
@@ -1269,9 +1374,11 @@ def parse_imethodcall(tup_tree):
 
 def parse_methodcall(tup_tree):
     """
-    <!ELEMENT METHODCALL ((LOCALCLASSPATH|LOCALINSTANCEPATH),PARAMVALUE*)>
-    <!ATTLIST METHODCALL
-         %CIMName;>
+      ::
+
+        <!ELEMENT METHODCALL ((LOCALCLASSPATH|LOCALINSTANCEPATH),PARAMVALUE*)>
+        <!ATTLIST METHODCALL
+            %CIMName;>
     """
 
     check_node(tup_tree, 'METHODCALL', ['NAME'], [],
@@ -1287,9 +1394,11 @@ def parse_methodcall(tup_tree):
 
 def parse_expmethodcall(tup_tree):
     """
-    <!ELEMENT EXPMETHODCALL (EXPPARAMVALUE*)>
-    <!ATTLIST EXPMETHODCALL
-        %CIMName;>
+      ::
+
+        <!ELEMENT EXPMETHODCALL (EXPPARAMVALUE*)>
+        <!ATTLIST EXPMETHODCALL
+            %CIMName;>
     """
 
     check_node(tup_tree, 'EXPMETHODCALL', ['NAME'], [], ['EXPPARAMVALUE'])
@@ -1301,13 +1410,17 @@ def parse_expmethodcall(tup_tree):
 
 
 def parse_paramvalue(tup_tree):
-    """Parse PARAMVALUE element """
-    ## <!ELEMENT PARAMVALUE (VALUE | VALUE.REFERENCE | VALUE.ARRAY |
-    ##                       VALUE.REFARRAY)?>
-    ## <!ATTLIST PARAMVALUE
-    ##   %CIMName;
-    ##   %ParamType;  #IMPLIED
-    ##   %EmbeddedObject;>
+    """Parse PARAMVALUE element.
+
+      ::
+
+        <!ELEMENT PARAMVALUE (VALUE | VALUE.REFERENCE | VALUE.ARRAY |
+                              VALUE.REFARRAY)?>
+        <!ATTLIST PARAMVALUE
+            %CIMName;
+            %ParamType;  #IMPLIED
+            %EmbeddedObject;>
+    """
 
     ## Version 2.1.1 of the DTD lacks the %ParamType attribute but it
     ## is present in version 2.2.  Make it optional to be backwards
@@ -1333,15 +1446,17 @@ def parse_paramvalue(tup_tree):
 
 
 def parse_iparamvalue(tup_tree):
-    """
-    Parse expected IPARAMVALUE element. I.e.
-       ## <!ELEMENT IPARAMVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
-       ##                       INSTANCENAME | CLASSNAME |
-       ##                       QUALIFIER.DECLARATION |
-       ##                       CLASS | INSTANCE | VALUE.NAMEDINSTANCE)?>
-       ## <!ATTLIST IPARAMVALUE %CIMName;>
+    """Parse expected IPARAMVALUE element. I.e.
 
-       :return: NAME, VALUE pair.
+      ::
+
+        <!ELEMENT IPARAMVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
+                              INSTANCENAME | CLASSNAME |
+                              QUALIFIER.DECLARATION |
+                              CLASS | INSTANCE | VALUE.NAMEDINSTANCE)?>
+        <!ATTLIST IPARAMVALUE %CIMName;>
+
+    :return: NAME, VALUE pair.
     """
 
     check_node(tup_tree, 'IPARAMVALUE', ['NAME'], [])
@@ -1364,9 +1479,12 @@ def parse_iparamvalue(tup_tree):
 
 def parse_expparamvalue(tup_tree):
     """Parse for EXPPARMVALUE Element. I.e.
-    <!ELEMENT EXPPARAMVALUE (INSTANCE?)>
-    <!ATTLIST EXPPARAMVALUE
-        %CIMName;>
+
+      ::
+
+        <!ELEMENT EXPPARAMVALUE (INSTANCE?)>
+        <!ATTLIST EXPPARAMVALUE
+            %CIMName;>
     """
 
     check_node(tup_tree, 'EXPPARAMVALUE', ['NAME'], [], ['INSTANCE'])
@@ -1390,8 +1508,13 @@ def parse_multiexprsp(tup_tree):   #pylint: disable=unused-argument
 
 
 def parse_simplersp(tup_tree):
-    """Parse for SIMPLERSP Element"""
-    ## <!ELEMENT SIMPLERSP (METHODRESPONSE | IMETHODRESPONSE)>
+    """Parse for SIMPLERSP Element.
+
+      ::
+
+        <!ELEMENT SIMPLERSP (METHODRESPONSE | IMETHODRESPONSE)>
+    """
+
     check_node(tup_tree, 'SIMPLERSP', [], [])
 
     child = one_child(tup_tree, ['METHODRESPONSE', 'IMETHODRESPONSE'])
@@ -1407,9 +1530,12 @@ def parse_simpleexprsp(tup_tree):   #pylint: disable=unused-argument
 
 def parse_methodresponse(tup_tree):
     """Parse expected METHODRESPONSE ELEMENT. I.e.
+
+      ::
+
         <!ELEMENT METHODRESPONSE (ERROR | (RETURNVALUE?, PARAMVALUE*))>
-            <!ATTLIST METHODRESPONSE
-                %CIMName;>
+        <!ATTLIST METHODRESPONSE
+            %CIMName;>
     """
 
     check_node(tup_tree, 'METHODRESPONSE', ['NAME'], [])
@@ -1428,6 +1554,9 @@ def parse_expmethodresponse(tup_tree):  #pylint: disable=unused-argument
 
 def parse_imethodresponse(tup_tree):
     """Parse the tuple for an IMETHODRESPONE Element. I.e.
+
+      ::
+
         <!ELEMENT IMETHODRESPONSE (ERROR | IRETURNVALUE?)>
         <!ATTLIST IMETHODRESPONSE %CIMName;>
     """
@@ -1441,10 +1570,13 @@ def parse_imethodresponse(tup_tree):
 
 def parse_error(tup_tree):
     """Parse ERROR element to get CODE and DESCRIPTION.
-    <!ELEMENT ERROR EMPTY>
-    <!ATTLIST ERROR
-        CODE CDATA #REQUIRED
-        DESCRIPTION CDATA #IMPLIED>
+
+      ::
+
+        <!ELEMENT ERROR EMPTY>
+        <!ATTLIST ERROR
+            CODE CDATA #REQUIRED
+            DESCRIPTION CDATA #IMPLIED>
     """
 
     ## TODO: Return a CIMError object, not a tuple
@@ -1456,11 +1588,14 @@ def parse_error(tup_tree):
 
 def parse_returnvalue(tup_tree):
     """Parse the RETURNVALUE element. Returns name, attributes, and
-       one child as a tuple.
+    one child as a tuple.
+
+      ::
+
+        <!ELEMENT RETURNVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
+                               VALUE.REFARRAY)>
+        <!ATTLIST RETURNVALUE %ParamType;       #IMPLIED>
     """
-    ## <!ELEMENT RETURNVALUE (VALUE | VALUE.ARRAY | VALUE.REFERENCE |
-    ##                        VALUE.REFARRAY)>
-    ## <!ATTLIST RETURNVALUE %ParamType;       #IMPLIED>
 
     ## Version 2.1.1 of the DTD lacks the %ParamType attribute but it
     ## is present in version 2.2.  Make it optional to be backwards
@@ -1476,14 +1611,17 @@ def parse_returnvalue(tup_tree):
 
 def parse_ireturnvalue(tup_tree):
     """Parse IRETURNVALUE element. Returns name, attributes and
-       values of the tup_tree.
+    values of the tup_tree.
+
+      ::
+
+        <!ELEMENT IRETURNVALUE (CLASSNAME* | INSTANCENAME* | VALUE* |
+                                VALUE.OBJECTWITHPATH* |
+                                VALUE.OBJECTWITHLOCALPATH* | VALUE.OBJECT* |
+                                OBJECTPATH* | QUALIFIER.DECLARATION* |
+                                VALUE.ARRAY? | VALUE.REFERENCE? | CLASS* |
+                                INSTANCE* | VALUE.NAMEDINSTANCE*)>
     """
-    ## <!ELEMENT IRETURNVALUE (CLASSNAME* | INSTANCENAME* | VALUE* |
-    ##                         VALUE.OBJECTWITHPATH* |
-    ##                         VALUE.OBJECTWITHLOCALPATH* | VALUE.OBJECT* |
-    ##                         OBJECTPATH* | QUALIFIER.DECLARATION* |
-    ##                         VALUE.ARRAY? | VALUE.REFERENCE? | CLASS* |
-    ##                         INSTANCE* | VALUE.NAMEDINSTANCE*)>
 
     check_node(tup_tree, 'IRETURNVALUE', [], [])
 
@@ -1509,11 +1647,11 @@ def parse_ireturnvalue(tup_tree):
 
 def parse_any(tup_tree):
     """Parse a fragment of XML. This function drives the rest of
-       the parser by calling 'parse_*' functions based on the name
-       of the element being parsed.
+    the parser by calling ``parse_*()`` functions based on the name
+    of the element being parsed.
 
-       It builds parser function name from incoming name in tup_tree
-       prepended with 'parse_' and calls that function.
+    It builds parser function name from incoming name in tup_tree
+    prepended with ``parse_`` and calls that function.
 
     Return is determined by function called.
     """
@@ -1528,12 +1666,13 @@ def parse_any(tup_tree):
 
 def parse_embeddedObject(val): # pylint: disable=invalid-name
     """Parse and embedded instance or class and return the
-       CIMInstance or CIMClass
+    CIMInstance or CIMClass.
 
-       :return: None if val is None. Returns either CIMClass or
-           CIMInstance or a list of them
+    :Returns:
+      None if val is None. Returns either CIMClass or CIMInstance or a list of
+      them.
 
-       :Raises: ParseError if there is an error in the XML
+    :Raises ParseError: There is an error in the XML.
     """
 
     if isinstance(val, list):
@@ -1578,6 +1717,7 @@ def unpack_value(tup_tree):
 
 def unpack_boolean(data):
     """Unpack a boolean, represented as "TRUE" or "FALSE" in CIM."""
+
     if data is None:
         return None
 

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -150,13 +150,12 @@ def GetInstance(instancename, LocalOnly=True, IncludeQualifiers=False,
     :param LocalOnly: Optional argument defining whether the
        only the properties defined in this instance are returned.
        Default= true. DEPRECATED
-    :param IncludeQualifier: Optional argument defining whether
+    :param IncludeQualifiers: Optional argument defining whether
         qualifiers are included. Default false. DEPRECATED
     :param IncludeClassOrigin: Optional argument defining wheteher
         class origin information is cinclude in the response. Default
         is False.
     :return: Dictionary containing the retrieved instance
-    :raises:
     """
     # pylint: disable=global-variable-not-assigned
     global _CONN     # pylint: disable=global-statement


### PR DESCRIPTION
This PR was triggered by Karl's comment 2 on issue #93, and then evolved in some more docstring changes.

Details, from the combined commit messages:

- Resolved nearly all Eydoc warnings.
- Added class names to all docstrings of `cim_obj` classes (see Karl's comment 2 on issue #93).
- Moved CIM-XML DTD definitions in `tupleparse.py` from Python comments into the docstrings.
- In `mof_compiler._print_logger()`, changed name of `str_` argument to `msg`, to avoid Epydoc warning about unresolved link target. This is an internal function so this should not be a problem for users.