### PR TITLE
Fixes #375: Missing indications

### DIFF
--- a/examples/listen.py
+++ b/examples/listen.py
@@ -18,9 +18,15 @@ import pywbem
 # For creating a self-signed certificate file with private key inside, issue:
 #    openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes
 
+COUNT = 1
+
+
 def _process_indication(indication, host):
     '''This function gets called when an indication is received.'''
-    print("Received indication from %s:\n%s" % (host, indication.tomof()))
+    global COUNT
+    print("Received indication %s from %s:\n%s" % (COUNT, host,
+                                                   indication.tomof()))
+    COUNT += 1
 
 def _get_argv(index, default=None):
     return _sys.argv[index] if len(_sys.argv) > index else default

--- a/examples/send_indication.sh
+++ b/examples/send_indication.sh
@@ -1,49 +1,128 @@
 #!/bin/bash
-# Send an indication to a local WBEM listener
+# Send  indications to a WBEM listener. 
+# See USAGE for cmd line parameter details.  
 
 # To use HTTPS, create a self-signed certificate with private key:
 #   openssl req -new -x509 -keyout tmp.pem -out tmp.pem -days 365 -nodes
 
 # To start the WBEM listener, use, in a different terminal session:
-#   PYTHONPATH=. examples/listen.py 127.0.0.1 5000 5001 tmp.pem tmp.pem
+#   PYTHONPATH=. examples/listen.py 127.0.0.1 5000 5001 examples/tmp.pem examples/tmp.pem
 
-ssl=1  # Use HTTPS
+function USAGE {
+cat << EOF
+Usage: `basename $0` url <options> ;
+    Send indications to a WBEM listener define by url and port.
+    Sends the number of indications defined by -d parameter.
 
-http_port="5000"
-https_port="5001"
-host="127.0.0.1"
-cert_file="tmp.pem"
-key_file="tmp.pem"
+    url  - url of listener including schema (default: http://127.0.0.1)
+           or https://<hostname>
 
-if [[ "$ssl" == "1" ]]; then
-  url="https://${host}:${https_port}"
+    Where the options are:
+    -h --help               Usage 
+
+    -p --port    integer    Listener port (default; 5000)
+    -c --cert    file_name  Certificate file (default; None)
+    -k --key     file_name  Key file (default; None)
+    -d --deliver count      Number of indications to deliver (default; 1)
+EOF
+}
+
+# default cmd line options
+
+port="5000"
+cert_file=""
+key_file=""
+NUMBER_TO_DELIVER=1
+URL="http://127.0.0.1"
+
+while test -n "$1"; do
+    case "$1" in
+        --help|-h)
+            USAGE
+            exit 1
+            ;;
+        -p|--port)
+            port="$2"
+            shift
+            ;;
+        -c|--certfile)
+            cert_file="$2"
+            shift
+            ;;
+        -k|--keyfile)
+            key_file="$2"
+            shift
+            ;;
+        -d|--deliver)
+            NUMBER_TO_DELIVER="$2"
+            shift
+            ;;
+        *)
+            echo all $1
+            if [[ $1 =~ "http" ]] ; then
+                URL=$1
+            else
+                echo unrecognized parameter $1. Terminating
+                exit 1
+                USAGE
+            fi
+            ;;
+    esac
+    shift # past argument or value
+done
+
+if [[ $URL =~ "https" ]] ; then
+  fullurl="$URL:${port}"
   key_opts="--insecure --key $key_file --cert $cert_file"
 else
-  url="http://${host}:${http_port}"
+  fullurl="$URL:${port}"
   key_opts=""
 fi
 
-data='<CIM CIMVERSION="2.0" DTDVERSION="2.4">
-  <MESSAGE ID="42" PROTOCOLVERSION="1.4">
-    <SIMPLEEXPREQ>
-      <EXPMETHODCALL NAME="ExportIndication">
-        <EXPPARAMVALUE NAME="NewIndication">
-          <INSTANCE CLASSNAME="CIM_AlertIndication">
-            <PROPERTY NAME="Severity" TYPE="string">
-              <VALUE>high</VALUE>
-            </PROPERTY>
-          </INSTANCE>
-        </EXPPARAMVALUE>
-      </EXPMETHODCALL>
-    </SIMPLEEXPREQ>
-  </MESSAGE>
-</CIM>'
+echo fullurl=$fullurl key_opts=$key_opts
 
