### PR TITLE
WIP fixes #215 enable the timeout for m2crypto

### DIFF
--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -450,14 +450,12 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                     # Therefore, we set the timeout at the level of the outer
                     # M2Crypto socket object.
                     # pylint: disable=using-constant-test
-                    if False:
-                        # TODO 2/16 AM: Currently disabled, figure out how to
-                        #               reenable.
-                        if self.timeout is not None:
-                            self.sock.set_socket_read_timeout(
-                                SSL.timeout(self.timeout))
-                            self.sock.set_socket_write_timeout(
-                                SSL.timeout(self.timeout))
+
+                    if self.timeout is not None:
+                        self.sock.set_socket_read_timeout(
+                            SSL.timeout(self.timeout))
+                        self.sock.set_socket_write_timeout(
+                            SSL.timeout(self.timeout))
 
                     self.sock.addr = (self.host, self.port)
                     self.sock.setup_ssl()


### PR DESCRIPTION
Teste manually with this simple patch and a hack to pegasus that disables responses so server accepts requests but does not respond.

Captured details in issue #215 but the general conclusion is:

1. enabling does not kill the server. It passes python 2 and 3 tests on my system.

2. It does cause the client to timeout with m2crypto.  However, the timeout times can run from correct to 300% of correct. (i.e. a 4 sec timeout causes timeout in from 4 to 12 seconds with most in 4 sec.)

3. We have another issue in that in when https verification is set we get a verification error exception and not a timeout exception.  See the details recorded in the issue

I had to do this manually since there is no automatic way to set the pegasus server to delay responses right now, it was a code hack.

I want to set up a mock to do this but have not completed that and not sure it is always the same thing since not all of the timers are in http itself. 