### PR TITLE
Fixes #196: Deprecated imethodcall() and methodcall().

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,10 @@ pywbem v0.9.0.dev0
 
 Released: Not yet
 
+Deprecations
+^^^^^^^^^^^^
+
+
 Clean Code
 ^^^^^^^^^^
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,6 +60,55 @@ The ``pywbem`` PyPI package is supported in these environments:
 OS X has not been tested and is therefore not listed, above. You are welcome to
 try it out and `report any issues <https://github.com/pywbem/pywbem/issues>`_.
 
+.. _`Deprecation policy`:
+
+Deprecation policy
+------------------
+
+Since its v0.7.0, the ``pywbem`` package attempts to be as backwards compatible
+as possible.
+
+However, in an attempt to clean up some of its history, and in order to prepare
+for future additions, the Python namespaces visible to users of ``pywbem`` need
+to be cleaned up.
+
+Also, occasionally functionality needs to be retired, because it is flawed and
+a better but incompatible replacement has emerged.
+
+In ``pywbem``, such changes are done by deprecating existing functionality,
+without removing it. The deprecated functionality is still supported throughout
+new minor releases. Eventually, a new major release will break compatibility and
+will remove the deprecated functionality.
+
+In order to prepare users of ``pywbem`` for that, deprecation of functionality
+is stated in the API documentation, and is made visible at runtime by issuing
+Python warnings of type ``DeprecationWarning`` (see the Python
+:mod:`py:warnings` module).
+
+Since Python 2.7, ``DeprecationWarning`` messages are suppressed by default.
+They can be shown for example in any of these ways:
+
+* By specifying the Python command line option: ``-W default``
+* By invoking Python with the environment variable: ``PYTHONWARNINGS=default``
+
+It is recommended that users of ``pywbem`` run their test code with
+``DeprecationWarning`` messages being shown, so they become aware of any use of
+deprecated functionality in ``pywbem``.
+
+Here is a summary of the deprecation and compatibility policy used by
+``pywbem``, by release type:
+
+* New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
+  compatible.
+* New minor release (M.N.U -> M.N+1.0): New deprecations may be added; as
+  backwards compatible as possible.
+* New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
+  removed; backwards compatibility may be broken.
+
+Compatibility is always seen from the perspective of the user of ``pywbem``, so
+a backwards compatible new ``pywbem`` release means that the user can safely
+upgrade to that new release without encountering compatibility issues.
+
 .. _'Special type names`:
 
 Special type names
@@ -93,6 +142,11 @@ This documentation uses a few special terms to refer to Python types:
       a type for callable objects (e.g. a function, calling a class returns a
       new instance, instances are callable if they have a
       :meth:`~py:object.__call__` method).
+
+   DeprecationWarning
+      a standard Python warning that indicates a deprecated functionality.
+      See section `Deprecation policy`_ and the standard Python module
+      :mod:`py:warnings` for details.
 
    Element
       class ``xml.dom.minidom.Element``. Its methods are described in section