-curl_opts="$key_opts --verbose --show-error --header 'Content-Type: text/xml' --data '${data}'"
+# loop to deliver the number of indications defined by
+# number_to_deliver
 
-cmd="curl $url $curl_opts"
-echo -e "Request payload:\n$data"
+START_TIME=$(date +%s)
+SEQ_NUMBER=0
+while [ $SEQ_NUMBER -lt $NUMBER_TO_DELIVER ]; do
 
-eval $cmd
+    let SEQ_NUMBER=SEQ_NUMBER+1
+    
+    CUR_TIME=$(date +%s)
+    DELTA_TIME=$((CUR_TIME-$START_TIME))
+    data='<?xml version="1.0" encoding="utf-8" ?>
+    <CIM CIMVERSION="2.0" DTDVERSION="2.4">
+      <MESSAGE ID="42" PROTOCOLVERSION="1.4">
+        <SIMPLEEXPREQ>
+          <EXPMETHODCALL NAME="ExportIndication">
+            <EXPPARAMVALUE NAME="NewIndication">
+              <INSTANCE CLASSNAME="CIM_AlertIndication">
+                <PROPERTY NAME="Severity" TYPE="string">
+                  <VALUE>high</VALUE>
+                </PROPERTY>
+                <PROPERTY NAME="Sequence_Number" TYPE="string">
+                  <VALUE>'$SEQ_NUMBER'</VALUE>
+                </PROPERTY>
+                <PROPERTY NAME="DELTA_TIME" TYPE="string">
+                  <VALUE>'$DELTA_TIME'</VALUE>
+                </PROPERTY>
+              </INSTANCE>
+            </EXPPARAMVALUE>
+          </EXPMETHODCALL>
+        </SIMPLEEXPREQ>
+      </MESSAGE>
+    </CIM>'
+
+    curl_opts="$key_opts --verbose --show-error --header 'Content-Type: text/xml' --data '${data}'"
+
+    cmd="curl $fullurl $curl_opts"
+    echo -e "Request payload:\n$data"
+
+    eval $cmd
+    echo send $SEQ_NUMBER of $NUMBER_TO_DELIVER
+done
+
 echo ""
 

