### PR TITLE
Fixes #354: Added info about paths in returned objects, and other docu fixes

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -456,3 +456,10 @@ The operation methods of :class:`~pywbem.WBEMConnection` raise
   - authentication failed
   - user is not authorized to access resource
 
+.. _`Default CA certificate paths`:
+
+Default CA certificate paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autodata:: pywbem.cim_http.DEFAULT_CA_CERT_PATHS
+

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -1,40 +1,88 @@
 usage: mof_compiler [options] moffile ...
 
-Compile MOF files, and update the repository of a WBEM server with the result.
+Compile MOF files, and update a namespace in a WBEM server with the result.
 
 Positional arguments:
   moffile               Path name of the MOF file to be compiled.
                         Can be specified multiple times.
 
 Server related options:
-  Specify the WBEM server and namespace
+  Specify the WBEM server and namespace the MOF compiler works against, for
+  looking up existing elements, and for applying the MOF compilation results
+  to.
 
-  -u url, --url url     URL of the WBEM server.
-                        Default: /var/run/tog-pegasus/cimxml.socket
+  -s url, --server url  Host name or URL of the WBEM server (required),
+                        in this format:
+                            [scheme://]host[:port]
+                        - scheme: Defines the protocol to use:
+                            - "https" for HTTPS protocol
+                            - "http" for HTTP protocol
+                          Default: "https".
+                        - host: Defines host name as follows:
+                             - short or fully qualified DNS hostname
+                             - literal IPV4 address(dotted)
+                             - literal IPV6 address (RFC 3986) with zone
+                               identifier extensions(RFC 6874)
+                               supporting "-" or %25 for the delimiter
+                        - port: Defines the WBEM server port to be used.
+                          Defaults:
+                             - 5988, when using HTTP
+                             - 5989, whenusing HTTPS
   -n namespace, --namespace namespace
-                        Namespace in the WBEM server to work against
-                        (required)
-  -l username, --username username
-                        Username for authenticating with the WBEM server.
-                        Default: No username
+                        Namespace in the WBEM server.
+                        Default: root/cimv2
+
+Connection security related options:
+  Specify user name and password or certificates and keys
+
+  -u user, --user user  User name for authenticating with the WBEM server.
+                        Default: No user name.
   -p password, --password password
                         Password for authenticating with the WBEM server.
-                        Default: No password
+                        Default: Will be prompted for, if user name
+                        specified.
+  -nvc, --no-verify-cert
+                        Client will not verify certificate returned by the
+                        WBEM server (see cacerts). This bypasses the client-
+                        side verification of the server identity, but allows
+                        encrypted communication with a server for which the
+                        client does not have certificates.
+  --cacerts cacerts     File or directory containing certificates that will be
+                        matched against a certificate received from the WBEM
+                        server. Set the --no-verify-cert option to bypass
+                        client verification of the WBEM server certificate.
+                        Default: Searches for matching certificates in the
+                        following system directories:
+                        /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+                        /etc/ssl/certs
+                        /etc/ssl/certificates
+  --certfile certfile   Client certificate file for authenticating with the
+                        WBEM server. If option specified the client attempts
+                        to execute mutual authentication.
+                        Default: Simple authentication.
+  --keyfile keyfile     Client private key file for authenticating with the
+                        WBEM server. Not required if private key is part of the
+                        certfile option. Not allowed if no certfile option.
+                        Default: No client key file. Client private key should
+                        then be part  of the certfile
 
 Action related options:
-  Specify actions against the repository. Default: create/update elements.
+  Specify actions against the WBEM server's namespace. Default:
+  Create/update elements.
 
-  -r, --remove          Remove elements (found in the MOF files) from the
-                        repository, instead of creating or updating them
-  -d, --dry-run         Don't actually modify the repository, just check MOF
-                        syntax. Connection to WBEM server is still required to
-                        check qualifiers.
+  -r, --remove          Remove elements (found in the MOF files) from the WBEM
+                        server's namespace, instead of creating or updating
+                        them
+  -d, --dry-run         Don't actually modify the WBEM server's namespace,
+                        just check MOF syntax. Connection to WBEM server is
+                        still required to check qualifiers.
 
 General options:
-  -s dir, --search dir  Path name of an additional search directory for MOF
-                        include files. Can be specified multiple times.
+  -I dir, --include dir
+                        Path name of a MOF include directory. Can be specified
+                        multiple times.
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Example: mof_compiler CIM_Schema_2.45.mof -u https://localhost:15989 -n
-root/cimv2 -l sheldon -p penny42
+Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost:15989 -n
+root/cimv2 -u sheldon -p penny42

--- a/makefile
+++ b/makefile
@@ -94,6 +94,7 @@ doc_dependent_files := \
     $(package_name)/cim_obj.py \
     $(package_name)/cim_operations.py \
     $(package_name)/cim_types.py \
+    $(package_name)/cim_http.py \
     $(package_name)/mof_compiler.py \
     $(package_name)/exceptions.py \
     $(package_name)/_listener.py \

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -682,8 +682,7 @@ class WBEMListener(object):
     def __repr__(self):
         """
         Return a representation of the :class:`~pywbem.WBEMListener` object
-        with all properties and instance variables that is suitable for
-        debugging.
+        with all attributes, that is suitable for debugging.
         """
         return "%s(host=%r, http_port=%s, https_port=%s, " \
                "certfile=%r, keyfile=%r, logger=%r, _servers=%r, " \
@@ -1355,7 +1354,7 @@ def callback_interface(indication, host):
 
       indication (:class:`~pywbem.CIMInstance`):
         Representation of the CIM indication that has been received.
-        Its `path` component is not set.
+        Its `path` attribute is `None`.
 
       host (:term:`string`):
         Host name or IP address of WBEM server sending the indication.

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -84,7 +84,7 @@ class OpArgs(OpArgs_tuple):
     """
     A named tuple representing the name and input arguments of the invocation
     of a :class:`~pywbem.WBEMConnection` method, with the following named fields
-    and instance variables:
+    and attributes:
 
     Attributes:
 
@@ -106,7 +106,7 @@ class OpResult(OpResult_tuple):
     """
     A named tuple representing the result of the invocation of a
     :class:`~pywbem.WBEMConnection` method, with the following named fields
-    and instance variables:
+    and attributes:
 
     Attributes:
 
@@ -134,7 +134,7 @@ HttpRequest_tuple = namedtuple("HttpRequest_tuple",
 class HttpRequest(HttpRequest_tuple):
     """
     A named tuple representing the HTTP request sent by the WBEM client, with
-    the following named fields and instance variables:
+    the following named fields and attributes:
 
     Attributes:
 
@@ -175,7 +175,7 @@ HttpResponse_tuple = namedtuple("HttpResponse_tuple",
 class HttpResponse(HttpResponse_tuple):
     """
     A named tuple representing the HTTP response received by the WBEM client,
-    with the following named fields and instance variables:
+    with the following named fields and attributes:
 
     Attributes:
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -162,8 +162,7 @@ class WBEMServer(object):
     def __repr__(self):
         """
         Return a representation of the :class:`~pywbem.WBEMServer` object
-        with all properties and instance variables that is suitable for
-        debugging.
+        with all attributes, that is suitable for debugging.
         """
         return "%s(url=%r, conn=%r, interop_ns=%s, namespaces=%s, " \
                "namespace_classname=%r, brand=%r, version=%r, " \

--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -24,7 +24,7 @@ This section defines constants for two areas:
 * CIM status codes (the ``CIM_ERR_*`` symbols). They are for example stored in
   :exc:`~pywbem.CIMError` exceptions.
 * Default CIM namespace :data:`~pywbem.cim_constants.DEFAULT_NAMESPACE`. It is
-  used as a default for the `namespace` argument of
+  used as a default for the `namespace` parameter of
   :class:`~pywbem.WBEMConnection`.
 
 Note: For tooling reasons, the constants are shown in the namespace

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -69,7 +69,7 @@ else:
     #pylint: disable=invalid-name
     SocketErrors = (socket.error,)
 
-__all__ = []
+__all__ = ['DEFAULT_CA_CERT_PATHS']
 
 def create_pywbem_ssl_context():
     """ Create an SSL context based on what is commonly accepted as the
@@ -119,7 +119,9 @@ def create_pywbem_ssl_context():
 DEFAULT_PORT_HTTP = 5988        # default port for http
 DEFAULT_PORT_HTTPS = 5989       # default port for https
 
-#TODO 5/16 ks This is a linux based set of defaults.
+# TODO 5/16 ks This is a linux based set of defaults:
+
+#: Default directory paths for looking up CA certificates.
 DEFAULT_CA_CERT_PATHS = \
      ['/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt', \
       '/etc/ssl/certs', '/etc/ssl/certificates']
@@ -379,7 +381,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
 
       recorder (:class:`~pywbem.BaseOperationRecorder`):
         Operation recorder, into which the HTTP request and HTTP response will
-        be staged as instance variables.
+        be staged as attributes.
 
     Returns:
         The CIM-XML formatted response data from the WBEM server, as a
@@ -469,7 +471,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
 
 
                 if sys.version_info[0:2] >= (2, 7):
-                    # the source_address argument was added in 2.7
+                    # the source_address parameter was added in Python 2.7
                     self.sock = socket.create_connection(
                         (self.host, self.port), None, self.source_address)
                 else:
@@ -611,7 +613,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
     local_auth_header = None
     try_limit = 5
 
-    # Make sure the data argument is converted to a UTF-8 encoded byte string.
+    # Make sure the data parameter is converted to a UTF-8 encoded byte string.
     # This is important because according to RFC2616, the Content-Length HTTP
     # header must be measured in Bytes (and the Content-Type header will
     # indicate UTF-8).

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -688,8 +688,8 @@ def mofstr(strvalue, indent=MOF_INDENT, maxline=MAX_MOF_LINE):
 
     After escaping, the string is broken into multiple lines, for better
     readability. The maximum line size is specified via the `maxline`
-    argument. The indentation for any spilled over lines (i.e. not the first
-    line) is specified via the `indent` argument.
+    parameter. The indentation for any spilled over lines (i.e. not the first
+    line) is specified via the `indent` parameter.
     """
 
     escaped_str = strvalue
@@ -783,7 +783,7 @@ class CIMInstanceName(_CIMComparisonMixin):
     A CIM instance path (aka *instance name*).
 
     A CIM instance path references a CIM instance in a namespace in a WBEM
-    server. Namespace and WBEM server may be unknown.
+    server. Namespace and WBEM server may be unspecified.
 
     This object can be used like a dictionary of the keybindings of the
     instance path, with the names of the keybindings (= key properties) as
@@ -794,23 +794,43 @@ class CIMInstanceName(_CIMComparisonMixin):
       classname (:term:`unicode string`):
         Name of the creation class of the referenced instance.
 
+        This variable will never be `None`.
+
       keybindings (`NocaseDict`_):
         Keybindings of the instance path (the key property values of the
         referenced instance).
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one key property value, with:
 
-      host (:term:`unicode string`):
-        URL of the WBEM server containing the CIM namespace of the
-        referenced instance.
+          * key (:term:`string`): Key property name
+          * value (:term:`CIM data type`): Key property value
 
-        `None` means that the host is unspecified.
+        This variable will never be `None`.
 
       namespace (:term:`unicode string`):
         Name of the CIM namespace containing the referenced instance.
 
         `None` means that the namespace is unspecified.
+
+      host (:term:`unicode string`):
+        Host and optionally port of the WBEM server containing the CIM
+        namespace of the referenced instance, in the format:
+
+          ``host[:port]``
+
+        The host can be specified in any of the usual formats:
+
+          * a short or fully qualified DNS hostname
+          * a literal (= dotted) IPv4 address
+          * a literal IPv6 address, formatted as defined in :term:`RFC3986`
+            with the extensions for zone identifiers as defined in
+            :term:`RFC6874`, supporting ``-`` (minus) for the delimiter
+            before the zone ID string, as an additional choice to ``%25``.
+
+        If no port is specified, the default port depends on the context in
+        which the object is used.
+
+        `None` means that the WBEM server is unspecified.
     """
 
     def __init__(self, classname, keybindings=None, host=None, namespace=None):
@@ -819,25 +839,26 @@ class CIMInstanceName(_CIMComparisonMixin):
 
           classname (:term:`string`):
             Name of the creation class of the referenced instance.
+
             Must not be `None`.
 
           keybindings (:class:`py:dict` or `NocaseDict`_):
             Keybindings for the instance path (the key property values
             of the referenced instance).
 
-            Each dictionary item specifies one key property value, with:
-
-            * key (:term:`string`): Key property
-              name
-            * value (:term:`CIM data type`): Key property value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
           host (:term:`string`):
-            URL of the WBEM server containing the CIM namespace of the
-            referenced instance.
+            Host and optionally port of the WBEM server containing the CIM
+            namespace of the referenced instance.
 
-            `None` means that the host is unspecified.
+            For details about the string format, see the corresponding instance
+            variable.
+
+            `None` means that the WBEM server is unspecified.
 
           namespace (:term:`string`):
             Name of the CIM namespace containing the referenced instance.
@@ -959,7 +980,7 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def update(self, *args, **kwargs):
         """
-        Add the named arguments and keyword arguments to the keybindings,
+        Add the positional arguments and keyword arguments to the keybindings,
         updating the values of those that already exist.
         """
         self.keybindings.update(*args, **kwargs)
@@ -1170,20 +1191,30 @@ class CIMInstance(_CIMComparisonMixin):
       classname (:term:`unicode string`):
         Name of the creation class of the instance.
 
+        This variable will never be `None`.
+
       properties (`NocaseDict`_):
         Properties for the instance.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one property value, with:
+
+        * key (:term:`string`): Property name
+        * value (:class:`~pywbem.CIMProperty`): Property value
+
+        This variable will never be `None`.
 
       qualifiers (`NocaseDict`_):
         Qualifiers for the instance.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one qualifier value, with:
+
+        * key (:term:`string`): Qualifier name
+        * value (:class:`~pywbem.CIMQualifier`): Qualifier value
 
         Note that :term:`DSP0200` has deprecated the presence of qualifier
         values on CIM instances.
+
+        This variable will never be `None`.
 
       path (CIMInstanceName):
         Instance path of the instance.
@@ -1211,21 +1242,16 @@ class CIMInstance(_CIMComparisonMixin):
           properties (:class:`py:dict` or `NocaseDict`_):
             Properties for the instance.
 
-            Each dictionary item specifies one property value, with:
-
-            * key (:term:`string`): Property name
-            * value (:class:`~pywbem.CIMProperty`): Property value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
           qualifiers (:class:`py:dict` or `NocaseDict`_):
             Qualifiers for the instance.
 
-            Each dictionary item specifies one qualifier value, with:
-
-            * key (:term:`string`): Qualifier
-              name
-            * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
@@ -1361,7 +1387,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     def update(self, *args, **kwargs):
         """
-        Add the named arguments and keyword arguments to the properties,
+        Add the positional arguments and keyword arguments to the properties,
         updating the values of those that already exist.
         """
 
@@ -1377,7 +1403,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     def update_existing(self, *args, **kwargs):
         """
-        Update the values of already existing properties from the named
+        Update the values of already existing properties from the positional
         arguments and keyword arguments.
         """
 
@@ -1543,24 +1569,40 @@ class CIMClassName(_CIMComparisonMixin):
     A CIM class path.
 
     A CIM class path references a CIM class in a namespace in a WBEM server.
-    Namespace and WBEM server may be unknown.
+    Namespace and WBEM server may be unspecified.
 
     Attributes:
 
       classname (:term:`unicode string`):
         Name of the referenced class.
 
-      host (:term:`unicode string`):
-        URL of the WBEM server containing the CIM namespace of the
-        referenced class.
-
-        `None` means that the host is unspecified.
+        This variable will never be `None`.
 
       namespace (:term:`unicode string`):
         Name of the CIM namespace containing the referenced class.
 
         `None` means that the namespace is unspecified.
-    """
+
+      host (:term:`unicode string`):
+        Host and optionally port of the WBEM server containing the CIM
+        namespace of the referenced class, in the format:
+
+          ``host[:port]``
+
+        The host can be specified in any of the usual formats:
+
+          * a short or fully qualified DNS hostname
+          * a literal (= dotted) IPv4 address
+          * a literal IPv6 address, formatted as defined in :term:`RFC3986`
+            with the extensions for zone identifiers as defined in
+            :term:`RFC6874`, supporting ``-`` (minus) for the delimiter
+            before the zone ID string, as an additional choice to ``%25``.
+
+        If no port is specified, the default port depends on the context in
+        which the object is used.
+
+        `None` means that the WBEM server is unspecified.
+"""
 
     def __init__(self, classname, host=None, namespace=None):
         """
@@ -1572,10 +1614,13 @@ class CIMClassName(_CIMComparisonMixin):
             Must not be `None`.
 
           host (:term:`string`):
-            URL of the WBEM server containing the CIM namespace of the
-            referenced class.
+            Host and optionally port of the WBEM server containing the CIM
+            namespace of the referenced class.
 
-            `None` means that the host is unspecified.
+            For details about the string format, see the corresponding instance
+            variable.
+
+            `None` means that the WBEM server is unspecified.
 
           namespace (:term:`string`):
             Name of the CIM namespace containing the referenced class.
@@ -1725,6 +1770,8 @@ class CIMClass(_CIMComparisonMixin):
       classname (:term:`unicode string`):
         Name of the class.
 
+        This variable will never be `None`.
+
       superclass (:term:`unicode string`):
         Name of the superclass of the class.
 
@@ -1733,20 +1780,32 @@ class CIMClass(_CIMComparisonMixin):
       properties (`NocaseDict`_):
         Property declarations of the class.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one property declaration, with:
+
+        * key (:term:`string`): Property name
+        * value (:class:`~pywbem.CIMProperty`): Property declaration
+
+        This variable will never be `None`.
 
       methods (`NocaseDict`_):
         Method declarations of the class.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one method declaration, with:
+
+        * key (:term:`string`): Nethod name
+        * value (:class:`~pywbem.CIMMethod`): Method declaration
+
+        This variable will never be `None`.
 
       qualifiers (`NocaseDict`_):
         Qualifier values of the class.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one qualifier value, with:
+
+        * key (:term:`string`): Qualifier name
+        * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+
+        This variable will never be `None`.
     """
 
     # pylint: disable=too-many-arguments
@@ -1763,20 +1822,16 @@ class CIMClass(_CIMComparisonMixin):
           properties (:class:`py:dict` or `NocaseDict`_):
             Property declarations for the class.
 
-            Each dictionary item specifies one property declaration, with:
-
-            * key (:term:`string`): Property name
-            * value (:class:`~pywbem.CIMProperty`): Property declaration
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
           methods (:class:`py:dict` or `NocaseDict`_):
             Method declarations for the class.
 
-            Each dictionary item specifies one method declaration, with:
-
-            * key (:term:`string`): Nethod name
-            * value (:class:`~pywbem.CIMMethod`): Method declaration
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
@@ -1788,11 +1843,8 @@ class CIMClass(_CIMComparisonMixin):
           qualifiers (:class:`py:dict` or `NocaseDict`_):
             Qualifier values for the class.
 
-            Each dictionary item specifies one qualifier value, with:
-
-            * key (:term:`string`): Qualifier
-              name
-            * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             If `None`, the class will have no qualifiers.
         """
@@ -1945,12 +1997,12 @@ class CIMProperty(_CIMComparisonMixin):
 
     For property values in CIM instances:
 
-      * The `value` instance variable is the actual value of the property.
+      * The `value` attribute is the actual value of the property.
       * Qualifiers are not allowed.
 
     For property declarations in CIM classes:
 
-      * The `value` instance variable is the default value of the property
+      * The `value` attribute is the default value of the property
         declaration.
       * Qualifiers are allowed.
 
@@ -1968,6 +2020,8 @@ class CIMProperty(_CIMComparisonMixin):
       name (:term:`unicode string`):
         Name of the property.
 
+        This variable will never be `None`.
+
       value (:term:`CIM data type`):
         Value of the property (interpreted as actual value when
         representing a property value, and as default value for property
@@ -1975,12 +2029,14 @@ class CIMProperty(_CIMComparisonMixin):
 
         `None` means that the value is Null.
 
-        For CIM data types string and char16, this instance variable will be a
+        For CIM data types string and char16, this attribute will be a
         :term:`unicode string`, even when specified as a :term:`byte string`
         in the constructor.
 
       type (:term:`unicode string`):
         Name of the CIM data type of the property (e.g. ``"uint8"``).
+
+        This variable will never be `None`.
 
       reference_class (:term:`unicode string`):
         The name of the referenced class, for reference properties.
@@ -1989,14 +2045,29 @@ class CIMProperty(_CIMComparisonMixin):
 
       embedded_object (:term:`unicode string`):
         A string value indicating the kind of embedded object represented
-        by the property value. For details about the possible values, see the
-        corresponding constructor parameter.
+        by the property value.
 
-        `None`, for properties not representing embedded objects.
+        The following values are defined for this parameter:
+
+        * ``"instance"``: The property is declared with the
+          ``EmbeddedInstance`` qualifier, indicating that the property
+          value is an embedded instance of the class specified as the value
+          of the ``EmbeddedInstance`` qualifier.
+          The property value must be a :class:`~pywbem.CIMInstance` object,
+          or `None`.
+        * ``"object"``: The property is declared with the
+          ``EmbeddedObject`` qualifier, indicating that the property
+          value is an embedded object (instance or class) of which the
+          class name is not known.
+          The property value must be a :class:`~pywbem.CIMInstance` or
+          :class:`~pywbem.CIMClass` object, or `None`.
+        * `None`, for properties not representing embedded objects.
 
       is_array (:class:`py:bool`):
         A boolean indicating whether the property is an array (`True`) or a
         scalar (`False`).
+
+        This variable will never be `None`.
 
       array_size (:term:`integer`):
         The size of the array property, for fixed-size arrays.
@@ -2022,8 +2093,12 @@ class CIMProperty(_CIMComparisonMixin):
       qualifiers (`NocaseDict`_):
         Qualifier values for the property declaration.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one qualifier value, with:
+
+        * key (:term:`string`): Qualifier name
+        * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+
+        This variable will never be `None`.
     """
 
     # pylint: disable=too-many-statements
@@ -2035,10 +2110,10 @@ class CIMProperty(_CIMComparisonMixin):
         # pylint: disable=too-many-statements,too-many-instance-attributes
         # pylint: disable=too-many-instance-attributes
         """
-        The constructor infers optional arguments that are not specified (for
+        The constructor infers optional parameters that are not specified (for
         example, it infers `type` from the Python type of `value` and other
-        information). If the specified arguments are inconsistent, an
-        exception is raised. If an optional argument is needed for some reason,
+        information). If the specified parameters are inconsistent, an
+        exception is raised. If an optional parameter is needed for some reason,
         an exception is raised.
 
         Parameters:
@@ -2058,8 +2133,8 @@ class CIMProperty(_CIMComparisonMixin):
           type (:term:`string`):
             Name of the CIM data type of the property (e.g. ``"uint8"``).
 
-            `None` means that the argument is unspecified, causing the
-            corresponding instance variable to be inferred. An exception is
+            `None` means that the parameter is unspecified, causing the
+            corresponding attribute to be inferred. An exception is
             raised if it cannot be inferred.
 
           class_origin (:term:`string`):
@@ -2086,25 +2161,22 @@ class CIMProperty(_CIMComparisonMixin):
             A boolean indicating whether the property is an array (`True`) or a
             scalar (`False`).
 
-            `None` means that the argument is unspecified, causing the
-            corresponding instance variable to be inferred from the `value`
+            `None` means that the parameter is unspecified, causing the
+            corresponding attribute to be inferred from the `value`
             parameter, and if that is `None` it defaults to `False` (scalar).
 
           reference_class (:term:`string`):
             The name of the referenced class, for reference properties.
 
-            `None` means that the argument is unspecified, causing the
-            corresponding instance variable to be inferred. An exception is
+            `None` means that the parameter is unspecified, causing the
+            corresponding attribute to be inferred. An exception is
             raised if it cannot be inferred.
 
           qualifiers (:class:`py:dict` or `NocaseDict`_):
             Qualifier values for the property declaration.
 
-            Each dictionary item specifies one qualifier value, with:
-
-            * key (:term:`string`): Qualifier
-              name
-            * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
@@ -2112,23 +2184,12 @@ class CIMProperty(_CIMComparisonMixin):
             A string value indicating the kind of embedded object represented
             by the property value. Has no meaning for property declarations.
 
-            The following values are defined for this argument:
+            For details about the possible values, see the corresponding
+            attribute.
 
-            * ``"instance"``: The property is declared with the
-              ``EmbeddedInstance`` qualifier, indicating that the property
-              value is an embedded instance of the class specified as the value
-              of the ``EmbeddedInstance`` qualifier.
-              The property value must be a :class:`~pywbem.CIMInstance` object,
-              or `None`.
-            * ``"object"``: The property is declared with the
-              ``EmbeddedObject`` qualifier, indicating that the property
-              value is an embedded object (instance or class) of which the
-              class name is not known.
-              The property value must be a :class:`~pywbem.CIMInstance` or
-              :class:`~pywbem.CIMClass` object, or `None`.
-            * `None`: The argument is unspecified, causing the corresponding
-              instance variable to be inferred. An exception is raised if it
-              cannot be inferred.
+            In addition, `None` means that the value is unspecified, causing
+            the corresponding attribute to be inferred. An exception is
+            raised if it cannot be inferred.
 
         Examples:
 
@@ -2656,8 +2717,13 @@ class CIMMethod(_CIMComparisonMixin):
       name (:term:`unicode string`):
         Name of the method.
 
+        This variable will never be `None`.
+
       return_type (:term:`unicode string`):
         Name of the CIM data type of the method return type (e.g. ``"uint32"``).
+
+        This variable will never be `None`. Note that void return types of
+        methods are not supported in CIM.
 
       class_origin (:term:`unicode string`):
         The CIM class origin of the method (the name
@@ -2675,14 +2741,22 @@ class CIMMethod(_CIMComparisonMixin):
       parameters (`NocaseDict`_):
         Parameter declarations for the method declaration.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one parameter declaration, with:
+
+        * key (:term:`string`): Parameter name
+        * value (:class:`~pywbem.CIMParameter`): Parameter declaration
+
+        This variable will never be `None`.
 
       qualifiers (`NocaseDict`_):
         Qualifier values for the method declaration.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one qualifier value, with:
+
+        * key (:term:`string`): Qualifier name
+        * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+
+        This variable will never be `None`.
     """
 
     # pylint: disable=too-many-arguments
@@ -2690,8 +2764,8 @@ class CIMMethod(_CIMComparisonMixin):
                  class_origin=None, propagated=False, qualifiers=None,
                  methodname=None):
         """
-        The constructor stores the input arguments as-is and does
-        not infer unspecified arguments from the others
+        The constructor stores the input parameters as-is and does
+        not infer unspecified parameters from the others
         (like :class:`~pywbem.CIMProperty` does).
 
         Parameters:
@@ -2699,6 +2773,7 @@ class CIMMethod(_CIMComparisonMixin):
           name (:term:`string`):
             Name of the method (just the method name, without class name
             or parenthesis).
+
             Must not be `None`.
 
             Deprecated: This argument has been named `methodname` before
@@ -2708,18 +2783,17 @@ class CIMMethod(_CIMComparisonMixin):
           return_type (:term:`string`):
             Name of the CIM data type of the method return type
             (e.g. ``"uint32"``).
+
             Must not be `None`
 
           parameters (:class:`py:dict` or `NocaseDict`_):
             Parameter declarations for the method declaration.
 
-            Each dictionary item specifies one parameter declaration, with:
+            For details about the dictionary items, see the corresponding
+            attribute.
 
-            * key (:term:`string`): Parameter
-              name
-            * value (:class:`~pywbem.CIMParameter`): Parameter declaration
-
-            If `None`, the method will have no parameters.
+            If `None`, the method will have no parameters, and the dictionary
+            will be empty.
 
           class_origin (:term:`string`):
             The CIM class origin of the method (the name
@@ -2737,11 +2811,8 @@ class CIMMethod(_CIMComparisonMixin):
           qualifiers (:class:`py:dict` or `NocaseDict`_):
             Qualifier values for the method declaration.
 
-            Each dictionary item specifies one qualifier value, with:
-
-            * key (:term:`string`): Qualifier
-              name
-            * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
         """
@@ -2901,8 +2972,12 @@ class CIMParameter(_CIMComparisonMixin):
       name (:term:`unicode string`):
         Name of the parameter.
 
+        This variable will never be `None`.
+
       type (:term:`unicode string`):
         Name of the CIM data type of the parameter (e.g. ``"uint8"``).
+
+        This variable will never be `None`.
 
       reference_class (:term:`unicode string`):
         The name of the referenced class, for reference parameters.
@@ -2913,6 +2988,8 @@ class CIMParameter(_CIMComparisonMixin):
         A boolean indicating whether the parameter is an array (`True`) or a
         scalar (`False`).
 
+        This variable will never be `None`.
+
       array_size (:term:`integer`):
         The size of the array parameter, for fixed-size arrays.
 
@@ -2922,8 +2999,12 @@ class CIMParameter(_CIMComparisonMixin):
       qualifiers (`NocaseDict`_):
         Qualifier values of the parameter declaration.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one qualifier value, with:
+
+        * key (:term:`string`): Qualifier name
+        * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+
+        This variable will never be `None`.
 
       value:
         Deprecated: Because the object represents a parameter declaration,
@@ -2936,8 +3017,8 @@ class CIMParameter(_CIMComparisonMixin):
                  array_size=None, qualifiers=None, value=None):
         # pylint: disable=redefined-builtin
         """
-        The constructor stores the input arguments as-is and does
-        not infer unspecified arguments from the others
+        The constructor stores the input parameters as-is and does
+        not infer unspecified parameters from the others
         (like :class:`~pywbem.CIMProperty` does).
 
         Parameters:
@@ -2971,11 +3052,8 @@ class CIMParameter(_CIMComparisonMixin):
           qualifiers (:class:`py:dict` or `NocaseDict`_):
             Qualifier values of the parameter declaration.
 
-            Each dictionary item specifies one qualifier value, with:
-
-            * key (:term:`string`): Qualifier
-              name
-            * value (:class:`~pywbem.CIMQualifier`): Qualifier value
+            For details about the dictionary items, see the corresponding
+            attribute.
 
             `None` is interpreted as an empty dictionary.
 
@@ -3001,7 +3079,7 @@ class CIMParameter(_CIMComparisonMixin):
 
     @property
     def value(self):
-        """Return value component(Deprecated)."""
+        """Return `value` attribute (Deprecated)."""
         warnings.warn(
             "The value attribute of CIMParameter is deprecated",
             DeprecationWarning)
@@ -3009,7 +3087,7 @@ class CIMParameter(_CIMComparisonMixin):
 
     @value.setter
     def value(self, value):
-        """Set value component(Deprecated)."""
+        """Set `value` attribute (Deprecated)."""
         warnings.warn(
             "The value attribute of CIMParameter is deprecated",
             DeprecationWarning)
@@ -3202,17 +3280,21 @@ class CIMQualifier(_CIMComparisonMixin):
       name (:term:`unicode string`):
         Name of the qualifier.
 
+        This variable will never be `None`.
+
       value (:term:`CIM data type`):
         Value of the qualifier.
 
         `None` means that the value is Null.
 
-        For CIM data types string and char16, this instance variable will be a
+        For CIM data types string and char16, this attribute will be a
         :term:`unicode string`, even when specified as a :term:`byte string`
         in the constructor.
 
       type (:term:`unicode string`):
         Name of the CIM data type of the qualifier (e.g. ``"uint8"``).
+
+        This variable will never be `None`.
 
       propagated (:class:`py:bool`):
         Indicates whether the qualifier value has been propagated from a
@@ -3250,10 +3332,10 @@ class CIMQualifier(_CIMComparisonMixin):
                  translatable=None):
         # pylint: disable=redefined-builtin
         """
-        The constructor infers optional arguments that are not specified (for
+        The constructor infers optional parameters that are not specified (for
         example, it infers `type` from the Python type of `value` and other
-        information). If the specified arguments are inconsistent, an
-        exception is raised. If an optional argument is needed for some reason,
+        information). If the specified parameters are inconsistent, an
+        exception is raised. If an optional parameter is needed for some reason,
         an exception is raised.
 
         Parameters:
@@ -3271,8 +3353,8 @@ class CIMQualifier(_CIMComparisonMixin):
           type (:term:`string`):
             Name of the CIM data type of the qualifier (e.g. ``"uint8"``).
 
-            `None` means that the argument is unspecified, causing the
-            corresponding instance variable to be inferred. An exception is
+            `None` means that the parameter is unspecified, causing the
+            corresponding attribute to be inferred. An exception is
             raised if it cannot be inferred.
 
           propagated (:class:`py:bool`):
@@ -3526,21 +3608,27 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
       name (:term:`unicode string`):
         Name of the qualifier.
 
+        This variable will never be `None`.
+
       type (:term:`unicode string`):
         Name of the CIM data type of the qualifier (e.g. ``"uint8"``).
+
+        This variable will never be `None`.
 
       value (:term:`CIM data type`):
         Default value of the qualifier.
 
         `None` means that the value is Null.
 
-        For CIM data types string and char16, this instance variable will be a
+        For CIM data types string and char16, this attribute will be a
         :term:`unicode string`, even when specified as a :term:`byte string`
         in the constructor.
 
       is_array (:class:`py:bool`):
         A boolean indicating whether the qualifier is an array (`True`) or a
         scalar (`False`).
+
+        This variable will never be `None`.
 
       array_size (:term:`integer`):
         The size of the array qualifier, for fixed-size arrays.
@@ -3551,8 +3639,18 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
       scopes (`NocaseDict`_):
         Scopes of the qualifier.
 
-        For details about the dictionary items, see the corresponding
-        constructor parameter.
+        Each dictionary item specifies one scope value, with:
+
+        * key (:term:`string`): Scope name, in upper case.
+        * value (:class:`py:bool`): Scope value, specifying whether the
+          qualifier has that scope (i.e. can be applied to a CIM element of
+          that kind).
+
+        Valid scope names are "CLASS", "ASSOCIATION", "REFERENCE",
+        "PROPERTY", "METHOD", "PARAMETER", "INDICATION", and "ANY".
+        `None` is interpreted as an empty dictionary.
+
+        This variable will never be `None`.
 
       tosubclass (:class:`py:bool`):
         If not `None`, specifies whether the qualifier value propagates
@@ -3621,17 +3719,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
           scopes (:class:`py:dict` or `NocaseDict`_):
             Scopes of the qualifier.
 
-            Each dictionary item specifies one scope value, with:
-
-            * key (:term:`string`): Scope name,
-              in upper case.
-            * value (:class:`py:bool`): Scope value, specifying whether the
-              qualifier has that scope (i.e. can be applied to a CIM element of
-              that kind).
-
-            Valid scope names are "CLASS", "ASSOCIATION", "REFERENCE",
-            "PROPERTY", "METHOD", "PARAMETER", "INDICATION", and "ANY".
-            `None` is interpreted as an empty dictionary.
+            For details about the dictionary items, see the corresponding
+            attribute.
 
           overridable (:class:`py:bool`):
             If not `None`, specifies whether the qualifier value is overridable
@@ -3937,7 +4026,7 @@ def tocimobj(type_, value):
         The value to be represented as a CIM object.
 
         In addition to the Python types listed in :ref:`CIM data types`, the
-        following Python types are supported for this argument:
+        following Python types are supported for this parameter:
 
         * `None`: The returned object will be `None`.
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -146,7 +146,7 @@ pull_inst_result_tuple = namedtuple("pull_inst_result_tuple",
 # openqueryInstances and PullInstance responses
 pull_query_result_tuple = namedtuple("pull_query_result_tuple",
                                      ["instances", "eos", "context",
-                                      "QueryResultClass"])
+                                      "query_class"])
 
 # unicode test to set illegal xml char constant
 if len(u'\U00010122') == 2:
@@ -269,7 +269,7 @@ def check_utf8_xml_chars(utf8_xml, meaning):
     context_after = 16     # number of chars to print after any bad chars
 
     if not isinstance(utf8_xml, six.binary_type):
-        raise TypeError("utf8_xml argument is not a byte string, "\
+        raise TypeError("utf8_xml parameter is not a byte string, "\
                         "but has type %s" % type(utf8_xml))
 
     # Check for ill-formed UTF-8 sequences. This needs to be done
@@ -369,14 +369,14 @@ class WBEMConnection(object):
     disturbing any callers).
 
     The connection remembers the XML of the last request and last reply if
-    debugging is turned on via the :attr:`debug` instance variable of the
+    debugging is turned on via the :attr:`debug` attribute of the
     connection object.
     This may be useful in debugging: If a problem occurs, you can examine the
-    :attr:`last_request` and :attr:`last_reply` instance variables of the
+    :attr:`last_request` and :attr:`last_reply` attributes of the
     connection object.
     These are the prettified XML of request and response, respectively.
     The real request and response that are sent and received are available in
-    the :attr:`last_raw_request` and :attr:`last_raw_reply` instance variables
+    the :attr:`last_raw_request` and :attr:`last_raw_reply` attributes
     of the connection object.
 
     The methods of this class may raise the following exceptions:
@@ -413,14 +413,14 @@ class WBEMConnection(object):
     Attributes:
 
       ... : All parameters of the :class:`~pywbem.WBEMConnection` constructor
-        are set as public instance variables with the same name.
+        are set as public attribute with the same name.
 
       debug (:class:`py:bool`): A boolean indicating whether logging of
         the last request and last reply is enabled.
 
-        The initial value of this instance variable is `False`.
+        The initial value of this attribute is `False`.
         Debug logging can be enabled for future operations by setting this
-        instance variable to `True`.
+        attribute to `True`.
 
       last_request (:term:`unicode string`):
         CIM-XML data of the last request sent to the WBEM server
@@ -464,51 +464,55 @@ class WBEMConnection(object):
               ``[{scheme}://]{host}[:{port}]``
 
             The following URL schemes are supported:
-              * ``https``: Causes HTTPS to be used.
-              * ``http``: Causes HTTP to be used.
+
+            * ``https``: Causes HTTPS to be used.
+            * ``http``: Causes HTTP to be used.
 
             The host can be specified in any of the usual formats:
-              * a short or fully qualified DNS hostname
-              * a literal (= dotted) IPv4 address
-              * a literal IPv6 address, formatted as defined in :term:`RFC3986`
-                with the extensions for zone identifiers as defined in
-                :term:`RFC6874`, supporting ``-`` (minus) for the delimiter
-                before the zone ID string, as an additional choice to ``%25``.
+
+            * a short or fully qualified DNS hostname
+            * a literal (= dotted) IPv4 address
+            * a literal IPv6 address, formatted as defined in :term:`RFC3986`
+              with the extensions for zone identifiers as defined in
+              :term:`RFC6874`, supporting ``-`` (minus) for the delimiter
+              before the zone ID string, as an additional choice to ``%25``.
 
             If no port is specified in the URL, the default ports are:
-              * If HTTPS is used, port 5989.
-              * If HTTP is used, port 5988.
+
+            * If HTTPS is used, port 5989.
+            * If HTTP is used, port 5988.
 
             Examples for some URL formats:
-              * ``"https://10.11.12.13:6988"``:
-                Use HTTPS to port 6988 on host 10.11.12.13
-              * ``"https://mysystem.acme.org"``:
-                Use HTTPS to port 5989 on host mysystem.acme.org
-              * ``"10.11.12.13"``:
-                Use HTTP to port 5988 on host 10.11.12.13
-              * ``"http://[2001:db8::1234]:15988"``:
-                Use HTTP to port 15988 on host 2001:db8::1234
-              * ``"http://[::ffff.10.11.12.13]"``:
-                Use HTTP to port 5988 on host ::ffff.10.11.12.13 (an
-                IPv4-mapped IPv6 address)
-              * ``"http://[2001:db8::1234%25eth0]"`` or
-                ``"http://[2001:db8::1234-eth0]"``:
-                Use HTTP to port 5988 to host 2001:db8::1234 (a link-local IPv6
-                address) using zone identifier eth0
+
+            * ``"https://10.11.12.13:6988"``:
+              Use HTTPS to port 6988 on host 10.11.12.13
+            * ``"https://mysystem.acme.org"``:
+              Use HTTPS to port 5989 on host mysystem.acme.org
+            * ``"10.11.12.13"``:
+              Use HTTP to port 5988 on host 10.11.12.13
+            * ``"http://[2001:db8::1234]:15988"``:
+              Use HTTP to port 15988 on host 2001:db8::1234
+            * ``"http://[::ffff.10.11.12.13]"``:
+              Use HTTP to port 5988 on host ::ffff.10.11.12.13 (an
+              IPv4-mapped IPv6 address)
+            * ``"http://[2001:db8::1234%25eth0]"`` or
+              ``"http://[2001:db8::1234-eth0]"``:
+              Use HTTP to port 5988 to host 2001:db8::1234 (a link-local IPv6
+              address) using zone identifier eth0
 
           creds (:class:`py:tuple` of userid, password):
             Credentials for HTTP authenticatiion with the WBEM server, as a
             tuple(userid, password), with:
 
-              * userid (:term:`string`):
-                Userid for authenticating with the WBEM server.
+            * userid (:term:`string`):
+              Userid for authenticating with the WBEM server.
 
-              * password (:term:`string`):
-                Password for that userid.
+            * password (:term:`string`):
+              Password for that userid.
 
-            If `None`, the client will not generate ``Authenticate`` headers
+            If `None`, the client will not generate ``Authorization`` headers
             in the HTTP request. Otherwise, the client will generate an
-            ``Authenticate`` header using HTTP Basic Authentication.
+            ``Authorization`` header using HTTP Basic Authentication.
 
             See :ref:`Authentication types` for an overview.
 
@@ -588,7 +592,7 @@ class WBEMConnection(object):
               certificate to the returned certificate in its chain of trust.
 
             * an integer that indicates whether the validation of the
-              certificate specified in the second argument passed or did not
+              certificate specified in the second parameter passed or did not
               pass the validation by `M2Crypto`. A value of 1 indicates a
               successful validation and 0 an unsuccessful one.
 
@@ -605,8 +609,8 @@ class WBEMConnection(object):
             prepared using the ``c_rehash`` tool included with OpenSSL, or the
             file path of a file in PEM format.
 
-            If `None`, default system paths will be used (see
-            `pywbem.cim_http.DEFAULT_CA_CERT_PATHS`)
+            If `None`, default directory paths will be used to look up CA
+            certificates (see :data:`~pywbem.cim_http.DEFAULT_CA_CERT_PATHS`).
 
           no_verification (:class:`py:bool`):
             Disables verification of the X.509 server certificate returned by
@@ -674,7 +678,7 @@ class WBEMConnection(object):
     def __repr__(self):
         """
         Return a representation of the :class:`~pywbem.WBEMConnection` object
-        with all instance variables (except for the password in the
+        with all attributes (except for the password in the
         credentials) that is suitable for debugging.
         """
 
@@ -1212,8 +1216,8 @@ class WBEMConnection(object):
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be enumerated, in any lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+            attribute will be ignored.
 
           namespace (:term:`string`):
             Name of the CIM namespace to be used, in any lexical case.
@@ -1233,7 +1237,13 @@ class WBEMConnection(object):
         Returns:
 
             A list of :class:`~pywbem.CIMInstanceName` objects that are the
-            enumerated instance paths.
+            enumerated instance paths, with its attributes set
+            as follows:
+
+            * `classname`: Name of the creation class of the instance.
+            * `keybindings`: Keybindings of the instance.
+            * `namespace`: Name of the CIM namespace containing the instance.
+            * `host`: `None`, indicating the WBEM server is unspecified.
 
         Raises:
 
@@ -1300,8 +1310,8 @@ class WBEMConnection(object):
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be enumerated, in any lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+            attribute will be ignored.
 
           namespace (:term:`string`):
             Name of the CIM namespace to be used, in any lexical case.
@@ -1383,6 +1393,15 @@ class WBEMConnection(object):
 
             A list of :class:`~pywbem.CIMInstance` objects that are
             representations of the enumerated instances.
+
+            The `path` attribute of each :class:`~pywbem.CIMInstance`
+            object is a :class:`~pywbem.CIMInstanceName` object with its
+            attributes set as follows:
+
+            * `classname`: Name of the creation class of the instance.
+            * `keybindings`: Keybindings of the instance.
+            * `namespace`: Name of the CIM namespace containing the instance.
+            * `host`: `None`, indicating the WBEM server is unspecified.
 
         Raises:
 
@@ -1514,8 +1533,8 @@ class WBEMConnection(object):
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be enumerated, in any lexical case.
             If specified as a :class:`~pywbem.CIMClassName` object, its
-            namespace component will be used as a default namespace as
-            described for the namespace argument, and its host component
+            `namespace` attribute will be used as a default namespace as
+            described for the `namespace` parameter, and its `host` attribute
             will be ignored.
 
           namespace (:term:`string`):
@@ -1527,7 +1546,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -1595,12 +1614,20 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` containing the following named elements:
+            A :class:`py:namedtuple` object that contains the following named
+            items:
 
-            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
-              Representations of the initial set of enumerated instance
-              paths.
-            * `eos` (:class:`py:bool`):
+            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance paths,
+              with their attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
               Indicates whether the enumeration session is exhausted
               after returning the initial set of enumerated instances.
 
@@ -1608,23 +1635,25 @@ class WBEMConnection(object):
                 server has closed the enumeration session.
               - If `False`, the enumeration session is not exhausted.
 
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
 
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
+              The tuple items are:
 
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
 
         Raises:
 
@@ -1707,8 +1736,8 @@ class WBEMConnection(object):
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be enumerated, in any lexical case.
             If specified as a :class:`~pywbem.CIMClassName` object, its
-            namespace component will be used as a default namespace as
-            described for the namespace argument, and its host component
+            `namespace` attribute will be used as a default namespace as
+            described for the `namespace` parameter, and its `host` attribute
             will be ignored.
 
           namespace (:term:`string`):
@@ -1781,7 +1810,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -1835,38 +1864,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instances.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -1875,9 +1872,55 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -1947,7 +1990,7 @@ class WBEMConnection(object):
         Open an enumeration session to retrieve the instance paths of
         the association instances that reference a source instance.
 
-        This method does not support retrieving classes
+        This method does not support retrieving classes.
 
         This method performs the OpenReferenceInstancePaths operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -1964,11 +2007,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName:
-            The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+          InstanceName (CIMInstanceName):
+            The instance path of the source instance.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -1986,7 +2029,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -2043,38 +2086,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
-              Representations of the initial set of enumerated instance paths.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -2083,9 +2094,52 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance paths,
+              with their attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -2147,6 +2201,8 @@ class WBEMConnection(object):
         Open an enumeration session to retrieve the association instances
         that reference a source instance.
 
+        This method does not support retrieving classes.
+
         This method performs the OpenReferenceInstances operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
@@ -2162,11 +2218,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName:
-            The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+          InstanceName (CIMInstanceName):
+            The instance path of the source instance.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -2216,7 +2272,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -2270,38 +2326,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instance paths.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -2310,10 +2334,55 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
 
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -2382,6 +2451,8 @@ class WBEMConnection(object):
         Open an enumeration session to retrieve the instance paths of the
         instances associated to a source instance.
 
+        This method does not support retrieving classes.
+
         This method performs the OpenAssociatorInstancePaths operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
@@ -2390,9 +2461,6 @@ class WBEMConnection(object):
         status and optionally instance paths.
         Otherwise, this method raises an exception.
 
-        This method does not allow the option of defining `InstanceName`
-        as a class and retrieving associated classes.
-
         Use :meth:`~pywbem.WBEMConnection.PullInstancePaths` request to
         retrieve the next set of instance paths
         or the :meth:`~pywbem.WBEMConnection.CloseEnumeration`
@@ -2400,11 +2468,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName:
-            The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+          InstanceName (CIMInstanceName):
+            The instance path of the source instance.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -2436,7 +2504,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -2494,39 +2562,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
-              Representations of the initial set of enumerated instance
-              names.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -2535,9 +2570,52 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the initial set of enumerated instance paths,
+              with their attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -2605,6 +2683,8 @@ class WBEMConnection(object):
         Open an enumeration session to retrieve the instances associated
         to a source instance.
 
+        This method does not support retrieving classes.
+
         This method performs the OpenAssociatorInstances operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
@@ -2612,9 +2692,6 @@ class WBEMConnection(object):
         If the operation succeeds, this method returns enumeration session
         status and optionally instances.
         Otherwise, this method raises an exception.
-
-        NOTE: This method does not allow the option of defined `InstanceName`
-        as a class and retrieving associated classes.
 
         The subsequent operation after this open is successful
         and result.eos = False must be either the
@@ -2624,11 +2701,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName:
-            The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+          InstanceName (CIMInstanceName):
+            The instance path of the source instance.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -2692,7 +2769,7 @@ class WBEMConnection(object):
 
           FilterQueryLanguage (:term:`string`):
             A string defining the name of the query language
-            used for the `FilterQuery` argument. The DMTF defined language
+            used for the `FilterQuery` parameter. The DMTF defined language
             (FQL) (:term:`DSP0212`) is specified as 'DMTF:FQL'.
 
           FilterQuery (:term:`string`):
@@ -2746,38 +2823,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instances.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -2786,9 +2831,55 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -2862,7 +2953,7 @@ class WBEMConnection(object):
         methods performing such operations.
 
         If the operation succeeds, this method returns enumeration session
-        status and optionally instances.
+        status and optionally CIM instances representing the query result.
         Otherwise, this method raises an exception.
 
         The subsequent operation after this open is successful
@@ -2890,8 +2981,7 @@ class WBEMConnection(object):
             used.
 
           ReturnQueryResultClass  (:class:`py:bool`):
-            Controls whether a class definition is returned in
-            `QueryResultClass`.
+            Controls whether a class definition is returned.
 
           OperationTimeout (:class:`~pywbem.Uint32`):
             Minimum time in seconds the WBEM Server shall maintain an open
@@ -2939,43 +3029,6 @@ class WBEMConnection(object):
               :term:`DSP0200` defines that the server-implemented default is
               to return zero instances.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instances.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-            * `QueryResultClass` (:class:`pywbem.CIMClass`):
-              If ReturnQuerhResultClass is True, this return parameter
-              shall contain a class definition that defines the properties
-              of each row of the query result.
-
-              NOTE: The inner tuple hides the need for a CIM namespace
-              on subsequent operations in the enumeration session. CIM
-              operations always require target namespace, but it never
-              makes sense to specify a different one in subsequent
-              operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -2984,9 +3037,54 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the initial set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is `None`, because query results are not addressable
+              CIM instances.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: The inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+            * **query_class** (:class:`~pywbem.CIMClass`):
+              If the `ReturnQueryResultClass` parameter is True, this tuple
+              item contains a class definition that defines the properties
+              of each row (instance) of the query result. Otherwise, `None`.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         @staticmethod
@@ -3059,7 +3157,7 @@ class WBEMConnection(object):
         session defined by the `enumeration_context` parameter.  The retrieved
         instances include their instance paths.
 
-        This method performs the PullInstanceWithPath operation
+        This method performs the PullInstancesWithPath operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
 
@@ -3070,17 +3168,17 @@ class WBEMConnection(object):
         Parameters:
 
           context (:term:`string`)
-            Identifies the enumeraton session, including its current
-            enumeration state. This must be the value of the `context`
-            item in the :class:`py:namedtuple` returned from the previous
+            Identifies the enumeration session, including its current
+            enumeration state. This must be the value of the `context` item in
+            the :class:`py:namedtuple` object returned from the previous
             open or pull operation for this enumeration.
 
             The tuple items are:
 
-            - server_context (:term:`string`):
+            * server_context (:term:`string`):
               Enumeration context string returned by the server. This
               string is opaque for the client.
-            - namespace (:term:`string`):
+            * namespace (:term:`string`):
               Name of the CIM namespace to be used for this operation.
 
           MaxObjectCount (:class:`~pywbem.Uint32`)
@@ -3094,38 +3192,6 @@ class WBEMConnection(object):
               be used by a client to leave the handling of any returned
               instances to a loop of Pull operations.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instances.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -3134,9 +3200,55 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the next set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -3181,7 +3293,7 @@ class WBEMConnection(object):
         Retrieve the next set of instance paths from an open enumeraton
         session defined by the `enumeration_context` parameter.
 
-        This method performs the PullInstanceWithPath operation
+        This method performs the PullInstancePaths operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
 
@@ -3192,17 +3304,17 @@ class WBEMConnection(object):
         Parameters:
 
           context (:term:`string`)
-            Identifies the enumeraton session, including its current
-            enumeration state. This must be the value of the `context`
-            item in the :class:`py:namedtuple` returned from the previous
+            Identifies the enumeration session, including its current
+            enumeration state. This must be the value of the `context` item in
+            the :class:`py:namedtuple` object returned from the previous
             open or pull operation for this enumeration.
 
             The tuple items are:
 
-            - server_context (:term:`string`):
+            * server_context (:term:`string`):
               Enumeration context string returned by the server. This
               string is opaque for the client.
-            - namespace (:term:`string`):
+            * namespace (:term:`string`):
               Name of the CIM namespace to be used for this operation.
 
           MaxObjectCount (:class:`~pywbem.Uint32`)
@@ -3216,38 +3328,6 @@ class WBEMConnection(object):
               be used by a client to leave the handling of any returned
               instances to a loop of Pull operations.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `paths` (list of :class:`~pywbem.CIMInstanceName`):
-              Representations of the initial set of enumerated instance paths.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -3256,9 +3336,52 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+              Representations of the next set of enumerated instance paths,
+              with their attributes set as follows:
+
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -3302,7 +3425,7 @@ class WBEMConnection(object):
         Retrieve the next set of instances from an open enumeraton
         session defined by the `enumeration_context` parameter.
 
-        This method performs the PullInstanceWithPath operation
+        This method performs the PullInstances operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
         methods performing such operations.
 
@@ -3313,17 +3436,17 @@ class WBEMConnection(object):
         Parameters:
 
           context (:term:`string`)
-            Identifies the enumeraton session, including its current
-            enumeration state. This must be the value of the `context`
-            item in the :class:`py:namedtuple` returned from the previous
+            Identifies the enumeration session, including its current
+            enumeration state. This must be the value of the `context` item in
+            the :class:`py:namedtuple` object returned from the previous
             open or pull operation for this enumeration.
 
             The tuple items are:
 
-            - server_context (:term:`string`):
+            * server_context (:term:`string`):
               Enumeration context string returned by the server. This
               string is opaque for the client.
-            - namespace (:term:`string`):
+            * namespace (:term:`string`):
               Name of the CIM namespace to be used for this operation.
 
           MaxObjectCount (:class:`~pywbem.Uint32`)
@@ -3337,38 +3460,6 @@ class WBEMConnection(object):
               be used by a client to leave the handling of any returned
               instances to a loop of Pull operations.
 
-        Returns:
-
-            A :class:`py:namedtuple` containing the following named elements:
-
-            * `instances` (list of :class:`~pywbem.CIMInstance`):
-              Representations of the initial set of enumerated instances.
-            * `eos` (:class:`py:bool`):
-              Indicates whether the enumeration session is exhausted
-              after returning the initial set of enumerated instances.
-
-              - If `True`, the enumeration session is exhausted, and the
-                server has closed the enumeration session.
-              - If `False`, the enumeration session is not exhausted.
-
-            * `context` (tuple of (server_context, namespace)):
-               Identifies the opened enumeration session. The client must
-               provide this value for subsequent operations on this
-               enumeration session. The tuple items are:
-
-               - server_context (:term:`string`):
-                 Enumeration context string returned by the server if
-                 the session is not exhausted, or `None` otherwise. This string
-                 is opaque for the client.
-               - namespace (:term:`string`):
-                 Name of the CIM namespace that was used for this operation.
-
-               NOTE: This inner tuple hides the need for a CIM namespace
-               on subsequent operations in the enumeration session. CIM
-               operations always require target namespace, but it never
-               makes sense to specify a different one in subsequent
-               operations on the same enumeration session.
-
         Keyword Arguments:
 
           extra :
@@ -3377,9 +3468,49 @@ class WBEMConnection(object):
             Note that :term:`DSP0200` does not define any additional parameters
             for this operation.
 
-        Exceptions:
+        Returns:
 
-            See the list of exceptions described in `WBEMConnection`.
+            A :class:`py:namedtuple` object that contains the following named
+            items:
+
+            * **instances** (list of :class:`~pywbem.CIMInstance`):
+              Representations of the next set of enumerated instances.
+
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is `None`, because this operation does not return instance
+              paths.
+
+            * **eos** (:class:`py:bool`):
+              Indicates whether the enumeration session is exhausted
+              after returning the initial set of enumerated instances.
+
+              - If `True`, the enumeration session is exhausted, and the
+                server has closed the enumeration session.
+              - If `False`, the enumeration session is not exhausted.
+
+            * **context** (:class:`py:tuple` of server_context, namespace):
+              Identifies the opened enumeration session. The client must
+              provide this value for subsequent operations on this
+              enumeration session.
+
+              The tuple items are:
+
+              * server_context (:term:`string`):
+                Enumeration context string returned by the server if
+                the session is not exhausted, or `None` otherwise. This string
+                is opaque for the client.
+              * namespace (:term:`string`):
+                Name of the CIM namespace that was used for this operation.
+
+              NOTE: This inner tuple hides the need for a CIM namespace
+              on subsequent operations in the enumeration session. CIM
+              operations always require target namespace, but it never
+              makes sense to specify a different one in subsequent
+              operations on the same enumeration session.
+
+        Raises:
+
+            Exceptions described in :class:`~pywbem.WBEMConnection`.
         """
 
         if self.operation_recorder:
@@ -3441,6 +3572,14 @@ class WBEMConnection(object):
             response to the previous open or pull operation for this
             enumeration sequence.
 
+        Keyword Arguments:
+
+          extra :
+            Additional keyword arguments are passed as additional operation
+            parameters to the WBEM server.
+            Note that :term:`DSP0200` does not define any additional parameters
+            for this operation.
+
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
@@ -3488,8 +3627,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName): Instance path of the instance to be
-            retrieved.
+          InstanceName (CIMInstanceName):
+            The instance path of the instance to be retrieved.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
           LocalOnly (:class:`py:bool`):
             Controls the exclusion of inherited properties from the returned
@@ -3548,6 +3690,13 @@ class WBEMConnection(object):
 
             A :class:`~pywbem.CIMInstance` object that is a representation of
             the retrieved instance.
+            Its `path` attribute is a :class:`~pywbem.CIMInstanceName` object
+            with its attributes set as follows:
+
+            * `classname`: Name of the creation class of the instance.
+            * `keybindings`: Keybindings of the instance.
+            * `namespace`: Name of the CIM namespace containing the instance.
+            * `host`: `None`, indicating the WBEM server is unspecified.
 
         Raises:
 
@@ -3616,13 +3765,13 @@ class WBEMConnection(object):
             A representation of the modified instance, also indicating its
             instance path.
 
-            The `path` instance variable of this object identifies the instance
-            to be modified. Its keybindings component is required. If its
-            namespace component is `None`, the default namespace of the
-            connection will be used. Its host component will be ignored.
+            The `path` attribute of this object identifies the instance to be
+            modified. Its `keybindings` attribute is required. If its
+            `namespace` attribute is `None`, the default namespace of the
+            connection will be used. Its `host` attribute will be ignored.
 
-            The `classname` component of the path and the `classname` attribute
-            of the instance must specify the same class name.
+            The `classname` attribute of the instance path and the `classname`
+            attribute of the instance must specify the same class name.
 
             The properties defined in this object specify the new property
             values for the instance to be modified. Missing properties
@@ -3731,7 +3880,7 @@ class WBEMConnection(object):
         Otherwise, this method raises an exception.
 
         The creation class for the new instance is taken from the `classname`
-        instance variable of the `NewInstance` parameter.
+        attribute of the `NewInstance` parameter.
 
         The namespace for the new instance is taken from these sources, in
         decreasing order of priority:
@@ -3744,19 +3893,18 @@ class WBEMConnection(object):
         Parameters:
 
           NewInstance (CIMInstance):
-            A representation of the instance to be created.
+            A representation of the CIM instance to be created.
 
-            The `classname` instance variable of this object specifies the
-            creation class for the new instance.
+            The `classname` attribute of this object specifies the creation
+            class for the new instance.
 
-            Apart from utilizing its namespace, the `path` instance variable
-            is ignored.
+            Apart from utilizing its namespace, the `path` attribute is ignored.
 
-            The `properties` instance variable of this object specifies initial
-            property values for the new instance.
+            The `properties` attribute of this object specifies initial
+            property values for the new CIM instance.
 
             Instance-level qualifiers have been deprecated in CIM, so any
-            qualifier values specified using the `qualifiers` instance variable
+            qualifier values specified using the `qualifiers` attribute
             of this object will be ignored.
 
           namespace (:term:`string`):
@@ -3834,8 +3982,11 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName): Instance path of the instance to be
-            deleted.
+          InstanceName (CIMInstanceName):
+            The instance path of the instance to be deleted.
+            If this object does not specify a namespace, the default namespace
+            of the connection is used.
+            Its `host` attribute will be ignored.
 
         Keyword Arguments:
 
@@ -3903,19 +4054,24 @@ class WBEMConnection(object):
         Parameters:
 
           ObjectName:
-            For instance level usage: The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            The object path of the source object, as follows:
 
-            For class level usage: The class path of the source class, as a
-            :term:`string` or :class:`~pywbem.CIMClassName` object.
-            If specified as a string, the string is interpreted as a class name
-            in the default namespace of the connection, and can have any
-            lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object that does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            * For instance level usage: The instance path of the source
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `host` attribute will be ignored.
+
+            * For class level usage: The class path of the source class, as a
+              :term:`string` or :class:`~pywbem.CIMClassName` object:
+
+              If specified as a string, the string is interpreted as a class
+              name in the default namespace of the connection, and can have any
+              lexical case.
+
+              If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+              attribute will be ignored. If this object does not specify
+              a namespace, the default namespace of the connection is used.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -3955,14 +4111,29 @@ class WBEMConnection(object):
 
         Returns:
 
-            Return data depends on `ObjectName` parameter:
+            : The returned list of objects depend on the usage:
 
-            **Instance level usage:** A list of
-            :class:`~pywbem.CIMInstanceName` objects that are the instance
-            paths of the associated instances.
+            * For instance level usage: A list of
+              :class:`~pywbem.CIMInstanceName` objects that are the instance
+              paths of the associated instances, with their attributes set as
+              follows:
 
-            **Class level usage:** A list of :class:`~pywbem.CIMClassName`
-            objects that are the class paths of the associated classes.
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
+
+            * For class level usage: A list of :class:`~pywbem.CIMClassName`
+              objects that are the class paths of the associated classes, with
+              their attributes set as follows:
+
+              * `classname`: Name of the class.
+              * `namespace`: Name of the CIM namespace containing the class.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
 
         Raises:
 
@@ -4031,19 +4202,24 @@ class WBEMConnection(object):
         Parameters:
 
           ObjectName:
-            For instance level usage: The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            The object path of the source object, as follows:
 
-            For class level usage: The class path of the source class, as a
-            :term:`string` or :class:`~pywbem.CIMClassName` object.
-            If specified as a string, the string is interpreted as a class name
-            in the default namespace of the connection, and can have any
-            lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its
-            `namespace` attribute is used; if that is `None`, the default
-            namespace of the connection is used.
+            * For instance level usage: The instance path of the source
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `host` attribute will be ignored.
+
+            * For class level usage: The class path of the source class, as a
+              :term:`string` or :class:`~pywbem.CIMClassName` object:
+
+              If specified as a string, the string is interpreted as a class
+              name in the default namespace of the connection, and can have any
+              lexical case.
+
+              If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+              attribute will be ignored. If this object does not specify
+              a namespace, the default namespace of the connection is used.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -4115,21 +4291,40 @@ class WBEMConnection(object):
 
         Returns:
 
-            Return structure depends on whether class or instance
-            is provided in the `ObjectName` parameter.
+            : The returned list of objects depend on the usage:
 
-            * **Instance level usage**: A list of
-                :class:`~pywbem.CIMInstance` objects that are representations
-                of the associated instances.
+            * For instance level usage: A list of
+              :class:`~pywbem.CIMInstance` objects that are representations
+              of the associated instances.
 
-            * **Class level usage**: `[(classname, class),...]`, a list of
-              tuples where each tuple contains:
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
 
-               *  **classname** (:class:`~pywbem.CIMClassName`): Host
-                  and namespace entities that are the representation of the
-                  name of the associated class.
-               *  **class** (:class:`~pywbem.CIMInstance`): The
-                  representation of the corresponding associated class
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
+
+            * For class level usage: A list of :class:`py:tuple` of
+              (classpath, class) objects that are representations of the
+              associated classes.
+
+              Each tuple represents one class and has these items:
+
+              * classpath (:class:`~pywbem.CIMClassName`): The class
+                path of the class, with its attributes set as follows:
+
+                * `classname`: Name of the class.
+                * `namespace`: Name of the CIM namespace containing the class.
+                * `host`: Host and optionally port of the WBEM server containing
+                  the CIM namespace, or `None` if the server did not return host
+                  information.
+
+              * class (:class:`~pywbem.CIMClass`): The representation of the
+                class.
 
         Raises:
 
@@ -4204,20 +4399,24 @@ class WBEMConnection(object):
         Parameters:
 
           ObjectName:
-            For instance level usage: The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            The object path of the source object, as follows:
 
-            For class level usage: The class path of the source class, as a
-            :term:`string` or :class:`~pywbem.CIMClassName`
-            object.
-            If specified as a string, the string is interpreted as a class name
-            in the default namespace of the connection, and can have any
-            lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its
-            `namespace` attribute is used; if that is `None`, the default
-            namespace of the connection is used.
+            * For instance level usage: The instance path of the source
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `host` attribute will be ignored.
+
+            * For class level usage: The class path of the source class, as a
+              :term:`string` or :class:`~pywbem.CIMClassName` object:
+
+              If specified as a string, the string is interpreted as a class
+              name in the default namespace of the connection, and can have any
+              lexical case.
+
+              If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+              attribute will be ignored. If this object does not specify
+              a namespace, the default namespace of the connection is used.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -4243,15 +4442,29 @@ class WBEMConnection(object):
 
         Returns:
 
-            Return data depends on `ObjectName` parameter:
+            : The returned list of objects depend on the usage:
 
-            **Instance level usage**: A list of
-            :class:`~pywbem.CIMInstanceName` objects that are the instance
-            paths of the referencing association instances.
+            * For instance level usage: A list of
+              :class:`~pywbem.CIMInstanceName` objects that are the instance
+              paths of the referencing association instances, with their
+              attributes set as follows:
 
-            **Class level usage:** A list of :class:`~pywbem.CIMClassName`
-            objects that are the class paths of the referencing association
-            classes.
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
+
+            * For class level usage: A list of :class:`~pywbem.CIMClassName`
+              objects that are the class paths of the referencing association
+              classes, with their attributes set as follows:
+
+              * `classname`: Name of the class.
+              * `namespace`: Name of the CIM namespace containing the class.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
 
         Raises:
 
@@ -4316,20 +4529,24 @@ class WBEMConnection(object):
         Parameters:
 
           ObjectName:
-            For instance level usage: The instance path of the source instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            The object path of the source object, as follows:
 
-            For class level usage: The class path of the source class, as a
-            :term:`string` or :class:`~pywbem.CIMClassName`
-            object.
-            If specified as a string, the string is interpreted as a class name
-            in the default namespace of the connection, and can have any
-            lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its
-            `namespace` attribute is used; if that is `None`, the default
-            namespace of the connection is used.
+            * For instance level usage: The instance path of the source
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `host` attribute will be ignored.
+
+            * For class level usage: The class path of the source class, as a
+              :term:`string` or :class:`~pywbem.CIMClassName` object:
+
+              If specified as a string, the string is interpreted as a class
+              name in the default namespace of the connection, and can have any
+              lexical case.
+
+              If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+              attribute will be ignored. If this object does not specify
+              a namespace, the default namespace of the connection is used.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
             Class name of an association class, in any lexical case,
@@ -4387,21 +4604,40 @@ class WBEMConnection(object):
 
         Returns:
 
-            Return structure depends on whether class or instance
-            is provided in the `ObjectName` parameter.
+            : The returned list of objects depend on the usage:
 
-            * **Instance level usage**: A list of
-                :class:`~pywbem.CIMInstance` objects that are representations
-                of the associated instances.
+            * For instance level usage: A list of
+              :class:`~pywbem.CIMInstance` objects that are representations
+              of the referencing association instances.
 
-            * **Class level usage**: `[(classname, class),..]`, a list of
-              tuples where each tuple contains:
+              The `path` attribute of each :class:`~pywbem.CIMInstance`
+              object is a :class:`~pywbem.CIMInstanceName` object with its
+              attributes set as follows:
 
-               *  **classname** (:class:`~pywbem.CIMClassName`): Host
-                  and namespace entities that are the representation of the
-                  name of the associated class.
-               *  **class** (:class:`~pywbem.CIMInstance`): The
-                  representation of the corresponding associated class
+              * `classname`: Name of the creation class of the instance.
+              * `keybindings`: Keybindings of the instance.
+              * `namespace`: Name of the CIM namespace containing the instance.
+              * `host`: Host and optionally port of the WBEM server containing
+                the CIM namespace, or `None` if the server did not return host
+                information.
+
+            * For class level usage: A list of :class:`py:tuple` of
+              (classpath, class) objects that are representations of the
+              referencing association classes.
+
+              Each tuple represents one class and has these items:
+
+              * classpath (:class:`~pywbem.CIMClassName`): The class
+                path of the class, with its attributes set as follows:
+
+                * `classname`: Name of the class.
+                * `namespace`: Name of the CIM namespace containing the class.
+                * `host`: Host and optionally port of the WBEM server containing
+                  the CIM namespace, or `None` if the server did not return host
+                  information.
+
+              * class (:class:`~pywbem.CIMClass`): The representation of the
+                class.
 
         Raises:
 
@@ -4488,26 +4724,30 @@ class WBEMConnection(object):
             parameter signature), in any lexical case.
 
           ObjectName:
-            For instance level usage: The instance path of the target instance,
-            as a :class:`~pywbem.CIMInstanceName` object. If that object does
-            not specify a namespace, the default namespace of the connection is
-            used.
+            The object path of the target object, as follows:
 
-            For class level usage: The class path of the target class, as a
-            :term:`string` or
-            :class:`~pywbem.CIMClassName` object.
-            If specified as a string, the string is interpreted as a class name
-            in the default namespace of the connection, and can have any
-            lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its
-            `namespace` attribute is used; if that is `None`, the default
-            namespace of the connection is used.
+            * For instance level usage: The instance path of the target
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `host` attribute will be ignored.
+
+            * For class level usage: The class path of the target class, as a
+              :term:`string` or :class:`~pywbem.CIMClassName` object:
+
+              If specified as a string, the string is interpreted as a class
+              name in the default namespace of the connection, and can have any
+              lexical case.
+
+              If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+              attribute will be ignored. If this object does not specify
+              a namespace, the default namespace of the connection is used.
 
           Params (:term:`py:iterable` of tuples of name,value):
             An iterable of input parameters for the CIM method.
 
             Each iterated item represents a single input parameter for the CIM
-            method and must be a `tuple(name, value)`, with:
+            method and must be a ``tuple(name, value)``, with these tuple items:
 
             * name (:term:`string`):
               Parameter name, in any lexical case
@@ -4526,18 +4766,19 @@ class WBEMConnection(object):
 
         Returns:
 
-            `tuple(returnvalue, outparams)`
+            A :class:`py:tuple` of (returnvalue, outparams), with these
+            tuple items:
 
             * returnvalue (:term:`CIM data type`):
               Return value of the CIM method.
-            * outparams (:ref:`NocaseDict`):
+            * outparams (`NocaseDict`_):
               Dictionary with all provided output parameters of the CIM method,
               with:
 
-                * key (:term:`unicode string`):
-                  Parameter name, preserving its lexical case
-                * value (:term:`CIM data type`):
-                  Parameter value
+              * key (:term:`unicode string`):
+                Parameter name, preserving its lexical case
+              * value (:term:`CIM data type`):
+                Parameter value
 
         Raises:
 
@@ -4648,7 +4889,7 @@ class WBEMConnection(object):
             A list of :class:`~pywbem.CIMInstance` objects that represents
             the query result.
 
-            These instances have their `path` instance variable set to identify
+            These instances have their `path` attribute set to identify
             their creation class and the target namespace of the query, but
             they are not addressable instances.
 
@@ -4729,7 +4970,7 @@ class WBEMConnection(object):
             Name of the class whose subclasses are to be retrieved, in any
             lexical case.
             If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            attribute will be ignored.
 
             If `None`, the top-level classes in the namespace will be
             retrieved.
@@ -4839,7 +5080,7 @@ class WBEMConnection(object):
             Name of the class whose subclasses are to be retrieved, in any
             lexical case.
             If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            attribute will be ignored.
 
             If `None`, the top-level classes in the namespace will be
             retrieved.
@@ -4973,8 +5214,8 @@ class WBEMConnection(object):
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be retrieved, in any lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+            attribute will be ignored.
 
           namespace (:term:`string`):
             Name of the namespace of the class to be retrieved, in any lexical
@@ -5178,6 +5419,8 @@ class WBEMConnection(object):
             The properties, methods and qualifiers defined in this object
             specify how the class is to be created.
 
+            Its `path` attribute is ignored.
+
           namespace (:term:`string`):
             Name of the namespace in which the class is to be created, in any
             lexical case.
@@ -5247,8 +5490,8 @@ class WBEMConnection(object):
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class to be deleted, in any lexical case.
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
-            component will be ignored.
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
+            attribute will be ignored.
 
           namespace (:term:`string`):
             Name of the namespace of the class to be deleted, in any lexical

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -146,7 +146,7 @@ pull_inst_result_tuple = namedtuple("pull_inst_result_tuple",
 # openqueryInstances and PullInstance responses
 pull_query_result_tuple = namedtuple("pull_query_result_tuple",
                                      ["instances", "eos", "context",
-                                      "query_class"])
+                                      "query_result_class"])
 
 # unicode test to set illegal xml char constant
 if len(u'\U00010122') == 2:
@@ -1215,12 +1215,12 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be enumerated, in any lexical case.
+            Name of the class to be enumerated (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -1309,12 +1309,12 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be enumerated, in any lexical case.
+            Name of the class to be enumerated (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -1375,7 +1375,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be
-            included in the returned instances, in any lexical case.
+            included in the returned instances (case independent).
 
             An empty iterable indicates to include no properties.
 
@@ -1531,14 +1531,14 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be enumerated, in any lexical case.
+            Name of the class to be enumerated (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its
             `namespace` attribute will be used as a default namespace as
             described for the `namespace` parameter, and its `host` attribute
             will be ignored.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -1614,10 +1614,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+            * **paths** (:class:`py:list` of :class:`~pywbem.CIMInstanceName`):
               Representations of the initial set of enumerated instance paths,
               with their attributes set as follows:
 
@@ -1734,14 +1734,14 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be enumerated, in any lexical case.
+            Name of the class to be enumerated (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its
             `namespace` attribute will be used as a default namespace as
             described for the `namespace` parameter, and its `host` attribute
             will be ignored.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -1802,7 +1802,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be
-            included in the returned instances, in any lexical case.
+            included in the returned instances (case independent).
 
             An empty iterable indicates to include no properties.
 
@@ -1874,10 +1874,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the initial set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -2007,23 +2007,23 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the source instance.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
             Its `host` attribute will be ignored.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -2096,10 +2096,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+            * **paths** (:class:`py:list` of :class:`~pywbem.CIMInstanceName`):
               Representations of the initial set of enumerated instance paths,
               with their attributes set as follows:
 
@@ -2218,23 +2218,23 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the source instance.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
             Its `host` attribute will be ignored.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -2265,7 +2265,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be included
-            in the returned instances (or classes), in any lexical case.
+            in the returned instances (or classes) (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -2336,10 +2336,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the initial set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -2468,37 +2468,37 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the source instance.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
             Its `host` attribute will be ignored.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an associated class, in any lexical case,
+            Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
           ResultRole (:term:`string`):
-            Role name (= property name) of the far end, in any
-            lexical case, to filter the result to include only traversals to
-            that far role.
+            Role name (= property name) of the far end (case independent),
+            to filter the result to include only traversals to that far
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -2572,10 +2572,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+            * **paths** (:class:`py:list` of :class:`~pywbem.CIMInstanceName`):
               Representations of the initial set of enumerated instance paths,
               with their attributes set as follows:
 
@@ -2701,37 +2701,37 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the source instance.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
             Its `host` attribute will be ignored.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an associated class, in any lexical case,
+            Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
           ResultRole (:term:`string`):
-            Role name (= property name) of the far end, in any
-            lexical case, to filter the result to include only traversals to
-            that far role.
+            Role name (= property name) of the far end (case independent),
+            to filter the result to include only traversals to that far
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -2762,7 +2762,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be included
-            in the returned instances (or classes), in any lexical case.
+            in the returned instances (or classes) (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -2833,10 +2833,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the initial set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -2975,7 +2975,7 @@ class WBEMConnection(object):
             parameter.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -3039,10 +3039,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the initial set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -3077,7 +3077,7 @@ class WBEMConnection(object):
               makes sense to specify a different one in subsequent
               operations on the same enumeration session.
 
-            * **query_class** (:class:`~pywbem.CIMClass`):
+            * **query_result_class** (:class:`~pywbem.CIMClass`):
               If the `ReturnQueryResultClass` parameter is True, this tuple
               item contains a class definition that defines the properties
               of each row (instance) of the query result. Otherwise, `None`.
@@ -3130,11 +3130,11 @@ class WBEMConnection(object):
 
             insts, eos, enum_ctxt = self._get_rslt_params(result, namespace)
 
-            query_class = _GetQueryRsltClass(result) if \
-                              ReturnQueryResultClass else None
+            query_result_class = _GetQueryRsltClass(result) if \
+                                 ReturnQueryResultClass else None
 
             result_tuple = pull_query_result_tuple(insts, eos, enum_ctxt,
-                                                   query_class)
+                                                   query_result_class)
 
         except Exception as exc:
             if self.operation_recorder:
@@ -3202,10 +3202,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the next set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -3338,10 +3338,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **paths** (list of :class:`~pywbem.CIMInstanceName`):
+            * **paths** (:class:`py:list of` :class:`~pywbem.CIMInstanceName`):
               Representations of the next set of enumerated instance paths,
               with their attributes set as follows:
 
@@ -3470,10 +3470,10 @@ class WBEMConnection(object):
 
         Returns:
 
-            A :class:`py:namedtuple` object that contains the following named
+            A :class:`py:namedtuple` object containing the following named
             items:
 
-            * **instances** (list of :class:`~pywbem.CIMInstance`):
+            * **instances** (:class:`py:list` of :class:`~pywbem.CIMInstance`):
               Representations of the next set of enumerated instances.
 
               The `path` attribute of each :class:`~pywbem.CIMInstance`
@@ -3627,7 +3627,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the instance to be retrieved.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
@@ -3673,7 +3673,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be
-            included in the returned instance, in any lexical case.
+            included in the returned instance (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -3761,7 +3761,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          ModifiedInstance (CIMInstance):
+          ModifiedInstance (:class:`~pywbem.CIMInstance`):
             A representation of the modified instance, also indicating its
             instance path.
 
@@ -3797,7 +3797,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be
-            modified, in any lexical case.
+            modified (case independent).
 
             An empty iterable indicates to modify no properties.
 
@@ -3892,7 +3892,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          NewInstance (CIMInstance):
+          NewInstance (:class:`~pywbem.CIMInstance`):
             A representation of the CIM instance to be created.
 
             The `classname` attribute of this object specifies the creation
@@ -3908,7 +3908,7 @@ class WBEMConnection(object):
             of this object will be ignored.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
         Keyword Arguments:
 
@@ -3982,7 +3982,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          InstanceName (CIMInstanceName):
+          InstanceName (:class:`~pywbem.CIMInstanceName`):
             The instance path of the instance to be deleted.
             If this object does not specify a namespace, the default namespace
             of the connection is used.
@@ -4056,48 +4056,48 @@ class WBEMConnection(object):
           ObjectName:
             The object path of the source object, as follows:
 
-            * For instance level usage: The instance path of the source
+            * For instance-level usage: The instance path of the source
               instance, as a :class:`~pywbem.CIMInstanceName` object.
               If this object does not specify a namespace, the default namespace
               of the connection is used.
               Its `host` attribute will be ignored.
 
-            * For class level usage: The class path of the source class, as a
+            * For class-level usage: The class path of the source class, as a
               :term:`string` or :class:`~pywbem.CIMClassName` object:
 
               If specified as a string, the string is interpreted as a class
-              name in the default namespace of the connection, and can have any
-              lexical case.
+              name in the default namespace of the connection
+              (case independent).
 
               If specified as a :class:`~pywbem.CIMClassName` object, its `host`
               attribute will be ignored. If this object does not specify
               a namespace, the default namespace of the connection is used.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an associated class, in any lexical case,
+            Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
           ResultRole (:term:`string`):
-            Role name (= property name) of the far end, in any
-            lexical case, to filter the result to include only traversals to
-            that far role.
+            Role name (= property name) of the far end (case independent),
+            to filter the result to include only traversals to that far
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -4113,7 +4113,7 @@ class WBEMConnection(object):
 
             : The returned list of objects depend on the usage:
 
-            * For instance level usage: A list of
+            * For instance-level usage: A list of
               :class:`~pywbem.CIMInstanceName` objects that are the instance
               paths of the associated instances, with their attributes set as
               follows:
@@ -4125,7 +4125,7 @@ class WBEMConnection(object):
                 the CIM namespace, or `None` if the server did not return host
                 information.
 
-            * For class level usage: A list of :class:`~pywbem.CIMClassName`
+            * For class-level usage: A list of :class:`~pywbem.CIMClassName`
               objects that are the class paths of the associated classes, with
               their attributes set as follows:
 
@@ -4204,48 +4204,48 @@ class WBEMConnection(object):
           ObjectName:
             The object path of the source object, as follows:
 
-            * For instance level usage: The instance path of the source
+            * For instance-level usage: The instance path of the source
               instance, as a :class:`~pywbem.CIMInstanceName` object.
               If this object does not specify a namespace, the default namespace
               of the connection is used.
               Its `host` attribute will be ignored.
 
-            * For class level usage: The class path of the source class, as a
+            * For class-level usage: The class path of the source class, as a
               :term:`string` or :class:`~pywbem.CIMClassName` object:
 
               If specified as a string, the string is interpreted as a class
-              name in the default namespace of the connection, and can have any
-              lexical case.
+              name in the default namespace of the connection
+              (case independent).
 
               If specified as a :class:`~pywbem.CIMClassName` object, its `host`
               attribute will be ignored. If this object does not specify
               a namespace, the default namespace of the connection is used.
 
           AssocClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an associated class, in any lexical case,
+            Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
           ResultRole (:term:`string`):
-            Role name (= property name) of the far end, in any
-            lexical case, to filter the result to include only traversals to
-            that far role.
+            Role name (= property name) of the far end (case independent),
+            to filter the result to include only traversals to that far
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -4276,7 +4276,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be included
-            in the returned instances (or classes), in any lexical case.
+            in the returned instances (or classes) (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -4293,7 +4293,7 @@ class WBEMConnection(object):
 
             : The returned list of objects depend on the usage:
 
-            * For instance level usage: A list of
+            * For instance-level usage: A list of
               :class:`~pywbem.CIMInstance` objects that are representations
               of the associated instances.
 
@@ -4308,7 +4308,7 @@ class WBEMConnection(object):
                 the CIM namespace, or `None` if the server did not return host
                 information.
 
-            * For class level usage: A list of :class:`py:tuple` of
+            * For class-level usage: A list of :class:`py:tuple` of
               (classpath, class) objects that are representations of the
               associated classes.
 
@@ -4401,34 +4401,34 @@ class WBEMConnection(object):
           ObjectName:
             The object path of the source object, as follows:
 
-            * For instance level usage: The instance path of the source
+            * For instance-level usage: The instance path of the source
               instance, as a :class:`~pywbem.CIMInstanceName` object.
               If this object does not specify a namespace, the default namespace
               of the connection is used.
               Its `host` attribute will be ignored.
 
-            * For class level usage: The class path of the source class, as a
+            * For class-level usage: The class path of the source class, as a
               :term:`string` or :class:`~pywbem.CIMClassName` object:
 
               If specified as a string, the string is interpreted as a class
-              name in the default namespace of the connection, and can have any
-              lexical case.
+              name in the default namespace of the connection
+              (case independent).
 
               If specified as a :class:`~pywbem.CIMClassName` object, its `host`
               attribute will be ignored. If this object does not specify
               a namespace, the default namespace of the connection is used.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -4444,7 +4444,7 @@ class WBEMConnection(object):
 
             : The returned list of objects depend on the usage:
 
-            * For instance level usage: A list of
+            * For instance-level usage: A list of
               :class:`~pywbem.CIMInstanceName` objects that are the instance
               paths of the referencing association instances, with their
               attributes set as follows:
@@ -4456,7 +4456,7 @@ class WBEMConnection(object):
                 the CIM namespace, or `None` if the server did not return host
                 information.
 
-            * For class level usage: A list of :class:`~pywbem.CIMClassName`
+            * For class-level usage: A list of :class:`~pywbem.CIMClassName`
               objects that are the class paths of the referencing association
               classes, with their attributes set as follows:
 
@@ -4531,34 +4531,34 @@ class WBEMConnection(object):
           ObjectName:
             The object path of the source object, as follows:
 
-            * For instance level usage: The instance path of the source
+            * For instance-level usage: The instance path of the source
               instance, as a :class:`~pywbem.CIMInstanceName` object.
               If this object does not specify a namespace, the default namespace
               of the connection is used.
               Its `host` attribute will be ignored.
 
-            * For class level usage: The class path of the source class, as a
+            * For class-level usage: The class path of the source class, as a
               :term:`string` or :class:`~pywbem.CIMClassName` object:
 
               If specified as a string, the string is interpreted as a class
-              name in the default namespace of the connection, and can have any
-              lexical case.
+              name in the default namespace of the connection
+              (case independent).
 
               If specified as a :class:`~pywbem.CIMClassName` object, its `host`
               attribute will be ignored. If this object does not specify
               a namespace, the default namespace of the connection is used.
 
           ResultClass (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Class name of an association class, in any lexical case,
+            Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
 
             `None` means that no such filtering is peformed.
 
           Role (:term:`string`):
-            Role name (= property name) of the source end, in any
-            lexical case, to filter the result to include only traversals from
-            that source role.
+            Role name (= property name) of the source end (case independent),
+            to filter the result to include only traversals from that source
+            role.
 
             `None` means that no such filtering is peformed.
 
@@ -4589,7 +4589,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be included
-            in the returned instances (or classes), in any lexical case.
+            in the returned instances (or classes) (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -4606,7 +4606,7 @@ class WBEMConnection(object):
 
             : The returned list of objects depend on the usage:
 
-            * For instance level usage: A list of
+            * For instance-level usage: A list of
               :class:`~pywbem.CIMInstance` objects that are representations
               of the referencing association instances.
 
@@ -4621,7 +4621,7 @@ class WBEMConnection(object):
                 the CIM namespace, or `None` if the server did not return host
                 information.
 
-            * For class level usage: A list of :class:`py:tuple` of
+            * For class-level usage: A list of :class:`py:tuple` of
               (classpath, class) objects that are representations of the
               referencing association classes.
 
@@ -4720,24 +4720,23 @@ class WBEMConnection(object):
         Parameters:
 
           MethodName (:term:`string`):
-            Name of the method to be invoked (without parenthesis or any
-            parameter signature), in any lexical case.
+            Name of the method to be invoked (case independent).
 
           ObjectName:
             The object path of the target object, as follows:
 
-            * For instance level usage: The instance path of the target
+            * For instance-level usage: The instance path of the target
               instance, as a :class:`~pywbem.CIMInstanceName` object.
               If this object does not specify a namespace, the default namespace
               of the connection is used.
               Its `host` attribute will be ignored.
 
-            * For class level usage: The class path of the target class, as a
+            * For class-level usage: The class path of the target class, as a
               :term:`string` or :class:`~pywbem.CIMClassName` object:
 
               If specified as a string, the string is interpreted as a class
-              name in the default namespace of the connection, and can have any
-              lexical case.
+              name in the default namespace of the connection
+              (case independent).
 
               If specified as a :class:`~pywbem.CIMClassName` object, its `host`
               attribute will be ignored. If this object does not specify
@@ -4750,7 +4749,7 @@ class WBEMConnection(object):
             method and must be a ``tuple(name, value)``, with these tuple items:
 
             * name (:term:`string`):
-              Parameter name, in any lexical case
+              Parameter name (case independent)
             * value (:term:`CIM data type`):
               Parameter value
 
@@ -4760,7 +4759,7 @@ class WBEMConnection(object):
             CIM method, with:
 
             * key (:term:`string`):
-              Parameter name, in any lexical case
+              Parameter name (case independent)
             * value (:term:`CIM data type`):
               Parameter value
 
@@ -4871,7 +4870,7 @@ class WBEMConnection(object):
             parameter.
 
           namespace (:term:`string`):
-            Name of the CIM namespace to be used, in any lexical case.
+            Name of the CIM namespace to be used (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -4960,15 +4959,15 @@ class WBEMConnection(object):
 
           namespace (:term:`string`):
             Name of the namespace in which the class names are to be
-            enumerated, in any lexical case.
+            enumerated (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
             also `None`, the default namespace of the connection will be used.
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class whose subclasses are to be retrieved, in any
-            lexical case.
+            Name of the class whose subclasses are to be retrieved
+            (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its host
             attribute will be ignored.
 
@@ -5069,16 +5068,16 @@ class WBEMConnection(object):
         Parameters:
 
           namespace (:term:`string`):
-            Name of the namespace in which the classes are to be enumerated, in
-            any lexical case.
+            Name of the namespace in which the classes are to be enumerated
+            (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
             also `None`, the default namespace of the connection will be used.
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class whose subclasses are to be retrieved, in any
-            lexical case.
+            Name of the class whose subclasses are to be retrieved
+            (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its host
             attribute will be ignored.
 
@@ -5213,13 +5212,13 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be retrieved, in any lexical case.
+            Name of the class to be retrieved (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
           namespace (:term:`string`):
-            Name of the namespace of the class to be retrieved, in any lexical
-            case.
+            Name of the namespace of the class to be retrieved
+            (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -5257,7 +5256,7 @@ class WBEMConnection(object):
 
           PropertyList (:term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties to be included
-            in the returned class, in any lexical case.
+            in the returned class (case independent).
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -5337,7 +5336,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          ModifiedClass (CIMClass):
+          ModifiedClass (:class:`~pywbem.CIMClass`):
             A representation of the modified class.
 
             The properties, methods and qualifiers defined in this object
@@ -5347,8 +5346,8 @@ class WBEMConnection(object):
             as :meth:`~pywbem.WBEMConnection.GetClass`.
 
           namespace (:term:`string`):
-            Name of the namespace in which the class is to be modified, in any
-            lexical case.
+            Name of the namespace in which the class is to be modified
+            (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5413,7 +5412,7 @@ class WBEMConnection(object):
 
         Parameters:
 
-          NewClass (CIMClass):
+          NewClass (:class:`~pywbem.CIMClass`):
             A representation of the class to be created.
 
             The properties, methods and qualifiers defined in this object
@@ -5422,8 +5421,8 @@ class WBEMConnection(object):
             Its `path` attribute is ignored.
 
           namespace (:term:`string`):
-            Name of the namespace in which the class is to be created, in any
-            lexical case.
+            Name of the namespace in which the class is to be created
+            (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5489,13 +5488,13 @@ class WBEMConnection(object):
         Parameters:
 
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
-            Name of the class to be deleted, in any lexical case.
+            Name of the class to be deleted (case independent).
             If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
           namespace (:term:`string`):
-            Name of the namespace of the class to be deleted, in any lexical
-            case.
+            Name of the namespace of the class to be deleted
+            (case independent).
 
             If `None`, the namespace of the `ClassName` parameter will be used,
             if specified as a :class:`~pywbem.CIMClassName` object. If that is
@@ -5567,7 +5566,7 @@ class WBEMConnection(object):
 
           namespace (:term:`string`):
             Name of the namespace in which the qualifier declarations are to be
-            enumerated, in any lexical case.
+            enumerated (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5638,12 +5637,12 @@ class WBEMConnection(object):
         Parameters:
 
           QualifierName (:term:`string`):
-            Name of the qualifier declaration to be retrieved, in any lexical
-            case.
+            Name of the qualifier declaration to be retrieved
+            (case independent).
 
           namespace (:term:`string`):
-            Name of the namespace of the qualifier declaration, in any lexical
-            case.
+            Name of the namespace of the qualifier declaration
+            (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5720,7 +5719,7 @@ class WBEMConnection(object):
 
           namespace (:term:`string`):
             Name of the namespace in which the qualifier declaration is to be
-            created or modified, in any lexical case.
+            created or modified (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5783,12 +5782,11 @@ class WBEMConnection(object):
         Parameters:
 
           QualifierName (:term:`string`):
-            Name of the qualifier declaration to be deleted, in any lexical
-            case.
+            Name of the qualifier declaration to be deleted (case independent).
 
           namespace (:term:`string`):
             Name of the namespace in which the qualifier declaration is to be
-            deleted, in any lexical case.
+            deleted (case independent).
 
             If `None`, the default namespace of the connection object will be
             used.
@@ -5846,10 +5844,10 @@ def is_subclass(ch, ns, super_class, sub):
         :class:`~pywbem.WBEMConnection` object.
 
       ns (:term:`string`):
-        Namespace, in any lexical case.
+        Namespace (case independent).
 
       super_class (:term:`string`):
-        Super class name, in any lexical case.
+        Super class name (case independent).
 
       sub:
         The subclass.  This can either be a string or a

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -233,7 +233,7 @@ class MinutesFromUTC(tzinfo):
         to deal with it.
 
         This implementation returns the offset used to initialize the object,
-        for any specified `dt` argument.
+        for any specified `dt` parameter.
         """
         return self.__offset
 
@@ -247,7 +247,7 @@ class MinutesFromUTC(tzinfo):
         pywbem user normally does not have to deal with it.
 
         This implementation returns an offset of 0 (indicating that DST is not
-        in effect), for any specified `dt` argument, because CIM datetime
+        in effect), for any specified `dt` parameter, because CIM datetime
         values do not represent DST information.
         """
         return timedelta(0)

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -63,9 +63,9 @@ class CIMError(Error):
     This exception indicates that the WBEM server returned an error response
     with a CIM status code. Derived from :exc:`~pywbem.Error`.
 
-    The `args` instance variable is a `tuple(status_code, status_description)`.
+    The `args` attribute is a `tuple(status_code, status_description)`.
 
-    The `message` instance variable is not set.
+    The `message` attribute is not set.
     """
 
     @property

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -330,8 +330,8 @@ def p_mofProduction(p):
 
 
 def _create_ns(p, handle, ns):
-    """Create a namespace in the target connection based on the handle
-       and ns arguments.
+    """Create a namespace in the target connection based on the `handle`
+       and `ns` parameters.
     """
 
     # Figure out the flavor of cim server
@@ -1208,8 +1208,9 @@ def p_qualifierDeclaration(p):
         scopes=scopes, **flavors)
 
 def _build_flavors(flist, qualdecl=None):
-    """Build and return a dictionary defining the flavors from the
-       flist argument
+    """
+    Build and return a dictionary defining the flavors from the `flist`
+    parameter.
     """
 
     flavors = {}
@@ -1706,7 +1707,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         self.classes = {}
         self.compile_ordered_classnames = []
         if conn is None:
-            # This instance variable is used only to make get/set
+            # This attribute is used only to make get/set
             # of 'default_namespace' behave as it should, in the case
             # of conn=None.
             self.__default_namespace = 'root/cimv2'
@@ -1949,7 +1950,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
 
 
 def _print_logger(msg):
-    """Print the msg argument to stdout."""
+    """Print the `msg` parameter to stdout."""
     print(msg)
 
 


### PR DESCRIPTION
Ready to be merged. Please review.

This one ended up to cover more than originally was intended.

Details, from the commit log:

There are these code (=non-docu) changes:

- Changed name of namedtuple item 'QueryResultClass' in result of `OpenQueryInstances()` to 'query_class'.
- Made `DEFAULT_CA_CERT_PATHS` constant in `cim_http` module public and documented it. It was referenced in the description of `WBEMConnection()`.

The rest are docu-only changes:

- Added missing information about paths in returned objects to all operations (it was missing in most of them). This was the actual reason for this change.
- Added missing information about paths in input objects in all operations (it was missing in only a few).
- Fixed incorrect description of `host` attribute of `CIMInstanceName` and `CIMClassName` which stated to be the WBEM server URL, to be just `host[:port]` instead.
- Fixed the format of return value descriptions to avoid "Result Type:" section in generated documentation. This sometimes could be achieved by certain words in the first sentence, but in two cases that was not sufficient and I discovered that inserting ": " before the first line did the trick.
- Fixed the format of exception descriptions to use "Raises:" instead of "Exceptions:" because the latter was not recognized by Sphinx as a valid alias to "Raises".
- Fixed documentation for `Pull*()` methods to return *next* set of items and not *initial* set of items.
- Made sure all pulled association methods state that they cannot be used to retrieve classes and made these statements consistent.
- Added statements in descriptions of CIM objects as to which attributes are guaranteed to never be `None`.
- Made statements about `extra` keyword argument consistent in all ops. w.r.t. wording and position.
- Swapped real descriptions and references to details between instance variables and ctor args, in all CIM object classes.
- Made terminology consistent between 'argument' vs. 'parameter'; used 'attribute' in place of 'instance variable' or 'component'.
- Fixed incorrect use of 'named argument' to become 'positional argument'.