### PR TITLE
Added runtime check for minimum Python 3 version 3.4 (for master branch)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -160,6 +160,9 @@ Bug fixes
   on `CIMDateTime` interval objects contained incorrect values for the minutes
   and seconds fields on Python 3 (issue #275).
 
+* Added check for minimum Python version 3.4 when running on Python 3.
+  That requirement was already documented, now it is also enforced in the code.
+
 
 pywbem v0.8.2
 -------------

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -90,5 +90,10 @@ from .exceptions import *
 
 from ._version import __version__
 
-if sys.version_info < (2, 6, 0):
-    raise RuntimeError('PyWBEM requires Python 2.6.0 or higher')
+_python_m = sys.version_info[0]
+_python_n = sys.version_info[1]
+if _python_m == 2 and _python_n < 6:
+    raise RuntimeError('On Python 2, PyWBEM requires Python 2.6 or higher')
+elif _python_m == 3 and _python_n < 4:
+    raise RuntimeError('On Python 3, PyWBEM requires Python 3.4 or higher')
+


### PR DESCRIPTION
This PR was created in order to address a side issues described in issue #179.

This PR targets the 0.9 (master) release stream, PR #291 will target the 0.8 release stream.

Ready to be merged. Please review.