### PR TITLE
Fixed FileNotFoundError not subscriptable problem in wbemcli for Python 3

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -186,6 +186,10 @@ Bug fixes
   This completely separates connect() code for python 3 ssl module from
   python 2 m2cyrpto.
 
+* Fixed problem that wbemcli in Python 3 when used without existing history
+  file would fail with "TypeError: 'FileNotFoundError' object is not
+  subscriptable" (issue #302).
+
 
 pywbem v0.8.2
 -------------

--- a/wbemcli
+++ b/wbemcli
@@ -987,10 +987,11 @@ Examples:
 
     # Read previous command line history
     if _HAVE_READLINE:
+        NotFoundError = getattr(__builtins__, 'FileNotFoundError', IOError)
         try:
             _readline.read_history_file(histfile)
-        except IOError as arg:
-            if arg[0] != _errno.ENOENT:
+        except NotFoundError as exc:
+            if exc.errno != _errno.ENOENT:
                 raise
 
     # Interact


### PR DESCRIPTION
Ready to be merged - please review. This solves the issue for the master branch.

Details, from the commit log:

- This fixes issue #302 for the wbemcli command, by accessing the error code no longer by array subscription, but by accessing the errno attribute.
- Also, established compatibility between the different exceptions raised before and starting with Python 3.3 (IOError vs FileNotFoundError).