### PR TITLE
Fixes a couple of issues. 1) the wrap function needs the hostname, 2)…

### DIFF
--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -511,6 +511,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                         ctx.load_verify_locations(cafile=self.ca_certs)
                     ctx.check_hostname = True
                 else:
+                    ctx.check_hostname = False
                     ctx.verify_mode = SSL.CERT_NONE
 
                 # setup the socket
@@ -518,7 +519,8 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                 sock.settimeout(self.timeout)
 
                 try:
-                    self.sock = ctx.wrap_socket(sock)
+                    self.sock = ctx.wrap_socket(sock,
+                                                server_hostname=self.host)
                     return self.sock.connect((self.host, self.port))
 
                 except SSLError as arg:
@@ -526,7 +528,7 @@ def wbem_request(url, data, creds, headers=[], debug=0, x509=None,
                         "SSL error %s: %s" % (arg.__class__, arg))
                 except CertificateError as arg:
                     raise ConnectionError(
-                        "SSL Certificateerror %s: %s" % (arg.__class__, arg))
+                        "SSL certificate error %s: %s" % (arg.__class__, arg))
 
     class FileHTTPConnection(HTTPBaseConnection, httplib.HTTPConnection):
         """Execute client connection based on a unix domain socket. """


### PR DESCRIPTION
… message misspelling, 3) insure check_hostname state.

This PR rolls PR #299 back into v0.8. It targets the socket_err_check_hostname_0.8 branch, so that once merged, that branch can be continued to be tested.