### PR TITLE
Fixes #34, fixes #154: Various improvements to wbemcli + None parameter fix

### DIFF
--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -623,7 +623,7 @@ class WBEMConnection(object):
         # Create parameter list
 
         plist = [cim_xml.IPARAMVALUE(x[0], tocimxml(x[1])) \
-                 for x in params.items()]
+                 for x in params.items() if x[1] is not None]
 
         # Build XML request
 

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -85,7 +85,7 @@ def _remote_connection(server, opts):
     if server[0] == '/':
         url = server
     else:
-        roto = 'https'
+        proto = 'https'
 
         if opts.no_ssl:
             proto = 'http'

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -48,43 +48,44 @@ function. For example:
 
 from __future__ import absolute_import
 
-import os
-import getpass
-import errno
-import code
-import argparse
+import sys as _sys
+import os as _os
+import getpass as _getpass
+import errno as _errno
+import code as _code
+import argparse as _argparse
 
 # Additional symbols for use in the interactive session
 from pprint import pprint as pp # pylint: disable=unused-import
 
 # Conditional support of readline module
 try:
-    import readline
+    import readline as _readline
     _HAVE_READLINE = True
 except ImportError as arg:
     _HAVE_READLINE = False
 
-from . import WBEMConnection
-from ._cliutils import SmartFormatter
+from . import *
+from ._cliutils import SmartFormatter as _SmartFormatter
 
 __all__ = []
 
 # Connection global variable. Set by remote_connection and use
 # by all functions that execute operations.
-_CONN = None
+CONN = None
 
-def remote_connection(server, opts):
+def _remote_connection(server, opts):
     """Initiate a remote connection, via PyWBEM. Arguments for
        the request are part of the command line arguments and include
        user name, password, namespace, etc.
     """
 
-    global _CONN     # pylint: disable=global-statement
+    global CONN     # pylint: disable=global-statement
 
     if server[0] == '/':
         url = server
     else:
-        proto = 'https'
+        roto = 'https'
 
         if opts.no_ssl:
             proto = 'http'
@@ -97,256 +98,785 @@ def remote_connection(server, opts):
     creds = None
 
     if opts.user is not None and opts.password is None:
-        opts.password = getpass.getpass('Enter password for %s: ' % opts.user)
+        opts.password = _getpass.getpass('Enter password for %s: ' % opts.user)
 
     if opts.user is not None or opts.password is not None:
         creds = (opts.user, opts.password)
 
-    _CONN = WBEMConnection(url, creds, default_namespace=opts.namespace)
+    CONN = WBEMConnection(url, creds, default_namespace=opts.namespace)
 
-    _CONN.debug = True
+    CONN.debug = True
 
-    return _CONN
+    return CONN
 
 #
 # Create some convenient global functions to reduce typing
 #
+
 # The following pylint disable is because many of the functions
 # in this file use CamelCase specifically to maintain equivalence to
 # the client functions in other languages. Do not change these names.
 # pylint: disable=invalid-name
