### PR TITLE
issue# 347 Allow tuple as input for PropertyList parameter in cim_operations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -221,6 +221,9 @@ Bug fixes
   as list of classes for class level return but it actually list of
   tuples of classname,class. (issue #339)
 
+* Extend PropertyList argument in request operations to be either list
+  or tuple. (issue #347)
+
 
 pywbem v0.8.2
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -151,6 +151,10 @@ Enhancements
 
 * Added description of supported authentication types in WBEM client API.
 
+* Allow tuple as input for PropertyList parameter of cim_operations.
+  Documentation indicated that iterable was allowed but was limited
+  to list. (issue #347)
+
 Bug fixes
 ^^^^^^^^^
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3858,7 +3858,7 @@ def tocimxml(value):
 
     # List of values
 
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         return cim_xml.VALUE_ARRAY([tocimxml(v) for v in value])
 
     raise ValueError("Can't convert %s (%s) to CIM XML" % \

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3856,12 +3856,12 @@ def tocimxml(value):
         else:
             return cim_xml.VALUE('FALSE')
 
-    # List of values
+    # Iterable of values
 
-    if isinstance(value, (list, tuple)):
+    try:
         return cim_xml.VALUE_ARRAY([tocimxml(v) for v in value])
-
-    raise ValueError("Can't convert %s (%s) to CIM XML" % \
+    except TypeError:
+        raise ValueError("Can't convert %s (%s) to CIM XML" % \
                      (value, builtin_type(value)))
 
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -21,7 +21,7 @@ import six
 from pywbem.cim_constants import *
 from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
                    CIMProperty, CIMQualifier, CIMQualifierDeclaration, \
-                   CIMMethod, WBEMConnection, CIMError,\
+                   CIMMethod, WBEMConnection, CIMError, Error, \
                    Uint8, Uint16, Uint32, Uint64, \
                    Sint8, Sint16, Sint32, Sint64, \
                    Real32, Real64, CIMDateTime
@@ -652,6 +652,19 @@ class GetInstance(ClientTest):
         self.assertTrue(isinstance(obj.path, CIMInstanceName))
         self.assertTrue(obj.path.namespace == self.namespace)
         self.assertTrue(len(obj.properties) == 1)
+
+        try:
+            obj = self.cimcall(self.conn.GetInstance,
+                               name,
+                               PropertyList=TEST_CLASS_PROPERTY1,
+                               LocalOnly=False)
+            self.fail('Exception expected')
+            
+        # use Error since this generates a connection error and
+        # within it a CIMError.
+        except Error as ce:
+            pass
+        
 
 class CreateInstance(ClientTest):
 


### PR DESCRIPTION
Extends test on input to allow both tuple and list. Extends tests in
run_cimoperations.py for more complete testing of propertylist and
some other tests.
Adds specific test for tuple input for propertylist.

Adds comment to changes.rst

This specifically allows the tuple as input.  Couple of minor issues here:

1. Do we really want to allow the tuple?
2. the tuple with single entry is a mess (requires a comma after the entry
3. If you do a tuple instead of a list with a single entry, it actually goes through but generates xml error because the tuple is not being handled as a tuple in cim_obj.py
4. Documentation defines list in some places and iterable in others.