### PR TITLE
Temporary workaround for issue 331 with Travis CI running on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,16 @@ install:
   - pip list
   - make develop
   - pip list
+  - python -c "import setuptools,os; print('Version of GitPython package:'); sp=os.path.dirname(os.path.dirname(setuptools.__file__)); print(open(sp+'/git/__init__.py','r').read())"
+
+# TODO 2016-05 AM: Remove displaying of GitPython version, once GitPython 2.0.4 is released.
+
+# commands to run builds & tests
+script:
   - make check
   - make build
-  - make builddoc
-
-# commands to run tests
-script:
+  - if [[ $(python -c "import sys; print('%s.%s'%sys.version_info[0:2])") != 2.6 ]]; then make builddoc; fi
   - make test
+
+# TODO 2016-05 AM: Remove disabling of "make builddoc" for Python 2.6, once GitPython 2.0.4 is released.
+

--- a/setup.py
+++ b/setup.py
@@ -346,6 +346,10 @@ def main():
             "pytest>=2.4",
             "pytest-cov",
             "Sphinx>=1.3",
+            # The ordereddict package is a backport of collections.OrderedDict
+            # to Python 2.6. OrderedDict is needed by the GitPython package
+            # since its 2.0.3 version. GitPython is needed by sphinx-git.
+            "ordereddict" if sys.version_info[0:2] == (2, 6) else None,
             "sphinx-git",
             "httpretty",
             "lxml",


### PR DESCRIPTION
Ready to be merged.
Please review quickly, because this is needed as a basis to get the other PR checks running again.

Details from the commit log:

- Added dependency to `ordereddict` PyPI package to `develop_requires` argument of setup script when running on Python 2.6.
- In Travis CI control file, moved some build commands from the "install" section to "script" section, in order to continue when they fail.
- In Travis CI control file, printed debug information about version and content of the GitPython package (temporary change until GitPython 2.0.4 gets released).
- In Travis CI control file, disabled `make builddoc` step when running on Python 2.6 (temporary change until GitPython 2.0.4 gets released).