### PR TITLE
Fixes #302: Fixed FileNotFoundError not subscriptable problem in wbemcli for Python 3

### DIFF
--- a/pywbem/NEWS
+++ b/pywbem/NEWS
@@ -6,6 +6,11 @@ pywbem-0.8.4.dev0  2016-05-09
     * Fixed an IndexError in cim_http.wbem_request() that occurred during
       handling of another exception.
 
+    * Fixed problem that wbemcli in Python 3 when used without existing history
+      file would fail with "TypeError: 'FileNotFoundError' object is not
+      subscriptable" (issue #302).
+
+
   ENHANCEMENTS:
 
     * Fixed description in INSTALL.md to correctly describe how to establish

--- a/pywbem/wbemcli.py
+++ b/pywbem/wbemcli.py
@@ -406,10 +406,11 @@ def main():
 
     # Read previous command line history
     if _HAVE_READLINE:
+        NotFoundError = getattr(__builtins__, 'FileNotFoundError', IOError)
         try:
-            readline.read_history_file(histfile)
-        except IOError as arg:
-            if arg[0] != errno.ENOENT:
+            _readline.read_history_file(histfile)
+        except NotFoundError as exc:
+            if exc.errno != _errno.ENOENT:
                 raise
 
     # Interact


### PR DESCRIPTION
Ready to be merged - please review. This fixes the issue for the stable_0.8 branch. Otherwise, same as PR #303.

Details, from the commit log:

- This fixes issue #302 for the wbemcli command, by accessing the error code no longer by array subscription, but by accessing the errno attribute.
- Also, established compatibility between the different exceptions raised before and starting with Python 3.3 (IOError vs FileNotFoundError).