--- a/makefile
+++ b/makefile
@@ -302,7 +302,7 @@ endif
 
 $(test_log_file): makefile $(package_name)/*.py testsuite/*.py coveragerc
 	rm -f $(test_log_file)
-	bash -c "set -o pipefail; PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=attic --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
+	bash -c "set -o pipefail; PYTHONWARNINGS=default PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=attic --ignore=releases -s 2>&1 |tee $(test_tmp_file)"
 	mv -f $(test_tmp_file) $(test_log_file)
 	@echo 'Done: Created test log file: $@'
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -82,6 +82,7 @@ import re
 from datetime import datetime, timedelta
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
+import warnings
 
 import six
 
@@ -607,13 +608,22 @@ class WBEMConnection(object):
         This is a low-level method that is used by the operation-specific
         methods of this class
         (e.g. :meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`).
-        Users should call these operation-specific methods instead of this
-        method.
-
         This method is not part of the external WBEM client library API; it is
         being included in the documentation only for tooling reasons.
-        For compatibility reasons, it has not been renamed to become a private
-        member.
+
+        Deprecated: Calling this function directly has been deprecated and
+        will issue a :term:`DeprecationWarning`.
+        Users should call the operation-specific methods instead of this
+        method.
+        """
+        warnings.warn(
+            "Calling imethodcall() directly is deprecated",
+            DeprecationWarning)
+        return self._imethodcall(methodname, namespace, **params)
+
+    def _imethodcall(self, methodname, namespace, **params):
+        """
+        Perform an intrinsic CIM-XML operation.
         """
 
         # Create HTTP headers
@@ -756,18 +766,26 @@ class WBEMConnection(object):
 
         return tup_tree
 
-    # pylint: disable=invalid-name
     def methodcall(self, methodname, localobject, Params=None, **params):
         """
         This is a low-level method that is used by the
         :meth:`~pywbem.WBEMConnection.InvokeMethod` method of this class.
-        Users should call :meth:`~pywbem.WBEMConnection.InvokeMethod` instead
-        of this method.
-
         This method is not part of the external WBEM client library API; it is
         being included in the documentation only for tooling reasons.
-        For compatibility reasons, it has not been renamed to become a private
-        member.
+
+        Deprecated: Calling this function directly has been deprecated and
+        will issue a :term:`DeprecationWarning`.
+        Users should call :meth:`~pywbem.WBEMConnection.InvokeMethod` instead
+        of this method.
+        """
+        warnings.warn(
+            "Calling methodcall() directly is deprecated",
+            DeprecationWarning)
+        return self._methodcall(methodname, localobject, Params, **params)
+
+    def _methodcall(self, methodname, localobject, Params=None, **params):
+        """
+        Perform an extrinsic CIM-XML method call.
         """
 
         # METHODCALL only takes a LOCALCLASSPATH or LOCALINSTANCEPATH
@@ -1092,7 +1110,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'EnumerateInstanceNames',
             namespace,
             ClassName=classname,
@@ -1216,7 +1234,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'EnumerateInstances',
             namespace,
             ClassName=classname,
@@ -1320,7 +1338,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(InstanceName)
         instancename = self._iparam_instancename(InstanceName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'GetInstance',
             namespace,
             InstanceName=instancename,
@@ -1410,7 +1428,7 @@ class WBEMConnection(object):
         instance = ModifiedInstance.copy()
         instance.path.namespace = None
 
-        self.imethodcall(
+        self._imethodcall(
             'ModifyInstance',
             namespace,
             ModifiedInstance=instance,
@@ -1471,7 +1489,7 @@ class WBEMConnection(object):
         instance = NewInstance.copy()
         instance.path = None
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'CreateInstance',
             namespace,
             NewInstance=instance,
@@ -1513,7 +1531,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(InstanceName)
         instancename = self._iparam_instancename(InstanceName)
 
-        self.imethodcall(
+        self._imethodcall(
             'DeleteInstance',
             namespace,
             InstanceName=instancename,
@@ -1607,7 +1625,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(ObjectName)
         objectname = self._iparam_objectname(ObjectName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'AssociatorNames',
             namespace,
             ObjectName=objectname,
@@ -1737,7 +1755,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(ObjectName)
         objectname = self._iparam_objectname(ObjectName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'Associators',
             namespace,
             ObjectName=objectname,
@@ -1827,7 +1845,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(ObjectName)
         objectname = self._iparam_objectname(ObjectName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'ReferenceNames',
             namespace,
             ObjectName=objectname,
@@ -1943,7 +1961,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(ObjectName)
         objectname = self._iparam_objectname(ObjectName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'References',
             namespace,
             ObjectName=objectname,
@@ -2061,7 +2079,7 @@ class WBEMConnection(object):
 
         # Make the method call
 
-        result = self.methodcall(MethodName, obj, Params, **params)
+        result = self._methodcall(MethodName, obj, Params, **params)
 
         # Convert optional RETURNVALUE into a Python object
 
@@ -2139,7 +2157,7 @@ class WBEMConnection(object):
 
         namespace = self._iparam_namespace_from(namespace)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'ExecQuery',
             namespace,
             QueryLanguage=QueryLanguage,
@@ -2228,7 +2246,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'EnumerateClassNames',
             namespace,
             ClassName=classname,
@@ -2340,7 +2358,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'EnumerateClasses',
             namespace,
             ClassName=classname,
@@ -2439,7 +2457,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'GetClass',
             namespace,
             ClassName=classname,
@@ -2497,7 +2515,7 @@ class WBEMConnection(object):
         klass = ModifiedClass.copy()
         klass.path = None
 
-        self.imethodcall(
+        self._imethodcall(
             'ModifyClass',
             namespace,
             ModifiedClass=klass,
@@ -2546,7 +2564,7 @@ class WBEMConnection(object):
         klass = NewClass.copy()
         klass.path = None
 
-        self.imethodcall(
+        self._imethodcall(
             'CreateClass',
             namespace,
             NewClass=klass,
@@ -2592,7 +2610,7 @@ class WBEMConnection(object):
         namespace = self._iparam_namespace_from(namespace)
         classname = self._iparam_classname(ClassName)
 
-        self.imethodcall(
+        self._imethodcall(
             'DeleteClass',
             namespace,
             ClassName=classname,
@@ -2641,7 +2659,7 @@ class WBEMConnection(object):
 
         namespace = self._iparam_namespace_from(namespace)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'EnumerateQualifiers',
             namespace,
             **extra)
@@ -2696,7 +2714,7 @@ class WBEMConnection(object):
 
         namespace = self._iparam_namespace_from(namespace)
 
-        result = self.imethodcall(
+        result = self._imethodcall(
             'GetQualifier',
             namespace,
             QualifierName=QualifierName,
@@ -2745,7 +2763,7 @@ class WBEMConnection(object):
 
         namespace = self._iparam_namespace_from(namespace)
 
-        unused_result = self.imethodcall(
+        unused_result = self._imethodcall(
             'SetQualifier',
             namespace,
             QualifierDeclaration=QualifierDeclaration,
@@ -2789,7 +2807,7 @@ class WBEMConnection(object):
 
         namespace = self._iparam_namespace_from(namespace)
 
-        unused_result = self.imethodcall(
+        unused_result = self._imethodcall(
             'DeleteQualifier',
             namespace,
             QualifierName=QualifierName,


### PR DESCRIPTION
Follows the deprecation policy added in PR #248.

Please review.