### PR TITLE
Fixed FileNotFoundError not subscriptable problem in examples/listen.py for Python 3

### DIFF
--- a/examples/listen.py
+++ b/examples/listen.py
@@ -70,10 +70,11 @@ help(listener): Display help for using listener instance.
 
     # Read previous command line history
     if _HAVE_READLINE:
+        NotFoundError = getattr(__builtins__, 'FileNotFoundError', IOError)
         try:
             _readline.read_history_file(histfile)
-        except IOError as exc:
-            if exc.args[0] != _errno.ENOENT:
+        except NotFoundError as exc:
+            if exc.errno != _errno.ENOENT:
                 raise
 
     # Interact


### PR DESCRIPTION
This PR fixes issue #302 for the examples/listen.py script. Because that is currently only in the listener branch, this PR targets that branch.

Ready to be merged, please review.

Details, from the commit log:

- This fixes issue 302 for the examples/listen.py script, by accessing the error code no longer by array subscription, but by accessing the errno attribute.
- Also, established compatibility between the different exceptions raised before and starting with Python 3.3 (IOError vs FileNotFoundError).