### PR TITLE
Minor doc improvements for MOF compiler API; rebased MofParseError.

### DIFF
--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -5,5 +5,30 @@ MOF compiler API
 ================
 
 .. automodule:: pywbem.mof_compiler
+
+.. _`MOF compiler`:
+
+MOF compiler
+------------
+
+.. autoclass:: pywbem.mof_compiler.MOFCompiler
    :members:
+
+.. _`Repository connections`:
+
+Repository connections
+----------------------
+
+.. autoclass:: pywbem.mof_compiler.BaseRepositoryConnection
+   :members:
+
+.. autoclass:: pywbem.mof_compiler.MOFWBEMConnection
+   :members:
+
+.. _`MOF compiler exceptions`:
+
+Exceptions
+----------
+
+.. autoclass:: pywbem.mof_compiler.MOFParseError
 


### PR DESCRIPTION
Ready to be merged. PLease review.

Details:

- Changed exception `MOFParseError` to be derived from `pywbem.Error` (was previously derived from `ValueError`).
- Added `BaseRepositoryConnection` to external MOF compiler API.
- Minor text changes in MOF compiler API documentation.