### PR TITLE
Fixes #157: Changed os-level dependency 'zip' and 'unzip' to 'tar' (stable_0.8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -417,8 +417,7 @@ def main():
                     "libxslt-devel",        # for installing Python lxml pkg
                     "libyaml-devel",        # for installing Python pyyaml pkg
                     "make",                 # PyWBEM has a makefile
-                    "zip",                  # for building distribution archive
-                    "unzip",                # for installing distrib. archive
+                    "tar",                  # for distribution archive
                     "patch",                # for patching Epydoc
                 ],
                 'centos': 'redhat',
@@ -429,8 +428,7 @@ def main():
                     "libxslt1-dev",
                     "libyaml-dev",
                     "make",
-                    "zip",
-                    "unzip",
+                    "tar",
                     "patch",
                 ],
                 'ubuntu': [
@@ -439,8 +437,7 @@ def main():
                     "libxslt1-dev",
                     "libyaml-dev",
                     "make",
-                    "zip",
-                    "unzip",
+                    "tar",
                     "patch",
                 ],
                 'suse': [
@@ -449,8 +446,7 @@ def main():
                     "libxslt-devel",
                     "libyaml-devel",
                     "make",
-                    "zip",
-                    "unzip",
+                    "tar",
                     "patch",
                 ],
             },


### PR DESCRIPTION
This PR solves issue #157 by changing the os-level dependencies 'zip' and 'unzip' to 'tar', to match the type of distribution archive that is being built. This was forgotten when moving back to the `.tar.gz` archive format in v0.8.1.

I have verified that a 'tar' package exists on the distros supported for os-level dependencies, and have tested `python setup.py develop_os` on CentOS 6.7 and Ubuntu 14.04.