### PR TITLE
Fixes #171 (try 2): Fixed errors and added tests for MOF lexer in mof_compiler.

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3519,7 +3519,7 @@ def tocimobj(type_, value):
     # String type
 
     if type_ == 'string':
-        return value
+        return _ensure_unicode(value)
 
     # Integer types
 
@@ -3558,7 +3558,7 @@ def tocimobj(type_, value):
     # Char16
 
     if type_ == 'char16':
-        raise ValueError('CIMType char16 not handled')
+        return _ensure_unicode(value)
 
     # Datetime
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -247,7 +247,12 @@ hexEscape = r'x[0-9a-fA-F]{1,4}'
 escapeSequence = r'[\\]((%s)|(%s))' % (simpleEscape, hexEscape)
 cChar = r"[^'\\\n\r]|(%s)" % escapeSequence
 sChar = r'[^"\\\n\r]|(%s)' % escapeSequence
-charValue = r"'%s'" % cChar
+
+charvalue_re = r"'(%s)'" % cChar
+
+@lex.TOKEN(charvalue_re)
+def t_charValue(t):
+    return t
 
 stringvalue_re = r'"(%s)*"' % sChar
 
@@ -1172,7 +1177,7 @@ def p_referenceInitializer(p):
             p[0] = p.parser.aliases[p[1]]
         except KeyError:
             ce = CIMError(CIM_ERR_FAILED,
-                          'Unknown alias: ' + p[0])
+                          'Unknown alias: ' + p[1])
             ce.file_line = (p.parser.file, p.lexer.lineno)
             raise ce
     else:
@@ -1385,7 +1390,7 @@ def p_instanceDeclaration(p):
             raise ce
         except ValueError as ve:
             ce = CIMError(CIM_ERR_INVALID_PARAMETER,
-                          'Invalid value for property: %s: %s' % \
+                          'Invalid value for property %s: %s' % \
                           (pname, ve.message))
             ce.file_line = (p.parser.file, p.lexer.lineno)
             raise ce

