### PR TITLE
Show last commit in 'Changes' section of Sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',   # disabed, raises anexception
+    'sphinx.ext.ifconfig',
+    'sphinx_git',            # requires 'sphinx-git' Python package
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 
-pywbem version |version|
-************************
+pywbem - A WBEM Client
+**********************
 
 Overview
 ========
@@ -50,6 +50,14 @@ Changes
 -------
 
 The change log is in the `pywbem/NEWS.md <NEWS.md>`_ file.
+
+.. ifconfig:: version.endswith('dev0')
+
+   This version of the documentation is development version |version| and
+   contains the `master` branch up to commit:
+
+   .. git_changelog::
+      :revisions: 1
 
 Compatibility
 -------------

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -4,3 +4,4 @@ six
 ply
 # M2Crypto>=0.24   # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.3
+sphinx-git

--- a/setup.py
+++ b/setup.py
@@ -324,6 +324,7 @@ def main():
             "pytest>=2.4",
             "pytest-cov",
             "Sphinx>=1.3",
+            "sphinx-git",
             "httpretty",
             "lxml",
             "PyYAML",   # Pypi package name of "yaml" package.


### PR DESCRIPTION
This PR shows the last commit of the `master` branch in the "Changes" section of the Sphinx documentation, if the package version is a development version. Because development versions are not increased, this identifies the level of documentation when in development.

Please review.