### PR TITLE
Fixes #297: Add deprecated warning message if validate_callback parameter on WBEM…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -227,7 +227,7 @@ Bug fixes
   
 * Fixed issue with tomof() output where datetime values were not quoted.
   (issue #289)
-  
+
 * Eliminate automatic setting of toinstance flavor in mof_compiler when
   tosubclass is set.  Also enabled use of toinstance flavor if defined
   in a class or qualifier declaration. (issue 193)
@@ -245,6 +245,9 @@ Bug fixes
 * Extend PropertyList argument in request operations to be either list
   or tuple. (issue #347)
 
+*  Added deprecated warning to WBEMConnection verify_callback parameter
+   since it is not used with python ssl module and will probably be 
+   removed completely in the future. (issue # 297)
 
 pywbem v0.8.2
 -------------

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -44,6 +44,7 @@ import platform
 import base64
 import threading
 from datetime import datetime
+import warnings
 
 import six
 from six.moves import http_client as httplib
@@ -303,7 +304,11 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
         :meth:`WBEMConnection.__init__`.
 
       verify_callback:
-        Used for HTTPS with certificates.
+        Used for HTTPS with certificates but only for python 2. Ignored with
+        python 3 since the  python 3 ssl implementation does not implement
+        any callback mechanism so setting this variable gains the
+        user nothing.
+
         For details, see the ``verify_callback`` parameter of
         :meth:`WBEMConnection.__init__`.
 
@@ -394,6 +399,10 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                              timeout=timeout)
             self.ca_certs = ca_certs
             self.verify_callback = verify_callback
+            # issue 297: Verify_callback is  not used in py 3
+            if verify_callback is not None and six.PY3:
+                warnings.warn("verify_callback parameter ignored",
+                              UserWarning)
 
         def connect(self):
             # pylint: disable=too-many-branches

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -547,6 +547,9 @@ class WBEMConnection(object):
             does not need to be used. See :ref:`Verification of the X.509 server
             certificate` for details.
 
+            Warning: This parameter is not used when the python environment
+            is Python 3 because the ssl module does not support it.
+
             If `None`, no such callback function will be registered.
 
             The specified function will be called for the returned certificate,


### PR DESCRIPTION
…Connection is used.

Added the warning if the parameter exists on the WBEMConnection call.  Also added documentation on the deprecated state and fact that not used with python 3