### PR TITLE
Fixes #363: Add test to newtworkerror.yaml for https timeout

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -747,6 +747,20 @@ Testing
   'make test' for the current Python environment, or with 'tox' for all
   supported Python environments.  (Andreas Maier)
 
+* Added multiple tests for client connection timeout. A mock test was added
+  for both HTTP and HTTPs.  However, this causes an error in python 2 with
+  HTTPS so two new options were added to test_client.py. First, a new
+  parameter ignore_python_version was added to the yaml to define a major
+  version of python for which a particulare testcase would be ignored.  Second
+  a non-documente option was added to test_client.py to execute a single
+  testcase if the name of that testcase is the only parameter on the
+  test_client.py cmd line.
+  Finally a whole new run_operationtimeout.py file was added to testsuite to
+  throughly test for timeouts. This runs ONLY against particular versions of
+  OpenPegasus because it required adding a new method to OpenPegasus. However,
+  it established that the timeouts apparently now really do work in both
+  python 2 and python 3 with both http and https. (see issue #363)
+
 Clean Code
 ^^^^^^^^^^
 

--- a/testsuite/run_operationtimeouts.py
+++ b/testsuite/run_operationtimeouts.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python
+
+"""
+Test CIM operations against a real WBEM server that is specified on the
+command line.  It executes a specific test to test for correct operation of
+the WBEMConnection timeout option in multiple modes of the server and client.
+Specifically it tests both http and https schemes and confirms that the
+timeout exception is received correctly over a wide range of timeout values.
+
+Note that this test uses a specific class and method in OpenPegasus today to
+execute an operation with a specified delay.
+
+The default for this test takes several minutes to run because of size of
+the maximum timeout (20 seconds)
+"""
+
+from __future__ import absolute_import
+
+# pylint: disable=missing-docstring,superfluous-parens,no-self-use
+import sys
+import unittest
+import warnings
+import datetime
+
+import six
+
+from pywbem.cim_constants import *
+from pywbem import WBEMConnection, Uint32, ConnectionError, TimeoutError
+
+
+# Identity of the OpenPegasus namespace, class, and method that implements
+# the delayed response. NOTE: This is only available on OpenPegasus 2.16.
+NAMESPACE = 'test/testprovider'
+TESTCLASS = 'Test_CLITestProviderClass'
+TESTMETHOD = 'delayedMethodResponse'
+
+class ElapsedTimer(object):
+    """
+        Set up elapsed time timer. Calculates time between initiation
+        and access.
+    """
+    def __init__(self):
+        """ Initiate the object with current time"""
+        self.start_time = datetime.datetime.now()
+
+    def reset(self):
+        """ Reset the start time for the timer"""
+        self.start_time = datetime.datetime.now()
+
+    def elapsed_ms(self):
+        """ Get the elapsed time in milliseconds. returns floating
+            point representation of elapsed time in seconds.
+        """
+        dt = datetime.datetime.now() - self.start_time
+        return ((dt.days * 24 * 3600) + dt.seconds) * 1000  \
+                + dt.microseconds / 1000.0
+
+    def elapsed_sec(self):
+        """ get the elapsed time in seconds. Returns floating
+            point representation of time in seconds
+        """
+        return self.elapsed_ms() / 1000
+
+class ClientTest(unittest.TestCase):
+    """ Base class that creates a pywbem.WBEMConnection for
+        subclasses to use based on cmd line arguments. It provides
+        a common cimcall method that executes test calls and logs
+        results
+    """
+
+    def setUp(self):
+        """Create a connection."""
+        #pylint: disable=global-variable-not-assigned
+        global args                 # pylint: disable=invalid-name
+
+        self.host = args['host']
+        self.verbose = args['verbose']
+        self.debug = args['debug']
+        self.maxtimeout = args['maxtimeout']
+        self.mintimeout = 2
+        self.stop_on_err = args['stopOnErr']
+
+        # set this because python 3 http libs generate many ResourceWarnings
+        # and unittest enables these warnings.
+        if not six.PY2:
+            #pylint: disable=undefined-variable
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    def connect(self, url, timeout=None):
+
+        self.log('setup connection {} timeout {}'.format(url, timeout))
+        conn = WBEMConnection(
+            url,
+            (args['username'], args['password']),
+            NAMESPACE,
+            timeout=timeout,
+            no_verification=True,
+            ca_certs=None)
+
+        # enable saving of xml for display
+        conn.debug = args['debug']
+        self.log('Connected {}'.format(url))
+        return conn
+
+
+    def log(self, data_):
+        """Display log entry if verbose"""
+        if self.debug:
+            print('{}'.format(data_))
+
+class ServerTimeoutTest(ClientTest):
+
+    def execute(self, url_type, timeout, delay):
+        """
+            Execute a single connect with timeout, followed by invokemethod
+            of the method that delays response and test for possible responses.
+
+            Tests for correct response type (good response if the delay is
+            less than the timeout and timeout exception if the delay is greater
+            than the timeout.  It ignores results where the operation delay
+            and timeout are equal since the result could be either timeout
+            or good response.
+        """
+        url = url_type + '://' + self.host
+        conn = self.connect(url, timeout=timeout)
+        execution_time = None
+
+        if self.debug:
+            print('execute url_type=%s timeout=%s delay=%s' % (url_type,
+                                                               timeout, delay))
+
+        try:
+            # Confirm server working with a simple request.
+            conn.GetClass('CIM_ManagedElement')
+            rslt = 0
+            err_flag = ""
+            opttimer = ElapsedTimer()
+            conn.InvokeMethod(TESTMETHOD, TESTCLASS,
+                              [('delayInSeconds', Uint32(delay))])
+
+            execution_time = opttimer.elapsed_sec()
+
+            if delay > timeout:
+                err_flag = "Timeout Error: delay gt timeout"
+                if self.stop_on_err:
+                    self.fail('should not get good response for %delay > %s' % \
+                              (delay, timeout))
+            if delay == timeout:
+                err_flag = "Good when timeout matches delay"
+
+        except ConnectionError as ce:
+            rslt = 2
+
+            self.fail('%s exception %s' % ('Failed ConnectionError)', ce))
+
+        except TimeoutError as ce:
+            execution_time = opttimer.elapsed_sec()
+            rslt = 1
+            # error if the operation delay is lt timeout value and we get
+            # a timeout
+            if delay < timeout:
+                err_flag = 'Error. delay < timeout'
+                if self.stop_on_err:
+                    self.fail('should not get timeout for %delay < %s' % \
+                              (delay, timeout))
+            if delay == timeout:
+                err_flag = "Timeout when timeout matches delay"
+
+        except Exception as ec:      #pylint: disable=broad-except
+            err_flag = "Test Failed"
+            rslt = 2
+            self.fail('%s exception %s' % ('Failed(Exception)', ec))
+
+        # generate table entry if verbose. This defines result for this
+        # test
+        if self.verbose:
+            rslt_txt = ['Good Rtn', 'Timeout ', 'Failure']
+
+            print('%-5s %-7s %7d %5d %10.2f  %s' % (url_type, rslt_txt[rslt],
+                                                    timeout, delay,
+                                                    execution_time,
+                                                    err_flag))
+
+        return (True if rslt == 1 else False)
+
+    def test_all(self):
+        """ Tests all of the variations in a loop."""
+
+        print('url   result   timeout delay  time(sec)  Comments')
+
+        for url_type in ['https', 'http']:
+            for timeout in range(self.mintimeout, self.maxtimeout):
+
+                # loop while good response received to test range of
+                # server delays. Test for range around current timeout value
+                break_loop = False
+                min_delay = timeout - 2
+                max_delay = timeout * 3
+                good_rtn_rcvd = False
+                timeout_rcvd = False
+                for delay in range(min_delay, max_delay):
+                    timed_out = self.execute(url_type, timeout, delay)
+                    if not timed_out:
+                        good_rtn_rcvd = True
+                    if timed_out:
+                        timeout_rcvd = True
+
+                    # After return indicates timeout, run one more test
+                    # then break delay loop. Assures that the timeour
+                    # response is consistent.
+                    if break_loop:
+                        break
+                    if timed_out:
+                        break_loop = True
+                # confirm that both a good response and timeout received for
+                # this delay range.
+                self.assertTrue(timeout_rcvd, "Timeout never received")
+                self.assertTrue(good_rtn_rcvd, "Good return never received")
+
+
+def parse_args(argv_):
+    argv = list(argv_)
+
+    if len(argv) <= 1:
+        print('Error: No arguments specified; Call with --help or -h for '\
+              'usage.')
+        sys.exit(2)
+    elif argv[1] == '--help' or argv[1] == '-h':
+        print('')
+        print('Test program for client timeout of cim operations.\n')
+        print('Pegasus only. Tests a range of timeout values against http\n ')
+        print('and https with operation that generates known delay.\n')
+        print('Complete test is in a single unittest function')
+        print('')
+        print('Usage:')
+        print('    %s [GEN_OPTS] URL [USERNAME%%PASSWORD [UT_OPTS '\
+              '[UT_CLASS ...]]] ' % argv[0])
+        print('')
+        print('Where:')
+        print('    GEN_OPTS            General options (see below).')
+        print('    HOST                Name of the target WBEM server.\n'\
+              '                        No Scheme prefix'\
+              '                        defines ssl usage')
+        print('    USERNAME            Userid used to log into '\
+              '                        WBEM server.\n' \
+              '                        Requests user input if not supplied')
+        print('    PASSWORD            Password used to log into '\
+              '                        WBEM server.\n' \
+              '                        Requests user input if not supplier')
+        print('')
+        print('General options[GEN_OPTS]:')
+        print('    --help, -h          Display this help text.')
+        print('    -t MAXTIMEOUT       Maximum timout value in sec. to test.\n'\
+              '                        default is 20 sec')
+        print('    -v                  Verbose output which includes\n' \
+              '                        result of each test')
+        print('    -s                  Stop test on first timeout error.\n' \
+              '                        Otherwise errors in timeout are just ' \
+              '                        reported. Other errors stop test.')
+        print('    -d                  Debug flag for extra displays')
+
+        #print('------------------------')
+        #print('Unittest arguments[UT_OPTS]:')
+        #print('')
+        sys.argv[1:] = ['--help']
+        unittest.main()
+        sys.exit(2)
+
+    args_ = {}
+    # set argument defaults
+    args_['maxtimeout'] = 20
+    args_['stopOnErr'] = False
+    args_['verbose'] = False
+    args_['username'] = None
+    args_['password'] = None
+    args_['debug'] = False
+
+    # options must proceed arguments
+    while True:
+        if argv[1][0] != '-':
+            # Stop at first non-option
+            break
+        elif argv[1] == '-t':
+            args_['maxtimeout'] = int(argv[2])
+            del argv[1:3]
+        elif argv[1] == '-d':
+            args_['delay'] = int(argv[2])
+            del argv[1:3]
+        elif argv[1] == '-v':
+            args_['verbose'] = True
+            del argv[1:2]
+        elif argv[1] == '-d':
+            args_['debug'] = True
+            del argv[1:2]
+        elif argv[1] == '-s':
+            args_['stopOnErr'] = True
+            del argv[1:2]
+        elif argv[1] == '-d':
+            args_['debug'] = True
+            del argv[1:2]
+        else:
+            print("Error: Unknown option: %s" % argv[1])
+            sys.exit(1)
+
+    args_['host'] = argv[1]
+    del argv[1:2]
+
+    if len(argv) >= 2:
+        args_['username'], args_['password'] = argv[1].split('%')
+        del argv[1:2]
+    #else:
+        ## Get user name and pw from console
+        #sys.stdout.write('Username: ')
+        #sys.stdout.flush()
+        #args_['username'] = sys.stdin.readline().strip()
+        #args_['password'] = getpass()
+    return args_, argv
+
+if __name__ == '__main__':
+    args, sys.argv = parse_args(sys.argv) # pylint: disable=invalid-name
+    print("Using WBEM Server:")
+    print("  host: %s" % args['host'])
+    print("  username: %s" % args['username'])
+    if args['password'] is not None:
+        print("  password: %s" % ("*"*len(args['password'])))
+    print("  maxtimeout: %s" % args['maxtimeout'])
+    print("  verbose: %s" % args['verbose'])
+    print("  stopOnErr: %s" % args['stopOnErr'])
+    print("  debug: %s" % args['debug'])
+
+    # Note: unittest options are defined in separate args after
+    # the url argument.
+
+    unittest.main()

--- a/testsuite/test_client/README.md
+++ b/testsuite/test_client/README.md
@@ -113,6 +113,12 @@ The top-level elements in the test case YAML are:
 * `description`:
   A short description of the testcase.
 
+* `ignore_python_version`
+  A single digit python version (2 or 3) that tells the client code to
+  ignore this test for that python version.  Should only be used in rare
+  cases where a test is really version dependent. To date the only case
+  is in HTTPS timeout processing where python 2 has an issue with mock.
+
 * `pywbem_request`:
   A specification of the PyWBEM client function to test, and the input
   arguments for its invocation.

--- a/testsuite/test_client/networkerror.yaml
+++ b/testsuite/test_client/networkerror.yaml
@@ -161,8 +161,8 @@
     http_response:
         exception: socket_ssl
 -
-    name: SocketTimeoutErrorHTTP
-    description: HTTP GetInstance raises socket.timeout because of timeout during sent
+    name: HTTPSocketTimeoutError
+    description: HTTP GetInstance raises socket.timeout because of send timeout
     pywbem_request:
         url: http://acme.com:80
         creds:
@@ -184,6 +184,61 @@
     http_request:
         verb: POST
         url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>False</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        exception: socket_timeout
+-
+    name: HTTPSSocketTimeoutError
+    ignore_python_version: 2    
+    description: HTTPS GetInstance raises ConnectionError because of send timeout
+    pywbem_request:
+        url: https://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 5
+        debug: false
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: ConnectionError
+    http_request:
+        verb: POST
+        url: https://acme.com:80/cimom
         headers:
             CIMOperation: MethodCall
             CIMMethod: GetInstance


### PR DESCRIPTION
**Ready for review.**   Added a new file to test timeouts against pegasus and they work across the board (see run_operationtimeouts.py.) Added options to test_client.py to ignore tests and one to execute a single test. Added a new mock test for timeouts but since there are issues with python 2 I had to add a new attribute to the yaml to ignore python versions for particular test cases.

As a freebie I added a simple way to execute a single test in test_client.py

Passes both the mock tests and the run_.. tests. now.


The following is notes on the original issues we were having.
Note per that issue I was originally getting a cert error instead of a socket error  when testing a mock connection timeout with https.   However, it redoing the test today, I started getting the following with m2crypto and good result with pywbem3/ssl module.  I am setting up the pr since Andy asked what exception I am getting

This adds the test for a mock https timeout but that test fails with m2crypto with the following error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/kschopmeyer/.virtualenvs/pywbem27/local/lib/python2.7/site-packages/httpretty/core.py", line 637, in fill_filekind
    headers
  File "/home/kschopmeyer/pywbem/githubpywbem/pywbem/testsuite/test_client.py", line 217, in socket_timeout
    raise socket.timeout("Socket timeout.")
timeout: Socket timeout.

Exception AttributeError: "Connection instance has no attribute 'ssl_close_flag'" in <bound method Connection.__del__ of <M2Crypto.SSL.Connection.Connection instance at 0x2afff0369290>> ignored