### PR TITLE
Fixes a couple of issues. 1) the wrap function needs the hostname, 2)…

### DIFF
--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -502,6 +502,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                         ctx.load_verify_locations(cafile=self.ca_certs)
                     ctx.check_hostname = True
                 else:
+                    ctx.check_hostname = False
                     ctx.verify_mode = SSL.CERT_NONE
 
                 # setup the socket
@@ -509,7 +510,8 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 sock.settimeout(self.timeout)
 
                 try:
-                    self.sock = ctx.wrap_socket(sock)
+                    self.sock = ctx.wrap_socket(sock,
+                                                server_hostname=self.host)
                     return self.sock.connect((self.host, self.port))
 
                 except SSLError as arg:
@@ -517,7 +519,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                         "SSL error %s: %s" % (arg.__class__, arg))
                 except CertificateError as arg:
                     raise ConnectionError(
-                        "SSL Certificateerror %s: %s" % (arg.__class__, arg))
+                        "SSL certificate error %s: %s" % (arg.__class__, arg))
 
     class FileHTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
         """Execute client connection based on a unix domain socket. """


### PR DESCRIPTION
… message misspelling, 3) insure check_hostname state

I ran through the tests again and hit a problem.  I cannot explain why the issue occurred because we passed the manual tests before this with no problem but I had to add server_hostname to the ssl wrap function to avoid an error.  Note that it is clear from the ssl python code that you must do this so I do not know how it worked before.

Somehow I messed up since when I went back to manually test, the python 3 tests with cacert failed (passed with python2)
