### PR TITLE
Save in process work to clean up mof indent issues #110 and #147

### DIFF
--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -757,6 +757,9 @@ class GetClass(ClientClassTest):
         if self.debug:
             print('GetClass gets name %s' % name)
         self.verify_class(cl)
+        mof_output = cl.tomof()
+        if self.verbose:
+            print('MOF OUTPUT\n%s' % (mof_output))
 
 class CreateClass(ClientClassTest):
 


### PR DESCRIPTION
Adds code for embedded instance tomof, generalizes mof indent, sets mof indent
from 7 to 4, fixes several places where line overflows 80 col.
Adds constants to control indent and uses them to generate
indented mof.
Handles properties with arrays of values so that they do
not overflow max line length.
Add more tests to test_cim_obj.py for mof output of classes
and instances.

Remove special tests added to run_cim_operations.py that should be part of this commit/pr. Will be in separate branch
Adds one optional test to run_cim_operations.py

NOTE: I think that I had another embedinstance branch but this branch covers the error in embedded instance

Somehow I got too much into one branch, both the embedded instance fix and the clean up of mof output formatting.  