### PR TITLE
fixes issue #421 Add functions to get listener destination and subscriptions from Server

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -234,6 +234,10 @@ Enhancements
   `pywbem.ConnectionError` in one case), and any other bad HTTP responses
   are now raised as a new exception `pywbem.HTTPError`.
 
+* Extend WBEMListener to get all ListenerDestination objects and
+  CIM_IndicationSubscription objects from WBEM Server. (issue #421).
+  )
+
 Bug fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
Ready For Review:

Adds two new functions to Listener.  These simply get the instances from
the corresponding CIM Class in the server so that a client can get
the server side of all of the various subscription classes.

COMMENT: I thought about adding a filter mechanism to this so you could filter by regex against particular properties (name, etc.) but concluded that if we want to filter lets make it a separate function.

Also, I am asking whether we should be getting the paths for these or the instances themselves but for the moment simply got the paths.  

DISCUSSION OF FUTURE REQUIREMENTS: should we add function or option to get instances rather than paths???