### PR TITLE
Fixes #197: Fixed issues with namespace and path in WBEMConnection methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -90,6 +90,18 @@ Enhancements
 * Created tomof() for CIMProperty making common functionality available
   to both class and instance tomof() pr # 151
 
+* Added an optional `namespace` parameter to the
+  `WBEMConnection.CreateInstance()` method, for consistency with other methods,
+  and to have an explicit alternative to the namespace in the path component of
+  the `NewInstance` parameter.
+
+* The `ClassName` parameter of several operation methods can be specified
+  as both a string and a `CIMClassName` object. In the latter case, a namespace
+  in that object was ignored so far. Now, it is honored. This affects the
+  following `WBEMConnection` methods: `EnumerateInstanceNames`,
+  `EnumerateInstances`, `EnumerateClassNames`, `EnumerateClasses`, `GetClass`,
+  `DeleteClass`.
+
 Bug fixes
 ^^^^^^^^^
 
@@ -104,6 +116,16 @@ Bug fixes
 
 * fix bug with class mof generation where output was not including array
   indicator ([]). Issue #233.
+
+* In the `WBEMConnection.ModifyInstance()` method, the class names in the
+  instance and path component of the `ModifiedInstance` parameter are required,
+  but that was neither described nor checked. It is now described and checked.
+
+* In the `WBEMConnection.ModifyInstance()` method, a host that was specified in
+  the path component of the `ModifiedInstance` parameter incorrectly caused
+  an INSTANCEPATH element to be created in the CIM-XML. This bug was fixed,
+  and a host is now ignored.
+
 
 pywbem v0.8.2
 -------------
@@ -125,7 +147,7 @@ Dependencies
   - `M2Crypto`
   - `ply`
   - `six`
-    
+
 
 pywbem v0.8.1
 -------------
@@ -155,7 +177,7 @@ Known Issues
   - The twisted client module `twisted_client.py`.
   - The Python provider modules `cim_provider.py` and `cim_provider2.py`.
   - The CIM indication listener in the `irecv` directory.
-    See issue #66 on GitHub. 
+    See issue #66 on GitHub.
 
 Changes
 ^^^^^^^

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -460,15 +460,20 @@ class ClientTest(unittest.TestCase):
                             "HTTP request is empty")
             exp_verb = tc_getattr(tc_name, exp_http_request, "verb")
             self.assertEqual(http_request.method, exp_verb,
-                             "verb in HTTP request")
+                             "Verb in HTTP request is: %s (expected: %s)" % \
+                             (http_request.method, exp_verb))
             exp_headers = tc_getattr(tc_name, exp_http_request, "headers", {})
             for header_name in exp_headers:
                 self.assertEqual(http_request.headers[header_name],
                                  exp_headers[header_name],
-                                 "headers in HTTP request")
+                                 "Value of %s header in HTTP request is: %s " \
+                                 "(expected: %s)" % \
+                                 (header_name,
+                                  http_request.headers[header_name],
+                                  exp_headers[header_name]))
             exp_data = tc_getattr(tc_name, exp_http_request, "data", None)
             self.assertXMLEqual(http_request.body, exp_data,
-                                "data in HTTP request")
+                                "Unexpected CIM-XML payload in HTTP request")
 
         # Continue with validating the result
 


### PR DESCRIPTION
Ready to be merged. Please review!

Details:

- Added an optional `namespace` parameter to the `WBEMConnection.CreateInstance()` method, for consistency with other methods, and to have an explicit alternative to the namespace in the path component of  the `NewInstance` parameter.
- The `ClassName` parameter of several operation methods can be specified as both a string and a `CIMClassName` object. In the latter case, a namespace in that object was ignored so far. Now, it is honored. This affects the following `WBEMConnection` methods: `EnumerateInstanceNames`, `EnumerateInstances`, `EnumerateClassNames`, `EnumerateClasses`, `GetClass`, `DeleteClass`.
- In the `WBEMConnection.ModifyInstance()` method, the class names in the instance and path component of the `ModifiedInstance` parameter are required, but that was neither described nor checked. It is now described and checked.
- In the `WBEMConnection.ModifyInstance()` method, a host that was specified in the path component of the `ModifiedInstance` parameter incorrectly caused an INSTANCEPATH element to be created in the CIM-XML. This bug was fixed, and a host is now ignored.
- Improved diagnostic messages in test_client() assertions.

**Discussion point:** This PR implements the agreement described in issue #197, with the following exception: For `CreateInstance()`, the namespace when taken from the path of the `NewInstance` is not considered deprecated as we had agreed. The argument for not deprecating it is that it is very similar to how we allow namespaces on `ClassName` arguments. The argument for deprecating it is that having a path on a NewInstance is inconsistent with the idea that this operation gets an instance with no path and the server determines the path.