### PR TITLE
Fixes #379: Add test to execute listener code

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -202,6 +202,10 @@ Enhancements
   message to be displayed. Note, this is an incompatible change in the
   command line options. (issue #216)
 
+* Extended run_cimoperation.py to include basic listener test to create and
+  delete indication subscriptions in the server.  This test does not process
+  indicaitons from the server. (issue#379)
+
 
 Bug fixes
 ^^^^^^^^^

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -1033,7 +1033,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
 
     def test_get_onebyone(self):
-        """Get instances with MaxObjectCount = 1)"""
+        """Enumerate instances with MaxObjectCount = 1)"""
 
         result = self.cimcall(
             self.conn.OpenEnumerateInstancePaths, 'CIM_ManagedElement',
@@ -1105,7 +1105,7 @@ class PullReferences(ClientTest):
 
         self.assertInstancesEqual(insts, instances)
 
-    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
+    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip test against all instances')
     def test_all_instances_in_ns(self):
         """Simplest invocation. Everything comes back in
            initial response with end-of-sequence == True
@@ -1199,7 +1199,7 @@ class PullReferencePaths(ClientTest):
 
         self.assertPathsEqual(paths_pulled, paths2)
 
-    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
+    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test for all instances')
     def test_all_instances_in_ns(self):
         """
             Simplest invocation. Execute and compae with results
@@ -1283,7 +1283,7 @@ class PullAssociators(ClientTest):
         self.assertInstancesEqual(insts, instances)
 
 
-    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
+    @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long  all instances test')
     def test_all_instances_in_ns(self):
         """Simplest invocation. Everything comes back in
            initial response with end-of-sequence == True
@@ -2820,50 +2820,67 @@ class PyWBEMServerClass(PegasusServerTestBase):
             print("Error: %s" % str(exc))
             self.fail("No Server class")
 
-
-
-
 class PyWBEMListenerClass(PegasusServerTestBase):
-    """Test the management of indications"""
+    """Test the management of indications with the listener class"""
 
-    def test_create_delete_indication(self):
+    #pylint: disable=invalid-name
+    def test_create_delete_subscription(self):
         """
         Create and delete a server and listener and create an indication.
-        Then delete everything
+        Then delete everything.
+        This is a pegasus specific test because it depends on the existence
+        of pegasus specific classes and providers.
         """
-        TEST_CLASS = 'Test_IndicationProviderClass'
-        TEST_CLASS_NAMESPACE = 'test/TestProvider'
-        TEST_QUERY = 'SELECT * from %s' % TEST_CLASS
+        # TODO modify this so it is not Pegasus dependent
+        if self.is_pegasus_test_build():
+            test_class = 'Test_IndicationProviderClass'
+            test_class_namespace = 'test/TestProvider'
+            test_query = 'SELECT * from %s' % test_class
 
-        server = WBEMServer(self.conn)
-        # Set arbitrary port for the http listener
-        http_listener_port = 50000
+            server = WBEMServer(self.conn)
 
-        # Create the listener and listener call back and start the listener
+            # Set arbitrary ports for the listener
+            http_listener_port = 50000
+            https_listener_port = 50001
 
-        listener = WBEMListener(getfqdn(), http_port=http_listener_port,
-                                https_port=None)
-        server_id = listener.add_server(server)
-        listener.start()
+            # Create the listener and listener call back and start the listener
 
-        filter_path = listener.add_dynamic_filter(server_id,
-                                                  TEST_CLASS_NAMESPACE,
-                                                  TEST_QUERY,
-                                                  query_language="DMTF:CQL")
+            listener = WBEMListener(getfqdn(), http_port=http_listener_port,
+                                    https_port=https_listener_port)
+            server_id = listener.add_server(server)
+            listener.start()
 
-        subscription_path = listener.add_subscription(server_id, filter_path)
+            filter_path = listener.add_dynamic_filter(server_id,
+                                                      test_class_namespace,
+                                                      test_query,
+                                                      query_language="DMTF:CQL")
 
-        host_filters = listener.get_dynamic_filters(server_id)
-        print('------------------------------------------------------------')
-        print(host_filters)
+            subscription_path = listener.add_subscription(server_id,
+                                                          filter_path)
 
+            host_filters = listener.get_dynamic_filters(server_id)
+            self.assertTrue(filter_path in host_filters)
 
-        listener.remove_subscription(self.system_url, subscription_path)
-        listener.remove_dynamic_filter(server_id, filter_path)
+            host_subscriptions = listener.get_subscriptions(server_id)
+            self.assertTrue(subscription_path in host_subscriptions)
 
-        time.sleep(2)
-        listener.stop()
-        listener.remove_server(server_id)
+            listener.remove_subscription(server_id, subscription_path)
+            listener.remove_dynamic_filter(server_id, filter_path)
+
+            # confirm that filter and subscription were removed
+            host_filters = listener.get_dynamic_filters(server_id)
+            self.assertFalse(filter_path in host_filters)
+
+            host_subscriptions = listener.get_subscriptions(server_id)
+            self.assertFalse(subscription_path in host_subscriptions)
+
+            time.sleep(2)
+            listener.stop()
+            listener.remove_server(server_id)
+
+        #TODO ks 6/16 add more tests including: multiple subscriptions, filters
+        #     actual indication production, Errors. extend for ssl, test
+        #     logging
 
 #################################################################
 # Main function


### PR DESCRIPTION
Ready for review and merge.

This is a single test in in run_cimoperations.py that creates and deletes server, listener, subscription, filter.  It does not process indications nor test for errors.  It does verify that the host has the defined filter and subscription and that it deletes them.  We need to add more tests but wanted to get the basic structure running.  Note that this test runs only against pegasus because it depends on a particular class/provider (pegasus validates subscriptions against providers)