### PR TITLE
Fixes #389: Changing 'array' to 'list' in cim_http.py

### DIFF
--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -419,7 +419,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
             if self.debuglevel > 0:
                 print("send: %r" % strng)
             blocksize = 8192
-            if hasattr(strng, 'read') and not isinstance(strng, array):
+            if hasattr(strng, 'read') and not isinstance(strng, list):
                 if self.debuglevel > 0:
                     print("sendIng a read()able")
                 data = strng.read(blocksize)


### PR DESCRIPTION
Ready to be merged.
Please review.

The reason the change loig is not updated with a fix entry, is that this error never showed up to the user, because in our case, the data object never has a ` read()` method.