-def EnumerateInstanceNames(classname, namespace=None):
-    """Enumerate the names of the instances of a CIM Class (including the
-    names of any subclasses) in the target namespace."""
+
+def EnumerateInstanceNames(cn, ns=None):
+    """
+    Enumerate the instance paths of instances of a class (including instances
+    of its subclasses) in a namespace.
+
+    Parameters:
+
+      cn (string): Class name.
+
+      ns (string): Namespace name. None will use the default namespace.
+
+    Returns:
+
+      list(CIMInstanceName): The enumerated instance paths.
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
+    global CONN     # pylint: disable=global-statement
 
-    return _CONN.EnumerateInstanceNames(classname, namespace=namespace)
+    return CONN.EnumerateInstanceNames(cn, ns)
 
 # pylint: disable=too-many-arguments
-def EnumerateInstances(classname, namespace=None, LocalOnly=True,
-                       DeepInheritance=True, IncludeQualifiers=False,
-                       IncludeClassOrigin=False):
-    """Enumerate instances of a CIM Class (includeing the instances of
-    any subclasses in the target namespace."""
-
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-
-    return _CONN.EnumerateInstances(classname,
-                                    namespace=namespace,
-                                    LocalOnly=LocalOnly,
-                                    DeepInheritance=DeepInheritance,
-                                    IncludeQualifiers=IncludeQualifiers,
-                                    IncludeClassOrigin=IncludeClassOrigin)
-
-
-def GetInstance(instancename, LocalOnly=True, IncludeQualifiers=False,
-                IncludeClassOrigin=False):
-    """Return a single CIM instance corresponding to the instance name
-    given.
-
-    :param instancename: ObjectPath defining the instance.
-    :param LocalOnly: Optional argument defining whether the
-       only the properties defined in this instance are returned.
-       Default= true. DEPRECATED
-    :param IncludeQualifiers: Optional argument defining whether
-        qualifiers are included. Default false. DEPRECATED
-    :param IncludeClassOrigin: Optional argument defining wheteher
-        class origin information is cinclude in the response. Default
-        is False.
-    :return: Dictionary containing the retrieved instance
+def EnumerateInstances(cn, ns=None, lo=None, di=None, iq=None, ico=None,
+                       pl=None):
     """
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
+    Enumerate the instances of a class (including instances of its subclasses)
+    in a namespace.
 
-    return _CONN.GetInstance(instancename,
-                             LocalOnly=LocalOnly,
-                             IncludeQualifiers=IncludeQualifiers,
-                             IncludeClassOrigin=IncludeClassOrigin)
+    Parameters:
 
-def DeleteInstance(instancename):
-    """Delete a single CIM instance.
+      cn (string): Class name.
 
-       :param instancename: CIMObjectPath defining the instance
-       :return:
+      ns (string): Namespace name. None will use the default namespace.
+
+      lo (bool):   LocalOnly flag: Exclude inherited properties.
+                   Deprecated: Server impls for True vary; Set to False.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      di (bool):   DeepInheritance flag: Include properties added by subclasses.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   Deprecated: Instance qualifiers have been deprecated in CIM.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   Deprecated: Server may treat as False.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      pl (list):   List of property names to be included. None means all.
+                   None causes it not to be included in the request to server.
+                   Server default: None
+
+    Returns:
+
+      list(CIMInstance): The enumerated instances.
     """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
+    global CONN     # pylint: disable=global-statement
 
-    return _CONN.DeleteInstance(instancename)
+    return CONN.EnumerateInstances(cn, ns,
+                                   LocalOnly=lo,
+                                   DeepInheritance=di,
+                                   IncludeQualifiers=iq,
+                                   IncludeClassOrigin=ico,
+                                   PropertyList=pl)
 
-# TODO KS: All of the following functions simply use args and kwargs. This
-#          makes sorting out arguments difficult for the user.
 
-def ModifyInstance(*args, **kwargs):
-    """Modify an existing instance"""
+def GetInstance(ip, lo=None, iq=None, ico=None, pl=None):
+    """
+    Retrieve an instance.
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.ModifyInstance(*args, **kwargs)
+    Parameters:
 
-def CreateInstance(*args, **kwargs):
-    """Create a new instance for an existing class"""
+      ip (CIMInstanceName): Instance path.
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.CreateInstance(*args, **kwargs)
+      lo (bool):   LocalOnly flag: Exclude inherited properties.
+                   Deprecated: Server impls for True vary; Set to False.
+                   None causes it not to be included in request to server.
+                   Server default: True
 
-def InvokeMethod(*args, **kwargs):
-    """Invoke a method"""
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   Deprecated: Instance qualifiers have been deprecated in CIM.
+                   None causes it not to be included in request to server.
+                   Server default: False
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.InvokeMethod(*args, **kwargs)
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   Deprecated:  Server impls. vary; Server may treat as False.
+                   None causes it not to be included in request to server.
+                   Server default: False
 
-def AssociatorNames(*args, **kwargs):
-    """Return associator names for the source class or instance"""
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.AssociatorNames(*args, **kwargs)
+      pl (list):   List of property names to be included. None means all.
+                   None causes it not to be included in request to server.
+                   Server default: None
 
-def Associators(*args, **kwargs):
-    """Return associators for the source class or instance"""
+    Returns:
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.Associators(*args, **kwargs)
-
-def ReferenceNames(*args, **kwargs):
-    """Return the refernence names for the target class or instance"""
+      CIMInstance: The retrieved instance.
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.ReferenceNames(*args, **kwargs)
+    global CONN     # pylint: disable=global-statement
 
-def References(*args, **kwargs):
-    """Return the instances or classes for the target instance or class"""
+    return CONN.GetInstance(ip,
+                            LocalOnly=lo,
+                            IncludeQualifiers=iq,
+                            IncludeClassOrigin=ico,
+                            PropertyList=pl)
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.References(*args, **kwargs)
 
-def EnumerateClassNames(*args, **kwargs):
-    "Enumerate the class names in the namespace"""
+def ModifyInstance(mi, iq=None, pl=None):
+    """
+    Modify the property values of an instance.
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.EnumerateClassNames(*args, **kwargs)
+    Parameters:
 
-def EnumerateClasses(*args, **kwargs):
-    """Enumerate the classes defined by the input arguments"""
+      mi (CIMInstance): Modified instance.
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.EnumerateClasses(*args, **kwargs)
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   Deprecated: Instance qualifiers have been deprecated in CIM.
+                   None causes it not to be included in request to server.
+                   Server default: False
 
-def GetClass(*args, **kwargs):
-    """ Get the class defined by the inputs"""
-
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.GetClass(*args, **kwargs)
-
-def DeleteClass(*args, **kwargs):
-    """Delete the class defined by the input. """
+      pl (list):   List of property names to be modified. None means all.
+                   None causes it not to be included in request to server.
+                   Server default: None
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.DeleteClass(*args, **kwargs)
+    global CONN     # pylint: disable=global-statement
 
-def ModifyClass(*args, **kwargs):
-    """Modify the class defined by the input arguments"""
+    CONN.ModifyInstance(mi,
+                        IncludeQualifiers=iq,
+                        PropertyList=pl)
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.ModifyClass(*args, **kwargs)
 
-def CreateClass(*args, **kwargs):
-    """Create a class from the input arguments"""
+def CreateInstance(ni):
+    """
+    Create an instance in a namespace.
 
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.CreateClass(*args, **kwargs)
+    Parameters:
 
-def EnumerateQualifiers(*args, **kwargs):
-    """Return the qualifier types that exist in the defined namespace"""
-    # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.EnumerateQualifiers(*args, **kwargs)
+      ni (CIMInstance): New instance (with namespace, classname, and properties
+                        attributes set).
 
-def GetQualifier(*args, **kwargs):
-    """Return the qualifier type defined by the input argument"""
+    Returns:
+      CIMInstanceName: Instance path of the new instance.
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.GetQualifier(*args, **kwargs)
+    global CONN     # pylint: disable=global-statement
 
-def SetQualifier(*args, **kwargs):
-    """Create a new qualifier type from the input arguments"""
+    return CONN.CreateInstance(ni)
+
+
+def DeleteInstance(ip):
+    """
+    Delete an instance.
+
+    Parameters:
+
+      ip (CIMInstanceName): Instance path.
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.SetQualifier(*args, **kwargs)
+    global CONN     # pylint: disable=global-statement
 
-def DeleteQualifier(*args, **kwargs):
-    """Delete a qualifier type"""
+    CONN.DeleteInstance(ip)
+
+
+def AssociatorNames(op, ac=None, rc=None, r=None, rr=None):
+    """
+    Instance level use: Retrieve the instance paths of the instances
+    associated to a source instance.
+
+    Class level use: Retrieve the class paths of the classes associated to a
+    source class.
+
+    Parameters:
+
+      op (CIMInstanceName): Source instance path; select instance level use.
+      op (CIMClassName): Source class path; select class level use.
+
+      ac (string): AssociationClass filter: Include only traversals across
+                   this association class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      rc (string): ResultClass filter: Include only traversals to this
+                   associated (result) class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      r (string):  Role filter: Include only traversals from this role
+                   (= reference name) in source object.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      rr (string): ResultRole filter: Include only traversals to this role
+                   (= reference name) in associated (=result) objects.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+    Returns:
+
+      list(CIMInstanceName): The instance paths of the associated instances.
+    """
 
     # pylint: disable=global-variable-not-assigned
-    global _CONN     # pylint: disable=global-statement
-    return _CONN.DeleteQualifier(*args, **kwargs)
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.AssociatorNames(op,
+                                AssocClass=ac,
+                                ResultClass=rc,
+                                Role=r,
+                                ResultRole=rr)
+
+
+def Associators(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None,
+                pl=None):
+    """
+    Instance level use: Retrieve the instances associated to a source instance.
+
+    Class level use: Retrieve the classes associated to a source class.
+
+    Parameters:
+
+      op (CIMInstanceName): Source instance path; select instance level use.
+      op (CIMClassName): Source class path; select class level use.
+
+      ac (string): AssociationClass filter: Include only traversals across
+                   this association class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      rc (string): ResultClass filter: Include only traversals to this
+                   associated (result) class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      r (string):  Role filter: Include only traversals from this role
+                   (= reference name) in source object.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      rr (string): ResultRole filter: Include only traversals to this role
+                   (= reference name) in associated (=result) objects.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   Deprecated: Instance qualifiers have been deprecated in CIM.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   Deprecated:  Server impls. vary; Server may treat as False.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      pl (list):   List of property names to be included. None means all.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+    Returns:
+
+      list(CIMInstance): The associated instances.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.Associators(op,
+                            AssocClass=ac,
+                            ResultClass=rc,
+                            Role=r,
+                            ResultRole=rr,
+                            IncludeQualifiers=iq,
+                            IncludeClassOrigin=ico,
+                            PropertyList=pl)
+
+
+def ReferenceNames(op, rc=None, r=None):
+    """
+    Instance level use: Retrieve the instance paths of the association
+    instances referencing a source instance.
+
+    Class level use: Retrieve the class paths of the association classes
+    referencing a source class.
+
+    Parameters:
+
+      op (CIMInstanceName): Source instance path; select instance level use.
+      op (CIMClassName): Source class path; select class level use.
+
+      rc (string): ResultClass filter: Include only traversals across this
+                   association (result) class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      r (string):  Role filter: Include only traversals from this role
+                   (= reference name) in source object.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+    Returns:
+      list(CIMInstanceName): The instance paths of the association instances.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.ReferenceNames(op,
+                               ResultClass=rc,
+                               Role=r)
+
+
+def References(op, rc=None, r=None, iq=None, ico=None, pl=None):
+    """
+    Instance level use: Retrieve the association instances referencing a source
+    instance.
+
+    Class level use: Retrieve the association classes referencing a source
+    class.
+
+    Parameters:
+
+      op (CIMInstanceName): Source instance path; select instance level use.
+      op (CIMClassName): Source class path; select class level use.
+
+      rc (string): ResultClass filter: Include only traversals across this
+                   association (result) class.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      r (string):  Role filter: Include only traversals from this role
+                   (= reference name) in source object.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   Deprecated: Instance qualifiers have been deprecated in CIM.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   Deprecated:  Server impls. vary; Server may treat as False.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      pl (list):   List of property names to be included. None means all.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+    Returns:
+
+      list(CIMInstance): The association instances.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.References(op,
+                           ResultClass=rc,
+                           Role=r,
+                           IncludeQualifiers=iq,
+                           IncludeClassOrigin=ico,
+                           PropertyList=pl)
+
+
+def InvokeMethod(mn, op, *params, **kwparams):
+    """
+    Invoke a method on a target instance or a static method on a target class.
+
+    Parameters:
+
+      mn (string): Method name.
+
+      op (CIMInstanceName): Target instance path.
+      op (CIMClassName): Target class path.
+
+      *params (named args): Input parameters for the method.
+
+      **kwparams (keyword args): Input parameters for the method.
+
+    Returns:
+
+      tuple(rv, out): Method return value, dict with output parameters.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.InvokeMethod(mn, op, *params, **kwparams)
+
+
+def EnumerateClassNames(ns=None, cn=None, di=None):
+    """
+    Enumerate the names of subclasses of a class, or of the top-level classes
+    in a namespace.
+
+    Parameters:
+
+      ns (string): Namespace name. None will use the default namespace.
+
+      cn (string): Class name. None will return the top-level classes.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      di (bool):   DeepInheritance flag: Include also indirect subclasses.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+    Returns:
+
+      list(string): The enumerated class names.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.EnumerateClassNames(ns,
+                                    ClassName=ns,
+                                    DeepInheritance=di)
+
+
+def EnumerateClasses(ns=None, cn=None, di=None, lo=None, iq=None, ico=None):
+    """
+    Enumerate the subclasses of a class, or the top-level classes in a
+    namespace.
+
+    Parameters:
+
+      ns (string): Namespace name. None will use the default namespace.
+
+      cn (string): Class name. None will return the top-level classes.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+      di (bool):   DeepInheritance flag: Include also indirect subclasses.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      lo (bool):   LocalOnly flag: Exclude inherited properties.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+    Returns:
+
+      list(string): The enumerated class names.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.EnumerateClassNames(ns,
+                                    ClassName=cn,
+                                    DeepInheritance=di,
+                                    LocalOnly=lo,
+                                    IncludeQualifiers=iq,
+                                    IncludeClassOrigin=ico)
+
+
+def GetClass(cn, ns=None, lo=None, iq=None, ico=None, pl=None):
+    """
+    Retrieve a class.
+
+    Parameters:
+
+      cn (string): Class name.
+
+      ns (string): Namespace name. None will use the default namespace.
+
+      lo (bool):   LocalOnly flag: Exclude inherited properties.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      iq (bool):   IncludeQualifiers flag: Include qualifiers.
+                   None causes it not to be included in request to server.
+                   Server default: True
+
+      ico (bool):  IncludeClassOrigin flag: Include class origin info for props.
+                   None causes it not to be included in request to server.
+                   Server default: False
+
+      pl (list):   List of property names to be included. None means all.
+                   None causes it not to be included in request to server.
+                   Server default: None
+
+    Returns:
+
+      list(CIMClass): The retrieved class.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.GetClass(cn, ns,
+                         LocalOnly=lo,
+                         IncludeQualifiers=iq,
+                         IncludeClassOrigin=ico,
+                         PropertyList=pl)
+
+
+def ModifyClass(mc, ns=None):
+    """
+    Modify a class.
+
+    Parameters:
+
+      mc (CIMClass): Modified class.
+
+      ns (string): Namespace name. None will use the default namespace.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.ModifyClass(mc, ns)
+
+
+def CreateClass(nc, ns=None):
+    """
+    Create a class in a namespace.
+
+    Parameters:
+
+      nc (CIMClass): New class.
+
+      ns (string): Namespace name. None will use the default namespace.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    CONN.CreateClass(nc, ns)
+
+
+def DeleteClass(cn, ns=None):
+    """
+    Delete a class.
+
+    Parameters:
+
+      cn (string): Class name.
+
+      ns (string): Namespace name. None will use the default namespace.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    CONN.DeleteClass(cn, ns)
+
+
+def EnumerateQualifiers(ns=None):
+    """
+    Enumerate qualifier types (= declarations) in a namespace.
+
+    Parameters:
+
+      ns (string): Namespace name. None will use the default namespace.
+
+    Returns:
+
+      list(CIMQualifierDeclaration): Enumerated qualifier types.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.EnumerateQualifiers(ns)
+
+
+def GetQualifier(qn, ns=None):
+    """
+    Retrieve a qualifier type (= declaration).
+
+    Parameters:
+
+      qn (string): Qualifier name.
+
+      ns (string): Namespace name. None will use the default namespace.
+
+    Returns:
+
+      CIMQualifierDeclaration: Retrieved qualifier type.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    return CONN.GetQualifier(qn, ns)
+
+
+def SetQualifier(qd, ns=None):
+    """
+    Create or modify a qualifier type (= declaration) in a namespace.
+
+    Parameters:
+
+      qd (CIMQualifierDeclaration): Qualifier type.
+
+      ns (string): Namespace name. None will use the default namespace.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    CONN.SetQualifier(qd, ns)
+
+
+def DeleteQualifier(qn, ns=None):
+    """
+    Delete a qualifier type (= declaration).
+
+    Parameters:
+
+      qn (string): Qualifier name.
+
+      ns (string): Namespace name. None will use the default namespace.
+    """
+
+    # pylint: disable=global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement
+
+    CONN.DeleteQualifier(qn, ns)
+
+
+def h():
+    """Print help text for interactive environment."""
+
+    print(_get_connection_info())
+    print("""
+Short and long names of operation functions:
+  ein = EnumerateInstanceNames
+  ei  = EnumerateInstances
+  gi  = GetInstance
+  mi  = ModifyInstance
+  ci  = CreateInstance
+  di  = DeleteInstance
+  an  = AssociatorNames
+  a   = Associators
+  rn  = ReferenceNames
+  r   = References
+  im  = InvokeMethod
+  ecn = EnumerateClassNames
+  ec  = EnumerateClasses
+  gc  = GetClass
+  mc  = ModifyClass
+  cc  = CreateClass
+  dc  = DeleteClass
+  eq  = EnumerateQualifiers
+  gq  = GetQualifier
+  sq  = SetQualifier
+  dq  = DeleteQualifier
+
+Connection:
+  CONN = WBEMConnection object connected to the WBEM server
+
+Debugging support:
+  pdb('<stmt>') = enter PDB debugger to execute <stmt>
+
+Printing support:
+  pp(<obj>) = pprint function, good for dicts
+  <obj>.repr() = Operation result objects have repr() for debugging
+  <obj>.tomof() = Operation result objects often have a tomof() producing a
+                  MOF string
+  <obj>.tocimxml().toxml() = Operation result objects have a tocimxml()
+                  producing a DOM object that has a toxml() function
+                  producing an XML string
+
+Help:
+  help(<op>) : Brief help; <op> is a short operation namei, e.g. help(gi)
+  help(conn.<OpName>): Detailed help; <OpName> is a long operation name,
+         e.g. help(conn.GetInstance). conn = WBEMConnection class.
+
+The symbols from the pywbem package namespace are available in this namespace
+""")
+
+def pdb(stmt):
+    """Run the statement under the PDB debugger."""
+    import pdb
+    pdb.set_trace()
+
+    exec(stmt) # Type 3 x "s" to get to stmt, and "cont" to end debugger.
 
 # Aliases for global functions above
-
 
 ein = EnumerateInstanceNames
 ei = EnumerateInstances
 gi = GetInstance
-di = DeleteInstance
 mi = ModifyInstance
 ci = CreateInstance
-
-im = InvokeMethod
+di = DeleteInstance
 
 an = AssociatorNames
-ao = Associators
+a = Associators
 rn = ReferenceNames
-re = References
+r = References
+
+im = InvokeMethod
 
 ecn = EnumerateClassNames
 ec = EnumerateClasses
 gc = GetClass
-dc = DeleteClass
 mc = ModifyClass
 cc = CreateClass
+dc = DeleteClass
 
 eq = EnumerateQualifiers
 gq = GetQualifier
 sq = SetQualifier
 dq = DeleteQualifier
 
+conn = WBEMConnection
 
-def get_banner():
+def _get_connection_info():
+    """Return a string with the connection info."""
+
+    info = 'Connected to %s' % CONN.url
+    if CONN.creds is not None:
+        info += ' as %s' % CONN.creds[0]
+    else:
+        info += ' without credentials'
+    info += ', default namespace %s' % CONN.default_namespace
+    return info
+
+
+def _get_banner():
     """Return a banner message for the interactive console."""
 
-    global _CONN     # pylint: disable=global-statement,global-variable-not-assigned
+    global CONN     # pylint: disable=global-statement,global-variable-not-assigned
 
     result = ''
-
-    # Note how we are connected
-    result += 'Connected to %s' % _CONN.url
-    if _CONN.creds is not None:
-        result += ' as %s' % _CONN.creds[0]
+    result += '\nPython %s' % _sys.version
+    result += '\n\nWbemcli interactive shell'
+    result += '\n%s' % _get_connection_info()
 
     # Give hint about exiting. Most people exit with 'quit()' which will
     # not return from the interact() method, and thus will not write
     # the history.
     result += '\nPress Ctrl-D to exit'
+    result += '\nType h() for help'
 
     return result
-
 
 def main():
     """Parse command line arguments, connect to the WBEM server and
@@ -354,7 +884,7 @@ def main():
     A help message is printed with `-h` or `--help`.
     """
 
-    global _CONN     # pylint: disable=global-statement
+    global CONN     # pylint: disable=global-statement
 
     prog = "wbemcli"  # Name of the script file invoking this module
     usage = '%(prog)s [options] server'
@@ -364,9 +894,9 @@ def main():
 Example:
   %s localhost --port 15989 -n root/cimv2 -u sheldon -p penny42
 """ % prog
-    argparser = argparse.ArgumentParser(
+    argparser = _argparse.ArgumentParser(
         prog=prog, usage=usage, description=desc, epilog=epilog,
-        add_help=False, formatter_class=SmartFormatter)
+        add_help=False, formatter_class=_SmartFormatter)
 
     pos_arggroup = argparser.add_argument_group(
         'Positional arguments')
@@ -415,31 +945,31 @@ Example:
         argparser.error('No WBEM server specified')
 
     # Set up a client connection
-    _CONN = remote_connection(args.server, args)
+    CONN = _remote_connection(args.server, args)
 
     # Determine file path of history file
     home_dir = '.'
-    if 'HOME' in os.environ:
-        home_dir = os.environ['HOME'] # Linux
-    elif 'HOMEPATH' in os.environ:
-        home_dir = os.environ['HOMEPATH'] # Windows
+    if 'HOME' in _os.environ:
+        home_dir = _os.environ['HOME'] # Linux
+    elif 'HOMEPATH' in _os.environ:
+        home_dir = _os.environ['HOMEPATH'] # Windows
     histfile = '%s/.wbemcli_history' % home_dir
 
     # Read previous command line history
     if _HAVE_READLINE:
         try:
-            readline.read_history_file(histfile)
+            _readline.read_history_file(histfile)
         except IOError as arg:
-            if arg[0] != errno.ENOENT:
+            if arg[0] != _errno.ENOENT:
                 raise
 
     # Interact
-    i = code.InteractiveConsole(globals())
-    i.interact(get_banner())
+    i = _code.InteractiveConsole(globals())
+    i.interact(_get_banner())
 
     # Save command line history
     if _HAVE_READLINE:
-        readline.write_history_file(histfile)
+        _readline.write_history_file(histfile)
 
     return 0
 

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -790,6 +790,7 @@ Short and long names of operation functions:
 
 Connection:
   CONN = WBEMConnection object connected to the WBEM server
+  conn = WBEMConnection class.
 
 Debugging support:
   pdb('<stmt>') = enter PDB debugger to execute <stmt>
@@ -804,11 +805,11 @@ Printing support:
                   producing an XML string
 
 Help:
-  help(<op>) : Brief help; <op> is a short operation namei, e.g. help(gi)
+  help(<op>) : Brief help; <op> is a short operation name, e.g. help(gi)
   help(conn.<OpName>): Detailed help; <OpName> is a long operation name,
-         e.g. help(conn.GetInstance). conn = WBEMConnection class.
+         e.g. help(conn.GetInstance).
 
-The symbols from the pywbem package namespace are available in this namespace
+The symbols from the pywbem package namespace are available in this namespace.
 """)
 
 def pdb(stmt):

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -793,21 +793,25 @@ Connection:
   conn = WBEMConnection class.
 
 Debugging support:
