### PR TITLE
Fixes #331: Require Gitpython 2.0.6 and re-enable make builddoc on py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ install:
 script:
   - make check
   - make build
-  - if [[ $(python -c "import sys; print('%s.%s'%sys.version_info[0:2])") != 2.6 ]]; then make builddoc; else echo "make builddoc is disabled on Python 2.6 until GitPython runs again (see its issue 457)"; fi
+  - make builddoc
   - make test
-
-# TODO 2016-05 AM: Remove disabling of "make builddoc" for Python 2.6, once GitPython runs on Python 2.6.
 

--- a/setup.py
+++ b/setup.py
@@ -348,10 +348,11 @@ def main():
             "Sphinx>=1.3",
             # The ordereddict package is a backport of collections.OrderedDict
             # to Python 2.6. OrderedDict is needed by the GitPython package
-            # since its 2.0.3 version (but only its 2.0.5 version uses it
-            # correctly). GitPython is needed by sphinx-git.
+            # since its 2.0.3 version (but only from 2.0.5 on it is used
+            # correctly, and only from 2.0.6 on does it work on Python 2.6).
+            # GitPython is needed by sphinx-git.
             "ordereddict" if sys.version_info[0:2] == (2, 6) else None,
-            "GitPython>=2.0.5",
+            "GitPython>=2.0.6",
             "sphinx-git",
             "httpretty",
             "lxml",


### PR DESCRIPTION
Ready to be merged (if Travis succeeds).
Please review.
