### PR TITLE
Fixes #277: Added description of authentication types in WBEM client API

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -149,6 +149,8 @@ Enhancements
   subclass to specifically test against OpenPegasus if OpenPegasus is
   detected as the server.
 
+* Added description of supported authentication types in WBEM client API.
+
 Bug fixes
 ^^^^^^^^^
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -197,3 +197,209 @@ Exceptions
    :members:
    :special-members: __str__
 
+.. _`Security considerations`:
+
+Security considerations
+-----------------------
+
+.. _`Authentication types`:
+
+Authentication types
+^^^^^^^^^^^^^^^^^^^^
+
+Authentication is the act of establishing the identity of a user on the
+client side to the server, and possibly also of establishing the identity of a
+server to the client.
+
+Because authentication in HTTP/HTTPS and therefore in CIM-XML is a complex
+topic, it is briefly described.
+
+There are two levels of authentication in CIM-XML:
+
+* TLS/SSL level authentication (only when HTTPS is used):
+
+  This kind of authentication is also known as *transport level authentication*.
+  It is used during the TLS/SSL handshake protocol, before any HTTP requests
+  flow.
+
+  In almost all cases (unless an anonymous cipher is used), this involves
+  an X.509 certificate that is presented by the server (therefore called
+  *server certificate*) and that allows the client to establish the identity
+  of the server.
+
+  It optionally involves an X.509 certificate that is presented by the client
+  (therefore called client certificate) and that allows the server to establish
+  the identity of the client or even of the client user, and thus can avoid
+  the use of credentials in the HTTP level authentication.
+
+  If a client certificate is used, the authentication scheme at the TLS/SSL
+  level is called *2-way authentication* (also known as *client authentication*
+  or *mutual SSL authentication*). If a client certificate is not
+  used, the authentication scheme is called *1-way authentication* (also known
+  as *SSL authentication*).
+
+  Userid/password credentials do not play any role in TLS/SSL level
+  authentication.
+
+* HTTP level authentication:
+
+  This kind of authentication is used in HTTP/HTTPS requests and responses (in
+  case of HTTPS, that is after the TLS/SSL handshake protocol has completed).
+
+  In case of *Basic Authentication* and *Digest Authentication* (see
+  :term:`RFC2617`), it involves passing credentials (userid and password) via
+  the ``Authenticate`` and ``WWW-Authenticate`` HTTP headers. In case of *no
+  authentication*, credentials are not passed.
+
+  A client can either provide the ``Authenticate`` header along with a request,
+  hoping that the server supports the authentication scheme that was used.
+
+  A client can also omit that header in the request, causing the server to send
+  an error response with a ``WWW-Authenticate`` header that tells the client
+  which authentication types are supported by the server (also known as a
+  *challenge*). The client then repeats the first request with one of the
+  supported authentication types.
+
+  HTTP is extensible w.r.t. authentication schemes, and so is CIM-XML.
+  However, the PyWBEM client only supports Basic Authentication and no
+  authentication.
+
+  X.509 certificates do not play any role in HTTP level authentication.
+
+HTTP/HTTPS knows a third level of authentication by the use of *session
+cookies*. CIM-XML does not define how cookies would be used, and the
+PyWBEM client does not deal with cookies in any way (i.e. it does not
+pass cookies provided in a response into the next request).
+
+The following table shows the possible combinations of protocol, TLS/SSL level
+and HTTP level authentication schemes, which information items need to be
+provided to the WBEM client API, and whether the combination is supported
+by the PyWBEM client:
+
+======== ========== =========== =========== ============ ======== =========
+Protocol SSL auth.  HTTP auth.  Credentials Client cert. CA cert. Supported
+======== ========== =========== =========== ============ ======== =========
+HTTP     N/A        None        No          No           No       Yes (1)
+HTTP     N/A        Basic       Yes         No           No       Yes (2)
+HTTP     N/A        Digest      Yes         No           No       No
+HTTPS    1-way      None        No          No           Yes (3)  Yes (1)
+HTTPS    1-way      Basic       Yes         No           Yes (3)  Yes
+HTTPS    1-way      Digest      Yes         No           Yes (3)  No
+HTTPS    2-way      None        No          Yes          Yes (3)  Yes (4)
+HTTPS    2-way      Basic       Yes         Yes          Yes (3)  Yes
+HTTPS    2-way      Digest      Yes         Yes          Yes (3)  No
+======== ========== =========== =========== ============ ======== =========
+
+Notes:
+
+(1) This option does not allow a server to establish the identity of the user.
+    Its use should be limited to environments where network access is secured.
+(2) The use of HTTP Basic Authentication is strongly discouraged, because the
+    password is sent unencrypted over the network.
+(3) A CA certificate is needed, unless server certificate verification is
+    disabled via the `no_verification` parameter (not recommended), or unless
+    an anonymous cipher is used for the server certificate (not recommended).
+(4) This is the most desirable option from a security perspective, if the
+    WBEM server is able to establish the user identity based on the client
+    certificate.
+
+The authentication types that can be used on a connection between a PyWBEM
+client and a WBEM server are set by the user when creating the
+:class:`~pywbem.WBEMConnection` object:
+
+* The scheme of the URL in the `url` parameter controls whether HTTP or HTTPS is
+  used.
+* The `cred` parameter may specify credentials (userid/password). If specified,
+  the PyWBEM client uses them for Basic Authentication at the HTTP level.
+  The PyWBEM client provides an ``Authenticate`` HTTP header on each request,
+  and also handles server challenges transparently to the user of the
+  WBEM client API, by retrying the original request.
+* The `x509` parameter may specify an X.509 client certificate and key. If
+  specified, the PyWBEM client uses Mutual Authentication; otherwise it uses
+  Simple Authentication at the TLS/SSL level.
+* The `ca_certs` parameter may specify X.509 CA certificates that are used
+  to validate the X.509 server certificate returned by the WBEM server.
+  X.509 CA certificates must be specified, unless the `no_verification`
+  parameter indicates not to validate the server certificate.
+
+It is important to understand which side actually makes decisions about the
+authentication type: The client only decides whether HTTP or HTTPS is used. The
+server decides everything else: Which HTTP authentication type is used
+(None, Basic, Digest), and whether an X.509 client certificate is requested
+from the client and if so, whether it tolerates a client not providing one.
+
+Therefore, the `cred` and `x509` parameters do not control the authentication
+type that is actually used, but merely prepare the PyWBEM client to deal with
+whatever authentication type the WBEM server elects to use.
+
+WBEM servers typically support corresponding configuration parameters.
+
+.. _`Verification of the X.509 server certificate`:
+
+Verification of the X.509 server certificate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using HTTPS, the TLS/SSL handshake protocol requires that the server always
+returns an :term:`X.509` server certificate to the client.
+
+The PyWBEM client performs the following verifications on the server certificate
+returned by the WBEM server:
+
+* Validation of the server certificate against the CA certificates specified in
+  the `ca_certs` parameter. This is done by the TLS/SSL components used by
+  pywbem.
+* Validation of the server certificate's expiration date, based on the system
+  clock. This is done by the TLS/SSL components used by pywbem.
+* Validation of the hostname, by comparing the Subject attribute of the server
+  certificate with the hostname specified in the `url` parameter.
+  This is done by pywbem itself.
+* Calling the validation function specified in the `verify_callback` parameter,
+  if any, and looking at its validation result.
+
+If any of these validations fails, the WBEM operation methods of the
+:class:`~pywbem.WBEMConnection` object raise a :exc:`pywbem.AuthError`.
+
+If verification was disabled via the `no_verification` parameter, none of these
+validations of the server certificate happens.
+
+.. _`Use of X.509 client certificates`:
+
+Use of X.509 client certificates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using HTTPS, the TLS/SSL handshake protocol provides the option for the
+client to present an X.509 certificate to the server (therefore called client
+certificate).
+
+This procedure is initiated by the server, by requesting that the client
+present a client certificate. If the client does not have one (for example,
+because the `x509` parameter was not specified in the PyWBEM client), it
+must send an empty list of certificates to the server. Depending on
+the server configuration, the server may or may not accept an empty list.
+If a client certificate is presented, the server must validate it.
+
+The server can support to accept the user identity specified in the client
+certificate as the user's identity, and refrain from sending HTTP challenges
+that request credentials.
+
+.. _`Authentication errors`:
+
+Authentication errors
+^^^^^^^^^^^^^^^^^^^^^
+
+The operation methods of :class:`~pywbem.WBEMConnection` raise
+:exc:`pywbem.AuthError` in any of these situations:
+
+* When client side verification of the X.509 server certificate fails.
+
+* When the WBEM server returns HTTP status 401 "Unauthorized". It typically
+  does that in any of these situations:
+
+  - no authorization information provided by client
+  - wrong HTTP authentication scheme used by client
+  - authentication failed
+  - user is not authorized to access resource
+
+* When the WBEM server returns HTTP status 404 "Forbidden". It typically
+  does that if it does not allow the client to issue CIM-XML requests.
+

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -233,6 +233,9 @@ References
    X.509
       `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <http://www.itu.int/rec/T-REC-X.509/en>`_
 
