### PR TITLE
Fixes #402: Modify compiler to separate class properties from instance properties

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -297,6 +297,16 @@ Bug fixes
 * WBEMServer.interop_ns now contains the returned interop namespace name,
   if possible, instead of the attempted one.
 
+* Fix issue where mof_compiler was setting values for compile of instances into
+  the class object and also setting the values for the last compiled instance
+  in a compile unit into all other compiled instances for the same class. Since
+  the concept of compiling a path into compiled instances is flawed (there is
+  no requirement to include all properties into a instance to compile that code
+  was removed so that the path is NOT build into a compiled instance. Finally
+  the qualifiers from the class were also included in compiled instances which
+  was incorrect and an accident of the code.  They are no longer included into
+  the compiled instances.)  (issue # 402)
+
 
 pywbem v0.8.2
 -------------

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -1,40 +1,88 @@
 usage: mof_compiler [options] moffile ...
 
-Compile MOF files, and update the repository of a WBEM server with the result.
+Compile MOF files, and update a namespace in a WBEM server with the result.
 
 Positional arguments:
   moffile               Path name of the MOF file to be compiled.
                         Can be specified multiple times.
 
 Server related options:
-  Specify the WBEM server and namespace
+  Specify the WBEM server and namespace the MOF compiler works against, for
+  looking up existing elements, and for applying the MOF compilation results
+  to.
 
-  -u url, --url url     URL of the WBEM server.
-                        Default: /var/run/tog-pegasus/cimxml.socket
+  -s url, --server url  Host name or URL of the WBEM server (required),
+                        in this format:
+                            [scheme://]host[:port]
+                        - scheme: Defines the protocol to use:
+                            - "https" for HTTPS protocol
+                            - "http" for HTTP protocol
+                          Default: "https".
+                        - host: Defines host name as follows:
+                             - short or fully qualified DNS hostname
+                             - literal IPV4 address(dotted)
+                             - literal IPV6 address (RFC 3986) with zone
+                               identifier extensions(RFC 6874)
+                               supporting "-" or %25 for the delimiter
+                        - port: Defines the WBEM server port to be used.
+                          Defaults:
+                             - 5988, when using HTTP
+                             - 5989, whenusing HTTPS
   -n namespace, --namespace namespace
-                        Namespace in the WBEM server to work against
-                        (required)
-  -l username, --username username
-                        Username for authenticating with the WBEM server.
-                        Default: No username
+                        Namespace in the WBEM server.
+                        Default: root/cimv2
+
+Connection security related options:
+  Specify user name and password or certificates and keys
+
+  -u user, --user user  User name for authenticating with the WBEM server.
+                        Default: No user name.
   -p password, --password password
                         Password for authenticating with the WBEM server.
-                        Default: No password
+                        Default: Will be prompted for, if user name
+                        specified.
+  -nvc, --no-verify-cert
+                        Client will not verify certificate returned by the
+                        WBEM server (see cacerts). This bypasses the client-
+                        side verification of the server identity, but allows
+                        encrypted communication with a server for which the
+                        client does not have certificates.
+  --cacerts cacerts     File or directory containing certificates that will be
+                        matched against a certificate received from the WBEM
+                        server. Set the --no-verify-cert option to bypass
+                        client verification of the WBEM server certificate.
+                        Default: Searches for matching certificates in the
+                        following system directories:
+                        /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+                        /etc/ssl/certs
+                        /etc/ssl/certificates
+  --certfile certfile   Client certificate file for authenticating with the
+                        WBEM server. If option specified the client attempts
+                        to execute mutual authentication.
+                        Default: Simple authentication.
+  --keyfile keyfile     Client private key file for authenticating with the
+                        WBEM server. Not required if private key is part of the
+                        certfile option. Not allowed if no certfile option.
+                        Default: No client key file. Client private key should
+                        then be part  of the certfile
 
 Action related options:
-  Specify actions against the repository. Default: create/update elements.
+  Specify actions against the WBEM server's namespace. Default:
+  Create/update elements.
 
-  -r, --remove          Remove elements (found in the MOF files) from the
-                        repository, instead of creating or updating them
-  -d, --dry-run         Don't actually modify the repository, just check MOF
-                        syntax. Connection to WBEM server is still required to
-                        check qualifiers.
+  -r, --remove          Remove elements (found in the MOF files) from the WBEM
+                        server's namespace, instead of creating or updating
+                        them
+  -d, --dry-run         Don't actually modify the WBEM server's namespace,
+                        just check MOF syntax. Connection to WBEM server is
+                        still required to check qualifiers.
 
 General options:
-  -s dir, --search dir  Path name of an additional search directory for MOF
-                        include files. Can be specified multiple times.
+  -I dir, --include dir
+                        Path name of a MOF include directory. Can be specified
+                        multiple times.
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Example: mof_compiler CIM_Schema_2.45.mof -u https://localhost:15989 -n
-root/cimv2 -l sheldon -p penny42
+Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost:15989 -n
+root/cimv2 -u sheldon -p penny42

--- a/testsuite/testmofs/test_instance.mof
+++ b/testsuite/testmofs/test_instance.mof
@@ -1,0 +1,49 @@
+// A class with all CIM data types
+
+#pragma include ("qualifiers.mof")
+
+#pragma include("test_types.mof")
+
+
+// TODO: Uncomment this to work on issues with instance MOF
+instance of EX_AllTypes as $inner
+{
+    k1 = 9921;
+    k2 = "SampleLabelInner";
+    pui8  = 0;
+    pui16 = 0;
+    pui32 = 0;
+    pui64 = 0;
+    psi8  = +127;
+    psi16 = +32767;
+    psi32 = +2147483647;
+    psi64 = +9223372036854775807;
+    ps    = "abcdefg";
+    pc    = 'a';
+    pb    = false;
+    pdt   = "01234567061213.123456:000";
+    peo   = Null;
+    pei   = Null;
+};
+
+instance of EX_AllTypes as $outer
+{
+    k1 = 9922;
+    k2 = "SampleLabelOuter";
+    pui8  = 255;
+    pui16 = 65535;
+    pui32 = 4294967295;
+    pui64 = 18446744073709551615;
+    psi8  = -128;
+    psi16 = -32768;
+    psi32 = -2147483648;
+    psi64 = -9223372036854775808;
+    ps    = "abcdefg";
+    pc    = 'a';
+    pb    = true;
+    pdt   = "20160409061213.123456+120";
+//    peo   = $inner;
+//    pei   = $inner;
+};
+
+

--- a/testsuite/testmofs/test_types.mof
+++ b/testsuite/testmofs/test_types.mof
@@ -4,64 +4,22 @@
 
 class EX_AllTypes
 {
-	[key] uint32 k1;
-	[key] string k2;
-	uint8  pui8;
-	uint16 pui16;
-	uint32 pui32;
-	uint64 pui64;
-	sint8  psi8;
-	sint16 psi16;
-	sint32 psi32;
-	sint64 psi64;
-	string ps;
-	char16 pc;
-	boolean pb;
-	datetime pdt;
-	[embeddedobject] string peo;
-	[embeddedinstance("EX_AllTypes")] string pei;
+    [key] uint32 k1;
+    [key] string k2;
+    uint8  pui8;
+    uint16 pui16;
+    uint32 pui32;
+    uint64 pui64;
+    sint8  psi8;
+    sint16 psi16;
+    sint32 psi32;
+    sint64 psi64;
+    string ps;
+    char16 pc;
+    boolean pb;
+    datetime pdt;
+    [embeddedobject] string peo;
+    [embeddedinstance("EX_AllTypes")] string pei;
 };
 
-/*
-// TODO: Uncomment this to work on issues with instance MOF
-instance of EX_AllTypes as $inner
-{
-	k1 = 9921;
-	k2 = "SampleLabel";
-	pui8  = 0;
-	pui16 = 0;
-	pui32 = 0;
-	pui64 = 0;
-	psi8  = +127;
-	psi16 = +32767;
-	psi32 = +2147483647;
-	psi64 = +9223372036854775807;
-	ps    = "abcdefg";
-	pc    = 'a';
-	pb    = false;
-	pdt   = "01234567061213.123456:000";
-	peo   = Null;
-	pei   = Null;
-};
 
-instance of EX_AllTypes as $outer
-{
-	k1 = 9922;
-	k2 = "SampleLabel";
-	pui8  = 255;
-	pui16 = 65535;
-	pui32 = 4294967295;
-	pui64 = 18446744073709551615;
-	psi8  = -128;
-	psi16 = -32768;
-	psi32 = -2147483648;
-	psi64 = -9223372036854775808;
-	ps    = "abcdefg";
-	pc    = 'a';
-	pb    = true;
-	pdt   = "20160409061213.123456+120";
-	peo   = $inner;
-	pei   = $inner;
-};
-
-*/


### PR DESCRIPTION
Issues agreed on I hope and fixed. **Ready For Review** with update 2 July morning.

When instances were created by the compiler, it got information from the
corresponding class but put the instance property values into the class
itself since the compiler was not copying the properties from the class to the instance.
Separated these so the instance properties go into the instance. This means:

1. We are not trashing the class when we do an instance compile.
2. Each instance receives its own properties if compiling more than one instance. Before the property values for the last instance compiled went into all instances and the class.
3. Originally it build instances with all properties from the class and included whatever value was in the class itself. Now only properties defined in the mof instance definition are put into the new instance.
4. Originally all the qualifiers from the class properties were seen in the instance properties.  Now we do not copy qualifiers so the instance created has only qualifiers that it may set.

Note: Removed the instances from TestTypes.mof to keep it a pure class test since that already
exists as a unit test and  set them into new class TestInstance.mof.

Added test mof TestInstance.mof for create instances.  This is based on the class used in the
TestType.mof file using a pragma to copy the class into a new TestInstance.mof file.   

The embedded instance properties in the instances are commented out because there is still an issue with those properties (see issue #147) (testing for 147 is where I found this issue this morning)

**DISCUSSION:** There are two issues for discussion:

1. Should we be moving the class-level property qualifiers to the instance properties.  Proposal NO.
**CONCLUSION:**  2 jul We agreed that we should not be putting class qualifiers into Instances.

2. The last lines of the instance mof builder in the compiler tries to build a path using the qualifiers
in the instance mof;  no key qualifier, therefore, no  property values assigned to path.  The question is whether we should even be trying to create the path part of the  instance mof-compile.
**CONCLUSION:** 2 jul We agreed that we should not try to build path

Since this was completely broken before this change. We blew up the class mof in trying to create the instance mof,  I would guess we are free to do what is right. There is no guarantee when you build instance mof that there are all the properties to build the path so I think that building the
path is illogical and we should just remove that code and document that.