--- a/testsuite/testmofs/qualifiers.mof
+++ b/testsuite/testmofs/qualifiers.mof
@@ -1,0 +1,216 @@
+// Copyright (c) 2007 DMTF.  All rights reserved.
+//===============
+//Meta Qualifiers
+//===============
+
+Qualifier Association : boolean = false, 
+    Scope(association), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Indication : boolean = false, 
+    Scope(class, indication), 
+    Flavor(DisableOverride, ToSubclass);
+
+//===================
+//Standard Qualifiers
+//===================
+
+Qualifier Abstract : boolean = false, 
+    Scope(class, association, indication), 
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Aggregate : boolean = false, 
+    Scope(reference), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Aggregation : boolean = false, 
+    Scope(association), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier ArrayType : string = "Bag", 
+    Scope(property, parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier BitMap : string[], 
+    Scope(property, method, parameter);
+
+Qualifier BitValues : string[], 
+    Scope(property, method, parameter), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier ClassConstraint : string[], 
+    Scope(class, association, indication);
+
+Qualifier Composition : boolean = false, 
+    Scope(association), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Correlatable : string[], 
+    Scope(property);
+
+Qualifier Counter : boolean = false, 
+    Scope(property, method, parameter);
+
+Qualifier Deprecated : string[], 
+    Scope(any), 
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Description : string = null, 
+    Scope(any), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier DisplayName : string = null, 
+    Scope(any), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier DN : boolean = false, 
+    Scope(property, method, parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier EmbeddedInstance : string = null, 
+    Scope(property, method, parameter);
+
+Qualifier EmbeddedObject : boolean = false, 
+    Scope(property, method, parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Exception : boolean = false, 
+    Scope(class, indication), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Experimental : boolean = false, 
+    Scope(any), 
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Gauge : boolean = false, 
+    Scope(property, method, parameter);
+
+Qualifier In : boolean = true, 
+    Scope(parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier IsPUnit : boolean = false, 
+    Scope(property, method, parameter);
+
+Qualifier Key : boolean = false, 
+    Scope(property, reference), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier MappingStrings : string[], 
+    Scope(any);
+
+Qualifier Max : uint32 = null, 
+    Scope(reference);
+
+Qualifier MaxLen : uint32 = null, 
+    Scope(property, method, parameter);
+
+Qualifier MaxValue : sint64 = null, 
+    Scope(property, method, parameter);
+
+Qualifier MethodConstraint : string[], 
+    Scope(method);
+
+Qualifier Min : uint32 = 0, 
+    Scope(reference);
+
+Qualifier MinLen : uint32 = 0, 
+    Scope(property, method, parameter);
+
+Qualifier MinValue : sint64 = null, 
+    Scope(property, method, parameter);
+
+Qualifier ModelCorrespondence : string[], 
+    Scope(any);
+
+Qualifier NullValue : string = null, 
+    Scope(property), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Octetstring : boolean = false, 
+    Scope(property, method, parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false, 
+    Scope(parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Override : string = null, 
+    Scope(property, reference, method), 
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Propagated : string = null, 
+    Scope(property), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier PropertyConstraint : string[], 
+    Scope(property, reference);
+
+Qualifier PUnit : string = null, 
+    Scope(property, method, parameter);
+
+Qualifier Read : boolean = true, 
+    Scope(property);
+
+Qualifier Reference : string = null, 
+    Scope(property);
+
+Qualifier Required : boolean = false, 
+    Scope(property, reference, method, parameter), 
+    Flavor(DisableOverride, ToSubclass);
+
+//  The Revision qualifier has been deprecated. For the replacement,
+//  see the usage rule for the version qualifier in the CIM
+//  Specification.
+
+Qualifier Revision : string = null, 
+    Scope(class, association, indication), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+// Deprecated
+
+Qualifier Schema : string = null, 
+    Scope(property, method), 
+    Flavor(DisableOverride, ToSubclass, Translatable);
+
+Qualifier Static : boolean = false, 
+    Scope(property, method), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Structure : boolean = false, 
+    Scope(class, indication), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Terminal : boolean = false, 
+    Scope(class, association, indication);
+
+Qualifier UMLPackagePath : string = null, 
+    Scope(class, association, indication);
+
+// Deprecated
+
+Qualifier Units : string = null, 
+    Scope(property, method, parameter), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier ValueMap : string[], 
+    Scope(property, method, parameter);
+
+Qualifier Values : string[], 
+    Scope(property, method, parameter), 
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier Version : string = null, 
+    Scope(class, association, indication), 
+    Flavor(EnableOverride, Restricted, Translatable);
+
+Qualifier Weak : boolean = false, 
+    Scope(reference), 
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Write : boolean = false, 
+    Scope(property);
+
+Qualifier XMLNamespaceName : string = null, 
+    Scope(property, method, parameter);
+

--- a/testsuite/testmofs/test_types.mof
+++ b/testsuite/testmofs/test_types.mof
@@ -1,0 +1,67 @@
+// A class with all CIM data types
+
+#pragma include ("qualifiers.mof")
+
+class EX_AllTypes
+{
+	[key] uint32 k1;
+	[key] string k2;
+	uint8  pui8;
+	uint16 pui16;
+	uint32 pui32;
+	uint64 pui64;
+	sint8  psi8;
+	sint16 psi16;
+	sint32 psi32;
+	sint64 psi64;
+	string ps;
+	char16 pc;
+	boolean pb;
+	datetime pdt;
+	[embeddedobject] string peo;
+	[embeddedinstance("EX_AllTypes")] string pei;
+};
+
+/*
+
+instance of EX_AllTypes as $inner
+{
+	k1 = 9921;
+	k2 = "SampleLabel";
+	pui8  = 0;
+	pui16 = 0;
+	pui32 = 0;
+	pui64 = 0;
+	psi8  = +127;
+	psi16 = +32767;
+	psi32 = +2147483647;
+	psi64 = +9223372036854775807;
+	ps    = "abcdefg";
+	pc    = 'a';
+	pb    = false;
+	pdt   = "01234567061213.123456:000";
+	peo   = Null;
+	pei   = Null;
+};
+
+instance of EX_AllTypes as $outer
+{
+	k1 = 9922;
+	k2 = "SampleLabel";
+	pui8  = 255;
+	pui16 = 65535;
+	pui32 = 4294967295;
+	pui64 = 18446744073709551615;
+	psi8  = -128;
+	psi16 = -32768;
+	psi32 = -2147483648;
+	psi64 = -9223372036854775808;
+	ps    = "abcdefg";
+	pc    = 'a';
+	pb    = true;
+	pdt   = "20160409061213.123456+120";
+	peo   = $inner;
+	pei   = $inner;
+};
+
+*/

--- a/testsuite/testmofs/test_types.mof
+++ b/testsuite/testmofs/test_types.mof
@@ -23,7 +23,7 @@ class EX_AllTypes
 };
 
 /*
-
+// TODO: Uncomment this to work on issues with instance MOF
 instance of EX_AllTypes as $inner
 {
 	k1 = 9921;

--- a/testsuite/unittest_extensions.py
+++ b/testsuite/unittest_extensions.py
@@ -103,3 +103,257 @@ class CIMObjectMixin(object):
         self.assertEqual(obj.embedded_object, embedded_object,
                           "embedded_object attribute")
 
+    def assertEqualCIMClass(self, act_class, exp_class):
+        """
+        Verify that two CIMClass objects are equal.
+        """
+        self.assertEqual(act_class.classname,
+                         exp_class.classname,
+                         "Unexpected classname: %s" % act_class.classname)
+        context = "class %s" % act_class.classname
+        self.assertEqual(act_class.superclass,
+                         exp_class.superclass,
+                         "Unexpected superclass: %s" % act_class.superclass)
+        self.assertEqualProperties(
+            act_class.properties, exp_class.properties,
+            context)
+        self.assertEqualMethods(
+            act_class.methods, exp_class.methods,
+            context)
+        self.assertEqualQualifiers(
+            act_class.qualifiers, exp_class.qualifiers,
+            context)
+
+    def assertEqualProperties(self, act_properties, exp_properties, context):
+        """
+        Verify that two dicts of CIMProperty objects are equal.
+        """
+
+        self.assertEqualKeys(act_properties,
+                             exp_properties,
+                             "%s, property names" % context)
+        for propname in act_properties:
+            self.assertEqualCIMProperty(
+                act_properties[propname], exp_properties[propname],
+                "%s, property %s" % (context, propname))
+
+    def assertEqualMethods(self, act_methods, exp_methods, context):
+        """
+        Verify that two dicts of CIMMethod objects are equal.
+        """
+
+        self.assertEqualKeys(act_methods,
+                             exp_methods,
+                             "%s, method names" % context)
+        for methname in act_methods:
+            self.assertEqualCIMMethod(
+                act_methods[methname], exp_methods[methname],
+                "%s, method %s" % (context, methname))
+
+    def assertEqualParameters(self, act_parameters, exp_parameters, context):
+        """
+        Verify that two dicts of CIMParameter objects are equal.
+        """
+
+        self.assertEqualKeys(act_parameters,
+                             exp_parameters,
+                             "%s, parameter names" % context)
+        for parmname in act_parameters:
+            self.assertEqualCIMParameter(
+                act_parameters[parmname], exp_parameters[parmname],
+                "%s, parameter %s" % (context, parmname))
+
+    def assertEqualQualifiers(self, act_qualifiers, exp_qualifiers, context):
+        """
+        Verify that two dicts of CIMQualifier objects are equal.
+        """
+
+        self.assertEqualKeys(act_qualifiers,
+                             exp_qualifiers,
+                             "%s, qualifier names" % context)
+        for qualname in act_qualifiers:
+            self.assertEqualCIMQualifier(
+                act_qualifiers[qualname], exp_qualifiers[qualname],
+                "%s, qualifier %s" % (context, qualname))
+
+    def assertEqualCIMProperty(self, act_property, exp_property, context):
+        """
+        Verify that two CIMProperty declaration objects are equal.
+        """
+
+        self.assertEqual(
+            act_property.name, exp_property.name,
+            "%s (dict key), name attribute: %s (expected: %s)" % \
+            (context,
+             act_property.name, exp_property.name))
+        self.assertEqual(
+            act_property.value, exp_property.value,
+            "%s, value attribute: %s (expected: %s)" % \
+            (context,
+             act_property.value, exp_property.value))
+        self.assertEqual(
+            act_property.type, exp_property.type,
+            "%s, type attribute: %s (expected: %s)" % \
+            (context,
+             act_property.type, exp_property.type))
+        self.assertEqual(
+            act_property.reference_class, exp_property.reference_class,
+            "%s, reference_class attribute: %s (expected: %s)" % \
+            (context,
+             act_property.reference_class, exp_property.reference_class))
+        self.assertEqual(
+            act_property.embedded_object, exp_property.embedded_object,
+            "%s, embedded_object attribute: %s (expected: %s)" % \
+            (context,
+             act_property.embedded_object, exp_property.embedded_object))
+        self.assertEqual(
+            act_property.is_array, exp_property.is_array,
+            "%s, is_array attribute: %s (expected: %s)" % \
+            (context,
+             act_property.is_array, exp_property.is_array))
+        self.assertEqual(
+            act_property.array_size, exp_property.array_size,
+            "%s, array_size attribute: %s (expected: %s)" % \
+            (context,
+             act_property.array_size, exp_property.array_size))
+        self.assertEqual(
+            act_property.class_origin, exp_property.class_origin,
+            "%s, class_origin attribute: %s (expected: %s)" % \
+            (context,
+             act_property.class_origin, exp_property.class_origin))
+        self.assertEqual(
+            act_property.propagated, exp_property.propagated,
+            "%s, propagated attribute: %s (expected: %s)" % \
+            (context,
+             act_property.propagated, exp_property.propagated))
+        self.assertEqualQualifiers(
+            act_property.qualifiers, exp_property.qualifiers,
+            context)
+
+    def assertEqualCIMMethod(self, act_method, exp_method, context):
+        """
+        Verify that two CIMMethod objects are equal.
+        """
+
+        self.assertEqual(
+            act_method.name, exp_method.name,
+            "%s (dict key), name attribute: %s (expected: %s)" % \
+            (context,
+             act_property.name, exp_property.name))
+        self.assertEqual(
+            act_method.return_type, exp_method.return_type,
+            "%s, return_type attribute: %s (expected: %s)" % \
+            (context,
+             act_property.return_type, exp_property.return_type))
+        self.assertEqual(
+            act_method.class_origin, exp_method.class_origin,
+            "%s, class_origin attribute: %s (expected: %s)" % \
+            (context,
+             act_property.class_origin, exp_property.class_origin))
+        self.assertEqual(
+            act_method.propagated, exp_method.propagated,
+            "%s, propagated attribute: %s (expected: %s)" % \
+            (context,
+             act_property.propagated, exp_property.propagated))
+        self.assertEqualParameters(
+            act_method.parameters, exp_method.parameters,
+            context)
+        self.assertEqualQualifiers(
+            act_method.qualifiers, exp_method.qualifiers,
+            context)
+
+    def assertEqualCIMParameter(self, act_parameter, exp_parameter, context):
+        """
+        Verify that two CIMParameter objects are equal.
+        """
+
+        self.assertEqual(
+            act_parameter.name, exp_parameter.name,
+            "%s (dict key), name attribute: %s (expected: %s)" % \
+            (context,
+             act_parameter.name, exp_parameter.name))
+        self.assertEqual(
+            act_parameter.type, exp_parameter.type,
+            "%s, type attribute: %s (expected: %s)" % \
+            (context,
+             act_parameter.type, exp_parameter.type))
+        self.assertEqual(
+            act_parameter.reference_class, exp_parameter.reference_class,
+            "%s, reference_class attribute: %s (expected: %s)" % \
+            (context,
+             act_parameter.reference_class, exp_parameter.reference_class))
+        self.assertEqual(
+            act_parameter.is_array, exp_parameter.is_array,
+            "%s, is_array attribute: %s (expected: %s)" % \
+            (context,
+             act_parameter.is_array, exp_parameter.is_array))
+        self.assertEqual(
+            act_parameter.array_size, exp_parameter.array_size,
+            "%s, array_size attribute: %s (expected: %s)" % \
+            (context,
+             act_parameter.array_size, exp_parameter.array_size))
+        self.assertEqualQualifiers(
+            act_parameter.qualifiers, exp_parameter.qualifiers,
+            context)
+
+    def assertEqualCIMQualifier(self, act_qualifier, exp_qualifier, context):
+        """
+        Verify that two CIMQualifier objects are equal.
+        """
+
+        self.assertEqual(
+            act_qualifier.name, exp_qualifier.name,
+            "%s (dict key), name attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.name, exp_qualifier.name))
+        self.assertEqual(
+            act_qualifier.value, exp_qualifier.value,
+            "%s, value attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.value, exp_qualifier.value))
+        self.assertEqual(
+            act_qualifier.type, exp_qualifier.type,
+            "%s, type attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.type, exp_qualifier.type))
+        self.assertEqual(
+            act_qualifier.propagated, exp_qualifier.propagated,
+            "%s, propagated attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.propagated, exp_qualifier.propagated))
+        self.assertEqual(
+            act_qualifier.overridable, exp_qualifier.overridable,
+            "%s, overridable attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.overridable, exp_qualifier.overridable))
+        self.assertEqual(
+            act_qualifier.tosubclass, exp_qualifier.tosubclass,
+            "%s, tosubclass attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.tosubclass, exp_qualifier.tosubclass))
+        self.assertEqual(
+            act_qualifier.toinstance, exp_qualifier.toinstance,
+            "%s, toinstance attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.toinstance, exp_qualifier.toinstance))
+        self.assertEqual(
+            act_qualifier.translatable, exp_qualifier.translatable,
+            "%s, translatable attribute: %s (expected: %s)" % \
+            (context,
+             act_qualifier.translatable, exp_qualifier.translatable))
+
+    def assertEqualKeys(self, act_dict, exp_dict, context):
+        """
+        Verify that two dicts have the same set of keys.
+        """
+        act_keys = set(act_dict.keys())
+        exp_keys = set(exp_dict.keys())
+        if act_keys != exp_keys:
+          missing_keys = exp_keys - act_keys
+          added_keys = act_keys - exp_keys
+          msg = "Different sets of %s" % context
+          if missing_keys:
+              msg += ", missing: %s" % list(missing_keys)
+          if added_keys:
+              msg += ", added: %s" % list(added_keys)
+          self.fail(msg)


### PR DESCRIPTION
This PR re-establishes the change that was lost by accident in PR #206.

Ready for merge. Please review.

Details, from the commit log:

- In `tocimobj()`, values with CIM type name 'string' were just returned. This did not step up to the promise of returning the CIM-XML representation, which must be a unicode string. Added code that ensures that the returned value is a unicode string, even when providing a byte string as input.
- CIM datatype char16 was not supported in `tocimobj()` and in the MOF compiler. Added support for 'char16'.
- If the MOF compiler encounters an unknown alias name, it raises a CIMError with status code CIM_ERR_FAILED and status description 'Unknown alias: <alias-name>'. The alias name was taken from the wrong tuple member, causing another exception to be raised. Fixed this bug.
- Added a MOF unit test class 'TestTypes` to `test_mof_compiler.py`, and a corresponding test MOF `testsuite/testmofs/test_types.mof`, which test a CIM class that has properties of all data types.
- Added testcases for hex numbers to test class `TestLexerNumber` in `test_mof_compiler.py`.
- Added test classes `TestLexerString` for CIM string data types, and `TestLexerChar` for CIM char16 data types.
- Extended `testsuite/unittest_extensions.py` with functions that compare CIM classes, CIM instances, properties, methods, parameters, qualifiers.