### PR TITLE
fixes #295 Move ssl context setter to a common separate function for both python…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -260,6 +260,11 @@ Bug fixes
    since it is not used with python ssl module and will probably be 
    removed completely in the future. (issue # 297)
 
+*  Created a common function for setting SSL defaults and tried to create
+   the same level of defaults for both Python2 (M2Crypto) and Python 3 (SSL
+   module).  The minimum level protocol set by the client is TLSV1 now whereas
+   in previous versions of pywbem it was SSLV23. (issue # 295)
+
 pywbem v0.8.2
 -------------
 


### PR DESCRIPTION
… 2 and 3

This pr creates a new common function in cim_http.py
(create_pyebem_ssl_context) that sets the context for both python 2 and
python 3 ssl.  It tries to create the same level of context restrictions
for both versions of SSL.  Note that in python 3 it uses the ssl
internal
default and documents that in the code.

This code has passed manual tests against open pegasus but we do not
have a complete https test automated at this point, even with a
testsuite/run... test so only manual tests and inspections have been
done.

The context setter limits the possible connections to:
1. TLSV1 and above
2. No compression
3. some other limits that are part of the python 3 ssl default.

I used the default function for python 3 simply because if we use the
detailed code it generates a lot of pylint messages.  We can review
that.

Adds note to changes.rst