### PR TITLE
fixes issue #420 Add an optional string id to listener and filter

### DIFF
--- a/examples/pegasusindicationtest.py
+++ b/examples/pegasusindicationtest.py
@@ -142,9 +142,6 @@ def run_test(svr_url, listener_host, user, password, http_listener_port, \
         6. Removes the filter and subscription and stops the listener
     """
 
-    #logging.basicConfig(stream=sys.stderr, level=logging.INFO,
-    #                    format= \
-    #                    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
 
     conn = WBEMConnection(svr_url, (user, password), no_verification=True)
     server = WBEMServer(conn)
@@ -155,7 +152,8 @@ def run_test(svr_url, listener_host, user, password, http_listener_port, \
     global LISTENER
 
     LISTENER = WBEMListener(listener_host, http_port=http_listener_port,
-                            https_port=https_listener_port)
+                            https_port=https_listener_port,
+                            listener_id="pegindicationtest")
 
     # set up listener logger.
     hdlr = logging.FileHandler('pegasusindications.log')


### PR DESCRIPTION
Ready for review:

Andreas: you may elect to put this on off until you finish restructuring listener

Adds an optional user defined string id to the listener
definition an another one to the filter definition.

The listener id is prepended to the name of all destination and
listener objects if it exists.  The filter id is prepended to the
name property of all filters after the listener id.

These are an informal mechanism for the user to identify instances
of filters and destination ojects that it has registered with the
WBEM server.

Nothing is prepended if these attributes are None