### PR TITLE
Fixes #9, Fixes #329: implement DMTF Pull Operations with tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -155,6 +155,24 @@ Enhancements
   Documentation indicated that iterable was allowed but was limited
   to list. (issue #347)
 
+* Implemented pull operations per DMTF specification DSP0200 and DSP0201.
+  This includes the following new client operations to execute enumeration
+  sequences:
+    - OpenEnumerateInstances
+    - OpenEnumerateInstancePaths
+    - OpenAssociatorInstances
+    - OpenAssociatorInstancePaths
+    - OpenReferenceInstances
+    - OpenReferenceInstancePaths
+    - OpenQueryInstances
+    - PullInstances
+    - PullInstancesWithPath
+    - PullInstancePaths
+    - CloseEnumeration
+  PyWBEM does NOT implement the EnumerationCount operation as it
+  is both deprecated and unusable. (Issue #9)
+  
+
 Bug fixes
 ^^^^^^^^^
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -224,6 +224,9 @@ References
    DSP0207
       `DMTF DSP0207, WBEM URI Mapping, Version 1.0 <http://www.dmtf.org/standards/published_documents/DSP0207_1.0.pdf>`_
 
+   DSP0212
+      `DMTF DSP0212, Filter Query Language, Version 1.0.1 <http://www.dmtf.org/standards/published_documents/DSP0212_1.0.1.pdf>`_
+
    DSP1033
       `DMTF DSP1033, Profile Registration Profile, Version 1.1 <http://www.dmtf.org/standards/published_documents/DSP1033_1.1.pdf>`_
 

--- a/examples/pullenuminstances.py
+++ b/examples/pullenuminstances.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+    Example of using Pull Operations to retrieve instances from a
+    WBEM Server. This example allows either simplistic command line
+    input with a fixed number of parameters or defaults to internal
+    definitions if incorrect number of  cmd line arguments are supplied.
+
+    It:
+        Creates a connection
+        Opens an enumeration session with OpenEnumerateInstances
+        Executes a pull loop until the result.eos =True
+        Displays overall statistics on the returns
+    It also displays the results of the open and each pull in detail
+"""
+
+from __future__ import print_function
+
+import sys
+import datetime
+from pywbem import WBEMConnection, CIMError, Error
+
+# Dfault connection attributes. Used if not all arguments are
+# supplied on the command line.
+USERNAME = 'blah'
+PASSWORD = 'blah'
+TEST_CLASS = 'CIM_ComputerSystem'
+TEST_NAMESPACE = 'root/cimv2'
+SERVER_URL = 'http://localhost'
+
+class ElapsedTimer(object):
+    """
+        Set up elapsed time timer. Calculates time between initiation
+        and access.
+    """
+    def __init__(self):
+        """ Initiate the object with current time"""
+        self.start_time = datetime.datetime.now()
+
+    def reset(self):
+        """ Reset the start time for the timer"""
+        self.start_time = datetime.datetime.now()
+
+    def elapsed_ms(self):
+        """ Get the elapsed time in milliseconds. returns floating
+            point representation of elapsed time in seconds.
+        """
+        dt = datetime.datetime.now() - self.start_time
+        return ((dt.days * 24 * 3600) + dt.seconds) * 1000  \
+                + dt.microseconds / 1000.0
+
+    def elapsed_sec(self):
+        """ get the elapsed time in seconds. Returns floating
+            point representation of time in seconds
+        """
+        return self.elapsed_ms() / 1000
+
+def connect_server(server_url, creds, namespace):
+    """
+        Connect to the server return the connection object.
+        This call should not generate any exceptions
+    """
+    return WBEMConnection(server_url, creds,
+                          default_namespace=namespace,
+                          no_verification=True)
+
+def execute_request(conn, classname, max_open, max_pull):
+    """
+        Enumerate instances defined by the function's
+        classname argument using the OpenEnumerateInstances and
+        PullInstancesWithPath.
+
+        * classname - Classname for the enumeration.
+
+        * max_open - defines the maximum number of instances
+          for the server to return for the open
+
+        *max_pull defines the maximum number of instances for the
+          WBEM server to return for each pull operation.
+
+        Displays results of each open or pull operation including
+        size, return parameters, and time to execute.
+
+        Any exception exits the function.
+    """
+    start = ElapsedTimer()
+    result = conn.OpenEnumerateInstances(classname,
+                                         MaxObjectCount=max_open)
+
+    print('open rtn eos=%s context=%s, count=%s time=%s ms' %
+          (result.eos, result.context, len(result.instances),
+           start.elapsed_ms()))
+
+    # save instances since we reuse result
+    insts = result.instances
+
+    # loop to make pull requests until end_of_sequence received.
+    pull_count = 0
+    while not result.eos:
+        pull_count += 1
+        op_start = ElapsedTimer()
+        result = conn.PullInstancesWithPath(result.context,
+                                            MaxObjectCount=max_pull)
+
+        insts.extend(result.instances)
+
+        print('pull rtn eos=%s context=%s, insts=%s time=%s ms' %
+              (result.eos, result.context, len(result.instances),
+               op_start.elapsed_ms()))
+
+
+    print('Result instance count=%s pull count=%s time=%.2f sec' % \
+          (len(insts), pull_count, start.elapsed_sec()))
+    return insts
+
+def main():
+    """
+        Get arguments and call the execution function
+    """
+
+    # if less than required arguments, use the defaults
+    if len(sys.argv) < 8:
+        print("Usage: %s server_url username password namespace classname "
+              "max_open, max_pull" %  sys.argv[0])
+        server_url = SERVER_URL
+        username = USERNAME
+        password = PASSWORD
+        namespace = TEST_NAMESPACE
+        classname = TEST_CLASS
+        max_open = 0
+        max_pull = 100
+    else:
+        server_url = sys.argv[1]
+        username = sys.argv[2]
+        password = sys.argv[3]
+        namespace = sys.argv[4]
+        classname = sys.argv[5]
+        max_open = sys.argv[6]
+        max_pull = sys.argv[7]
+
+    # create the credentials tuple for WBEMConnection
+    creds = (username, password)
+
+    print('Parameters: server_url=%s\n username=%s\n namespace=%s\n' \
+          ' classname=%s\n max_open=%s,\n max_pull=%s' % \
+          (server_url, username, namespace, classname, max_open, max_pull))
+
+    # call method to connect to the server
+    conn = connect_server(server_url, creds, namespace)
+
+    #Call method to execute the enumeration sequence and return instances
+    try:
+        instances = execute_request(conn, classname, max_open, max_pull)
+
+        # print the resulting instances
+        for instance in instances:
+            print('\npath=%s\n%s' % (instance.path, instance.tomof()))
+
+    # handle any exception
+    except Error as err:
+        # If CIMError, display CIMError attributes
+        if isinstance(err, CIMError):
+            print('Operation Failed: CIMError: code=%s, Description=%s' % \
+                  (err.status_code_name, err.status_description))
+        else:
+            print ("Operation failed: %s" % err)
+        sys.exit(1)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())
+
+
+

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -29,46 +29,74 @@ a WBEM server.
 All WBEM operations defined in :term:`DSP0200` can be issued across this connection.
 Each method of this class corresponds directly to a WBEM operation.
 
-======================================================  ==============================================================
-WBEMConnection method                                   Purpose
-======================================================  ==============================================================
-:meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`   Enumerate the instance paths of instances of a class
-                                                        (including instances of its subclasses).
-:meth:`~pywbem.WBEMConnection.EnumerateInstances`       Enumerate the instances of a class (including instances of its
-                                                        subclasses)
-:meth:`~pywbem.WBEMConnection.GetInstance`              Retrieve an instance
-:meth:`~pywbem.WBEMConnection.ModifyInstance`           Modify the property values of an instance
-:meth:`~pywbem.WBEMConnection.CreateInstance`           Create an instance
-:meth:`~pywbem.WBEMConnection.DeleteInstance`           Delete an instance
-------------------------------------------------------  --------------------------------------------------------------
-:meth:`~pywbem.WBEMConnection.AssociatorNames`          Retrieve the instance paths of the instances (or classes)
-                                                        associated to a source instance (or source class)
-:meth:`~pywbem.WBEMConnection.Associators`              Retrieve the instances (or classes) associated to a source
-                                                        instance (or source class)
-:meth:`~pywbem.WBEMConnection.ReferenceNames`           Retrieve the instance paths of the association instances (or
-                                                        association classes) that reference a source instance (or
-                                                        source class)
-:meth:`~pywbem.WBEMConnection.References`               Retrieve the association instances (or association classes)
-                                                        that reference a source instance (or source class)
-------------------------------------------------------  --------------------------------------------------------------
-:meth:`~pywbem.WBEMConnection.InvokeMethod`             Invoke a method on a target instance or on a target class
-------------------------------------------------------  --------------------------------------------------------------
-:meth:`~pywbem.WBEMConnection.ExecQuery`                Execute a query in a namespace
-------------------------------------------------------  --------------------------------------------------------------
-:meth:`~pywbem.WBEMConnection.EnumerateClassNames`      Enumerate the names of subclasses of a class, or of the
-                                                        top-level classes in a namespace
-:meth:`~pywbem.WBEMConnection.EnumerateClasses`         Enumerate the subclasses of a class, or the top-level classes
-                                                        in a namespace
-:meth:`~pywbem.WBEMConnection.GetClass`                 Retrieve a class
-:meth:`~pywbem.WBEMConnection.ModifyClass`              Modify a class
-:meth:`~pywbem.WBEMConnection.CreateClass`              Create a class
-:meth:`~pywbem.WBEMConnection.DeleteClass`              Delete a class
-------------------------------------------------------  --------------------------------------------------------------
-:meth:`~pywbem.WBEMConnection.EnumerateQualifiers`      Enumerate qualifier declarations
-:meth:`~pywbem.WBEMConnection.GetQualifier`             Retrieve a qualifier declaration
-:meth:`~pywbem.WBEMConnection.SetQualifier`             Create or modify a qualifier declaration
-:meth:`~pywbem.WBEMConnection.DeleteQualifier`          Delete a qualifier declaration
-======================================================  ==============================================================
+==========================================================  ==============================================================
+WBEMConnection method                                       Purpose
+==========================================================  ==============================================================
+:meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`       Enumerate the instance paths of instances of a class
+                                                            (including instances of its subclasses).
+:meth:`~pywbem.WBEMConnection.EnumerateInstances`           Enumerate the instances of a class (including instances of its
+                                                            subclasses)
+:meth:`~pywbem.WBEMConnection.GetInstance`                  Retrieve an instance
+:meth:`~pywbem.WBEMConnection.ModifyInstance`               Modify the property values of an instance
+:meth:`~pywbem.WBEMConnection.CreateInstance`               Create an instance
+:meth:`~pywbem.WBEMConnection.DeleteInstance`               Delete an instance
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.AssociatorNames`              Retrieve the instance paths of the instances (or classes)
+                                                            associated to a source instance (or source class)
+:meth:`~pywbem.WBEMConnection.Associators`                  Retrieve the instances (or classes) associated to a source
+                                                            instance (or source class)
+:meth:`~pywbem.WBEMConnection.ReferenceNames`               Retrieve the instance paths of the association instances (or
+                                                            association classes) that reference a source instance (or
+                                                            source class)
+:meth:`~pywbem.WBEMConnection.References`                   Retrieve the association instances (or association classes)
+                                                            that reference a source instance (or source class)
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.InvokeMethod`                 Invoke a method on a target instance or on a target class
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.ExecQuery`                    Execute a query in a namespace
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.OpenEnumerateInstances`       Open enumeration session to retrieve instances of
+                                                            of a class (including instances of its subclass)
+:meth:`~pywbem.WBEMConnection.OpenAssociatorInstances`      Open enumeration session to retrieve the instances
+                                                            associated to a source instance
+:meth:`~pywbem.WBEMConnection.OpenReferenceInstances`       Open enumeration session to retrieve the instances
+                                                            that reference a source instance
+:meth:`~pywbem.WBEMConnection.PullInstancesWithPath`        Continue enumeration session opened with
+                                                            OpenEnumerateInstances, OpenAssociatorInstances, or
+                                                            OpenReferenceinstances
+:meth:`~pywbem.WBEMConnection.OpenEnumerateInstancePaths`   Open enumeration session to retrieve instances of a class
+                                                            (including instances of its subclass)
+:meth:`~pywbem.WBEMConnection.OpenAssociatorInstancePaths`  Open enumeration session to retrieve the instances
+                                                            associated to a source instance
+:meth:`~pywbem.WBEMConnection.OpenReferenceInstancePaths`   Open enumeration session to retrieve the instances that
+                                                            reference a source instance
+:meth:`~pywbem.WBEMConnection.PullInstancePaths`            Continue enumeration session opened with
+                                                            OpenEnumerateInstancePaths, OpenAssociatorInstancePaths,
+                                                            or OpenReferenceInstancePaths
+:meth:`~pywbem.WBEMConnection.OpenQueryInstances`           Open query request to retrieve instances defined by
+                                                            the query parameter in a namespace
+:meth:`~pywbem.WBEMConnection.PullInstances`                Continue enumeration of enumeration session opened
+                                                            with OpenExecQuery
+:meth:`~pywbem.WBEMConnection.CloseEnumeration`             Close an enumeration session in process.
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.EnumerateClassNames`          Enumerate the names of subclasses of a class, or of the
+                                                            top-level classes in a namespace
+:meth:`~pywbem.WBEMConnection.EnumerateClasses`             Enumerate the subclasses of a class, or the top-level classes
+                                                            in a namespace
+:meth:`~pywbem.WBEMConnection.GetClass`                     Retrieve a class
+:meth:`~pywbem.WBEMConnection.ModifyClass`                  Modify a class
+:meth:`~pywbem.WBEMConnection.CreateClass`                  Create a class
+:meth:`~pywbem.WBEMConnection.DeleteClass`                  Delete a class
+----------------------------------------------------------  --------------------------------------------------------------
+:meth:`~pywbem.WBEMConnection.EnumerateQualifiers`          Enumerate qualifier declarations
+:meth:`~pywbem.WBEMConnection.GetQualifier`                 Retrieve a qualifier declaration
+:meth:`~pywbem.WBEMConnection.SetQualifier`                 Create or modify a qualifier declaration
+:meth:`~pywbem.WBEMConnection.DeleteQualifier`              Delete a qualifier declaration
+==========================================================  ==============================================================
+
+NOTE: The method EnumerationCount is to be deprecated from the DMTF specs
+and has not been implemented by any servers so was not implemented
+in pywbem
 """
 # pylint: enable=line-too-long
 # Note: When used before module docstrings, Pylint scopes the disable statement
@@ -83,9 +111,9 @@ from datetime import datetime, timedelta
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 import warnings
+from collections import namedtuple
 
 import six
-
 from . import cim_xml
 from .cim_constants import DEFAULT_NAMESPACE
 from .cim_types import CIMType, CIMDateTime, atomic_to_cim_xml
@@ -97,11 +125,30 @@ from .tupleparse import parse_cim
 from .tupletree import dom_to_tupletree
 from .exceptions import Error, ParseError, AuthError, ConnectionError, \
                         TimeoutError, CIMError
+from .cim_constants import *  # pylint: disable=wildcard-import
 
 __all__ = ['WBEMConnection', 'PegasusUDSConnection', 'SFCBUDSConnection',
            'OpenWBEMUDSConnection']
 
+# Global named tuples. Used by the pull operation responses to return
+# (entities, end_of_sequence, and enumeration_context) to the caller.
 
+# openenumerateInstances, OpenAssociators, etc and PullInstanceWithPath
+# responses
+#pylint: disable=invalid-name
+pull_path_result_tuple = namedtuple("pull_path_result_tuple",
+                                    ["paths", "eos", "context"])
+
+# OpenEnumerateInstancePaths, etc.  and PullInstancePath responses
+pull_inst_result_tuple = namedtuple("pull_inst_result_tuple",
+                                    ["instances", "eos", "context"])
+
+# openqueryInstances and PullInstance responses
+pull_query_result_tuple = namedtuple("pull_query_result_tuple",
+                                     ["instances", "eos", "context",
+                                      "QueryResultClass"])
+
+# unicode test to set illegal xml char constant
 if len(u'\U00010122') == 2:
     # This is a "narrow" Unicode build of Python (the normal case).
     _ILLEGAL_XML_CHARS_RE = re.compile(
@@ -341,9 +388,9 @@ class WBEMConnection(object):
 
       - :exc:`~pywbem.AuthError` - Authentication failed with the WBEM server.
 
-      - :exc:`~pywbem.ParseError` - The response from the WBEM server cannot be
-        parsed (for example, invalid characters or UTF-8 sequences, ill-formed
-        XML, or invalid CIM-XML).
+      - :exc:`~pywbem.ParseError` - The response from the WBEM server cannot
+        be parsed (for example, invalid characters or UTF-8 sequences,
+        ill-formed XML, or invalid CIM-XML).
 
       - :exc:`~pywbem.CIMError` - The WBEM server returned an error response
         with a CIM status code.
@@ -368,8 +415,8 @@ class WBEMConnection(object):
       ... : All parameters of the :class:`~pywbem.WBEMConnection` constructor
         are set as public instance variables with the same name.
 
-      debug (:class:`py:bool`): A boolean indicating whether logging of the
-        last request and last reply is enabled.
+      debug (:class:`py:bool`): A boolean indicating whether logging of
+        the last request and last reply is enabled.
 
         The initial value of this instance variable is `False`.
         Debug logging can be enabled for future operations by setting this
@@ -629,7 +676,8 @@ class WBEMConnection(object):
                 self.default_namespace, self.x509, self.verify_callback,
                 self.ca_certs, self.no_verification, self.timeout)
 
-    def imethodcall(self, methodname, namespace, **params):
+    def imethodcall(self, methodname, namespace, response_params_rqd=None, \
+                    **params):
         """
         This is a low-level method that is used by the operation-specific
         methods of this class
@@ -645,9 +693,12 @@ class WBEMConnection(object):
         warnings.warn(
             "Calling imethodcall() directly is deprecated",
             DeprecationWarning)
-        return self._imethodcall(methodname, namespace, **params)
+        return self._imethodcall(methodname, namespace,
+                                 response_params_rqd=response_params_rqd,
+                                 **params)
 
-    def _imethodcall(self, methodname, namespace, **params):
+    def _imethodcall(self, methodname, namespace, response_params_rqd=None, \
+                     **params):
         """
         Perform an intrinsic CIM-XML operation.
         """
@@ -781,18 +832,32 @@ class WBEMConnection(object):
 
         if tup_tree is None:
             return None
+        if len(tup_tree) == 0:
+            return None
 
-        if tup_tree[0] == 'ERROR':
-            code = int(tup_tree[1]['CODE'])
-            if 'DESCRIPTION' in tup_tree[1]:
-                raise CIMError(code, tup_tree[1]['DESCRIPTION'])
-            raise CIMError(code, 'Error code %s' % tup_tree[1]['CODE'])
+        # ERROR | ...
+        if tup_tree[0][0] == 'ERROR':
+            err = tup_tree[0]
+            code = int(err[1]['CODE'])
+            if 'DESCRIPTION' in err[1]:
+                raise CIMError(code, err[1]['DESCRIPTION'])
+            raise CIMError(code, 'Error code %s' % err[1]['CODE'])
+        if response_params_rqd is None:
+            #expect either ERROR | IRETURNVALUE*
+            err = tup_tree[0]
+            if err[0] != 'IRETURNVALUE':
+                raise ParseError('Expecting IRETURNVALUE element, got %s' \
+                                 % err[0])
+            return tup_tree
 
-        if tup_tree[0] != 'IRETURNVALUE':
-            raise ParseError('Expecting IRETURNVALUE element, got %s' \
-                             % tup_tree[0])
-
-        return tup_tree
+        # At this point should have optional RETURNVALUE and at maybe one
+        # paramvalue element representing the pull return parameters
+        # of end_of_sequence/enumeration_context
+        # (IRETURNVALUE*, PARAMVALUE?)
+        else:
+            # TODO Further tests on this IRETURN or PARAMVALUE
+            # Could be IRETURNVALUE or a PARAMVALUE
+            return tup_tree
 
     def methodcall(self, methodname, localobject, Params=None, **params):
         """
@@ -1015,6 +1080,7 @@ class WBEMConnection(object):
         return tt
 
     def _iparam_namespace_from_namespace(self, obj):
+        # pylint: disable=invalid-name,
         """Determine the namespace from a namespace string, or `None`. The
         default namespace of the connection object is used, if needed.
 
@@ -1033,6 +1099,7 @@ class WBEMConnection(object):
         return namespace
 
     def _iparam_namespace_from_objectname(self, obj):
+        # pylint: disable=invalid-name,
         """Determine the namespace from an object name, that can be a class
         name string, a CIMClassName or CIMInstanceName object, or `None`.
         The default namespace of the connection object is used, if needed.
@@ -1168,7 +1235,7 @@ class WBEMConnection(object):
 
         instancenames = []
         if result is not None:
-            instancenames = result[2]
+            instancenames = result[0][2]
 
         for instancename in instancenames:
             instancename.namespace = namespace
@@ -1299,13 +1366,1731 @@ class WBEMConnection(object):
             **extra)
 
         instances = []
-        if result is not None:
-            instances = result[2]
 
+        if result is not None:
+            instances = result[0][2]
+
+        # TODO ks 6/16 would the setattr be faster?
+        # TODO: ks 6/16 should we check before setting?
+        #[setattr(i.path, 'namespace', namespace) for i in instances]
         for instance in instances:
             instance.path.namespace = namespace
 
         return instances
+
+    @staticmethod
+    def _get_rslt_params(result, namespace):
+        """Common processing for pull results to separate
+           end-of-sequence, enum-context, and endities in IRETURNVALUE.
+           Returns tuple of entities in IRETURNVALUE, end_of_sequence,
+           and enumeration_context)
+        """
+        #TODO ks 6/16 make this None???
+        rtn_objects = []
+        end_of_sequence = False
+        enumeration_context = None
+        valid_result = False
+
+        for p in result:
+            if p[0] == 'EndOfSequence':
+                if p[2] is None:
+                    valid_result = True
+                elif isinstance(p[2], six.string_types) and \
+                    p[2].lower() in ['true', 'false']:
+                    valid_result = True if p[2].lower() == 'true' else False
+                    end_of_sequence = valid_result
+
+            elif p[0] == 'EnumerationContext':
+                if p[2] is None:
+                    valid_result = True
+                if isinstance(p[2], six.string_types):
+                    enumeration_context = p[2]
+                    valid_result = True
+
+            elif p[0] == "IRETURNVALUE":
+                rtn_objects = p[2]
+
+        if not valid_result:
+            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence " \
+                           "or EnumerationContext required")
+
+        # convert enum context if eos is True
+        rtn_ctxt = None if end_of_sequence else (enumeration_context,
+                                                 namespace)
+
+        return (rtn_objects, end_of_sequence, rtn_ctxt)
+
+    def OpenEnumerateInstancePaths(self, ClassName, namespace=None,
+                                   FilterQueryLanguage=None, FilterQuery=None,
+                                   OperationTimeout=None, ContinueOnError=None,
+                                   MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+
+        """
+        Open an enumeration session to enumerate the instance paths of
+        instances of a class (including instances of its subclasses) in
+        a namespace.
+
+        This method performs the OpenEnumerateInstancePaths operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns status on the
+        enumeration session and optionally instance paths.
+        Otherwise, this method raises an exception.
+
+        Use :meth:`~pywbem.WBEMConnection.PullInstancePaths` request to
+        retrieve the next set of instance paths
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request to close the enumeration session early.
+
+        Parameters:
+
+          ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Name of the class to be enumerated, in any lexical case.
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            namespace component will be used as a default namespace as
+            described for the namespace argument, and its host component
+            will be ignored.
+
+          namespace (:term:`string`):
+            Name of the CIM namespace to be used, in any lexical case.
+
+            If `None`, the namespace of the `ClassName` parameter will be used,
+            if specified as a :class:`~pywbem.CIMClassName` object. If that is
+            also `None`, the default namespace of the connection will be used.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter. Not all WBEM
+            servers allow FilterQuery filtering for this operation
+            (i.e. return the CIM_ERR_NOT_SUPPORTED exception when filtering
+            is specified) because the act of the server filtering
+            requires that it generate instances and then discard them.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance
+              paths.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
+        """
+        if namespace is None and isinstance(ClassName, CIMClassName):
+            namespace = ClassName.namespace
+        namespace = self._iparam_namespace_from_namespace(namespace)
+        classname = self._iparam_classname(ClassName)
+
+        result = self._imethodcall(
+            'OpenEnumerateInstancePaths',
+            namespace,
+            ClassName=classname,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+            
+        return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenEnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
+                               DeepInheritance=None, IncludeQualifiers=None,
+                               IncludeClassOrigin=None, PropertyList=None,
+                               FilterQueryLanguage=None, FilterQuery=None,
+                               OperationTimeout=None, ContinueOnError=None,
+                               MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to get instances of a class
+        (including instances of its subclasses).
+
+        This method performs the OpenEnumerateInstances operation
+        (see :term:`DSP0200`)
+        .
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        Use :meth:`~pywbem.WBEMConnection.PullInstances` request to
+        retrieve the next set of instance paths
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request to close the enumeration session early.
+
+        :Parameters:
+
+          ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Name of the class to be enumerated, in any lexical case.
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            namespace component will be used as a default namespace as
+            described for the namespace argument, and its host component
+            will be ignored.
+
+          namespace (:term:`string`):
+            Name of the CIM namespace to be used, in any lexical case.
+
+            If `None`, the namespace of the `ClassName` parameter will be used,
+            if specified as a :class:`~pywbem.CIMClassName` object. If that is
+            also `None`, the default namespace of the connection will be used.
+
+          LocalOnly (:class:`py:bool`):
+            Controls the exclusion of inherited properties from the returned
+            instances, as follows:
+
+            * If `False`, inherited properties are not excluded.
+            * If `True`, inherited properties are basically excluded, but the
+              behavior may be WBEM server specific.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `True`.
+
+            This parameter has been deprecated in :term:`DSP0200` and should be
+            set to `False` by the caller.
+
+          DeepInheritance (:class:`py:bool`):
+            Indicates that properties added by subclasses of the specified
+            class are to be included in the returned instances, as follows:
+
+            * If `False`, properties added by subclasses are not included.
+            * If `True`, properties added by subclasses are included.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `True`.
+
+            Note, the semantics of the `DeepInheritance` parameter in
+            :meth:`~pywbem.WBEMConnection.EnumerateClasses` and
+            :meth:`~pywbem.WBEMConnection.EnumerateClassNames`
+            is different.
+
+          IncludeQualifiers (:class:`py:bool`):
+            Indicates that qualifiers are to be included in the returned
+            instance, as follows:
+
+            * If `False`, qualifiers are not included.
+            * If `True`, qualifiers are included if the WBEM server implements
+              support for this parameter.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+            This parameter has been deprecated in :term:`DSP0200`. Clients
+            cannot rely on it being implemented by WBEM servers.
+
+          IncludeClassOrigin (:class:`py:bool`):
+            Indicates that class origin information is to be included on each
+            property in the returned instances, as follows:
+
+            * If `False`, class origin information is not included.
+            * If `True`, class origin information is included.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+          PropertyList (:term:`py:iterable` of :term:`string`):
+            An iterable specifying the names of the properties to be
+            included in the returned instances, in any lexical case.
+
+            An empty iterable indicates to include no properties.
+
+            If `None`, all properties are included.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+
+        if namespace is None and isinstance(ClassName, CIMClassName):
+            namespace = ClassName.namespace
+        namespace = self._iparam_namespace_from_namespace(namespace)
+        classname = self._iparam_classname(ClassName)
+
+        result = self._imethodcall(
+            'OpenEnumerateInstances',
+            namespace,
+            ClassName=classname,
+            LocalOnly=LocalOnly,
+            DeepInheritance=DeepInheritance,
+            IncludeQualifiers=IncludeQualifiers,
+            IncludeClassOrigin=IncludeClassOrigin,
+            PropertyList=PropertyList,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenReferenceInstancePaths(self, InstanceName, ResultClass=None,
+                                   Role=None,
+                                   FilterQueryLanguage=None, FilterQuery=None,
+                                   OperationTimeout=None, ContinueOnError=None,
+                                   MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to retrieve the instance paths of
+        the association instances that reference a source instance.
+
+        This method does not support retrieving classes
+
+        This method performs the OpenReferenceInstancePaths operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instance paths.
+        Otherwise, this method raises an exception.
+
+        Use :meth:`~pywbem.WBEMConnection.PullInstances` request to
+        retrieve the next set of instance paths
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request to close the enumeration session early.
+
+        Parameters:
+
+          InstanceName:
+            The instance path of the source instance,
+            as a :class:`~pywbem.CIMInstanceName` object. If that object does
+            not specify a namespace, the default namespace of the connection is
+            used.
+
+          ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an association class, in any lexical case,
+            to filter the result to include only traversals of that association
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          Role (:term:`string`):
+            Role name (= property name) of the source end, in any
+            lexical case, to filter the result to include only traversals from
+            that source role.
+
+            `None` means that no such filtering is peformed.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter.  Not all WBEM
+            servers allow FilterQuery filtering for this operation
+            because the act of the server filtering requires
+            that it generate instances and then discard them.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance paths.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+
+        namespace = self._iparam_namespace_from_objectname(InstanceName)
+        instancename = self._iparam_instancename(InstanceName)
+
+        result = self._imethodcall(
+            'OpenReferenceInstancePaths',
+            namespace,
+            InstanceName=instancename,
+            ResultClass=self._iparam_classname(ResultClass),
+            Role=Role,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenReferenceInstances(self, InstanceName, ResultClass=None,
+                               Role=None, IncludeQualifiers=None,
+                               IncludeClassOrigin=None, PropertyList=None,
+                               FilterQueryLanguage=None, FilterQuery=None,
+                               OperationTimeout=None, ContinueOnError=None,
+                               MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to retrieve the association instances
+        that reference a source instance.
+
+        This method performs the OpenReferenceInstances operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        Use :meth:`~pywbem.WBEMConnection.PullInstances` request to
+        retrieve the next set of instance paths
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request to close the enumeration session early.
+
+        Parameters:
+
+          InstanceName:
+            The instance path of the source instance,
+            as a :class:`~pywbem.CIMInstanceName` object. If that object does
+            not specify a namespace, the default namespace of the connection is
+            used.
+
+          ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an association class, in any lexical case,
+            to filter the result to include only traversals of that association
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          Role (:term:`string`):
+            Role name (= property name) of the source end, in any
+            lexical case, to filter the result to include only traversals from
+            that source role.
+
+            `None` means that no such filtering is peformed.
+
+          IncludeQualifiers (:class:`py:bool`):
+            Indicates that qualifiers are to be included in the returned
+            instances (or classes), as follows:
+
+            * If `False`, qualifiers are not included.
+            * If `True`, qualifiers are included if the WBEM server implements
+              support for this parameter.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+            This parameter has been deprecated in :term:`DSP0200`. Clients
+            cannot rely on it being implemented by WBEM servers.
+
+          IncludeClassOrigin (:class:`py:bool`):
+            Indicates that class origin information is to be included on each
+            property or method in the returned instances (or classes), as
+            follows:
+
+            * If `False`, class origin information is not included.
+            * If `True`, class origin information is included.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+          PropertyList (:term:`py:iterable` of :term:`string`):
+            An iterable specifying the names of the properties to be included
+            in the returned instances (or classes), in any lexical case.
+            An empty iterable indicates to include no properties.
+
+            If `None`, all properties are included.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instance paths.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+
+        """
+
+        #TODO ks 6/16 Limit to instance name. No classname allowed.
+        namespace = self._iparam_namespace_from_objectname(InstanceName)
+        instancename = self._iparam_instancename(InstanceName)
+
+        result = self._imethodcall(
+            'OpenReferenceInstances',
+            namespace,
+            InstanceName=instancename,
+            ResultClass=self._iparam_classname(ResultClass),
+            Role=Role,
+            IncludeQualifiers=IncludeQualifiers,
+            IncludeClassOrigin=IncludeClassOrigin,
+            PropertyList=PropertyList,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenAssociatorInstancePaths(self, InstanceName, AssocClass=None,
+                                    ResultClass=None, Role=None,
+                                    ResultRole=None,
+                                    FilterQueryLanguage=None, FilterQuery=None,
+                                    OperationTimeout=None, ContinueOnError=None,
+                                    MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to retrieve the instance paths of the
+        instances associated to a source instance.
+
+        This method performs the OpenAssociatorInstancePaths operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instance paths.
+        Otherwise, this method raises an exception.
+
+        This method does not allow the option of defining `InstanceName`
+        as a class and retrieving associated classes.
+
+        Use :meth:`~pywbem.WBEMConnection.PullInstancePaths` request to
+        retrieve the next set of instance paths
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request to close the enumeration session early.
+
+        Parameters:
+
+          InstanceName:
+            The instance path of the source instance,
+            as a :class:`~pywbem.CIMInstanceName` object. If that object does
+            not specify a namespace, the default namespace of the connection is
+            used.
+
+          AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an association class, in any lexical case,
+            to filter the result to include only traversals of that association
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an associated class, in any lexical case,
+            to filter the result to include only traversals to that associated
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          Role (:term:`string`):
+            Role name (= property name) of the source end, in any
+            lexical case, to filter the result to include only traversals from
+            that source role.
+
+            `None` means that no such filtering is peformed.
+
+          ResultRole (:term:`string`):
+            Role name (= property name) of the far end, in any
+            lexical case, to filter the result to include only traversals to
+            that far role.
+
+            `None` means that no such filtering is peformed.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter. Not all WBEM
+            servers allow FilterQuery filtering for this operation
+            (i.e. return the CIM_ERR_NOT_SUPPORTED exception when filtering
+            is specified) because the act of the server filtering
+            requires that it generate instances and then discard them.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance
+              names.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+
+        namespace = self._iparam_namespace_from_objectname(InstanceName)
+        instancename = self._iparam_instancename(InstanceName)
+
+        result = self._imethodcall(
+            'OpenAssociatorInstancePaths',
+            namespace,
+            InstanceName=instancename,
+            AssocClass=self._iparam_classname(AssocClass),
+            ResultClass=self._iparam_classname(ResultClass),
+            Role=Role,
+            ResultRole=ResultRole,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenAssociatorInstances(self, InstanceName, AssocClass=None,
+                                ResultClass=None, Role=None, ResultRole=None,
+                                IncludeQualifiers=None,
+                                IncludeClassOrigin=None,
+                                PropertyList=None, FilterQueryLanguage=None,
+                                FilterQuery=None, OperationTimeout=None,
+                                ContinueOnError=None, MaxObjectCount=None,
+                                **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to retrieve the instances associated
+        to a source instance.
+
+        This method performs the OpenAssociatorInstances operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        NOTE: This method does not allow the option of defined `InstanceName`
+        as a class and retrieving associated classes.
+
+        The subsequent operation after this open is successful
+        and result.eos = False must be either the
+        :meth:`~pywbem.WBEMConnection.PullInstances` request
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request.
+
+        Parameters:
+
+          InstanceName:
+            The instance path of the source instance,
+            as a :class:`~pywbem.CIMInstanceName` object. If that object does
+            not specify a namespace, the default namespace of the connection is
+            used.
+
+          AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an association class, in any lexical case,
+            to filter the result to include only traversals of that association
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
+            Class name of an associated class, in any lexical case,
+            to filter the result to include only traversals to that associated
+            class (or subclasses).
+
+            `None` means that no such filtering is peformed.
+
+          Role (:term:`string`):
+            Role name (= property name) of the source end, in any
+            lexical case, to filter the result to include only traversals from
+            that source role.
+
+            `None` means that no such filtering is peformed.
+
+          ResultRole (:term:`string`):
+            Role name (= property name) of the far end, in any
+            lexical case, to filter the result to include only traversals to
+            that far role.
+
+            `None` means that no such filtering is peformed.
+
+          IncludeQualifiers (:class:`py:bool`):
+            Indicates that qualifiers are to be included in the returned
+            instances (or classes), as follows:
+
+            * If `False`, qualifiers are not included.
+            * If `True`, qualifiers are included if the WBEM server implements
+              support for this parameter.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+            This parameter has been deprecated in :term:`DSP0200`. Clients
+            cannot rely on it being implemented by WBEM servers.
+
+          IncludeClassOrigin (:class:`py:bool`):
+            Indicates that class origin information is to be included on each
+            property or method in the returned instances (or classes), as
+            follows:
+
+            * If `False`, class origin information is not included.
+            * If `True`, class origin information is included.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default to be used. :term:`DSP0200`
+              defines that the server-implemented default is `False`.
+
+          PropertyList (:term:`py:iterable` of :term:`string`):
+            An iterable specifying the names of the properties to be included
+            in the returned instances (or classes), in any lexical case.
+            An empty iterable indicates to include no properties.
+
+            If `None`, all properties are included.
+
+          FilterQueryLanguage (:term:`string`):
+            A string defining the name of the query language
+            used for the `FilterQuery` argument. The DMTF defined language
+            (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
+
+          FilterQuery (:term:`string`):
+            A string defining the query that is to be sent
+            to the WBEM server using the query language defined by
+            the `FilterQueryLanguage` parameter.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+
+        namespace = self._iparam_namespace_from_objectname(InstanceName)
+        instancename = self._iparam_instancename(InstanceName)
+
+        result = self._imethodcall(
+            'OpenAssociatorInstances',
+            namespace,
+            InstanceName=instancename,
+            AssocClass=self._iparam_classname(AssocClass),
+            ResultClass=self._iparam_classname(ResultClass),
+            Role=Role,
+            ResultRole=ResultRole,
+            IncludeQualifiers=IncludeQualifiers,
+            IncludeClassOrigin=IncludeClassOrigin,
+            PropertyList=PropertyList,
+            FilterQueryLanguage=FilterQueryLanguage,
+            FilterQuery=FilterQuery,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def OpenQueryInstances(self, FilterQueryLanguage, FilterQuery,
+                           namespace=None, ReturnQueryResultClass=None,
+                           OperationTimeout=None, ContinueOnError=None,
+                           MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+        """
+        Open an enumeration session to execute a query in a namespace.
+
+        This method performs the OpenQueryInstances operation
+        (see :term:`DSP0200`).
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        The subsequent operation after this open is successful
+        and result.eos is False, must be either the
+        :meth:`~pywbem.WBEMConnection.PullInstances` request
+        or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
+        request.
+
+        Parameters:
+
+          FilterQueryLanguage (:term:`string`):
+            Name of the query language used in the `Query` parameter, e.g.
+            "DMTF:CQL" for CIM Query Language, and "WQL" for WBEM Query
+            Language. "DMTF:FQL" is not a valid query language for this
+            request.
+
+          FilterQuery (:term:`string`):
+            Query string in the query language specified in the `QueryLanguage`
+            parameter.
+
+          namespace (:term:`string`):
+            Name of the CIM namespace to be used, in any lexical case.
+
+            If `None`, the default namespace of the connection object will be
+            used.
+
+          ReturnQueryResultClass  (:class:`py:bool`):
+            Controls whether a class definition is returned in
+            `QueryResultClass`.
+
+          OperationTimeout (:class:`~pywbem.Uint32`):
+            Minimum time in seconds the WBEM Server shall maintain an open
+            enumeration session after a previous Open or Pull request is
+            sent to the client. Once this timeout time has expired, the
+            WBEM server may close the enumeration session.
+
+            * If not `None`, this parameter is sent to the WBEM server as the
+              proposed timeout for the enumeration session. A value of 0
+              indicates that the server is expected to never time out. The
+              server may reject the proposed value, causing a
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_INVALID_OPERATION_TIMEOUT`.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default timeout to be used.
+
+          ContinueOnError (:class:`py:bool`):
+            Indicates to the WBEM server to continue sending responses
+            after an error response has been sent.
+
+            * If `True`, the server is to continue sending responses after
+              sending an error response. Not all servers support continuation
+              on error; a server that does not support it must send an error
+              response if `True` was specified, causing
+              :class:`~pywbem.CIMError` to be raised with status code
+              :attr:`~pywbem.CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED`.
+            * If `False`, the server is requested to close the enumeration after
+              sending an error response.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              `False`.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server may return
+            for this request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+            * If `None`, this parameter is not passed to the WBEM server, and
+              causes the server-implemented default behaviour to be used.
+              :term:`DSP0200` defines that the server-implemented default is
+              to return zero instances.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+            * `QueryResultClass` (:class:`pywbem.CIMClass`):
+              If ReturnQuerhResultClass is True, this return parameter
+              shall contain a class definition that defines the properties
+              of each row of the query result.
+
+              NOTE: The inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+
+        @staticmethod
+        def _GetQueryyRsltClass(result):
+            """ Get the QueryResultClass and return it or generate
+                exception.
+            """
+
+            for p in result:
+                if p[0] == 'QueryResultClass' and isinstance(p[2], CIMClass):
+                    return p[2]
+            raise CIMError(CIM_ERR_INVALID_PARAMETER,
+                           "ReturnQueryResultClass invalid or missing.")
+
+        namespace = self._iparam_namespace_from_objectname(namespace)
+
+        result = self._imethodcall(
+            'OpenQueryInstances',
+            namespace,
+            FilterQuery=FilterQuery,
+            FilterQueryLanguage=FilterQueryLanguage,
+            ReturnQueryResultClass=ReturnQueryResultClass,
+            OperationTimeout=OperationTimeout,
+            ContinueOnError=ContinueOnError,
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        insts, eos, enum_ctxt = self._get_rslt_params(result, namespace)
+
+        query_class = _GetQuerryRsltClass(result) if \
+                          ReturnQueryResultClass else None
+
+        return pull_query_result_tuple(insts, eos, enum_ctxt, query_class)
+        
+
+
+    def PullInstancesWithPath(self, context, MaxObjectCount,
+                              **extra):
+        # pylint: disable=invalid-name
+
+        """
+        Retrieve the next set of instances with path from an open enumeraton
+        session defined by the `enumeration_context` parameter.  The retrieved
+        instances include their instance paths.
+
+        This method performs the PullInstanceWithPath operation
+        (see :term:`DSP0200`).
+
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        :Parameters:
+          context (:term:`string`)
+            Identifies the enumeraton session, including its current
+            enumeration state. This must be the value of the `context`
+            item in the :class:`py:namedtuple` returned from the previous
+            open or pull operation for this enumeration.
+
+            The tuple items are:
+
+            - server_context (:term:`string`):
+              Enumeration context string returned by the server. This
+              string is opaque for the client.
+            - namespace (:term:`string`):
+              Name of the CIM namespace to be used for this operation.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server shall return
+            for this request. This parameter is required for each
+            Pull request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+        namespace = context[1]
+
+        result = self._imethodcall(
+            'PullInstancesWithPath',
+            namespace=namespace,
+            EnumerationContext=context[0],
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
+        # pylint: disable=invalid-name
+
+        """
+        Retrieve the next set of instance paths from an open enumeraton
+        session defined by the `enumeration_context` parameter.
+
+        This method performs the PullInstanceWithPath operation
+        (see :term:`DSP0200`).
+
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instance paths.
+        Otherwise, this method raises an exception.
+
+        :Parameters:
+          context (:term:`string`)
+            Identifies the enumeraton session, including its current
+            enumeration state. This must be the value of the `context`
+            item in the :class:`py:namedtuple` returned from the previous
+            open or pull operation for this enumeration.
+
+            The tuple items are:
+
+            - server_context (:term:`string`):
+              Enumeration context string returned by the server. This
+              string is opaque for the client.
+            - namespace (:term:`string`):
+              Name of the CIM namespace to be used for this operation.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server shall return
+            for this request. This parameter is required for each
+            Pull request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance paths.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+        namespace = context[1]
+
+        result = self._imethodcall(
+            'PullInstancePaths',
+            namespace=namespace,
+            EnumerationContext=context[0],
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def PullInstances(self, context, MaxObjectCount=None, \
+                          **extra):
+        # pylint: disable=invalid-name
+
+        """
+        Retrieve the next set of instances from an open enumeraton
+        session defined by the `enumeration_context` parameter.
+
+        This method performs the PullInstanceWithPath operation
+        (see :term:`DSP0200`).
+
+        If the operation succeeds, this method returns enumeration session
+        status and optionally instances.
+        Otherwise, this method raises an exception.
+
+        :Parameters:
+          context (:term:`string`)
+            Identifies the enumeraton session, including its current
+            enumeration state. This must be the value of the `context`
+            item in the :class:`py:namedtuple` returned from the previous
+            open or pull operation for this enumeration.
+
+            The tuple items are:
+
+            - server_context (:term:`string`):
+              Enumeration context string returned by the server. This
+              string is opaque for the client.
+            - namespace (:term:`string`):
+              Name of the CIM namespace to be used for this operation.
+
+          MaxObjectCount (:class:`~pywbem.Uint32`)
+            Maximum number of instances the WBEM server shall return
+            for this request. This parameter is required for each
+            Pull request.
+
+            * If positive, the WBEM server is to return no more than the
+              specified number of instances.
+            * If zero, the WBEM server is to return no instances. This may
+              be used by a client to leave the handling of any returned
+              instances to a loop of Pull operations.
+
+        :Returns:
+
+            A :class:`py:namedtuple` containing the following named elements:
+
+            * `instances` (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+            * `eos` (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * `context` (tuple of (server_context, namespace)):
+               Identifies the opened enumeration session. The client must
+               provide this value for subsequent operations on this
+               enumeration session. The tuple items are:
+
+               - server_context (:term:`string`):
+                 Enumeration context string returned by the server if
+                 the session is not exhausted, or `None` otherwise. This string
+                 is opaque for the client.
+               - namespace (:term:`string`):
+                 Name of the CIM namespace that was used for this operation.
+
+               NOTE: This inner tuple hides the need for a CIM namespace
+               on subsequent operations in the enumeration session. CIM
+               operations always require target namespace, but it never
+               makes sense to specify a different one in subsequent
+               operations on the same enumeration session.
+
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
+        :Exceptions:
+
+            See the list of exceptions described in `WBEMConnection`.
+        """
+        namespace = context[1]
+
+        result = self._imethodcall(
+            'PullInstances',
+            namespace=namespace,
+            EnumerationContext=context[0],
+            MaxObjectCount=MaxObjectCount,
+            response_params_rqd=True,
+            **extra)
+
+        return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
+        
+
+    def CloseEnumeration(self, context, **extra):
+        # pylint: disable=invalid-name
+        """
+        The CloseEnumeration closes an open enumeration session, performing
+        an early termination of an incomplete enumeration session.
+
+        This method performs the CloseEnumeration operation
+        (see :term:`DSP0200`).
+
+        This method should not used if the enumeration session has
+        terminated and will result in an exception response.
+
+        If the operation succeeds, this method returns. Otherwise, it
+        raises an exception.
+
+        :Parameters:
+
+          context (:term: `string`)
+            The `enumeration_context` paramater must contain the
+            `Context` value returned by the WBEM server with the
+            response to the previous open or pull operation for this
+            enumeration sequence.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
+        """
+
+        self._imethodcall(
+            'CloseEnumeration',
+            namespace=context[1],
+            EnumerationContext=context[0],
+            **extra)
 
     def GetInstance(self, InstanceName, LocalOnly=None, IncludeQualifiers=None,
                     IncludeClassOrigin=None, PropertyList=None, **extra):
@@ -1401,7 +3186,7 @@ class WBEMConnection(object):
             PropertyList=PropertyList,
             **extra)
 
-        instance = result[2][0]
+        instance = result[0][2][0]
         instance.path = instancename
         instance.path.namespace = namespace
 
@@ -1578,7 +3363,7 @@ class WBEMConnection(object):
             NewInstance=instance,
             **extra)
 
-        instancename = result[2][0]
+        instancename = result[0][2][0]
         instancename.namespace = namespace  # TODO: Why not accept returned ns?
 
         return instancename
@@ -1723,7 +3508,7 @@ class WBEMConnection(object):
         if result is None:
             return []
 
-        return [x[2] for x in result[2]]
+        return [x[2] for x in result[0][2]]
 
     def Associators(self, ObjectName, AssocClass=None, ResultClass=None,
                     Role=None, ResultRole=None, IncludeQualifiers=None,
@@ -1866,7 +3651,7 @@ class WBEMConnection(object):
         if result is None:
             return []
 
-        return [x[2] for x in result[2]]
+        return [x[2] for x in result[0][2]]
 
     def ReferenceNames(self, ObjectName, ResultClass=None, Role=None, **extra):
         # pylint: disable=invalid-name, line-too-long
@@ -1953,7 +3738,7 @@ class WBEMConnection(object):
         if result is None:
             return []
 
-        return [x[2] for x in result[2]]
+        return [x[2] for x in result[0][2]]
 
     def References(self, ObjectName, ResultClass=None, Role=None,
                    IncludeQualifiers=None, IncludeClassOrigin=None,
@@ -2081,7 +3866,7 @@ class WBEMConnection(object):
         if result is None:
             return []
 
-        return [x[2] for x in result[2]]
+        return [x[2] for x in result[0][2]]
 
     #
     # Method invocation operation
@@ -2273,7 +4058,7 @@ class WBEMConnection(object):
         instances = []
 
         if result is not None:
-            instances = [tt[2] for tt in result[2]]
+            instances = [tt[2] for tt in result[0][2]]
 
         for instance in instances:
             instance.path.namespace = namespace
@@ -2365,7 +4150,7 @@ class WBEMConnection(object):
         if result is None:
             return []
         else:
-            return [x.classname for x in result[2]]
+            return [x.classname for x in result[0][2]]
 
     def EnumerateClasses(self, namespace=None, ClassName=None,
                          DeepInheritance=None, LocalOnly=None,
@@ -2483,7 +4268,7 @@ class WBEMConnection(object):
         if result is None:
             return []
 
-        return result[2]
+        return result[0][2]
 
     def GetClass(self, ClassName, namespace=None, LocalOnly=None,
                  IncludeQualifiers=None, IncludeClassOrigin=None,
@@ -2582,7 +4367,7 @@ class WBEMConnection(object):
             PropertyList=PropertyList,
             **extra)
 
-        return result[2][0]
+        return result[0][2][0]
 
     def ModifyClass(self, ModifiedClass, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -2783,7 +4568,7 @@ class WBEMConnection(object):
             **extra)
 
         if result is not None:
-            qualifiers = result[2]
+            qualifiers = result[0][2]
         else:
             qualifiers = []
 
@@ -2839,7 +4624,7 @@ class WBEMConnection(object):
             **extra)
 
         if result is not None:
-            names = result[2][0]
+            names = result[0][2][0]
 
         return names
 

--- a/testsuite/test_client/openenuminstances.yaml
+++ b/testsuite/test_client/openenuminstances.yaml
@@ -1,0 +1,161 @@
+-
+    name: OpenEnumerateInstances1
+    description: OpenEnumerateInstances succeeds
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: OpenEnumerateInstances
+            ClassName: PyWBEM_Person
+            LocalOnly: false
+    pywbem_response:
+        pullresult:
+            context: null
+            eos: True
+            instances: 
+                -
+                    pywbem_object: CIMInstance
+                    classname: PYWBEM_Person
+                    properties:
+                        CreationClassName: PyWBEM_Person
+                        Name: Fritz
+                        Address: Fritz Town
+                    path:
+                        pywbem_object: CIMInstanceName
+                        classname: PYWBEM_Person
+                        host : Fred
+                        namespace: root/cimv2
+                        keybindings:
+                            CreationClassname: PyWBEM_Person
+                            Name: Fritz
+                -
+                    pywbem_object: CIMInstance
+                    classname: PyWBEM_Person
+                    properties:
+                        CreationClassName: PyWBEM_Person
+                        Name: Alice
+                        Address: Alice Town
+                    path:
+                        pywbem_object: CIMInstanceName
+                        classname: PyWBEM_Person
+                        host: fred
+                        namespace: root/cimv2
+                        keybindings:
+                            CreationClassname: PyWBEM_Person
+                            Name: Alice
+
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: OpenEnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+             <?xml version="1.0" encoding="utf-8" ?>
+             <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                 <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                     <SIMPLEREQ>
+                         <IMETHODCALL NAME="OpenEnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                 <NAMESPACE NAME="root"/>
+                                 <NAMESPACE NAME="cimv2"/>
+                             </LOCALNAMESPACEPATH>
+                             <IPARAMVALUE NAME="ClassName">
+                                 <CLASSNAME NAME="PyWBEM_Person"/>
+                             </IPARAMVALUE>
+                             <IPARAMVALUE NAME="LocalOnly">
+                                 <VALUE>False</VALUE>
+                             </IPARAMVALUE>
+                         </IMETHODCALL>
+                     </SIMPLEREQ>
+                 </MESSAGE>
+             </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="OpenEnumerateInstances">
+                            <IRETURNVALUE>
+                                <VALUE.INSTANCEWITHPATH>
+                                    <INSTANCEPATH>
+                                        <NAMESPACEPATH>
+                                            <HOST>fred</HOST>
+                                            <LOCALNAMESPACEPATH>
+                                                <NAMESPACE NAME="root"/>
+                                                <NAMESPACE NAME="cimv2"/>
+                                            </LOCALNAMESPACEPATH>
+                                        </NAMESPACEPATH>
+                                        <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                            <KEYBINDING NAME="CreationClassName">
+                                                <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                            </KEYBINDING>
+                                            <KEYBINDING NAME="Name">
+                                                <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                                            </KEYBINDING>
+                                        </INSTANCENAME>
+                                    </INSTANCEPATH>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Fritz</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Fritz Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.INSTANCEWITHPATH>
+                             <VALUE.INSTANCEWITHPATH>
+                                    <INSTANCEPATH>
+                                        <NAMESPACEPATH>
+                                            <HOST>Fred</HOST>
+                                            <LOCALNAMESPACEPATH>
+                                                <NAMESPACE NAME="root"/>
+                                                <NAMESPACE NAME="cimv2"/>
+                                            </LOCALNAMESPACEPATH>
+                                        </NAMESPACEPATH>
+                                        <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                            <KEYBINDING NAME="CreationClassName">
+                                                <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                            </KEYBINDING>
+                                            <KEYBINDING NAME="Name">
+                                                <KEYVALUE VALUETYPE="string">Alice</KEYVALUE>
+                                            </KEYBINDING>
+                                        </INSTANCENAME>
+                                    </INSTANCEPATH>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Alice</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Alice Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.INSTANCEWITHPATH>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>TRUE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE></VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+


### PR DESCRIPTION
This commit includes OpenEnumerateInstancesWithPath,
PullInstancesWithPath, CloseEnumeration, OpenEnumerateInstancePaths,
and PullInstancePaths. The documentation is defined for all but
OpenEnumerateInstancePaths and PullInstancePaths.

The mock test is broken but there is a first set of tests in
run_cimoperations.py that executes a number of variations of
OpenEnumerateInstancePaths with pull and close against OpenPegasus.

NOT READY FOR MERGE.

Here is first cut of part ready for review and comment.  In particular, this currently fails mock and only about hallf of operaitons there.  Since the documentaiton for each operation is enormous would like to get the first one clean (OpenEnumerateInstances) before doing the other opens.

Also some code is hacky and we should discuss the enum_context thing class.

Anyway, it actually works now.