### PR TITLE
fix issue #264 adds test for Null to CIMMethod return_type

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -210,6 +210,9 @@ Bug fixes
 * Fixed problem in class-level associator operations that namespace was classname
   when classname was passed as a string (issue #322).
 
+* Fixed hole in checking where class CIMMethod allowed None as a return_type.
+  (issue #264)
+
 
 pywbem v0.8.2
 -------------

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -417,6 +417,9 @@ class NocaseDict(object):
 
     @staticmethod
     def __ordering_deprecated():
+        """Function to issue deprecation warning for ordered comparisons
+        """
+
         warnings.warn(
             "Ordering comparisons for pywbem.NocaseDict are deprecated",
             DeprecationWarning)
@@ -2700,6 +2703,7 @@ class CIMMethod(_CIMComparisonMixin):
           return_type (:term:`string`):
             Name of the CIM data type of the method return type
             (e.g. ``"uint32"``).
+            Must not be `None`
 
           parameters (:class:`py:dict` or `NocaseDict`_):
             Parameter declarations for the method declaration.
@@ -2744,6 +2748,10 @@ class CIMMethod(_CIMComparisonMixin):
         # TODO: Propagated is bool; _ensure_unicode() is unnecessary
         self.propagated = _ensure_unicode(propagated)
         self.qualifiers = NocaseDict(qualifiers)
+
+        # Check valid `return_type`
+        if return_type is None:
+            raise ValueError('return_type must not be None')
 
     def _cmp(self, other):
         """

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -2248,9 +2248,10 @@ class InitCIMClass(unittest.TestCase):
                                         CIMProperty('InstanceID', None,
                                                     type='string')})
 
-        # Initialise with methods
+        # Initialise with method
 
-        CIMClass('CIM_Foo', methods={'Delete': CIMMethod('Delete')})
+        CIMClass('CIM_Foo', methods={'Delete': CIMMethod('Delete',
+                                                         'uint32')})
 
         # Initialise with qualifiers
 
@@ -2261,7 +2262,7 @@ class CopyCIMClass(unittest.TestCase):
     def test_all(self):
 
         c = CIMClass('CIM_Foo',
-                     methods={'Delete': CIMMethod('Delete')},
+                     methods={'Delete': CIMMethod('Delete', 'uint32')},
                      qualifiers={'Key': CIMQualifier('Value', True)})
 
         co = c.copy()
@@ -2303,7 +2304,7 @@ class CIMClassEquality(unittest.TestCase):
                       CIMProperty('InstanceID', None,
                                   type='string')}
 
-        methods = {'Delete': CIMMethod('Delete')}
+        methods = {'Delete': CIMMethod('Delete', 'uint32')}
 
         qualifiers = {'Key': CIMQualifier('Key', True)}
 
@@ -2358,7 +2359,8 @@ class CIMClassToXML(ValidateTest):
                       root_elem_CIMClass)
 
         self.validate(CIMClass('CIM_Foo',
-                               methods={'Delete': CIMMethod('Delete')}),
+                               methods={'Delete': CIMMethod('Delete',
+                                                            'uint32')}),
                       root_elem_CIMClass)
 
         self.validate(CIMClass('CIM_Foo',
@@ -2762,6 +2764,17 @@ class CIMMethodString(unittest.TestCase, RegexpMixin):
 
         self.assertRegexpContains(s, 'FooMethod')
         self.assertRegexpContains(s, 'uint32')
+
+class CIMMethodNoReturn(unittest.TestCase):
+    """Test that CIMMethod without return value fails"""
+
+    def test_all(self):
+        try:
+            str(CIMMethod('FooMethod'))
+            self.fail('Expected Exception')
+
+        except ValueError:
+            pass
 
 class CIMMethodToXML(ValidateTest):
 


### PR DESCRIPTION
fixes existing tests that did not include this parameter. Adds test to
confirm that the new test on return_type works.  adds to changes.rst

Sorry for the bad pr last night.   Can only guess that I must have branched frop the pull ops branch.

