### PR TITLE
207 Deprecated `value` instance variable and ctor parameter of `CIMParameter`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,10 @@ pywbem v0.9.0.dev0
 
 Released: Not yet
 
+Deprecations
+^^^^^^^^^^^^
+
+
 Clean Code
 ^^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Released: Not yet
 Deprecations
 ^^^^^^^^^^^^
 
+* Deprecated the use of the `value` instance variable and ctor parameter
+  of the `CIMParameter` class, because that class represents CIM parameter
+  declarations, which do not have a default value.
 
 Clean Code
 ^^^^^^^^^^

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,6 +60,55 @@ The ``pywbem`` PyPI package is supported in these environments:
 OS X has not been tested and is therefore not listed, above. You are welcome to
 try it out and `report any issues <https://github.com/pywbem/pywbem/issues>`_.
 
+.. _`Deprecation policy`:
+
+Deprecation policy
+------------------
+
+Since its v0.7.0, the ``pywbem`` package attempts to be as backwards compatible
+as possible.
+
+However, in an attempt to clean up some of its history, and in order to prepare
+for future additions, the Python namespaces visible to users of ``pywbem`` need
+to be cleaned up.
+
+Also, occasionally functionality needs to be retired, because it is flawed and
+a better but incompatible replacement has emerged.
+
+In ``pywbem``, such changes are done by deprecating existing functionality,
+without removing it. The deprecated functionality is still supported throughout
+new minor releases. Eventually, a new major release will break compatibility and
+will remove the deprecated functionality.
+
+In order to prepare users of ``pywbem`` for that, deprecation of functionality
+is stated in the API documentation, and is made visible at runtime by issuing
+Python warnings of type ``DeprecationWarning`` (see the Python
+:mod:`py:warnings` module).
+
+Since Python 2.7, ``DeprecationWarning`` messages are suppressed by default.
+They can be shown for example in any of these ways:
+
+* By specifying the Python command line option: ``-W default``
+* By invoking Python with the environment variable: ``PYTHONWARNINGS=default``
+
+It is recommended that users of ``pywbem`` run their test code with
+``DeprecationWarning`` messages being shown, so they become aware of any use of
+deprecated functionality in ``pywbem``.
+
+Here is a summary of the deprecation and compatibility policy used by
+``pywbem``, by release type:
+
+* New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
+  compatible.
+* New minor release (M.N.U -> M.N+1.0): New deprecations may be added; as
+  backwards compatible as possible.
+* New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
+  removed; backwards compatibility may be broken.
+
+Compatibility is always seen from the perspective of the user of ``pywbem``, so
+a backwards compatible new ``pywbem`` release means that the user can safely
+upgrade to that new release without encountering compatibility issues.
+
 .. _'Special type names`:
 
 Special type names
@@ -93,6 +142,11 @@ This documentation uses a few special terms to refer to Python types:
       a type for callable objects (e.g. a function, calling a class returns a
       new instance, instances are callable if they have a
       :meth:`~py:object.__call__` method).
+
+   DeprecationWarning
+      a standard Python warning that indicates a deprecated functionality.
+      See section `Deprecation policy`_ and the standard Python module
+      :mod:`py:warnings` for details.
 
    Element
       class ``xml.dom.minidom.Element``. Its methods are described in section

--- a/makefile
+++ b/makefile
@@ -302,7 +302,7 @@ endif
 
 $(test_log_file): makefile $(package_name)/*.py testsuite/*.py coveragerc
 	rm -f $(test_log_file)
-	bash -c "set -o pipefail; PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=attic --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
+	bash -c "set -o pipefail; PYTHONWARNINGS=default PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=attic --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
 	mv -f $(test_tmp_file) $(test_log_file)
 	@echo 'Done: Created test log file: $@'
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -66,6 +66,7 @@ in detail in this documentation.
 from __future__ import print_function, absolute_import
 
 from datetime import datetime, timedelta
+import warnings
 
 import six
 if six.PY2:
@@ -2814,9 +2815,9 @@ class CIMParameter(_CIMComparisonMixin):
         constructor parameter.
 
       value:
-        This variable has no meaning; the object represents only
-        parameter declarations, but not parameter values in method
-        invocations. Parameter declarations do not have a default value.
+        Deprecated: Because the object represents a parameter declaration,
+        this attribute does not make any sense. Accessing it will issue
+        a :term:`DeprecationWarning`.
     """
 
     # pylint: disable=too-many-arguments
@@ -2868,9 +2869,9 @@ class CIMParameter(_CIMComparisonMixin):
             `None` is interpreted as an empty dictionary.
 
           value:
-            This parameter has no meaning; the object represents only
-            parameter declarations, but not parameter values in method
-            invocations. Parameter declarations do not have a default value.
+            Deprecated: Because the object represents a parameter declaration,
+            this parameter does not make any sense. Specifying a value other
+            than `None` will issue a :term:`DeprecationWarning`.
         """
 
         type_ = type  # Minimize usage of the builtin 'type'
@@ -2881,8 +2882,25 @@ class CIMParameter(_CIMComparisonMixin):
         self.is_array = is_array
         self.array_size = array_size
         self.qualifiers = NocaseDict(qualifiers)
-        self.value = _ensure_unicode(value)
-        # TODO 2016-03 AM: The code above assumes value is a string
+        if value is not None:
+            warnings.warn(
+                "The value parameter of CIMParameter is deprecated",
+                DeprecationWarning)
+        self._value = value
+
+    @property
+    def value(self):
+        warnings.warn(
+            "The value attribute of CIMParameter is deprecated",
+            DeprecationWarning)
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        warnings.warn(
+            "The value attribute of CIMParameter is deprecated",
+            DeprecationWarning)
+        self._value = value
 
     def _cmp(self, other):
         """


### PR DESCRIPTION
Follows the deprecation policy added in PR #248.

Please review.