### PR TITLE
Fixes #358 Correct variable mispelling in OpenExecQuery

### DIFF
--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1579,9 +1579,9 @@ class WBEMConnection(object):
             MaxObjectCount=MaxObjectCount,
             response_params_rqd=True,
             **extra)
-            
+
         return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenEnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                                DeepInheritance=None, IncludeQualifiers=None,
@@ -1807,7 +1807,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenReferenceInstancePaths(self, InstanceName, ResultClass=None,
                                    Role=None,
@@ -1976,7 +1976,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenReferenceInstances(self, InstanceName, ResultClass=None,
                                Role=None, IncludeQualifiers=None,
@@ -2178,7 +2178,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenAssociatorInstancePaths(self, InstanceName, AssocClass=None,
                                     ResultClass=None, Role=None,
@@ -2367,7 +2367,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenAssociatorInstances(self, InstanceName, AssocClass=None,
                                 ResultClass=None, Role=None, ResultRole=None,
@@ -2589,7 +2589,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def OpenQueryInstances(self, FilterQueryLanguage, FilterQuery,
                            namespace=None, ReturnQueryResultClass=None,
@@ -2730,7 +2730,7 @@ class WBEMConnection(object):
         """
 
         @staticmethod
-        def _GetQueryyRsltClass(result):
+        def _GetQueryRsltClass(result):
             """ Get the QueryResultClass and return it or generate
                 exception.
             """
@@ -2757,11 +2757,11 @@ class WBEMConnection(object):
 
         insts, eos, enum_ctxt = self._get_rslt_params(result, namespace)
 
-        query_class = _GetQuerryRsltClass(result) if \
+        query_class = _GetQueryRsltClass(result) if \
                           ReturnQueryResultClass else None
 
         return pull_query_result_tuple(insts, eos, enum_ctxt, query_class)
-        
+
 
 
     def PullInstancesWithPath(self, context, MaxObjectCount,
@@ -2861,7 +2861,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
@@ -2958,7 +2958,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_path_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def PullInstances(self, context, MaxObjectCount=None, \
                           **extra):
@@ -3056,7 +3056,7 @@ class WBEMConnection(object):
             **extra)
 
         return pull_inst_result_tuple(*self._get_rslt_params(result, namespace))
-        
+
 
     def CloseEnumeration(self, context, **extra):
         # pylint: disable=invalid-name


### PR DESCRIPTION
Never make last minute change without full test. Fixed variable mispelling that I made at last minute and did not run through complete test set.  Also removes a few trailing spaces.