--- a/examples/send_indications.py
+++ b/examples/send_indications.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+
+"""
+    Python script to create and send indications to a listener
+"""
+
+from __future__ import print_function, absolute_import
+import sys
+from time import time
+import argparse as _argparse
+from pywbem._cliutils import SmartFormatter as _SmartFormatter
+import requests
+import re
+from random import randint
+
+
+def create_indication_data(msg_id, sequence_number, delta_time, protocol_ver):
+    data_template = """<?xml version="1.0" encoding="utf-8" ?>
+    <CIM CIMVERSION="2.0" DTDVERSION="2.4">
+      <MESSAGE ID="%(msg_id)s" PROTOCOLVERSION="%(protocol_ver)s">
+        <SIMPLEEXPREQ>
+          <EXPMETHODCALL NAME="ExportIndication">
+            <EXPPARAMVALUE NAME="NewIndication">
+              <INSTANCE CLASSNAME="CIM_AlertIndication">
+                <PROPERTY NAME="Severity" TYPE="string">
+                  <VALUE>high</VALUE>
+                </PROPERTY>
+                <PROPERTY NAME="SequenceNumber" TYPE="string">
+                  <VALUE>%(sequence_number)s</VALUE>
+                </PROPERTY>
+                <PROPERTY NAME="DELTA_TIME" TYPE="string">
+                  <VALUE>%(delta_time)s</VALUE>
+                </PROPERTY>
+              </INSTANCE>
+            </EXPPARAMVALUE>
+          </EXPMETHODCALL>
+        </SIMPLEEXPREQ>
+      </MESSAGE>
+    </CIM>"""
+
+    data = {'sequence_number' : sequence_number, 'delta_time' : delta_time,
+            'protocol_ver' : protocol_ver, 'msg_id' : msg_id}
+    return data_template%data
+
+
+def send_indication(url, headers, payload, verbose):
+
+    try:
+        response = requests.post(url, headers=headers, data=payload, timeout=4)
+    except Exception as ex:
+        print('Exception %s' % ex)
+        return False
+
+    if verbose:
+        print('\nResponse code=%s headers=%s data=%s' % (response.status_code,
+                                                         response.headers,
+                                                         response.text))
+
+    return True if(response.status_code == 200) else False
+
+def get_args():
+    """
+        Get the command line arguments. use --help to get info on cmd line
+        arguments
+    """
+
+    prog = "sendIndications"
+    usage = '%(prog)s [options] listener-url'
+    desc = 'Send indications to a listener.'
+    epilog = """
+Examples:
+  %s https://127.0.0.1 -p 5000 -u sheldon -p penny
+
+  %s http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
+""" % (prog, prog)
+
+    argparser = _argparse.ArgumentParser(
+        prog=prog, usage=usage, description=desc, epilog=epilog,
+        add_help=False, formatter_class=_SmartFormatter)
+
+    pos_arggroup = argparser.add_argument_group(
+        'Positional arguments')
+
+    pos_arggroup.add_argument(
+        'url', metavar='url', nargs='?', default='http://127.0.0.1',
+        help='Optional url of listener '
+             'If supplied, must be schema+address[:port]. Schema determines ' \
+             ' whether http or https are used. Port may be defined in url ' \
+             'or with -p option. If not included default port = 5000')
+
+    general_arggroup = argparser.add_argument_group('General options')
+    general_arggroup.add_argument(
+        '-v', '--verbose', dest='verbose',
+        action='store_true', default=False,
+        help='Print more messages while processing')
+
+    general_arggroup.add_argument(
+        '--listenerPort', '-p', default=5000,
+        metavar="port",
+        type=int,
+        help='Integer argument defines listener port.')
+    general_arggroup.add_argument(
+        '--count', '-c', default=1,
+        metavar='integer',
+        type=int,
+        help='Integer argument defines number of indications to send.')
+
+    general_arggroup.add_argument(
+        '-h', '--help', action='help',
+        help='Show this help message and exit')
+
+    security_arggroup = argparser.add_argument_group(
+        'Connection security related options',
+        'Specify user name and password or certificates and keys')
+    security_arggroup.add_argument(
+        '--certfile', dest='cert_file', metavar='certfile',
+        help='R|Client certificate file for authenticating with the\n' \
+             'WBEM server. If option specified the client attempts\n' \
+             'to execute mutual authentication.\n'
+             'Default: Simple authentication.')
+    security_arggroup.add_argument(
+        '--keyfile', dest='key_file', metavar='keyfile',
+        help='R|Client private key file for authenticating with the\n' \
+             'WBEM server. Not required if private key is part of the\n' \
+             'certfile option. Not allowed if no certfile option.\n' \
+             'Default: No client key file. Client private key should\n' \
+             'then be part  of the certfile')
+
+    args = argparser.parse_args()
+
+    if re.match('^http', args.url) is None:
+        print('ERROR: url must include schema. received %s' % args.url)
+        sys.exit(1)
+
+    if args.verbose:
+        print('args %s' % args)
+
+    return args
+
+def main():
+    """
+    """
+    opts = get_args()
+
+    start_time = time()
+
+    full_url = opts.url
+    if opts.listenerPort is not None:
+        full_url = '%s:%s' % (opts.url, opts.listenerPort)
+
+    if opts.verbose:
+        print('full_url=%s' % full_url)
+
+    cim_protocol_version = '1.4'
+
+    headers = {'content-type' : 'application/xml; charset=utf-8',
+               'CIMExport' : 'MethodRequest',
+               'CIMExportMethod' : 'ExportIndication',
+               'Accept-Encoding' : 'Identity',
+               'CIMProtocolVersion' : cim_protocol_version}
+    # includes accept-encoding because of requests issue.  He supplies it if
+    # we don't TOD try None
+
+    delta_time = time() - start_time
+    rand_base = randint(1, 1000)
+
+    for i in xrange(opts.count):
+
+        msg_id = '%s' % (i + rand_base)
+        payload = create_indication_data(msg_id, i, delta_time,
+                                         cim_protocol_version)
+
+        if opts.verbose:
+            print('headers=%s\n\npayload=%s' % (headers, payload))
+
+        success = send_indication(full_url, headers, payload, opts.verbose)
+
+        if success:
+            print('sent # %s' % i)
+        else:
+            print('Error return from send. Terminating.')
+            return
+
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -151,6 +151,7 @@ __all__ = ['WBEMListener', 'callback_interface']
 
 class ThreadedHTTPServer(socketserver.ThreadingMixIn,
                          BaseHTTPServer.HTTPServer):
