### PR TITLE
fixes issues #169 and #204 Clean up MofParseError Class and test conflicting flavors

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -238,6 +238,15 @@ Enhancements
   CIM_IndicationSubscription objects from WBEM Server. (issue #421).
   )
 
+* Clarify MofParseError by defining attributes as part of the class init and
+  moving some code from productions to the class itself (issue #169). This
+  make MofParseError exception more suitable for use from the productions
+  themselves. The original definition was really only for use as a call from
+  ply. Add tests for invalid qualifier flavors to unit tests and add test in
+  mof_compiler.py for conflicting flavors ex. tosubclass and restricted in
+  the same definition. This test uses the new MofParseError (issue #204)
+
+
 Bug fixes
 ^^^^^^^^^
 

--- a/mof_compiler
+++ b/mof_compiler
@@ -275,7 +275,7 @@ Example:
                 fname = os.path.curdir + '/' + fname
             mofcomp.compile_file(fname, args.namespace)
     except Error as exc:
-        print("%s: %s" % (exc.__class__.__name__, exc))
+        # mof compiler outputs its own error messages today.
         sys.exit(1)
 
     if args.remove and not args.dry_run:

--- a/testsuite/testmofs/parse_error03.mof
+++ b/testsuite/testmofs/parse_error03.mof
@@ -23,6 +23,7 @@ class Novell_DHCPSubnetInfo
 
 	[Description ("Number of defined IP's in the range" }]
 	uint16 DefinedIPs;
+    // Error is extra } above
 
 	[Description("Number of used IP's in the range")]
 	uint16 UsedIPs;


### PR DESCRIPTION
**Andy:** Ready for Review. See one question below.

Note: resubmitted with fix for issue#204 added since that is a test for new MOFParseError exception.

Note: For Tuesday and Wednesday morning travis repeatedly failed.  However, it passed completely as of about 13:00 US CDT Wednesday.

Adds attributes at the class level for the MOFParseError class and
cleans up the error processing. This identifies the attributes,
centralizes
how they are acquired (several are acquired from the parser token
returned).  It prints out the same error message as before these
changes.

Adds a simple test for conflicting flavors (tosubclass and restricted or enableoverride and disable override). Also adds tests for case insensitivity in flavors and invalid flavor names.

Note that this does NOT test for conflicts between flavors in a qualifier and its corresponding qualifier declaraction (ex. qualifier declaration has disableoveride and qualifier has enable override)

 