### PR TITLE
Removed `value` from str() and repr() of CIMParameter

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3127,10 +3127,10 @@ class CIMParameter(_CIMComparisonMixin):
         Return a short string representation of the
         :class:`~pywbem.CIMParameter` object for human consumption.
         """
-        return '%s(name=%r, value=%r, type=%r, ' \
+        return '%s(name=%r, type=%r, ' \
                'reference_class=%r, ' \
                'is_array=%r, ...)' % \
-               (self.__class__.__name__, self.name, self.value, self.type,
+               (self.__class__.__name__, self.name, self.type,
                 self.reference_class,
                 self.is_array)
 
@@ -3139,11 +3139,11 @@ class CIMParameter(_CIMComparisonMixin):
         Return a string representation of the :class:`~pywbem.CIMParameter`
         object that is suitable for debugging.
         """
-        return '%s(name=%r, value=%r, type=%r, ' \
+        return '%s(name=%r, type=%r, ' \
                'reference_class=%r, ' \
                'is_array=%r, array_size=%r, ' \
                'qualifiers=%r)' % \
-               (self.__class__.__name__, self.name, self.value, self.type,
+               (self.__class__.__name__, self.name, self.type,
                 self.reference_class,
                 self.is_array, self.array_size,
                 self.qualifiers)


### PR DESCRIPTION
We deprecated the use of `CIMParameter.value`, and so we should not show it in `__str__()` and `__repr__()`. Besides that, accessing it in these functions would cause a `DeprecationWarning` to be issued.

PR #467 already removed the item in the change log that was stating that `value` was added to `CIMParameter.__str__()`.