### PR TITLE
Improved and fixed documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,34 @@
 [![Test on master](https://img.shields.io/travis/pywbem/pywbem/master.svg?style=plastic&label=test%20on%20master)](https://travis-ci.org/pywbem/pywbem/branches)
 [![PyPI version](https://img.shields.io/pypi/v/pywbem.svg?style=plastic&label=PyPI%20version)](https://pypi.python.org/pypi/pywbem)
 
-PyWBEM Client
--------------
+About this project
+------------------
 
-The PyWBEM Client project provides a WBEM client library and some related
-utilities, written in pure Python.
+Pywbem is a WBEM client, written in pure Python. It runs on Python 2 and
+Python 3.
 
 A WBEM client allows issuing operations to a WBEM server, using the CIM
-operations over HTTP (CIM-XML) protocol defined in the DMTF standards
-DSP0200 and DSP0201. See http://www.dmtf.org/standards/wbem for information
-about WBEM. This is used for all kinds of systems management tasks that are
-supported by the system running the WBEM server.
+operations over HTTP (CIM-XML) protocol defined in the DMTF standards DSP0200
+and DSP0201. The CIM/WBEM infrastructure is used for a wide variety of systems
+management tasks supported by systems running WBEM servers. See
+[WBEM Standards](http://www.dmtf.org/standards/wbem) for more information about
+WBEM.
 
 Usage
 -----
 
-For information on how to use the PyWBEM Client for your own development
-projects, or how to contribute to it, go to the
-[PyWBEM Client page](http://pywbem.github.io/pywbem/)
+For information on how to use pywbem, or how to contribute to it, go to the
+[pywbem page](http://pywbem.github.io/pywbem/).
 
-Project Plans
+Project plans
 -------------
 
 **Version 0.9.0** - (UPDATE 21 Aug. 2016) - Delaying 0.9.0 release by
 one more week to resolve open issues. Current expected release is now
 26 August 2016
 
-**Version 0.9.0** - (UPDATE 2 Aug. 2016) The PyWBEM team has concluded that
-we will delay the release of version 0.9.0 to 20 August 2016 because of
+**Version 0.9.0** - (UPDATE 2 Aug. 2016) The pywbem team has concluded that
+we will delay the release of version 0.9.0 to 20 August 2016 because of a couple
 of open issues, in particular, the new listener. While the current listener in
 the development code works we feel we should restructure it to allow indication
 listeners to be independent of the functions of subscription management.
@@ -38,7 +38,7 @@ rewrite in version 0.10.0.
 This release was orignally scheduled for
 early June 2016.  See issue #163 for an overview of version 0.9.0 goal sand the
 github issues for milestone 0.9.0 for details on what changes are done and
-planned for PyWBEM version 0.9.0.
+planned for pywbem version 0.9.0.
 
 **Version 0.10.0** - Next version after the version 0.9.0 release. See the issues
 for milestone 0.10.0 for current planning for this release. Generally release
@@ -47,6 +47,6 @@ expected about 2 months after 0.9.0 but that is a very preliminary estimate.
 License
 -------
 
-The PyWBEM Client is provided under the
+Pywbem is provided under the
 [GNU Lesser General Public License (LGPL) version 2.1](src/pywbem/LICENSE.txt),
 or (at your option) any later version.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,9 +56,11 @@ Enhancements
 ^^^^^^^^^^^^
 
 * The distribution formats have been extended. There are now:
+
   - Source archive (existed)
   - Universal wheel (new)
   - Windows installable (new)
+
   (issue #242)
 
 * Upgraded M2Crypto to use official 0.24.0 from PyPI.
@@ -170,17 +172,19 @@ Enhancements
 * Implemented pull operations per DMTF specification DSP0200 and DSP0201.
   This includes the following new client operations to execute enumeration
   sequences:
-    - OpenEnumerateInstances
-    - OpenEnumerateInstancePaths
-    - OpenAssociatorInstances
-    - OpenAssociatorInstancePaths
-    - OpenReferenceInstances
-    - OpenReferenceInstancePaths
-    - OpenQueryInstances
-    - PullInstances
-    - PullInstancesWithPath
-    - PullInstancePaths
-    - CloseEnumeration
+
+  - OpenEnumerateInstances
+  - OpenEnumerateInstancePaths
+  - OpenAssociatorInstances
+  - OpenAssociatorInstancePaths
+  - OpenReferenceInstances
+  - OpenReferenceInstancePaths
+  - OpenQueryInstances
+  - PullInstances
+  - PullInstancesWithPath
+  - PullInstancePaths
+  - CloseEnumeration
+
   PyWBEM does NOT implement the EnumerationCount operation as it
   is both deprecated and unusable. (Issue #9)
 
@@ -212,17 +216,17 @@ Enhancements
 
 * Implemented server and listener classes(issue #66) to provide the following:
 
-      - `WBEMServer` class for a WBEM server that uses a WBEMconnection. This
-      class provides access to the common elements of the WBEMServer profile
-      including namespaces, interop namespace, profile information, server
-      branding, central/scoping class algorithm, etc.
+  - `WBEMServer` class for a WBEM server that uses a WBEMconnection. This
+    class provides access to the common elements of the WBEMServer profile
+    including namespaces, interop namespace, profile information, server
+    branding, central/scoping class algorithm, etc.
       
-      - `WBEMListener` class that allows management of indication subscriptions
-      and the creation of a listener entity to receive indications.
+  - `WBEMListener` class that allows management of indication subscriptions
+    and the creation of a listener entity to receive indications.
 
-      **Experimental** -The WBEMServer and WBEMListener are experimental for
-      pywbem version 0.9.0 since this is the initial release of a significant
-      change and subject to changes to the API
+  **Experimental** - The WBEMServer and WBEMListener are experimental for
+  pywbem version 0.9.0 since this is the initial release of a significant
+  change and subject to changes to the API
 
 * Extend the server class with a function (filterProfiles) to select a
   subset of profiles from the server based on organization, profile name,
@@ -236,7 +240,6 @@ Enhancements
 
 * Extend WBEMListener to get all ListenerDestination objects and
   CIM_IndicationSubscription objects from WBEM Server. (issue #421).
-  )
 
 * Clarify MofParseError by defining attributes as part of the class init and
   moving some code from productions to the class itself (issue #169). This
@@ -316,14 +319,14 @@ Bug fixes
 * Extend PropertyList argument in request operations to be either list
   or tuple. (issue #347)
 
-*  Added deprecated warning to WBEMConnection verify_callback parameter
-   since it is not used with python ssl module and will probably be 
-   removed completely in the future. (issue # 297)
+* Added deprecated warning to WBEMConnection verify_callback parameter
+  since it is not used with python ssl module and will probably be 
+  removed completely in the future. (issue # 297)
 
-*  Created a common function for setting SSL defaults and tried to create
-   the same level of defaults for both Python2 (M2Crypto) and Python 3 (SSL
-   module).  The minimum level protocol set by the client is TLSV1 now whereas
-   in previous versions of pywbem it was SSLV23. (issue # 295)
+* Created a common function for setting SSL defaults and tried to create
+  the same level of defaults for both Python2 (M2Crypto) and Python 3 (SSL
+  module).  The minimum level protocol set by the client is TLSV1 now whereas
+  in previous versions of pywbem it was SSLV23. (issue # 295)
 
 * WBEMServer.interop_ns now contains the returned interop namespace name,
   if possible, instead of the attempted one.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -185,8 +185,8 @@ Enhancements
   - PullInstancePaths
   - CloseEnumeration
 
-  PyWBEM does NOT implement the EnumerationCount operation as it
-  is both deprecated and unusable. (Issue #9)
+  The EnumerationCount operation is NOT implemented, because it is both
+  deprecated and unusable. (Issue #9)
 
 * Added a tutorial section to the generated documentation, using
   Jupyter Notebooks for each tutorial page. (issue #324)

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -20,11 +20,11 @@ This chapter has the following sections:
   types.
 * :ref:`CIM status codes` - CIM status codes returned by failing WBEM
   operations.
-* :ref:`Exceptions` - Exceptions specific to **pywbem** that may be raised.
+* :ref:`Exceptions` - Exceptions specific to pywbem that may be raised.
 * :ref:`Security considerations` - Information about authentication types and
   certificates.
 
-A number of these topics apply also to the other APIs of the **pywbem** package.
+A number of these topics apply also to the other APIs of the pywbem package.
 
 .. _`WBEM operations`:
 
@@ -335,20 +335,19 @@ There are two levels of authentication in CIM-XML:
   supported authentication types.
 
   HTTP is extensible w.r.t. authentication schemes, and so is CIM-XML.
-  However, the PyWBEM client only supports Basic Authentication and no
-  authentication.
+  However, pywbem only supports Basic Authentication and no authentication.
 
   X.509 certificates do not play any role in HTTP level authentication.
 
 HTTP/HTTPS knows a third level of authentication by the use of *session
-cookies*. CIM-XML does not define how cookies would be used, and the
-PyWBEM client does not deal with cookies in any way (i.e. it does not
-pass cookies provided in a response into the next request).
+cookies*. CIM-XML does not define how cookies would be used, and pywbem does
+not deal with cookies in any way (i.e. it does not pass cookies provided in a
+response into the next request).
 
 The following table shows the possible combinations of protocol, TLS/SSL level
 and HTTP level authentication schemes, which information items need to be
 provided to the WBEM client API, and whether the combination is supported
-by the PyWBEM client:
+by pywbem:
 
 ======== ========== =========== =========== ============ ======== =========
 Protocol SSL auth.  HTTP auth.  Credentials Client cert. CA cert. Supported
@@ -384,17 +383,16 @@ WBEM server are set by the user when creating the
 * The scheme of the URL in the `url` parameter controls whether the HTTP or
   HTTPS protocol is used.
 * The `cred` parameter may specify credentials (userid/password). If specified,
-  the PyWBEM client uses them for Basic Authentication at the HTTP level.
-  The PyWBEM client provides an ``Authenticate`` HTTP header on each request,
-  and also handles server challenges transparently to the user of the
-  WBEM client API, by retrying the original request.
+  pywbem uses them for Basic Authentication at the HTTP level. Pywbem provides
+  an ``Authenticate`` HTTP header on each request, and also handles server
+  challenges transparently to the user of the WBEM client API, by retrying the
+  original request.
 * The `x509` parameter may specify an X.509 client certificate and key. If
-  specified, the PyWBEM client uses 2-way authentication; otherwise it uses
-  1-way authentication at the TLS/SSL level.
+  specified, pywbem uses 2-way authentication; otherwise it uses 1-way
+  authentication at the TLS/SSL level.
 * The `ca_certs` parameter may specify the location of X.509 CA certificates
   that are used to validate the X.509 server certificate returned by the WBEM
-  server.
-  If not specified, the PyWBEM client assumes default locations for these
+  server. If not specified, pywbem assumes default locations for these
   certificates.
 
 It is important to understand which side actually makes decisions about
@@ -407,8 +405,8 @@ is used, the client proposes cipher suites it supports, and the server picks
 one of them.
 
 Therefore, the `cred` and `x509` parameters do not control the authentication
-scheme that is actually used, but merely prepare the PyWBEM client to deal with
-whatever authentication scheme the WBEM server elects to use.
+scheme that is actually used, but merely prepare pywbem to deal with whatever
+authentication scheme the WBEM server elects to use.
 
 WBEM servers typically support corresponding configuration parameters.
 
@@ -421,8 +419,8 @@ When using HTTPS, the TLS/SSL handshake protocol requires that the server always
 returns an :term:`X.509` server certificate to the client (unless anonymous
 ciphers are used, which is not recommended).
 
-The PyWBEM client performs the following verifications on the server certificate
-returned by the WBEM server:
+Pywbem performs the following verifications on the server certificate returned
+by the WBEM server:
 
 * Validation of the server certificate against the CA certificates specified in
   the `ca_certs` parameter. This is done by the TLS/SSL components used by
@@ -452,10 +450,10 @@ certificate).
 
 This procedure is initiated by the server, by requesting that the client
 present a client certificate. If the client does not have one (for example,
-because the `x509` parameter was not specified in the PyWBEM client), it
-must send an empty list of certificates to the server. Depending on
-the server configuration, the server may or may not accept an empty list.
-If a client certificate is presented, the server must validate it.
+because the `x509` parameter was not specified in pywbem), it must send an
+empty list of certificates to the server. Depending on the server
+configuration, the server may or may not accept an empty list. If a client
+certificate is presented, the server must validate it.
 
 The server can support to accept the user identity specified in the client
 certificate as the user's identity, and refrain from sending HTTP challenges

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -4,7 +4,27 @@
 WBEM client library API
 =======================
 
-.. automodule:: pywbem
+The WBEM client library API supports issuing WBEM operations to a WBEM server,
+using the CIM operations over HTTP (CIM-XML) protocol defined in the DMTF
+standards :term:`DSP0200` and :term:`DSP0201`.
+
+This chapter has the following sections:
+
+* :ref:`WBEM operations` - Class :class:`~pywbem.WBEMConnection` is the main
+  class of the WBEM client library API and is used to issue WBEM operations to
+  a WBEM server.
+* :ref:`CIM objects` - Python classes for representing CIM objects (instances,
+  classes, properties, etc.) that are used by the WBEM operations as input or
+  output.
+* :ref:`CIM data types` - Python classes for representing values of CIM data
+  types.
+* :ref:`CIM status codes` - CIM status codes returned by failing WBEM
+  operations.
+* :ref:`Exceptions` - Exceptions specific to **pywbem** that may be raised.
+* :ref:`Security considerations` - Information about authentication types and
+  certificates.
+
+A number of these topics apply also to the other APIs of the **pywbem** package.
 
 .. _`WBEM operations`:
 

--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -6,9 +6,9 @@ MOF compiler API
 
 .. automodule:: pywbem.mof_compiler
 
-.. _`MOF compiler`:
+.. _`MOFCompiler`:
 
-MOF compiler
+MOFCompiler
 ------------
 
 .. autoclass:: pywbem.mof_compiler.MOFCompiler
@@ -31,4 +31,5 @@ Exceptions
 ----------
 
 .. autoclass:: pywbem.mof_compiler.MOFParseError
+   :members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,10 +62,10 @@ else:
 # General information about the project.
 project = u'pywbem'
 #copyright = u''
-author = u'PyWBEM team'
+author = u'pywbem team'
 
 # The short description of the package.
-_short_description = u'PyWBEM - a WBEM client written in pure Python'
+_short_description = u'Pywbem - a WBEM client written in pure Python'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -345,8 +345,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'PyWBEM_Client', _short_description,
-     author, 'PyWBEM_Client', _short_description,
+    (master_doc, 'pywbem', _short_description,
+     author, 'pywbem', _short_description,
      'Miscellaneous'),
 ]
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,9 +1,0 @@
-
-.. _`Configuration`:
-
-Configuration
-=============
-
-.. automodule:: pywbem.config
-      :members:
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 pywbem - A WBEM client
 **********************
 
-The **pywbem** package provides a WBEM client, written in pure Python.
+The pywbem package provides a WBEM client, written in pure Python.
 It supports Python 2 and Python 3.
 
 A WBEM client allows issuing operations to a WBEM server, using the CIM
@@ -17,7 +17,7 @@ and not necessarily require a large amount of programming knowledge. It is
 suitable for a large range of tasks from simply poking around to writing web
 and GUI applications.
 
-The general **pywbem** web site is: http://pywbem.github.io/pywbem/index.html.
+The general pywbem web site is: http://pywbem.github.io/pywbem/index.html.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,23 @@
 
-pywbem - A WBEM Client
+pywbem - A WBEM client
 **********************
 
-The **pywbem** PyPI package provides a WBEM client, written in pure Python.
+The **pywbem** package provides a WBEM client, written in pure Python.
 It supports Python 2 and Python 3.
+
+A WBEM client allows issuing operations to a WBEM server, using the CIM
+operations over HTTP (CIM-XML) protocol defined in the DMTF standards
+:term:`DSP0200` and :term:`DSP0201`.
+This is used for all kinds of systems management tasks that are supported by
+the system running the WBEM server.
+See :term:`WBEM Standards` for more information about WBEM.
 
 This package is based on the idea that a good WBEM client should be easy to use
 and not necessarily require a large amount of programming knowledge. It is
 suitable for a large range of tasks from simply poking around to writing web
 and GUI applications.
 
-This documentation describes the API of the **pywbem** PyPI package.
-
-Its general web site is: http://pywbem.github.io/pywbem/index.html.
+The general **pywbem** web site is: http://pywbem.github.io/pywbem/index.html.
 
 .. toctree::
    :maxdepth: 2
@@ -25,6 +30,5 @@ Its general web site is: http://pywbem.github.io/pywbem/index.html.
    listener.rst
    compiler.rst
    utilities.rst
-   config.rst
    changes.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,15 @@
 
-pywbem - A WBEM client
+Pywbem - A WBEM client
 **********************
 
-The pywbem package provides a WBEM client, written in pure Python.
-It supports Python 2 and Python 3.
+Pywbem is a WBEM client, written in pure Python. It supports Python 2 and
+Python 3.
 
 A WBEM client allows issuing operations to a WBEM server, using the CIM
 operations over HTTP (CIM-XML) protocol defined in the DMTF standards
 :term:`DSP0200` and :term:`DSP0201`.
-This is used for all kinds of systems management tasks that are supported by
-the system running the WBEM server.
+The CIM/WBEM infrastructure is used for a wide variety of systems
+management tasks supported by systems running WBEM servers.
 See :term:`WBEM Standards` for more information about WBEM.
 
 This package is based on the idea that a good WBEM client should be easy to use

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,7 +60,7 @@ functionality:
 Package version
 ---------------
 
-The version of the **pywbem** package can be accessed by programs using the
+The version of the pywbem package can be accessed by programs using the
 ``pywbem.__version__`` variable:
 
 .. autodata:: pywbem._version.__version__
@@ -75,7 +75,7 @@ Note: For tooling reasons, the variable is shown as
 Supported environments
 ----------------------
 
-The **pywbem** package is supported in these environments:
+The pywbem package is supported in these environments:
 
 * on Windows, with Python 2.6, 2.7, 3.4, 3.5, and higher 3.x
 
@@ -89,7 +89,7 @@ try it out and `report any issues <https://github.com/pywbem/pywbem/issues>`_.
 Standards conformance
 ---------------------
 
-The **pywbem** package conforms to the following CIM and WBEM standards,
+The pywbem package conforms to the following CIM and WBEM standards,
 in the version specified when following the links to the standards:
 
 * The supported WBEM protocol is CIM-XML; it conforms to :term:`DSP0200` and
@@ -124,22 +124,22 @@ in the version specified when following the links to the standards:
 Deprecation policy
 ------------------
 
-Since its v0.7.0, the **pywbem** package attempts to be as backwards compatible
+Since its v0.7.0, the pywbem package attempts to be as backwards compatible
 as possible.
 
 However, in an attempt to clean up some of its history, and in order to prepare
-for future additions, the Python namespaces visible to users of the **pywbem**
+for future additions, the Python namespaces visible to users of the pywbem
 package need to be cleaned up.
 
 Also, occasionally functionality needs to be retired, because it is flawed and
 a better but incompatible replacement has emerged.
 
-In the **pywbem** package, such changes are done by deprecating existing
+In the pywbem package, such changes are done by deprecating existing
 functionality, without removing it. The deprecated functionality is still
 supported throughout new minor releases. Eventually, a new major release will
 break compatibility and will remove the deprecated functionality.
 
-In order to prepare users of the **pywbem** package for that, deprecation of
+In order to prepare users of the pywbem package for that, deprecation of
 functionality is stated in the API documentation, and is made visible at
 runtime by issuing Python warnings of type ``DeprecationWarning`` (see the
 Python :mod:`py:warnings` module).
@@ -150,12 +150,12 @@ They can be shown for example in any of these ways:
 * By specifying the Python command line option: ``-W default``
 * By invoking Python with the environment variable: ``PYTHONWARNINGS=default``
 
-It is recommended that users of the **pywbem** package run their test code with
+It is recommended that users of the pywbem package run their test code with
 ``DeprecationWarning`` messages being shown, so they become aware of any use of
 deprecated functionality.
 
 Here is a summary of the deprecation and compatibility policy used by
-the **pywbem** package, by release type:
+the pywbem package, by release type:
 
 * New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
   compatible.
@@ -164,8 +164,8 @@ the **pywbem** package, by release type:
 * New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
   removed; backwards compatibility may be broken.
 
-Compatibility is always seen from the perspective of the user of the **pywbem**
-package, so a backwards compatible new **pywbem** release means that the user
+Compatibility is always seen from the perspective of the user of the pywbem
+package, so a backwards compatible new pywbem release means that the user
 can safely upgrade to that new release without encountering compatibility
 issues.
 
@@ -174,11 +174,11 @@ issues.
 Python namespaces
 -----------------
 
-The external APIs of the **pywbem** package are defined by the symbols in the
+The external APIs of the pywbem package are defined by the symbols in the
 ``pywbem`` namespace. With a few exceptions, that is the only Python namespace
 that needs to be imported by users.
 
-With **pywbem** versions prior to v0.8, it was common for users to import the
+With pywbem versions prior to v0.8, it was common for users to import the
 sub-modules of pywbem (e.g. ``pywbem.cim_obj``). The sub-modules that existed
 prior to v0.8 are still available for compatibility reasons.
 Starting with v0.8, the ``pywbem`` namespace was cleaned up, and not all public
@@ -187,7 +187,7 @@ namespace anymore. The symbols in the sub-module namespaces are still available
 for compatibility, including those that are no longer available in the
 ``pywbem`` namespace. However, any use of symbols from the sub-module namespaces
 is deprecated starting with v0.8, and you should assume that a future version of
-**pywbem** will remove them. If you miss any symbol you were used to use, please
+pywbem will remove them. If you miss any symbol you were used to use, please
 `open an issue <https://github.com/pywbem/pywbem/issues>`_.
 
 New sub-modules added since v0.8 have a leading underscore in their name in
@@ -197,7 +197,7 @@ they should not be imported by users.
 The only exception to the single-namespace rule stated above, is the
 :ref:`MOF compiler API`, which uses the ``pywbem.mof_compiler`` namespace.
 
-This documentation describes only the external APIs of the **pywbem** package,
+This documentation describes only the external APIs of the pywbem package,
 and omits any internal symbols and any sub-modules.
 
 .. _`Configuration variables`:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -4,57 +4,78 @@
 Introduction
 ============
 
-.. _`Contents of the package`:
+.. _`Functionality`:
 
 Functionality
 -------------
 
-The **pywbem** PyPI package provides the following functionality:
+The WBEM client provided in the pywbem package supports the following
+functionality:
 
-* WBEM client library API
+* :ref:`WBEM client library API`
 
-  The :ref:`WBEM client library API` supports issuing WBEM operations to a
-  WBEM server, using the CIM operations over HTTP (CIM-XML) protocol defined
-  in the DMTF standards :term:`DSP0200` and :term:`DSP0201`.
+  This API supports issuing WBEM operations to a WBEM server, using the CIM
+  operations over HTTP (CIM-XML) protocol defined in the DMTF standards
+  :term:`DSP0200` and :term:`DSP0201`.
 
-* WBEM listener API
+* :ref:`WBEM server API`
 
-  The :ref:`WBEM listener API` supports starting and stopping a WBEM listener
-  thread that waits for indications (i.e. events) emitted by a WBEM server
-  using the CIM-XML protocol. The API also supports managing subscriptions
-  for such indications.
+  This API encapsulates certain functionality of a WBEM server for use by a
+  WBEM client application, such as determining the Interop namespace of the
+  server, or the management profiles advertised by the server.
 
-* WBEM server API
+* :ref:`WBEM listener API`
 
-  The :ref:`WBEM server API` represents a general access point for basic server
-  functionality to a client, such as determining the Interop namespace of the
-  server, or the advertised management profiles.
+  This API supports starting and stopping a WBEM listener that waits for
+  indications (i.e. events) emitted by a WBEM server using the CIM-XML
+  protocol. The API also supports managing subscriptions for such indications.
 
-* WBEM utility commands
+* :ref:`MOF compiler API`
 
-  * :ref:`mof_compiler` - A MOF compiler that takes MOF files as input and
-    creates, updates or removes CIM instances, classes or qualifier types in a
-    CIM repository.
+  This API provides for invoking the MOF compiler and for plugging in your own
+  CIM repository into the MOF compiler.
+
+* :ref:`WBEM utility commands`
+
+  The pywbem package provides a few utility commands:
+
+  * :ref:`mof_compiler`
+
+    A MOF compiler that takes MOF files as input and creates, updates or
+    removes CIM instances, classes or qualifier types in a CIM repository.
 
     See :term:`DSP0004` for a description of MOF (Managed Object Format).
 
-    The MOF compiler has an API for using it from within a program.
-
     By default, the CIM repository used by the MOF compiler is in a WBEM
-    server. The MOF compiler API provides for plugging in your own CIM
+    server. The :ref:`MOF compiler API` provides for plugging in your own CIM
     repository the compiler can work against.
 
-    See :ref:`MOF compiler API` for a description of the API.
+  * :ref:`wbemcli`
 
-  * :ref:`wbemcli` - A WBEM command line interface that provides an interactive
-    Python environment for issuing WBEM operations to a WBEM server.
+    A WBEM command line interface that provides an interactive Python
+    environment for issuing WBEM operations to a WBEM server.
+
+.. _`Package version`:
+
+Package version
+---------------
+
+The version of the **pywbem** package can be accessed by programs using the
+``pywbem.__version__`` variable:
+
+.. autodata:: pywbem._version.__version__
+
+Note: For tooling reasons, the variable is shown as
+``pywbem._version.__version__``, but it should be used as
+``pywbem.__version__``.
 
 .. _`Compatibility`:
+.. _`Supported environments`:
 
-Compatibility
--------------
+Supported environments
+----------------------
 
-The ``pywbem`` PyPI package is supported in these environments:
+The **pywbem** package is supported in these environments:
 
 * on Windows, with Python 2.6, 2.7, 3.4, 3.5, and higher 3.x
 
@@ -63,72 +84,65 @@ The ``pywbem`` PyPI package is supported in these environments:
 OS X has not been tested and is therefore not listed, above. You are welcome to
 try it out and `report any issues <https://github.com/pywbem/pywbem/issues>`_.
 
-.. _`Deprecation policy`:
+.. _`Standards conformance`:
 
 Standards conformance
 ---------------------
 
-The ``pywbem`` package conforms to the following CIM and WBEM standards,
+The **pywbem** package conforms to the following CIM and WBEM standards,
 in the version specified when following the links to the standards:
 
-* The protocol supported by the PyWBEM client and listener is CIM-XML; it
-  conforms to :term:`DSP0200` and :term:`DSP0201`.
+* The supported WBEM protocol is CIM-XML; it conforms to :term:`DSP0200` and
+  :term:`DSP0201`.
 
-  Limitations:
+* The CIM-XML representation of :ref:`CIM objects` as produced by their
+  ``tocimxml()`` and ``tocimxmlstr()`` methods conforms to :term:`DSP0201`.
 
-  - Pulled enumeration operations are not currently supported.
-  - Indication delivery and the WBEM listener support is experimental (see
-    :ref:`WBEM listener API`).
-
-* The support for the CIM-XML representation of :ref:`CIM objects`, as
-  produced by their ``tocimxml()`` and ``tocimxmlstr()`` methods
-  conforms to :term:`DSP0201`.
-
-* The CIM metamodel implemented by ``pywbem`` (e.g. in its :ref:`CIM objects`)
-  conforms to :term:`DSP0004`.
-
-* The support for MOF as produced by the ``tomof()`` methods on
-  :ref:`CIM objects` and as parsed by the :class:`MOFCompiler` class conforms
-  to :term:`DSP0004`.
+* The MOF as produced by the ``tomof()`` methods on :ref:`CIM objects` and as
+  parsed by the MOF compiler conforms to :term:`DSP0004`.
 
   Limitations:
 
   - Several `issues in the MOF compiler
     <https://github.com/pywbem/pywbem/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+MOF>`_.
 
+* The implemented CIM metamodel (e.g. in the :ref:`CIM objects`) conforms to
+  :term:`DSP0004`.
+
 * The WBEM URIs produced by the :meth:`pywbem.CIMInstanceName.__str__` and
   :meth:`pywbem.CIMClassName.__str__` methods conform to :term:`DSP0207`.
 
-TODO: The following applies to the ``listener`` branch; remove this todo if merged:
+* The mechanisms for discovering the Interop namespace of a WBEM server and the
+  management profiles advertised by a WBEM server and their central instances
+  in the :ref:`WBEM server API` conforms to :term:`DSP1033`.
 
-* The support for discovering the Interop namespace, management profiles and
-  their central instances in the :ref:`WBEM server API` conforms to
-  :term:`DSP1033`.
+* The mechanisms for subscribing for CIM indications in the
+  :ref:`WBEM listener API` conforms to :term:`DSP1054`.
 
-* The support for subscribing for CIM indications conforms to :term:`DSP1054`.
+.. _`Deprecation policy`:
 
 Deprecation policy
 ------------------
 
-Since its v0.7.0, the ``pywbem`` package attempts to be as backwards compatible
+Since its v0.7.0, the **pywbem** package attempts to be as backwards compatible
 as possible.
 
 However, in an attempt to clean up some of its history, and in order to prepare
-for future additions, the Python namespaces visible to users of ``pywbem`` need
-to be cleaned up.
+for future additions, the Python namespaces visible to users of the **pywbem**
+package need to be cleaned up.
 
 Also, occasionally functionality needs to be retired, because it is flawed and
 a better but incompatible replacement has emerged.
 
-In ``pywbem``, such changes are done by deprecating existing functionality,
-without removing it. The deprecated functionality is still supported throughout
-new minor releases. Eventually, a new major release will break compatibility and
-will remove the deprecated functionality.
+In the **pywbem** package, such changes are done by deprecating existing
+functionality, without removing it. The deprecated functionality is still
+supported throughout new minor releases. Eventually, a new major release will
+break compatibility and will remove the deprecated functionality.
 
-In order to prepare users of ``pywbem`` for that, deprecation of functionality
-is stated in the API documentation, and is made visible at runtime by issuing
-Python warnings of type ``DeprecationWarning`` (see the Python
-:mod:`py:warnings` module).
+In order to prepare users of the **pywbem** package for that, deprecation of
+functionality is stated in the API documentation, and is made visible at
+runtime by issuing Python warnings of type ``DeprecationWarning`` (see the
+Python :mod:`py:warnings` module).
 
 Since Python 2.7, ``DeprecationWarning`` messages are suppressed by default.
 They can be shown for example in any of these ways:
@@ -136,12 +150,12 @@ They can be shown for example in any of these ways:
 * By specifying the Python command line option: ``-W default``
 * By invoking Python with the environment variable: ``PYTHONWARNINGS=default``
 
-It is recommended that users of ``pywbem`` run their test code with
+It is recommended that users of the **pywbem** package run their test code with
 ``DeprecationWarning`` messages being shown, so they become aware of any use of
-deprecated functionality in ``pywbem``.
+deprecated functionality.
 
 Here is a summary of the deprecation and compatibility policy used by
-``pywbem``, by release type:
+the **pywbem** package, by release type:
 
 * New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
   compatible.
@@ -150,9 +164,49 @@ Here is a summary of the deprecation and compatibility policy used by
 * New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
   removed; backwards compatibility may be broken.
 
-Compatibility is always seen from the perspective of the user of ``pywbem``, so
-a backwards compatible new ``pywbem`` release means that the user can safely
-upgrade to that new release without encountering compatibility issues.
+Compatibility is always seen from the perspective of the user of the **pywbem**
+package, so a backwards compatible new **pywbem** release means that the user
+can safely upgrade to that new release without encountering compatibility
+issues.
+
+.. _'Python namespaces`:
+
+Python namespaces
+-----------------
+
+The external APIs of the **pywbem** package are defined by the symbols in the
+``pywbem`` namespace. With a few exceptions, that is the only Python namespace
+that needs to be imported by users.
+
+With **pywbem** versions prior to v0.8, it was common for users to import the
+sub-modules of pywbem (e.g. ``pywbem.cim_obj``). The sub-modules that existed
+prior to v0.8 are still available for compatibility reasons.
+Starting with v0.8, the ``pywbem`` namespace was cleaned up, and not all public
+symbols available in the sub-module namespaces are available in the ``pywbem``
+namespace anymore. The symbols in the sub-module namespaces are still available
+for compatibility, including those that are no longer available in the
+``pywbem`` namespace. However, any use of symbols from the sub-module namespaces
+is deprecated starting with v0.8, and you should assume that a future version of
+**pywbem** will remove them. If you miss any symbol you were used to use, please
+`open an issue <https://github.com/pywbem/pywbem/issues>`_.
+
+New sub-modules added since v0.8 have a leading underscore in their name in
+order to document that they are considered an implementation detail and that
+they should not be imported by users.
+
+The only exception to the single-namespace rule stated above, is the
+:ref:`MOF compiler API`, which uses the ``pywbem.mof_compiler`` namespace.
+
+This documentation describes only the external APIs of the **pywbem** package,
+and omits any internal symbols and any sub-modules.
+
+.. _`Configuration variables`:
+
+Configuration variables
+-----------------------
+
+.. automodule:: pywbem.config
+      :members:
 
 .. _'Special type names`:
 
@@ -247,3 +301,6 @@ References
 
    RFC6874
       `IETF RFC6874, Representing IPv6 Zone Identifiers in Address Literals and Uniform Resource Identifiers, February 2013 <https://tools.ietf.org/html/rfc6874>`_
+
+   WBEM Standards
+      `DMTF WBEM Standards <http://www.dmtf.org/standards/wbem>`_

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -9,8 +9,7 @@ Introduction
 Functionality
 -------------
 
-The WBEM client provided in the pywbem package supports the following
-functionality:
+Pywbem supports the following functionality:
 
 * :ref:`WBEM client library API`
 
@@ -37,7 +36,7 @@ functionality:
 
 * :ref:`WBEM utility commands`
 
-  The pywbem package provides a few utility commands:
+  Pywbem includes a few utility commands:
 
   * :ref:`mof_compiler`
 
@@ -75,7 +74,7 @@ Note: For tooling reasons, the variable is shown as
 Supported environments
 ----------------------
 
-The pywbem package is supported in these environments:
+Pywbem is supported in these environments:
 
 * on Windows, with Python 2.6, 2.7, 3.4, 3.5, and higher 3.x
 
@@ -89,8 +88,8 @@ try it out and `report any issues <https://github.com/pywbem/pywbem/issues>`_.
 Standards conformance
 ---------------------
 
-The pywbem package conforms to the following CIM and WBEM standards,
-in the version specified when following the links to the standards:
+Pywbem conforms to the following CIM and WBEM standards, in the version
+specified when following the links to the standards:
 
 * The supported WBEM protocol is CIM-XML; it conforms to :term:`DSP0200` and
   :term:`DSP0201`.
@@ -124,25 +123,24 @@ in the version specified when following the links to the standards:
 Deprecation policy
 ------------------
 
-Since its v0.7.0, the pywbem package attempts to be as backwards compatible
-as possible.
+Since its v0.7.0, Pywbem attempts to be as backwards compatible as possible.
 
 However, in an attempt to clean up some of its history, and in order to prepare
-for future additions, the Python namespaces visible to users of the pywbem
-package need to be cleaned up.
+for future additions, the Python namespaces visible to users of pywbem need to
+be cleaned up.
 
 Also, occasionally functionality needs to be retired, because it is flawed and
 a better but incompatible replacement has emerged.
 
-In the pywbem package, such changes are done by deprecating existing
-functionality, without removing it. The deprecated functionality is still
-supported throughout new minor releases. Eventually, a new major release will
-break compatibility and will remove the deprecated functionality.
+In pywbem, such changes are done by deprecating existing functionality, without
+removing it. The deprecated functionality is still supported throughout new
+minor releases. Eventually, a new major release will break compatibility and
+will remove the deprecated functionality.
 
-In order to prepare users of the pywbem package for that, deprecation of
-functionality is stated in the API documentation, and is made visible at
-runtime by issuing Python warnings of type ``DeprecationWarning`` (see the
-Python :mod:`py:warnings` module).
+In order to prepare users of pywbem for that, deprecation of functionality is
+stated in the API documentation, and is made visible at runtime by issuing
+Python warnings of type ``DeprecationWarning`` (see the Python
+:mod:`py:warnings` module).
 
 Since Python 2.7, ``DeprecationWarning`` messages are suppressed by default.
 They can be shown for example in any of these ways:
@@ -154,8 +152,8 @@ It is recommended that users of the pywbem package run their test code with
 ``DeprecationWarning`` messages being shown, so they become aware of any use of
 deprecated functionality.
 
-Here is a summary of the deprecation and compatibility policy used by
-the pywbem package, by release type:
+Here is a summary of the deprecation and compatibility policy used by pywbem,
+by release type:
 
 * New update release (M.N.U -> M.N.U+1): No new deprecations; fully backwards
   compatible.
@@ -164,19 +162,18 @@ the pywbem package, by release type:
 * New major release (M.N.U -> M+1.0.0): Deprecated functionality may get
   removed; backwards compatibility may be broken.
 
-Compatibility is always seen from the perspective of the user of the pywbem
-package, so a backwards compatible new pywbem release means that the user
-can safely upgrade to that new release without encountering compatibility
-issues.
+Compatibility is always seen from the perspective of the user of pywbem, so a
+backwards compatible new pywbem release means that the user can safely upgrade
+to that new release without encountering compatibility issues.
 
 .. _'Python namespaces`:
 
 Python namespaces
 -----------------
 
-The external APIs of the pywbem package are defined by the symbols in the
-``pywbem`` namespace. With a few exceptions, that is the only Python namespace
-that needs to be imported by users.
+The external APIs of pywbem are defined by the symbols in the ``pywbem``
+namespace. With a few exceptions, that is the only Python namespace that needs
+to be imported by users.
 
 With pywbem versions prior to v0.8, it was common for users to import the
 sub-modules of pywbem (e.g. ``pywbem.cim_obj``). The sub-modules that existed
@@ -190,15 +187,15 @@ is deprecated starting with v0.8, and you should assume that a future version of
 pywbem will remove them. If you miss any symbol you were used to use, please
 `open an issue <https://github.com/pywbem/pywbem/issues>`_.
 
-New sub-modules added since v0.8 have a leading underscore in their name in
-order to document that they are considered an implementation detail and that
+New sub-modules added since pywbem v0.8 have a leading underscore in their name
+in order to document that they are considered an implementation detail and that
 they should not be imported by users.
 
 The only exception to the single-namespace rule stated above, is the
 :ref:`MOF compiler API`, which uses the ``pywbem.mof_compiler`` namespace.
 
-This documentation describes only the external APIs of the pywbem package,
-and omits any internal symbols and any sub-modules.
+This documentation describes only the external APIs of pywbem, and omits any
+internal symbols and any sub-modules.
 
 .. _`Configuration variables`:
 

--- a/docs/listener.rst
+++ b/docs/listener.rst
@@ -4,6 +4,8 @@
 WBEM listener API
 =================
 
+.. _`WBEMListener`:
+
 WBEMListener
 ^^^^^^^^^^^^
 
@@ -13,6 +15,8 @@ WBEMListener
    :members:
 
 .. autofunction:: pywbem.callback_interface
+
+.. _`WBEMSubscriptionManager`:
 
 WBEMSubscriptionManager
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -6,11 +6,15 @@ WBEM server API
 
 .. automodule:: pywbem._server
 
+.. _`WBEMServer`:
+
 WBEMServer
 ^^^^^^^^^^
 
 .. autoclass:: pywbem.WBEMServer
    :members:
+
+.. _`ValueMapping`:
 
 ValueMapping
 ^^^^^^^^^^^^

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -4,7 +4,7 @@
 Tutorial
 ========
 
-This is a short tutorial about using PyWBEM. It is intended to be enough to get
+This is a short tutorial about using pywbem. It is intended to be enough to get
 people up and going who already know a bit about WBEM and CIM.
 
 Python code examples this tutorial are shown using

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -4,7 +4,7 @@
 WBEM utility commands
 =====================
 
-The **pywbem** package provides a number of WBEM utility commands.
+The pywbem package provides a number of WBEM utility commands.
 They are all implemented as pure-Python scripts.
 
 These commands are installed into the Python script directory and should

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -4,40 +4,57 @@
 WBEM utility commands
 =====================
 
-The **pywbem** PyPI package provides a number of WBEM utility commands.
+The **pywbem** package provides a number of WBEM utility commands.
 They are all implemented as pure-Python scripts.
 
 These commands are installed into the Python script directory and should
-therefore be available in the command search path.
+therefore automatically be available in the command search path.
+
+The following commands are provided:
+
+* :ref:`mof_compiler`
+
+  A MOF compiler that takes MOF files as input and creates, updates or
+  removes CIM instances, classes or qualifier types in a CIM repository.
+
+* :ref:`wbemcli`
+
+  A WBEM command line interface that provides an interactive Python
+  environment for issuing WBEM operations to a WBEM server.
 
 .. _`mof_compiler`:
 
 mof_compiler
 ------------
 
-A MOF compiler. It compiles MOF files, and updates the repository of a WBEM
-server with the result.
-
-.. include:: mof_compiler.help.txt
-   :literal:
+The ``mof_compiler`` command is a MOF compiler. It compiles MOF files, and
+updates the repository of a WBEM server with the result.
 
 The MOF compiler can also be invoked from programs via the
 :ref:`MOF compiler API`.
 
-The MOF compiler has a pluggable interface for the MOF repository. The default
-implementation of that interface uses a WBEM server as its MOF repository.
+The MOF compiler has a pluggable interface for the CIM repository. The default
+implementation of that interface uses a WBEM server as its repository.
 The plug interface is also described in the :ref:`MOF compiler API`.
+
+Here is the help text of the command:
+
+.. include:: mof_compiler.help.txt
+   :literal:
 
 .. _`wbemcli`:
 
 wbemcli
 -------
 
-A WBEM client CLI. It is implemented as an interactive shell.
-
-.. include:: wbemcli.help.txt
-   :literal:
+The ``wbemcli`` command is a WBEM client command line interface (CLI). It is
+implemented as an interactive shell.
 
 The WBEM client CLI does not have an external API on its own; it is for the
 most part a consumer of the :ref:`WBEM client library API`.
+
+Here is the help text of the command:
+
+.. include:: wbemcli.help.txt
+   :literal:
 

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -20,7 +20,7 @@
 #
 
 """
-The **pywbem** package provides a WBEM client, written in pure Python.
+Pywbem is a WBEM client, written in pure Python.
 It supports Python 2 and Python 3.
 """
 
@@ -50,7 +50,7 @@ from ._version import __version__
 _python_m = sys.version_info[0]
 _python_n = sys.version_info[1]
 if _python_m == 2 and _python_n < 6:
-    raise RuntimeError('On Python 2, PyWBEM requires Python 2.6 or higher')
+    raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
 elif _python_m == 3 and _python_n < 4:
-    raise RuntimeError('On Python 3, PyWBEM requires Python 3.4 or higher')
+    raise RuntimeError('On Python 3, pywbem requires Python 3.4 or higher')
 

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -20,56 +20,8 @@
 #
 
 """
-The external API of the WBEM client library is defined by the symbols that
-are exported from the ``pywbem`` Python package and its sub-modules via their
-``__all__`` variables.
-
-Public symbols that are not listed in the ``__all__`` variables are still
-available for compatibility reasons (the ``__all__`` variables and a definition
-of the external API were introduced in pywbem v0.8). However, they may change
-over time.
-
-Consumers of this package that use other symbols than those from the external
-API are at the risk of suffering from incompatible changes in future versions
-of this package.
-
-The external API is completely available in the ``pywbem`` namespace. That
-is the only namespace that needs to be imported by users of the API. The
-sub-modules do not need to be imported. It is recommended to use the symbols
-in the ``pywbem`` namespace and not those of the sub-modules.
-
-With a few exceptions for tooling reasons, this documentation describes the
-symbols of the ``pywbem`` namespace.
-
-The WBEM client library API consists of the following elements:
-
-* :ref:`Package version` - Provides access to the version of the ``pywbem``
-  package.
-* :ref:`WBEM operations` - Class :class:`WBEMConnection` is the main class of
-  the WBEM client library and its methods issue WBEM operations to a WBEM
-  server.
-* :ref:`CIM objects` - Python classes for representing CIM objects (instances,
-  classes, properties, etc.) that are used by the WBEM operations as input or
-  output.
-* :ref:`CIM data types` - Python classes for representing values of CIM data
-  types.
-* :ref:`CIM status codes` - CIM status codes returned by failing WBEM
-  operations.
-* :ref:`Exceptions` - Exceptions specific to pywbem that may be raised.
-
-.. _`Package version`:
-
-Package version
----------------
-
-The package version can be accessed by programs using the following variable.
-
-Note: For tooling reasons, the variable is shown in the namespace
-``pywbem._version``. However, it is also available in the ``pywbem`` namespace
-and should be used from there.
-
-.. autodata:: pywbem._version.__version__
-
+The **pywbem** package provides a WBEM client, written in pure Python.
+It supports Python 2 and Python 3.
 """
 
 # There are submodules, but clients shouldn't need to know about them.

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -553,7 +553,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """
         Overrides the inherited method to add the pywbem listener version.
         """
-        return 'PyWBEM-Listener/%s %s %s ' % \
+        return 'pywbem-listener/%s %s %s ' % \
             (__version__, self.server_version, self.sys_version)
 
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -15,21 +15,28 @@
 #
 
 """
-The `WBEM server API`_ provides basic functionality of a WBEM server that is
-relevant for a client:
+The WBEM server API encapsulates certain functionality of a WBEM server for use
+by a WBEM client application, such as determining the Interop namespace of the
+server, or the management profiles advertised by the server.
 
-* The :class:`~pywbem.WBEMServer` class serves as a general access point for
-  clients. It provides an API for applications that for example allows
-  determining the Interop namespace of the server, or the advertised
-  management profiles.
+This chapter has the following sections:
 
-* The :class:`~pywbem.ValueMapping` class maps corresponding entries in
-  Values and ValueMap qualifiers of a CIM element and supports a
-  translation between the two.
+* :ref:`Example <Server Example>` - An example on how to use the API.
+
+* :ref:`WBEMServer` - The :class:`~pywbem.WBEMServer` class serves as a general
+  access point for clients to WBEM servers. It allows determining the Interop
+  namespace of the server, or the advertised management profiles.
+
+* :ref:`ValueMapping` - The :class:`~pywbem.ValueMapping` class maps
+  corresponding values of the `Values` and `ValueMap` qualifiers of a CIM
+  element and supports the translation of the actual value (often an integer)
+  to the corresponding value of the `Values` qualifier.
 
 .. note::
 
-   At this point, the WBEM listener API is experimental.
+   At this point, the WBEM server API is experimental.
+
+.. _`Server Example`:
 
 Example
 -------
@@ -196,7 +203,7 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
         """
         if self._interop_ns is None:
             self._determine_interop_ns()
@@ -212,9 +219,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Namespace class could not be
-            determined.
+              determined.
         """
         if self._namespace_classname is None:
             self._determine_namespaces()
@@ -230,9 +237,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Namespace class could not be
-            determined.
+              determined.
         """
         if self._namespaces is None:
             self._determine_namespaces()
@@ -255,9 +262,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Unexpected number of
-            CIM_ObjectManager instances.
+              CIM_ObjectManager instances.
         """
         if self._brand is None:
             self._determine_brand()
@@ -273,9 +280,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Unexpected number of
-            CIM_ObjectManager instances.
+              CIM_ObjectManager instances.
         """
         if self._version is None:
             self._determine_brand()
@@ -292,7 +299,7 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
         """
         if self._profiles is None:
             self._determine_profiles()
@@ -310,23 +317,22 @@ class WBEMServer(object):
         Parameters:
 
             profile_org (:term:`string`) or None: the `RegisteredOrganization`
-            to match the `RegisteredOrganization of the profile.
-            If None, this parameter is ignored in the filter
+              to match the `RegisteredOrganization` of the profile.
+              If None, this parameter is ignored in the filter
 
             profile_name (:term:`string`) or None: the `RegisteredName`.
-            If None, this parameter is ignored in the filter
+              If None, this parameter is ignored in the filter
 
             profile_version (:term:`string`) or None: the `RegisteredVersion`.
-            If None, this parameter is ignored in the filter
+              If None, this parameter is ignored in the filter
 
         Raises:
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             KeyError: If an instance in the list of profiles is incomplete
-            and does not include the required properties.
-
+              and does not include the required properties.
         """
 
         org_vm = ValueMapping.for_property(self, self.interop_ns,
@@ -358,9 +364,9 @@ class WBEMServer(object):
         This method supports the following profile advertisement methodologies
         (see :term:`DSP1033`), and attempts them in this order:
 
-          * GetCentralInstances methodology (new in :term:`DSP1033` 1.1)
-          * Central class methodology
-          * Scoping class methodology
+        * GetCentralInstances methodology (new in :term:`DSP1033` 1.1)
+        * Central class methodology
+        * Scoping class methodology
 
         Use of the scoping class methodology requires specifying the central
         class, scoping class and scoping path defined by the profile. If any
@@ -529,7 +535,7 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
         """
         test_classname = 'CIM_Namespace'
         interop_ns = None
@@ -617,9 +623,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Namespace class could not be
-            determined.
+              determined.
         """
         ns_insts = None
         ns_classname = None
@@ -661,9 +667,9 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
             CIMError: CIM_ERR_NOT_FOUND, Unexpected number of
-            CIM_ObjectManager instances.
+              CIM_ObjectManager instances.
         """
         cimom_insts = self._conn.EnumerateInstances(
             "CIM_ObjectManager", namespace=self.interop_ns)
@@ -712,7 +718,7 @@ class WBEMServer(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
-            determined.
+              determined.
         """
         mp_insts = self._conn.EnumerateInstances("CIM_RegisteredProfile",
                                                  namespace=self.interop_ns)
@@ -730,11 +736,13 @@ class ValueMapping(object):
     This is done by retrieving the CIM class definition defining the CIM
     element in question, and by inspecting its ValueMap and Values qualifiers.
 
-    The actual translation of the values is performed by the :meth:`tovalues`
-    method.
+    The actual translation of the values is performed by the
+    :meth:`~pywbem.ValueMapping.tovalues` method.
 
     Instances of this class should be created through one of the factory class
-    methods: :meth:`for_property`, :meth:`for_method`, or :meth:`for_parameter`.
+    methods: :meth:`~pywbem.ValueMapping.for_property`,
+    :meth:`~pywbem.ValueMapping.for_method`, or
+    :meth:`~pywbem.ValueMapping.for_parameter`.
 
     Value ranges (``"2..4"``) and the indicator for unclaimed values (``".."``)
     in the ValueMap qualifier are supported.

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -22,7 +22,7 @@
 Version of the pywbem package.
 """
 
-#: Version of the **pywbem** package, as a :term:`string`.
+#: Version of the pywbem package, as a :term:`string`.
 #:
 #: Possible formats for the version string are:
 #:

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -22,7 +22,7 @@
 Version of the pywbem package.
 """
 
-#: Version of the ``pywbem`` package, as a string.
+#: Version of the **pywbem** package, as a :term:`string`.
 #:
 #: Possible formats for the version string are:
 #:

--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -245,5 +245,5 @@ PROVIDERTYPE_METHOD = 5
 PROVIDERTYPE_CONSUMER = 6               # Indication consumer
 PROVIDERTYPE_QUERY = 7
 
-DEFAULT_NAMESPACE = 'root/cimv2'        #: Default namespace for PyWBEM
+DEFAULT_NAMESPACE = 'root/cimv2'        #: Default CIM namespace
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1352,8 +1352,8 @@ class CIMInstance(_CIMComparisonMixin):
                 self.property_list:
             if self.path is not None and key not in self.path.keybindings:
                 return
-        # Convert value to appropriate PyWBEM type
 
+        # Convert value to appropriate pywbem type
         if isinstance(value, CIMProperty):
             val = value
         else:

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -554,7 +554,7 @@ class WBEMConnection(object):
             Registers a callback function that will be called to verify the
             X.509 server certificate returned by the WBEM server during the
             TLS/SSL handshake, in addition to the validation already performed
-            by the TLS/SSL support in the PyWBEM client.
+            by the TLS/SSL support.
 
             This parameter is ignored when HTTP is used.
 

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -534,7 +534,9 @@ class CIMInt(CIMType, _Longint):
     The valid value range is enforced when an instance of a subclass of this
     class (e.g. :class:`~pywbem.Uint8`) is created. Values outside of the
     valid range raise a :exc:`ValueError`.
-
+    The enforcement of the valid value range can be disabled via the
+    configuration variable :data:`~pywbem.config.ENFORCE_INTEGER_RANGE`.
+    
     Instances of subclasses of this class can be initialized with the usual
     input arguments supported by :term:`integer`, for example:
 

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -68,7 +68,7 @@ def _text(data):
 
     Note: The API for the minidom text node function has changed in
     Python 2.3.  The code for older Python versions has been removed from this
-    function in PyWBEM 0.8; the Python version check is now done in
+    function in pywbem v0.8; the Python version check is now done in
     __init__.py.
     """
 
@@ -942,7 +942,7 @@ class PROPERTY(CIMElement):
         # work unfortunately, because SFCB supports either form but not both
         # attributes in the same request.
         # As a result, the best choice is to use only the standards-conforming
-        # mixed case form in any requests sent by PyWBEM.
+        # mixed case form in any requests sent by pywbem.
 
         if qualifiers:
             self.appendChildren(qualifiers)

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -15,12 +15,12 @@
 #
 
 """
-The **pywbem** package supports a very limited number of configuration
-variables that influence certain specific behavior.
+Pywbem supports a very limited number of configuration variables that influence
+certain specific behavior.
 
-These configuration variables are read by **pywbem** only after its modules
-have been loaded, so they can be modified by the user directly after
-importing ``pywbem``. For example:
+These configuration variables are read by pywbem only after its modules have
+been loaded, so they can be modified by the user directly after importing
+pywbem. For example:
 
 ::
 

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -27,9 +27,9 @@ pywbem. For example:
     import pywbem
     pywbem.ENFORCE_INTEGER_RANGE = False
 
-Note that the source file defining these variables should not be changed by the
-user. Instead, use the technique described above to modify the configuration
-variables.
+Note that the pywbem source file defining these variables should not be changed
+by the user. Instead, the technique shown in the example above should be used to
+modify the configuration variables.
 
 Note: Due to limitations of the documentatin tooling, the following
 configuration variables are shown in the ``pywbem.config`` namespace. However,
@@ -40,12 +40,14 @@ they should be used from the ``pywbem`` namespace.
 
 __all__ = ['ENFORCE_INTEGER_RANGE']
 
-#: Enforce the value range in CIM integer types (e.g. :class:`~pywbem.Uint8`).
-#: For details, see the :class:`~pywbem.CIMInt` base class.
+#: Enforce the allowable value range for CIM integer types (e.g.
+#: :class:`~pywbem.Uint8`). For details, see the :class:`~pywbem.CIMInt` base
+#: class.
 #:
-#: * True (default): Enforce the value range; Assigning values out of range
-#:   causes :exc:`~py:exceptions.ValueError` to be raised.
-#: * False: Do not enforce the value range; Assigning values out of range
-#:   works.
+#: * True (default): Pywbem enforces the allowable value range; Assigning
+#:   values out of range causes :exc:`~py:exceptions.ValueError` to be raised.
+#: * False: Pywbem does not enforce the allowable value range; Assigning values
+#:   out of range works in pywbem. Note that a WBEM server may or may not
+#:   reject such out-of-range values.
 ENFORCE_INTEGER_RANGE = True
 

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -15,20 +15,25 @@
 #
 
 """
-The :mod:`pywbem.config` module sets configuration variables for PyWBEM.
+The **pywbem** package supports a very limited number of configuration
+variables that influence certain specific behavior.
 
-These configuration variables are used by PyWBEM only after its modules
+These configuration variables are read by **pywbem** only after its modules
 have been loaded, so they can be modified by the user directly after
-importing :mod:`pywbem`. For example:
+importing ``pywbem``. For example:
 
 ::
 
     import pywbem
-    pywbem.config.ENFORCE_INTEGER_RANGE = False
+    pywbem.ENFORCE_INTEGER_RANGE = False
 
-Note that the source file of the :mod:`pywbem.config` module should not be
-changed by the user. Instead, use the technique described above to modify
-the variables.
+Note that the source file defining these variables should not be changed by the
+user. Instead, use the technique described above to modify the configuration
+variables.
+
+Note: Due to limitations of the documentatin tooling, the following
+configuration variables are shown in the ``pywbem.config`` namespace. However,
+they should be used from the ``pywbem`` namespace.
 """
 
 # This module is meant to be safe for 'import *'.
@@ -36,6 +41,7 @@ the variables.
 __all__ = ['ENFORCE_INTEGER_RANGE']
 
 #: Enforce the value range in CIM integer types (e.g. :class:`~pywbem.Uint8`).
+#: For details, see the :class:`~pywbem.CIMInt` base class.
 #:
 #: * True (default): Enforce the value range; Assigning values out of range
 #:   causes :exc:`~py:exceptions.ValueError` to be raised.

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -23,20 +23,36 @@
 The language in which CIM classes are specified, is called `MOF` (for Managed
 Object Format). It is defined in :term:`DSP0004`.
 
-The ``pywbem.mof_compiler`` module provides a MOF compiler.
+The **pywbem** package includes a MOF compiler.
 
-MOF compilers are not operating just on its MOF input. In most cases, the CIM
-elements defined in the MOF input will have dependencies on other CIM elements.
-For this reason, most MOF compilers (and this one as well) need access to
-a CIM repository that contains all the CIM elements that can be used as
-dependencies. The result of the MOF compilation is again applied to that
-repository. So except for the very first time when the repository is still
-empty, a MOF compiler always operates against existing CIM elements and
-performs some kind of delta update, creating new elements, or updating existing
-elements.
+MOF compilers take MOF files as input, compile them and the result is used to
+update a target CIM repository. The repository may initially be empty, or may
+contain the result of earlier MOF compilations that are used to resolve
+dependencies the new MOF compilation may have.
 
 The MOF compiler in this package also has an option to remove CIM elements
 from the repository it has a definition for in the MOF files it processes.
+
+The MOF compiler API provides for invoking the MOF compiler and for plugging in
+your own CIM repository into the MOF compiler.
+
+The MOF compiler API is available in the ``pywbem.mof_compiler`` module.
+
+This chapter has the following sections:
+
+* :ref:`MOFCompiler` - Describes the :class:`~pywbem.mof_compiler.MOFCompiler`
+  class, which allows invoking the MOF compiler programmatically.
+
+* :ref:`Repository connections` - Describes the
+  :class:`~pywbem.mof_compiler.BaseRepositoryConnection` class that defines
+  the interface for connecting to a CIM repository, and the
+  :class:`~pywbem.mof_compiler.MOFWBEMConnection` class that is a connection
+  to an in-memory repository on top of an underlying repository, and is used
+  by the MOF compiler to provide rollback support.
+
+* :ref:`Exceptions <MOF compiler exceptions>` - Describes the exceptions
+  that can be raised by the MOF compiler, in addition to the exceptions
+  that can be raised by the :ref:`WBEM client library API`.
 """
 
 from __future__ import print_function, absolute_import
@@ -302,13 +318,14 @@ class MOFParseError(Error):
         """
         Parameters:
 
-            parser_token (PLY.ParserToken):
-                Parser token for the error. This token contains information on
-                the location of the error in the mof file. Details of the
-                token are set into the MofParseError object.
+          parser_token:
+            PLY parser token for the error (that is, the ``p`` argument
+            of a PLY parser function). This token contains information on
+            the location of the error in the MOF file, which is copied
+            into this object, and is accessible via properties.
 
-            msg  (:term:`string`):
-              Message text supplied by the creator of the error
+          msg (:term:`string`):
+            Message text supplied by the creator of the error
         """
 
         if parser_token is None:
@@ -323,36 +340,38 @@ class MOFParseError(Error):
 
     @property
     def lineno(self):
-        """ line number in file where error occurred
-        """
+        """Line number in the MOF file where the error occurred."""
         return self.args[0]
 
     @property
     def column(self):
-        """ Column in file line where error occurred
-        """
+        """Position within the line where the error occurred."""
         return self.args[1]
 
     @property
     def file(self):
-        """ Name of file where error occurred
+        """
+        File name of the MOF file where the error occurred, as a
+        :term:`string`.
         """
         return self.args[2]
 
     @property
     def context(self):
-        """ Context string that is inserted in output display on line below
-            file line.  Consists of a segment of the mof surrounding the
-            error position with a second line that uses the '^' char to
-            locate the token in error.
+        """
+        Context string that can be inserted when printing the error message.
+        The context string consists of a first line with a segment of the MOF
+        surrounding the error position, and a second line that uses the '^'
+        character to indicate the token in error.
         """
         return self.args[3]
 
     @property
     def msg(self):
-        """ Message that may be part of error. Generally this is produced when
-            the actual error position is not known but may be added by
-            some production errors
+        """
+        Message that may be part of the error, as a :term:`string`. Generally,
+        this is produced when the actual error position is not known but may be
+        added by some production errors.
         """
         return self._msg
 
@@ -368,14 +387,14 @@ class MOFParseError(Error):
 
     def get_err_msg(self):
         """
-            Generate string defining compiler error message. Generates a
-            string that defines an error message in the form
+        Return the MOF compiler error message as a :term:`string`, in the
+        format (assuming all components are provided):
 
-            Syntax error: <file> : <line> : <msg>
+        ::
 
-            context string mof text with error
-
-            context indicator of location of error in text.
+            Syntax error:<file>:<lineno>: <msg>
+            <context - MOF segment>
+            <context - location indicator>
         """
         ret_str = 'Syntax error:'
         if self.file is not None and self.lineno is not None:

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -23,7 +23,7 @@
 The language in which CIM classes are specified, is called `MOF` (for Managed
 Object Format). It is defined in :term:`DSP0004`.
 
-The **pywbem** package includes a MOF compiler.
+The pywbem package includes a MOF compiler.
 
 MOF compilers take MOF files as input, compile them and the result is used to
 update a target CIM repository. The repository may initially be empty, or may

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,16 @@
 # Author: Tim Potter <tpot@hp.com>
 #
 
+# The module docstring is used as the long package description:
 """
-PyWBEM is a WBEM client and some related utilities, written in pure Python.
+Pywbem is a WBEM client, written in pure Python. It supports Python 2 and
+Python 3.
 
 A WBEM client allows issuing operations to a WBEM server, using the CIM
-operations over HTTP (CIM-XML) protocol defined in the DMTF standards DSP0200
-and DSP0201. See http://www.dmtf.org/standards/wbem for information about
-WBEM. This is used for all kinds of systems management tasks that are
-supported by the system running the WBEM server.
+operations over HTTP (CIM-XML) protocol defined in the DMTF standards
+DSP0200 and DSP0201. The CIM/WBEM infrastructure is used for a wide variety of
+systems management tasks supported by systems running WBEM servers.
+See http://www.dmtf.org/standards/wbem for more information about WBEM.
 """
 
 from __future__ import print_function, absolute_import
@@ -307,7 +309,7 @@ def main():
         'author_email': 'tpot@hp.com',
         'maintainer': 'Andreas Maier',
         'maintainer_email': 'maiera@de.ibm.com',
-        'description': 'PyWBEM Client - A WBEM client and related utilities',
+        'description': 'pywbem - A WBEM client',
         'long_description': __doc__,
         'platforms': ['any'],
         'url': 'http://pywbem.github.io/pywbem/',


### PR DESCRIPTION
This PR makes a number of changes in the documentation, that I think are needed before we release v0.9.0.

Ready for review and merge.

Details:
- Moved "Package version" chapter from "WBEM client library API" section into
  "Introduction" section.
- Fixed missing and incorrect anchors in `client.rst`.
- Refactored package docu (module docstring in `__init.py__`), by moving
  (and improving) information about namespaces and external symbols into a new
  chapter "Python namespaces" in the "Introduction" section, and by moving the
  introduction of the chapters to the WBEM client library API into `client.rst`,
  adding the entry for "Security Considerations".
- Improved the introduction text of the "WBEM server API", "WBEM listener
  API", and "MOF compiler API" chapters.
- For `ValueMapping`, corrected the statement that bidirectional translation of
  values is supported, to state that only translation from the actual value
  to the Values value is supported.
- Added anchors for the sections within the "WBEM server API" and "WBEM listener
  API" chapters.
- Moved the "Configuration" chapter as a section into the "Introduction"
  chapter, and improved it.
- Stated that config variables should be used from the `pywbem` namespace (not
  from `pywbem.config`).
- Fixed a few indentation issues in changes.rst.
- Added a reference to "WBEM Standards", and referenced it from the package
  intro.
- Some more minor improvements.
- Included the member functions and properties of `MOFParseError` into the
  MOF compiler API (they had been forgotten so far), and improved their
  documentation.
- Fixed formatting issues in WBEM listener API and WBEM server API.