### PR TITLE
Fixes #263: tomof() output of CIMClass / CIMMethod / CIMParameter drops array indicator

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -117,6 +117,8 @@ Bug fixes
 
 * Modify qualifier.tomof processing to stay within 80 column limits. Issue #35
 
+* fix bug in method mof output where array flag "[]" left off array parameters.
+
 pywbem v0.8.2
 -------------
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1928,10 +1928,10 @@ class CIMClass(_CIMComparisonMixin):
         # Properties; indent one level from class definition
 
         for prop_val in self.properties.values():
+
             ret_str += prop_val.tomof(False, indent)
 
         # Methods, indent one level from class definition
-
         for method in self.methods.values():
             ret_str += '\n%s' % method.tomof(indent)
 
@@ -3158,8 +3158,11 @@ class CIMParameter(_CIMComparisonMixin):
             indent (:term:`integer`): Number of spaces to indent each parameter
         """
 
-        if self.is_array and self.array_size is not None:
-            array_str = "[%s]" % self.array_size
+        if self.is_array:
+            if self.array_size is not None:
+                array_str = "[%s]" % self.array_size
+            else:
+                array_str = "[]"
         else:
             array_str = ''
 


### PR DESCRIPTION
…omof() output drops array indicator

The mof should output an array indicator "[]" when CIMParameter is_array
is set and with the array size if array_size is not None.  The code
correctly issues the one if array size is set but ignores the array
indicator output if only is_array is set.

The CIMMethod.tomof() was outputting an extra \n after last method.