### PR TITLE
Improved installation and its description for Swig failures.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,68 +12,83 @@ and it includes the usual install mode and development mode.
 OS-level prerequisites are installed using new setup.py commands `install_os`
 (for the usual install mode) and `develop_os` (for development mode). These
 commands perform the installation for a number of well-known Linux
-distributions, using `sudo` (so your userid needs to be authorized for `sudo`,
-if you run these commands). For other Linux distributions and operating
-systems, these setup.py commands just display the names of the OS-level
+distributions, using `sudo` under the covers (so your userid needs to be
+authorized for `sudo`, if you run these commands). For other Linux
+distributions and operating systems, these setup.py commands just display the
+names of the OS-level
 packages that would be needed on RHEL, leaving it to the user to
 translate the package names to the actual system, and to establish the
 prerequisites. This approach is compatible with PyPI because `pip install`
 invokes `setup.py install` but not the new commands. It is also compatible
 with packaging PyWBEM into OS-level Python packages, for the same reason.
 This approach is also compatible with 
-[virtual Python environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
+[virtual Python environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+because `sudo` is invoked under the covers for installing the OS-level
+packages, so you can still invoke setup.py without sudo for targeting the
+current virtual Python environment.
 
 Examples
 --------
 
-* Install latest version from PyPI into default system Python (assuming
-  OS-level prerequisites are already satisfied):
+* Install latest version from PyPI into the current virtual Python:
+
+      pip install pywbem
+
+  If the OS-level prerequisites are not yet satisfied, then this command
+  will fail. You can then perform this sequence of commands to get the
+  the OS-level prerequisites installed in addition:
+
+      pip download pywbem
+      tar -xf pywbem-*.tar.gz
+      cd pywbem-*
+      python setup.py install_os install
+
+  Note that you do not need to use 'sudo' in the command line, because you
+  want to install the Python packages into the current virtual Python. The
+  OS-level packages are installed by invoking 'sudo' under the covers.
+
+  The OS-level prerequisites will be installed to the system, and the Python
+  prerequisites along with PyWBEM itself will be installed into the current
+  virtual Python environment.
+
+* Install latest version from PyPI into the system Python:
 
       sudo pip install pywbem
 
   If the OS-level prerequisites are not yet satisfied, then this command
-  will fail. You can then install the OS-level prerequisites and retry:
+  will fail. You can then perform this sequence of commands to get the
+  the OS-level prerequisites installed in addition:
 
+      pip download pywbem
+      tar -xf pywbem-*.tar.gz
+      cd pywbem-*
       sudo python setup.py install_os install
 
-* Install latest version from PyPI into new Python 2.7 virtual environment
-  (assuming OS-level prerequisites are already satisfied):
-
-      mkvirtualenv -p python2.7 pywbem27
-      pip install pywbem
-
-  Again, you can install the OS-level prerequisites and retry, if this fails:
-
-      python setup.py install_os install
-
   The OS-level prerequisites will be installed to the system, and the Python
-  prerequisites into the current Python environment.
+  prerequisites along with PyWBEM itself will be installed into the system
+  Python environment.
 
-* Install from master branch on GitHub into new Python 2.7 virtual environment,
-  installing OS-level prerequisites as needed:
+* Install the latest development version from GitHub into the current
+  virtual Python, installing OS-level prerequisites as needed:
 
       git clone git@github.com:pywbem/pywbem.git pywbem
       cd pywbem
-      mkvirtualenv -p python2.7 pywbem27
       python setup.py install_os install
 
-  Note that you do not need to use 'sudo' in the command line, because you
-  want to install into the current virtual Python. The OS-level packages are
-  installed by invoking 'sudo' under the covers.
+* Install from a particular distribution archive on GitHub into the current
+  virtual Python, installing OS-level prerequisites as needed:
 
-* Install from a particular distribution archive on GitHub into new Python 2.7
-  virtual environment, installing OS-level prerequisites as needed:
-
-      wget https://github.com/pywbem/pywbem/blob/master/dist/pywbem-0.8/pywbem-0.8.1.tar.gz
-      tar -vf pywbem-0.8.1.tar.gz
-      cd pywbem-0.8.1
-      mkvirtualenv -p python2.7 pywbem27
+      wget https://github.com/pywbem/pywbem/blob/master/dist/pywbem-0.8/pywbem-0.8.3.tar.gz
+      tar -xf pywbem-0.8.3.tar.gz
+      cd pywbem-0.8.3
       python setup.py install_os install
 
 * The installation of PyWBEM in development mode is supported as
   well:
 
-      python setup.py develop_os develop
+      git clone git@github.com:pywbem/pywbem.git pywbem
+      cd pywbem
+      make develop
 
   This will install additional OS-level and Python packages that are needed
   for development and test of PyWBEM.

--- a/os_setup.py
+++ b/os_setup.py
@@ -499,7 +499,8 @@ class BaseInstaller(object):
         self.env = None
 
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Interface definition: Install an OS or Python package,
         optionally applying version requirements.
 
@@ -516,6 +517,7 @@ class BaseInstaller(object):
         * version_reqs (list): None, or list of zero or more strings that are
           version requirements for the package (e.g. ('>=3.0', '!=3.5')).
         * dry_run (boolean): Display what would happen instead of doing it.
+        * reinstall (boolean): Reinstall the package if already installed.
 
         Returns: Nothing
 
@@ -816,7 +818,8 @@ class PythonInstaller(BaseInstaller):
             installed = self.ensure_installed(
                 pkg_name, version_reqs, dry_run, verbose, ignore=False)
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Install a Python package, optionally ensuring that the specified
         version requirements are satisfied.
 
@@ -824,11 +827,15 @@ class PythonInstaller(BaseInstaller):
         `BaseInstaller.do_install()`.
         """
         pkg_req = self.pkg_req(pkg_name, version_reqs)
+        args = ['install']
+        if reinstall:
+            args.append('--ignore-installed')
+        args.append(pkg_req)
         if dry_run:
-            print("Dry-running: pip install %s" % pkg_req)
+            print("Dry-running: pip %s" % ' '.join(args))
         else:
-            print("Running: pip install %s" % pkg_req)
-            rc = pip.main(['install', pkg_req])
+            print("Running: pip %s" % ' '.join(args))
+            rc = pip.main(args)
             if rc != 0:
                 raise DistutilsSetupError("Pip returns rc=%d" % rc)
 
@@ -1089,7 +1096,8 @@ class OSInstaller(BaseInstaller):
             installed = self.ensure_installed(
                 pkg_name, version_reqs, dry_run, verbose, ignore=False)
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Install an OS package, optionally ensuring that the specified
         version requirements are satisfied.
 
@@ -1195,14 +1203,16 @@ class YumInstaller(OSInstaller):
         else:
             self.installer_cmd = "yum"
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Install an OS package, optionally ensuring that the specified
         version requirements are satisfied.
 
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
-        cmd = "sudo %s install -y %s" % (self.installer_cmd, pkg_name)
+        subcmd = 'reinstall' if reinstall else 'install'
+        cmd = "sudo %s %s -y %s" % (self.installer_cmd, subcmd, pkg_name)
         if dry_run:
             print("Dry-running: %s" % cmd)
         else:
@@ -1261,14 +1271,16 @@ class AptInstaller(OSInstaller):
     def __init__(self):
         OSInstaller.__init__(self)
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Install an OS package, optionally ensuring that the specified
         version requirements are satisfied.
 
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
-        cmd = "sudo apt-get install -y %s" % pkg_name
+        reinstall_opt = '--reinstall' if reinstall else ''
+        cmd = "sudo apt-get install -y %s %s" % (reinstall_opt, pkg_name)
         if dry_run:
             print("Dry-running: %s" % cmd)
         else:
@@ -1331,14 +1343,16 @@ class ZypperInstaller(OSInstaller):
     def __init__(self):
         OSInstaller.__init__(self)
 
-    def do_install(self, pkg_name, version_reqs=None, dry_run=False):
+    def do_install(self, pkg_name, version_reqs=None, dry_run=False,
+                   reinstall=False):
         """Install an OS package, optionally ensuring that the specified
         version requirements are satisfied.
 
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
-        cmd = "sudo zypper -y %s" % pkg_name
+        reinstall_opt = '-f' if reinstall else ''
+        cmd = "sudo zypper -y %s %s" % (reinstall_opt, pkg_name)
         if dry_run:
             print("Dry-running: %s" % cmd)
         else:

--- a/setup.py
+++ b/setup.py
@@ -52,17 +52,10 @@ from os_setup import shell, shell_check, import_setuptools
 # Package version - Keep in sync with pywbem/__init__.py!
 _version = '0.8.4.dev0'  # pylint: disable=invalid-name
 
-def install_swig(installer, dry_run, verbose):
-    """Custom installer function for `os_setup` module.
-    This function makes sure that Swig is installed, either by installing the
-    corresponding OS-level package, or by downloading the source and building
-    it.
-
-    Parameters: see description of `os_setup` module.
+def _check_get_swig(swig_min_version, verbose):
+    """Chewck if Swig is available in the PATH in the right version.
+    Returns True if it needs to be installed/updated.
     """
-
-    swig_min_version = "2.0"
-
     if verbose:
         print("Testing for availability of Swig >=%s in PATH..." %\
               swig_min_version)
@@ -90,6 +83,20 @@ def install_swig(installer, dry_run, verbose):
             if verbose:
                 print("Installed Swig version is sufficient: %s" %\
                       swig_version)
+    return get_swig
+
+def install_swig(installer, dry_run, verbose):
+    """Custom installer function for `os_setup` module.
+    This function makes sure that Swig is installed, either by installing the
+    corresponding OS-level package, or by downloading the source and building
+    it.
+
+    Parameters: see description of `os_setup` module.
+    """
+
+    swig_min_version = "2.0"
+
+    get_swig = _check_get_swig(swig_min_version, verbose)
 
     if get_swig:
 
@@ -119,7 +126,16 @@ def install_swig(installer, dry_run, verbose):
             swig_pkg_name, swig_version_reqs, dry_run, verbose,
             ignore=True)
 
-        if not installed:
+        if installed and _check_get_swig(swig_min_version, verbose):
+            # Package was tampered with (e.g. swig command renamed)
+
+            if verbose:
+                print("Reinstalling Swig package over existing one...")
+
+            installer.do_install(swig_pkg_name, swig_version_reqs, dry_run,
+                                 reinstall=True)
+
+        elif not installed:
 
             # Build Swig from its source
             swig_build_version = "2.0.12"
@@ -406,7 +422,6 @@ def main():
                     ["python35-devel", "python35u-devel", "python3-devel"] \
                         if py_version_m_n == "3.5" else \
                     "python-devel",
-                    "git>=1.7",             # for retrieving fixed M2Crypto
                 ],
                 'centos': 'redhat',
                 'fedora': 'redhat',
@@ -416,7 +431,6 @@ def main():
                     install_swig,
                     "python-dev" if py_version_m == "2"
                     else "python%s-dev" % py_version_m,
-                    "git>=1.7",
                 ],
                 'debian': 'ubuntu',
                 'suse': [
@@ -424,7 +438,6 @@ def main():
                     "gcc-c++>=4.4",
                     install_swig,
                     "libpython%s-devel" % py_version_m_n,
-                    "git>=1.7",
                 ],
             },
             # TODO: Add support for Windows.


### PR DESCRIPTION
This PR is ready to be merged. Please review.

It addresses issue #280 by explaining how to establish the OS-level prerequisites such as Swig.

Details:

- Fixed description in `INSTALL.md` to correctly describe how to establish OS-level prerequisites.
- Improved Swig installation code by reinstalling Swig if it was installed but still cannot be found in PATH (e.g. if the installation was tampered with).
- Removed dependency on git (this was a leftover from when M2Crypto needed to be obtained from its development repo).