+   RFC2617
+      `IETF RFC2617, HTTP Authentication: Basic and Digest Access Authentication, June 1999 <https://tools.ietf.org/html/rfc2617>`_
+
    RFC3986
       `IETF RFC3986, Uniform Resource Identifier (URI): Generic Syntax, January 2005 <https://tools.ietf.org/html/rfc3986>`_
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -441,7 +441,7 @@ class WBEMConnection(object):
                 address) using zone identifier eth0
 
           creds (:class:`py:tuple` of userid, password):
-            Credentials for authenticating with the WBEM server, as a
+            Credentials for HTTP authenticatiion with the WBEM server, as a
             tuple(userid, password), with:
 
               * userid (:term:`string`):
@@ -450,6 +450,12 @@ class WBEMConnection(object):
               * password (:term:`string`):
                 Password for that userid.
 
+            If `None`, the client will not generate ``Authenticate`` headers
+            in the HTTP request. Otherwise, the client will generate an 
+            ``Authenticate`` header using HTTP Basic Authentication.
+
+            See :ref:`Authentication types` for an overview.
+
           default_namespace (:term:`string`):
             Name of the CIM namespace to be used by default (if no namespace
             is specified for an operation).
@@ -457,30 +463,42 @@ class WBEMConnection(object):
             Default: :data:`~pywbem.cim_constants.DEFAULT_NAMESPACE`.
 
           x509 (:class:`py:dict`):
