### PR TITLE
Fixes #470: Make usage of Jupyter tutorials more obvious

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -472,7 +472,7 @@ intersphinx_cache_limit = 5
 # results in the link caption "this issue".
 
 extlinks = {
-  'nbview': ('http://nbviewer.jupyter.org/github/pywbem/pywbem/blob/master/docs/notebooks/%s', 'View '),
+  'nbview': ('http://nbviewer.jupyter.org/github/pywbem/pywbem/blob/master/docs/notebooks/%s', ''),
   'nbdown': ('https://github.com/pywbem/pywbem/raw/master/docs/notebooks/%s', '')
 }
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -4,32 +4,31 @@
 Tutorial
 ========
 
-This is a short tutorial about using pywbem. It is intended to be enough to get
-people up and going who already know a bit about WBEM and CIM.
+This section contains a few short tutorials about using pywbem. It is intended
+to be enough to get people up and going who already know a bit about WBEM and
+CIM.
 
-Python code examples this tutorial are shown using
-`Jupyter Notebooks <jupyter-notebook-beginner-guide.readthedocs.io/>`_
-(formerly known as IPython Notebooks), using the online
+The tutorials in this section are 
+`Jupyter Notebooks <http://jupyter-notebook-beginner-guide.readthedocs.io/>`_,
+and are shown using the online
 `Jupyter Notebook Viewer <http://nbviewer.jupyter.org/>`_.
-This allows viewing them without having Jupyter installed locally.
+This allows viewing the tutorials without having Jupyter Notebook installed
+locally.
 
-In order to run or modify the examples, Jupyter Notebook must be installed,
-and a running WBEM server should be available.
+In order to view a tutorial, just click on a link in this table:
 
-The following table lists the available tutorials:
-
-======================================================== ==================================
-View the tutorial                                        Download the Jupyter notebook
-======================================================== ==================================
-:nbview:`Making Connections <connections.ipynb>`         :nbdown:`connections.ipynb`
-:nbview:`Python Data Model for CIM <datamodel.ipynb>`    :nbdown:`datamodel.ipynb`
-:nbview:`EnumerateInstances <enuminsts.ipynb>`           :nbdown:`enuminsts.ipynb`
-:nbview:`EnumerateInstanceNames <enuminstnames.ipynb>`   :nbdown:`enuminstnames.ipynb`
-:nbview:`GetInstance <getinstance.ipynb>`                :nbdown:`getinstance.ipynb`
-:nbview:`Create+DeleteInstance <createdeleteinst.ipynb>` :nbdown:`createdeleteinst.ipynb`
-:nbview:`ModifyInstance <modifyinstance.ipynb>`          :nbdown:`modifyinstance.ipynb`
-:nbview:`InvokeMethod <invokemethod.ipynb>`              :nbdown:`invokemethod.ipynb`
-======================================================== ==================================
+==================================  ===========================================
+Tutorial                            Short description
+==================================  ===========================================
+:nbview:`connections.ipynb`         Making connections to a WBEM server
+:nbview:`datamodel.ipynb`           Representation of CIM objects in Python
+:nbview:`enuminsts.ipynb`           EnumerateInstances
+:nbview:`enuminstnames.ipynb`       EnumerateInstanceNames
+:nbview:`getinstance.ipynb`         GetInstance
+:nbview:`createdeleteinst.ipynb`    CreateInstance + DeleteInstance
+:nbview:`modifyinstance.ipynb`      ModifyInstance
+:nbview:`invokemethod.ipynb`        InvokeMethod
+==================================  ===========================================
 
 For the following topics, tutorials are not yet available:
 
@@ -38,5 +37,24 @@ For the following topics, tutorials are not yet available:
 * Association Operations
 * Class Operations
 * Qualifier Operations
-* WBEM Server
-* WBEM Listener
+* WBEMServer
+* WBEMListener
+* WBEMSubscriptionManager
+
+Executing code in the tutorials
+-------------------------------
+
+You cannot directly modify or execute the code in the tutorials using the
+Jupyter Notebook Viewer, though. In order to do that, the Jupyter Notebook
+Viewer provides a download button at the top right corner of the page.
+
+You must have Jupyter Notebook
+`installed <https://jupyter.readthedocs.io/en/latest/install.html>`_,
+preferrably in a
+`virtual Python environment <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_,
+and you must have pywbem installed.
+
+To see a list of your downloaded notebook files, start Jupyter Notebook as
+follows::
+
+    jupyter notebook --notebook-dir={your-notebook-dir}


### PR DESCRIPTION
Please review.

Best way to review this is building the documentation using `make builddoc` and looking at the Tutorials page of the documentation.