### PR TITLE
Fixes #377: Incorrect lexical case of Interop namespace name with OpenPegasus

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -273,6 +273,10 @@ Bug fixes
    module).  The minimum level protocol set by the client is TLSV1 now whereas
    in previous versions of pywbem it was SSLV23. (issue # 295)
 
+* WBEMServer.interop_ns now contains the returned interop namespace name,
+  if possible, instead of the attempted one.
+
+
 pywbem v0.8.2
 -------------
 


### PR DESCRIPTION
Ready to be merged.
Please review.

Details: The root cause for showing `root/PG_Interop` as the Interop nanmespace for OpenPegasus was that that was the attempted namespace name, and the current code used the attempted name if successful.
This has been changed to inspect the returned CIM_Namespace instance paths and to use their `Name` keybinding, if possible. Otherwise, the attempted name is still used.