-            :term:`X.509` certificates for HTTPS to be used instead of the
-            credentials provided in the `creds` parameter.
-            This parameter is used only when the `url` parameter specifies
-            a scheme of ``"https"``.
+            :term:`X.509` client certificate and key file to be presented
+            to the WBEM server during the TLS/SSL handshake.
 
-            If `None`, certificates are not used (and credentials are used
-            instead).
+            This parameter is ignored when HTTP is used.
 
-            Otherwise, certificates are used instead of the credentials,
-            and this parameter must be a dictionary containing the following
+            If `None`, no client certificate is presented to the server,
+            resulting in 1-way authentication to be used.
+
+            Otherwise, the client certificate is presented to the server,
+            resulting in 2-way authentication to be used.
+            This parameter must be a dictionary containing the following
             two items:
 
-              * ``"cert_file"``: The file path of a file containing an
-                :term:`X.509` certificate, as a :term:`string` object.
+              * ``"cert_file"`` (:term:`string`):
+                The file path of a file containing an :term:`X.509` client
+                certificate.
 
-              * ``"key_file"``: The file path of a file containing the private
-                key belonging to the public key that is part of the
-                :term:`X.509` certificate file, as a :term:`string` object.
+              * ``"key_file"`` (:term:`string`):
+                The file path of a file containing the private key belonging to
+                the public key that is part of the :term:`X.509` certificate
+                file.
+
+            See :ref:`Authentication types` for an overview.
 
           verify_callback (:term:`callable`):
             Registers a callback function that will be called to verify the
-            certificate returned by the WBEM server during the SSL handshake,
-            in addition to the verification already performed by the SSL
-            support in the WBEM client.
+            X.509 server certificate returned by the WBEM server during the
+            TLS/SSL handshake, in addition to the validation already performed
+            by the TLS/SSL support in the PyWBEM client.
+
+            This parameter is ignored when HTTP is used.
+
+            Note that the validation performed by the TLS/SSL support already
+            includes the usual validation, so that normally a callback function
+            does not need to be used. See :ref:`Verification of the X.509 server
+            certificate` for details.
 
             If `None`, no such callback function will be registered.
 
@@ -520,22 +538,29 @@ class WBEMConnection(object):
 
           ca_certs (:term:`string`):
             Location of CA certificates (trusted certificates) for
-            verification purposes.
+            verifying the X.509 server certificate returned by the WBEM server.
+
+            This parameter is ignored when HTTP is used.
 
             The parameter value is either the directory path of a directory
             prepared using the ``c_rehash`` tool included with OpenSSL, or the
             file path of a file in PEM format.
 
-            If `None`, the default system path will be used.
+            If `None`, a default system path will be used.
 
           no_verification (:class:`py:bool`):
-            Indicates that verification of the certificate returned by the WBEM
-            server is disabled (both by `M2Crypto` and by the callback function
-            specified in `verify_callback`).
+            Disables verification of the X.509 server certificate returned by
+            the WBEM server during TLS/SSL handshake, and disables the
+            invocation of a verification function specified in
+            `verify_callback`.
 
-            Disabling the verification is insecure and should be avoided.
+            If `True`, verification is disabled; otherwise, verification is
+            enabled.
 
-            If `True`, verification is disabled; otherwise, it is enabled.
+            This parameter is ignored when HTTP is used.
+
+            Disabling the verification of the server certificate is insecure
+            and should be avoided!
 
           timeout (:term:`number`):
             Timeout in seconds, for requests sent to the server. If the server

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -546,7 +546,8 @@ class WBEMConnection(object):
             prepared using the ``c_rehash`` tool included with OpenSSL, or the
             file path of a file in PEM format.
 
-            If `None`, a default system path will be used.
+            If `None`, default system paths will be used (see
+            `pywbem.cim_http.DEFAULT_CA_CERT_PATHS`)
 
           no_verification (:class:`py:bool`):
             Disables verification of the X.509 server certificate returned by


### PR DESCRIPTION
This PR updates the description of the `WBEMConnection` constructor somewhat, and mainly adds a new section "Security Considerations" in the WBEM Client Library API.

This PR is ready to be merged. Please review (This is best done via `make builddoc` and reading the HTML output).