### PR TITLE
Add support for Linux Mint

### DIFF
--- a/os_setup.py
+++ b/os_setup.py
@@ -945,6 +945,7 @@ class OSInstaller(BaseInstaller):
             "fedora": YumInstaller,
             "debian": AptInstaller,
             "ubuntu": AptInstaller,
+            "linuxmint": AptInstaller,
             "suse": ZypperInstaller,
         }
 

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ def install_swig(installer, dry_run, verbose):
                 'fedora': "swig",
                 'debian': "swig",
                 'ubuntu': "swig",
+                'linuxmint': "swig",
                 'suse': "swig",
             },
         }
@@ -156,6 +157,10 @@ def install_swig(installer, dry_run, verbose):
                         "libpcre3-dev",
                     ],
                     'ubuntu': [
+                        "libpcre3",
+                        "libpcre3-dev",
+                    ],
+                    'linuxmint': [
                         "libpcre3",
                         "libpcre3-dev",
                     ],
@@ -362,6 +367,7 @@ def main():
                     "git>=1.7",
                 ],
                 'debian': 'ubuntu',
+                'linuxmint': 'ubuntu',
                 'suse': [
                     "openssl-devel>=1.0.1",
                     "gcc-c++>=4.4",
@@ -395,6 +401,14 @@ def main():
                     "tar",
                 ],
                 'ubuntu': [
+                    "libxml2-dev",
+                    "libxml2-utils",
+                    "libxslt1-dev",
+                    "libyaml-dev",
+                    "make",
+                    "tar",
+                ],
+                'linuxmint': [
                     "libxml2-dev",
                     "libxml2-utils",
                     "libxslt1-dev",


### PR DESCRIPTION
This adds support for manually installing pywbem on Linux Mint (=Ubuntu). Otherwise it would be:

	$ python setup.py install_os
	running install_os
	install_os: Installing prerequisite OS packages for platform: linuxmint
	Processing OS package requirement: libssl-dev>=1.0.1
	Processing OS package requirement: g++>=4.4
	Testing for availability of Swig >=2.0 in PATH...
	Swig is available in PATH; testing its version...
	Installed Swig version is sufficient: 2.0.11
	Processing OS package requirement: python-dev
	Processing OS package requirement: git>=1.7
	Error: This platform (linuxmint) is not supported for installation of OS packages.
	The following OS packages need to be verified and installed manually, if missing:
		libssl-dev >=1.0.1
		g++ >=4.4
		python-dev
		git >=1.7
	error: Errors occurred (see previous messages)
