### PR TITLE
Fixes #185: Fixed KeyError when iterating over CIMInstance or CIMInstanceName.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -65,6 +65,11 @@ Enhancements
   exception, so that now all pywbem specific exceptions are derived from
   `Error`.
 
+Bug fixes:
+
+* In `CIMInstance` and `CIMInstanceName`, fixed KeyError when iterating
+  over the objects.
+
 pywbem v0.8.2
 -------------
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -845,6 +845,9 @@ class CIMInstanceName(_CIMComparisonMixin):
     def __len__(self):
         return len(self.keybindings)
 
+    def __iter__(self):
+        return six.iterkeys(self.keybindings)
+
     def copy(self):
         """Return a copy of the :class:`~pywbem.CIMInstanceName` object.
         """
@@ -1180,6 +1183,9 @@ class CIMInstance(_CIMComparisonMixin):
 
     def __len__(self):
         return len(self.properties)
+
+    def __iter__(self):
+        return six.iterkeys(self.properties)
 
     def copy(self):
         """Return copy of the :class:`~pywbem.CIMInstance` object."""


### PR DESCRIPTION
Fixed the problem and extended the testcases in the `DictTest` class in `test_cim_obj.py` so that the problem would have been found. Also, changed from hard-coding the expected dict values to passing them in.

Ready for merging, please review.