+    """Defines an HTTPServer class for indication reception"""
     pass
 
 
@@ -406,7 +407,9 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 msgid, IMPLEMENTED_PROTOCOL_VERSION),
             IMPLEMENTED_CIM_VERSION, IMPLEMENTED_DTD_VERSION)
 
-        resp_body = resp_xml.toxml()
+        resp_body = '<?xml version="1.0" encoding="utf-8" ?>\n' + \
+                    resp_xml.toxml()
+
         if isinstance(resp_body, six.text_type):
             resp_body = resp_body.encode("utf-8")
 
@@ -434,8 +437,9 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     ),
                 msgid, IMPLEMENTED_PROTOCOL_VERSION),
             IMPLEMENTED_CIM_VERSION, IMPLEMENTED_DTD_VERSION)
+        resp_body = '<?xml version="1.0" encoding="utf-8" ?>\n' + \
+                    resp_xml.toxml()
 
-        resp_body = resp_xml.toxml()
         if isinstance(resp_body, six.text_type):
             resp_body = resp_body.encode("utf-8")
 

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -52,7 +52,7 @@ from six.moves import urllib
 
 from .cim_obj import CIMClassName, CIMInstanceName, _ensure_unicode, \
                     _ensure_bytes
-from .exceptions import ConnectionError, AuthError, TimeoutError
+from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
 
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -819,11 +819,14 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                     cimerror_hdr = response.getheader('CIMError', None)
                     if cimerror_hdr is not None:
                         cimdetails = {}
-                        pgdetails_hdr = response.getheader('PGErrorDetail', None)
+                        pgdetails_hdr = response.getheader('PGErrorDetail',
+                                                           None)
                         if pgdetails_hdr is not None:
-                            cimdetails['PGErrorDetail'] = urllib.parse.unquote(pgdetails_hdr)
                             #pylint: disable=too-many-function-args
-                        raise HTTPError(response.status, response.reason, cimerror_hdr, cimdetails)
+                            cimdetails['PGErrorDetail'] = \
+                                urllib.parse.unquote(pgdetails_hdr)
+                        raise HTTPError(response.status, response.reason,
+                                        cimerror_hdr, cimdetails)
 
                     raise HTTPError(response.status, response.reason)
 


### PR DESCRIPTION
Pls Review. Ready for Merge. 3 July 2016 

This pr corrects issues that were causing massive indication lost between pegasus server and listeners.  Specifically this fixes some issues in the listener that was causing responses to get lost and some issues in the tests that were causing failures with pegasus indications.

It creates a new test sender in python sendIndications.py in the example directory and fixes some errors in listener just to be sure the issue was not with the shell script sender.

Modifies the send_indication.sh to send multiple indications and adds argument parser for better understanding.  NOTE: Not really sure we need this in the future.  the corresponding sendIndications.py is parallel in operation and does not depend on curl, and will be more complete.

The good news is that we are probably not losing indications now.  The bad news is that we are  receiving more than are sent.  Send 2, and the indication listener says we got 3. Send 200 and it says we received 400.  Looks like somewhere we have issues in resending, etc.






