### PR TITLE
Fixes #193: Remove toinstance flavor

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -200,6 +200,10 @@ Bug fixes
   
 * Fixed issue with tomof() output where datetime values were not quoted.
   (issue #289)
+  
+* Eliminate automatic setting of toinstance flavor in mof_compiler when
+  tosubclass is set.  Also enabled use of toinstance flavor if defined
+  in a class or qualifier declaration. (issue 193)
 
 * Fixed problem in class-level associator operations that namespace was classname
   when classname was passed as a string (issue #322).

--- a/mof_compiler
+++ b/mof_compiler
@@ -27,7 +27,7 @@ with the result.
 
 Invoke with `-h` or `--help` for a help message.
 """
-
+import os
 import sys 
 import argparse
 from getpass import getpass

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -135,6 +135,7 @@ reserved = {
     'schema':'SCHEMA',
     'scope':'SCOPE',
     'tosubclass':'TOSUBCLASS',
+    'toinstance':'TOINSTANCE',
     'translatable':'TRANSLATABLE',
     'true':'TRUE',
     }
@@ -835,6 +836,7 @@ def p_flavor(p):
               | DISABLEOVERRIDE
               | RESTRICTED
               | TOSUBCLASS
+              | TOINSTANCE
               | TRANSLATABLE
               """
     p[0] = p[1].lower()
@@ -1214,8 +1216,8 @@ def _build_flavors(flist, qualdecl=None):
     if qualdecl is not None:
         flavors = {'overridable':qualdecl.overridable,
                    'translatable':qualdecl.translatable,
-                   'toinstance':qualdecl.toinstance,
-                   'tosubclass':qualdecl.tosubclass}
+                   'tosubclass':qualdecl.tosubclass,
+                   'toinstance':qualdecl.toinstance}
     if 'disableoverride' in flist:
         flavors['overridable'] = False
     if 'enableoverride' in flist:
@@ -1226,11 +1228,10 @@ def _build_flavors(flist, qualdecl=None):
         flavors['tosubclass'] = False
     if 'tosubclass' in flist:
         flavors['tosubclass'] = True
-    try:
-        if flavors['tosubclass']:
-            flavors['toinstance'] = True
-    except KeyError:
-        pass
+    if 'toinstance' in flist:
+        flavors['toinstance'] = True
+    # issue #193 ks 5/16 removed tosubclass & set toinstance.
+
     return flavors
 
 def p_qualifierName(p):
@@ -1307,6 +1308,7 @@ def p_defaultFlavor(p):
     flist = p[4]
     flavors = {'ENABLEOVERRIDE':True,
                'TOSUBCLASS':True,
+               'TOINSTANCE':False,
                'DISABLEOVERRIDE':False,
                'RESTRICTED':False,
                'TRANSLATABLE':False}
@@ -1463,6 +1465,7 @@ def p_identifier(p):
                   | SCHEMA
                   | SCOPE
                   | TOSUBCLASS
+                  | TOINSTANCE
                   | TRANSLATABLE
                   """
                   #| ASSOCIATION

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -136,7 +136,6 @@ class ClientTest(unittest.TestCase):
                 self.assertIsInstance(prop, CIMProperty)
 
 
-
 #################################################################
 # Instance provider interface tests
 #################################################################
@@ -214,7 +213,6 @@ class EnumerateInstances(ClientTest):
                     return value.class_origin is None
                 except KeyError:
                     return True
-
 
     def test_simple(self):
         """Simplest invocation of EnumerateInstances"""
@@ -958,6 +956,7 @@ class EnumerateClassNames(ClientTest):
             for n in sub_names:
                 self.assertTrue(isinstance(n, six.string_types))
             subname_list += sub_names
+
         full_name_list += subname_list
         self.assertTrue(TEST_CLASS in full_name_list,
                         'test class not found')


### PR DESCRIPTION
Fixed this issue and added tests to confirm behavior.  The one discussion item is that in addition to removing the function that forced the toinstance flavor if the tosubclass flavor was set, we also allow the toinstance to be set specifically if it is set in the mof.  

**DISCUSSION**: Should we allow the mof writer to ever input with the toinstance flavor set either on qualifier declaration, or class.  To me it would probably never be used but seems logical.