### PR TITLE
Fixes #381: Added support for a config variable to control enforcing the value range of CIM integer types

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -125,7 +125,9 @@ Enhancements
   input parameters that are supported by `int()`.
 
 * Added the concept of a valid value range for the CIM integer data types, that
-  is enforced at construction time.
+  is enforced at construction time. For compatibility, this strict checking can
+  be turned off via a config variable:
+  `pywbem.config.ENFORCE_INTEGER_RANGE = False`.
 
 * Extended wbemcli arguments to include all possible arguments that would
   be logical for a ssl or non-ssl client. This included arguments for

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,9 @@
+
+.. _`Configuration`:
+
+Configuration
+=============
+
+.. automodule:: pywbem.config
+      :members:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,5 +25,6 @@ Its general web site is: http://pywbem.github.io/pywbem/index.html.
    listener.rst
    compiler.rst
    utilities.rst
+   config.rst
    changes.rst
 

--- a/makefile
+++ b/makefile
@@ -99,6 +99,7 @@ doc_dependent_files := \
     $(package_name)/_listener.py \
     $(package_name)/_recorder.py \
     $(package_name)/_server.py \
+    $(package_name)/config.py \
 
 # PyLint config file
 pylint_rc_file := pylint.rc

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -90,6 +90,7 @@ from .exceptions import *
 from ._server import *
 from ._listener import *
 from ._recorder import *
+from .config import *
 
 from ._version import __version__
 

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -80,6 +80,8 @@ if six.PY2:
 else:
     _Longint = int
 
+from . import config
+
 __all__ = ['MinutesFromUTC', 'CIMType', 'CIMDateTime', 'CIMInt', 'Uint8',
            'Sint8', 'Uint16', 'Sint16', 'Uint32', 'Sint32', 'Uint64', 'Sint64',
            'CIMFloat', 'Real32', 'Real64']
@@ -570,9 +572,10 @@ class CIMInt(CIMType, _Longint):
 
     def __new__(cls, *args, **kwargs):
         value = _Longint(*args, **kwargs)
-        if value > cls.maxvalue or value < cls.minvalue:
-            raise ValueError("Integer value %s is out of range for CIM " \
-                             "datatype %s" % (value, cls.cimtype))
+        if config.ENFORCE_INTEGER_RANGE:
+            if value > cls.maxvalue or value < cls.minvalue:
+                raise ValueError("Integer value %s is out of range for CIM " \
+                                 "datatype %s" % (value, cls.cimtype))
         # The value needs to be processed here, because int/long is unmutable
         return super(CIMInt, cls).__new__(cls, *args, **kwargs)
 

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -1,0 +1,45 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+"""
+The :mod:`pywbem.config` module sets configuration variables for PyWBEM.
+
+These configuration variables are used by PyWBEM only after its modules
+have been loaded, so they can be modified by the user directly after
+importing :mod:`pywbem`. For example:
+
+::
+
+    import pywbem
+    pywbem.config.ENFORCE_INTEGER_RANGE = False
+
+Note that the source file of the :mod:`pywbem.config` module should not be
+changed by the user. Instead, use the technique described above to modify
+the variables.
+"""
+
+# This module is meant to be safe for 'import *'.
+
+__all__ = ['ENFORCE_INTEGER_RANGE']
+
+#: Enforce the value range in CIM integer types (e.g. :class:`~pywbem.Uint8`).
+#:
+#: * True (default): Enforce the value range; Assigning values out of range
+#:   causes :exc:`~py:exceptions.ValueError` to be raised.
+#: * False: Do not enforce the value range; Assigning values out of range
+#:   works.
+ENFORCE_INTEGER_RANGE = True
+


### PR DESCRIPTION
Ready to be merged.
Please review.

This PR introduces a `pywbem.config` module for setting config variables.

It defines a first config variable `ENFORCE_INTEGER_RANGE` that controls whether the value range of CIM integer types is enforced or not.

The config variables are documented in a new chapter "Configuration".