-  pdb('<stmt>') = enter PDB debugger to execute <stmt>
+  pdb('<stmt>')    Enter PDB debugger to execute <stmt>
 
 Printing support:
-  pp(<obj>) = pprint function, good for dicts
-  <obj>.repr() = Operation result objects have repr() for debugging
-  <obj>.tomof() = Operation result objects often have a tomof() producing a
-                  MOF string
-  <obj>.tocimxml().toxml() = Operation result objects have a tocimxml()
-                  producing a DOM object that has a toxml() function
-                  producing an XML string
+  pp(<obj>)        pprint function, good for dicts
+  repr(<obj>)      Operation result objects have repr() for debugging
+  print(<obj>.tomof())
+                   Operation result objects often have a tomof()
+                   producing a MOF string
+  <obj>.tocimxml().toxml()
+                   Operation result objects have a tocimxml()
+                   producing a DOM object that has a toxml() function
+                   producing an XML string
 
 Help:
-  help(<op>) : Brief help; <op> is a short operation name, e.g. help(gi)
-  help(conn.<OpName>): Detailed help; <OpName> is a long operation name,
-         e.g. help(conn.GetInstance).
+  help(<op>)       Brief help; <op> is a short operation name, e.g. help(gi)
+  help(conn.<OpName>)
+                   Detailed help; <OpName> is a long operation name, e.g.
+                   help(conn.GetInstance).
+  'q' to get back from help().
 
 The symbols from the pywbem package namespace are available in this namespace.
 """)


### PR DESCRIPTION
I think this PR completely addresses the issues described in #34. Please review to that extent.

Also, make sure to run operations that have the IncludeClassOrigin parameter against SFCB and OpenPegasus, as well as EnumerateClasses.

The improvements in wbemcli required a fix in `cim_operations.imethodcall()` where any parameters that are `None` are now omitted from the request. They were running into issue #154, which is hereby also fixed. I think this change is safe to make, because if it is not made, None in any case leads to the ValueError exception described in #154.

Details from the commit message:

* Fixed issue that passing param=None to imethodcall() causes ValueError.

* Added help, added missing functionality.
    - Added an interactive help function `Help()` / `h()` and hinted to it in banner message.
    - Improved docstrings of convenience operations functions, to improve the result of `help(ei)`, etc.
    - Made the detailed description of the operations (WBEMConnection methods) available as `help(conn.GetInstance)` etc.
    - Made pywbem namespace content available, so that `help(CIMInstance)` works.
    - Renamed the connection object to `CONN` (was `_CONN`).
    - Renamed all symbols that are not needed in the interactive environment, to become private, by adding an underscore.
    - Added PropertyList support to EnumerateInstances and GetInstance.
    - Renamed the arguments of the convenience operation functions to be short (e.g. `cn` for class name), for easier typing.
    - Changed all convenience operation functions that had `*args` and `**kwargs`  arguments to have specific arguments.
    - Changed some defaults of some boolean arguments (compared to the WBEMConnection methods) to be more convenient (e.g. LocalOnly = False, IncludeQualifiers on classes = True).
    - Added support for debugging via pdb (see help).
