### PR TITLE
Fixes #370, fixes #371: Cleaned up exception handling in `WBEMOperation` methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ tmp.*
 pywbem.egg-info
 MANIFEST
 parser.out
-moflog.txt
+moflog*.txt
 pylint_done
 .coverage
 /build/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -211,6 +211,10 @@ Enhancements
   and profile version (issue #378) with a demo in examples/explure.py and
   tests in run_cim_operations.py
 
+* Cleaned up exception handling in `WBEMConnection` methods: Authentication
+  errors are now always raised as `pywbem.AuthError` (OpenWBEM raised
+  `pywbem.ConnectionError` in one case), and any other bad HTTP responses
+  are now raised as a new exception `pywbem.HTTPError`.
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -242,6 +242,10 @@ Exceptions
 
 .. autoclass:: pywbem.AuthError
 
+.. autoclass:: pywbem.HTTPError
+   :members:
+   :special-members: __str__
+
 .. autoclass:: pywbem.TimeoutError
 
 .. autoclass:: pywbem.ParseError

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -236,6 +236,9 @@ References
    X.509
       `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <http://www.itu.int/rec/T-REC-X.509/en>`_
 
+   RFC2616
+      `IETF RFC2616, Hypertext Transfer Protocol -- HTTP/1.1, June 1999 <https://tools.ietf.org/html/rfc2616>`_
+
    RFC2617
       `IETF RFC2617, HTTP Authentication: Basic and Digest Access Authentication, June 1999 <https://tools.ietf.org/html/rfc2617>`_
 

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -1,40 +1,88 @@
 usage: mof_compiler [options] moffile ...
 
-Compile MOF files, and update the repository of a WBEM server with the result.
+Compile MOF files, and update a namespace in a WBEM server with the result.
 
 Positional arguments:
   moffile               Path name of the MOF file to be compiled.
                         Can be specified multiple times.
 
 Server related options:
-  Specify the WBEM server and namespace
+  Specify the WBEM server and namespace the MOF compiler works against, for
+  looking up existing elements, and for applying the MOF compilation results
+  to.
 
-  -u url, --url url     URL of the WBEM server.
-                        Default: /var/run/tog-pegasus/cimxml.socket
+  -s url, --server url  Host name or URL of the WBEM server (required),
+                        in this format:
+                            [scheme://]host[:port]
+                        - scheme: Defines the protocol to use:
+                            - "https" for HTTPS protocol
+                            - "http" for HTTP protocol
+                          Default: "https".
+                        - host: Defines host name as follows:
+                             - short or fully qualified DNS hostname
+                             - literal IPV4 address(dotted)
+                             - literal IPV6 address (RFC 3986) with zone
+                               identifier extensions(RFC 6874)
+                               supporting "-" or %25 for the delimiter
+                        - port: Defines the WBEM server port to be used.
+                          Defaults:
+                             - 5988, when using HTTP
+                             - 5989, whenusing HTTPS
   -n namespace, --namespace namespace
-                        Namespace in the WBEM server to work against
-                        (required)
-  -l username, --username username
-                        Username for authenticating with the WBEM server.
-                        Default: No username
+                        Namespace in the WBEM server.
+                        Default: root/cimv2
+
+Connection security related options:
+  Specify user name and password or certificates and keys
+
+  -u user, --user user  User name for authenticating with the WBEM server.
+                        Default: No user name.
   -p password, --password password
                         Password for authenticating with the WBEM server.
-                        Default: No password
+                        Default: Will be prompted for, if user name
+                        specified.
+  -nvc, --no-verify-cert
+                        Client will not verify certificate returned by the
+                        WBEM server (see cacerts). This bypasses the client-
+                        side verification of the server identity, but allows
+                        encrypted communication with a server for which the
+                        client does not have certificates.
+  --cacerts cacerts     File or directory containing certificates that will be
+                        matched against a certificate received from the WBEM
+                        server. Set the --no-verify-cert option to bypass
+                        client verification of the WBEM server certificate.
+                        Default: Searches for matching certificates in the
+                        following system directories:
+                        /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+                        /etc/ssl/certs
+                        /etc/ssl/certificates
+  --certfile certfile   Client certificate file for authenticating with the
+                        WBEM server. If option specified the client attempts
+                        to execute mutual authentication.
+                        Default: Simple authentication.
+  --keyfile keyfile     Client private key file for authenticating with the
+                        WBEM server. Not required if private key is part of the
+                        certfile option. Not allowed if no certfile option.
+                        Default: No client key file. Client private key should
+                        then be part  of the certfile
 
 Action related options:
-  Specify actions against the repository. Default: create/update elements.
+  Specify actions against the WBEM server's namespace. Default:
+  Create/update elements.
 
-  -r, --remove          Remove elements (found in the MOF files) from the
-                        repository, instead of creating or updating them
-  -d, --dry-run         Don't actually modify the repository, just check MOF
-                        syntax. Connection to WBEM server is still required to
-                        check qualifiers.
+  -r, --remove          Remove elements (found in the MOF files) from the WBEM
+                        server's namespace, instead of creating or updating
+                        them
+  -d, --dry-run         Don't actually modify the WBEM server's namespace,
+                        just check MOF syntax. Connection to WBEM server is
+                        still required to check qualifiers.
 
 General options:
-  -s dir, --search dir  Path name of an additional search directory for MOF
-                        include files. Can be specified multiple times.
+  -I dir, --include dir
+                        Path name of a MOF include directory. Can be specified
+                        multiple times.
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Example: mof_compiler CIM_Schema_2.45.mof -u https://localhost:15989 -n
-root/cimv2 -l sheldon -p penny42
+Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost:15989 -n
+root/cimv2 -u sheldon -p penny42

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -388,6 +388,9 @@ class WBEMConnection(object):
 
       - :exc:`~pywbem.AuthError` - Authentication failed with the WBEM server.
 
+      - :exc:`~pywbem.HTTPError` - HTTP error (bad status code) received from
+        WBEM server.
+
       - :exc:`~pywbem.ParseError` - The response from the WBEM server cannot
         be parsed (for example, invalid characters or UTF-8 sequences,
         ill-formed XML, or invalid CIM-XML).


### PR DESCRIPTION
Ready to be merged. Please review

Details:

- Authentication errors are now always raised as `AuthError`. (OpenWBEM raised `ConnectionError` in one case).
- Any other bad HTTP responses are now raised as a new exception `HTTPError`.
- `HTTPError` and `CIMError` now have a ctor to improve documentation and to verify at least the number of args.