### PR TITLE
Fixes  #147: Change CIMProperty tomof output for embeddedinst

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2589,7 +2589,9 @@ class CIMProperty(_CIMComparisonMixin):
 
         if self.type == 'string':
             if self.embedded_object is not None:
-                val_ = value_.tocimxml().toxml()
+                # TODO ks 8/16 do special formatting for this so output
+                # sort of looks like mof, not just a string with lfs
+                val_ = value_.tomof()
             else:
                 val_ = value_
             _mof = mofstr(val_, indent=indent)


### PR DESCRIPTION
Change to output MOF per dsp0004  for tomof() of an embeddedinstance  property rather than than xml.  Add test to run_cimoperations.py for the mof.  See DSP0004, Appendix F1.