### PR TITLE
Mof roundtrip test test added to mof_compile

### DIFF
--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -1704,6 +1704,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         self.qualifiers = {}
         self.instances = {}
         self.classes = {}
+        self.compile_ordered_classnames = []
         if conn is None:
             # This instance variable is used only to make get/set
             # of 'default_namespace' behave as it should, in the case
@@ -1837,6 +1838,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                     raise
 
         try:
+            self.compile_ordered_classnames.append(cc.classname)
+
+            # The following generates an exception for each new ns
             self.classes[self.default_namespace][cc.classname] = cc
         except KeyError:
             self.classes[self.default_namespace] = \
@@ -2052,6 +2056,8 @@ class MOFCompiler(object):
         if ns not in self.parser.classnames:
             self.parser.classnames[ns] = []
         try:
+            # Call the parser.  To generate detailed output of states
+            # add debug=1 to following line.
             rv = self.parser.parse(mof, lexer=lexer)
             self.parser.file = oldfile
             self.parser.mof = oldmof


### PR DESCRIPTION
Adds new test for mof roundtrip.  At this point, this test fails in the recompile; we get a number of compile errors during the recompile and I have not been able to isolate them.  We do have issues in the mof output apparently

When we can get through the recompile we can recombine this with the more schema test so that we only have to compile the schema one time, reducing the test time significantly.  I am keeping it separate to be sure that the FullSchema test actually runs.

We have two choices
1. add this test to master now and accept that we get failures
2. Try to get the mof output completely fixed.

NOTE: I thought that this would be easy but the output is very large and the placing of errors does not yet appear logical.

NOTE: I tried to figure out how to run the compile test one time and save the resulting output but short of a set of globals or putting the variables in the MOFTest class have not figured out yet.