### PR TITLE
Use GitPython 2.0.5 and improve Python installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,13 @@ install:
   - pip list
   - make develop
   - pip list
-  - python -c "import setuptools,os; print('Version of GitPython package:'); sp=os.path.dirname(os.path.dirname(setuptools.__file__)); print(open(sp+'/git/__init__.py','r').read())"
-
-# TODO 2016-05 AM: Remove displaying of GitPython version, once GitPython 2.0.4 is released.
 
 # commands to run builds & tests
 script:
   - make check
   - make build
-  - if [[ $(python -c "import sys; print('%s.%s'%sys.version_info[0:2])") != 2.6 ]]; then make builddoc; fi
+  - if [[ $(python -c "import sys; print('%s.%s'%sys.version_info[0:2])") != 2.6 ]]; then make builddoc; else echo "make builddoc is disabled on Python 2.6 until GitPython runs again (see its issue 457)"; fi
   - make test
 
-# TODO 2016-05 AM: Remove disabling of "make builddoc" for Python 2.6, once GitPython 2.0.4 is released.
+# TODO 2016-05 AM: Remove disabling of "make builddoc" for Python 2.6, once GitPython runs on Python 2.6.
 

--- a/setup.py
+++ b/setup.py
@@ -348,8 +348,10 @@ def main():
             "Sphinx>=1.3",
             # The ordereddict package is a backport of collections.OrderedDict
             # to Python 2.6. OrderedDict is needed by the GitPython package
-            # since its 2.0.3 version. GitPython is needed by sphinx-git.
+            # since its 2.0.3 version (but only its 2.0.5 version uses it
+            # correctly). GitPython is needed by sphinx-git.
             "ordereddict" if sys.version_info[0:2] == (2, 6) else None,
+            "GitPython>=2.0.5",
             "sphinx-git",
             "httpretty",
             "lxml",


### PR DESCRIPTION
GitHub 2.0.5 has been released yesterday, and includes the fix needed for Python 2.6 (of using OrderedDict from ordereddict, if not available in collections).

Unfortunately, GitPython 2.0.5 introduced a new issue for Python 2.6, see [GitPython issue 457](https://github.com/gitpython-developers/GitPython/issues/457), so `make builddoc` still needs to be disabled for the time being.

This PR is still ready to be merged, and a future PR can re-enable `make builddoc` on Python 2.6.

Please review.

Details from the commit log:

- Updated the setup script to require Gitpython 2.0.5.
- Updated the Travis CI control file to remove the debug displaying of the GitPython version.
- In os_setup, changed Python installer to use XML-RPC API of new PyPI warehouse site to fix issues with old PyPI site.
- Note: Unfortunately, a new issue in GitPython (#457) with Python 2.6 still requires disabling make builddoc on Python 2.6 for the time being.