### PR TITLE
Fixes #466: Implements the enumerate generator methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,6 +82,21 @@ Enhancements
   are now conditionally created, dependent on the owned instances that have
   been discovered upon restart of the WBEMSubscriptionManager.
 
+* Add new methods to WBEMConnection to provide integrated APIs for the
+  non-pull and pull operations, reducing the amount of code app writers must
+  produce and providing a pythonic (generator based) interface for the
+  methods that enumerate instances and instance paths, enumerator associators
+  and references (ssue #466)).  These new methods have names in the pattern
+  Iter<name of original function>. Thus, for example the new method
+  IterEnumerateInstances creates a new API to integrate EnumerateInstances
+  and the OpenEnumerateInstancesWithPath/PullInstancesWithPath.  See the
+  documentation for more information on these API's
+  Generally the form of these operations are:
+
+  result_generator = IterEnumerateInstances(...)
+  for instance in result_generator:
+      <do something with instance>
+
 Bug fixes
 ^^^^^^^^^
 

--- a/examples/enumerator_generator.py
+++ b/examples/enumerator_generator.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+    Example of using Iterator Operations to retrieve instances from a
+    WBEM Server. This example executes the IterEnumerateInstances and the
+    corresponding IterEnumeratePaths operations.
+
+    It:
+        Creates a connection
+        Opens an enumeration session with OpenEnumerateInstances
+        Executes a pull loop until the result.eos =True
+        Displays overall statistics on the returns
+    It also displays the results of the open and each pull in detail
+"""
+
+from __future__ import print_function
+
+import sys
+import argparse as _argparse
+from pywbem import WBEMConnection, CIMError, Error
+from pywbem._cliutils import SmartFormatter as _SmartFormatter
+
+def _str_to_bool(str_):
+    """Convert string to bool (in argparse context)."""
+    if str_.lower() not in ['true', 'false', 'none']:
+        raise ValueError('Need bool; got %r' % str_)
+    return {'true': True, 'false': False, 'none': None}[str_.lower()]
+
+def add_nullable_boolean_argument(parser, name, default=None, help_=None):
+    """Add a boolean argument to an ArgumentParser instance."""
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '--' + name, nargs='?', default=default, const=True, type=_str_to_bool,
+        help=help_)
+    group.add_argument('--no' + name, dest=name, action='store_false',
+                       help=help_)
+
+def create_parser(prog):
+    """
+    Parse command line arguments, connect to the WBEM server and open the
+    interactive shell.
+    """
+
+    usage = '%(prog)s [options] server'
+    desc = 'Provide an interactive shell for issuing operations against' \
+           ' a WBEM server.'
+    epilog = """
+Examples:
+  %s https://localhost:15345 -n vendor -u sheldon -p penny
+          - (https localhost, port=15345, namespace=vendor user=sheldon
+         password=penny)
+
+  %s http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
+""" % (prog, prog)
+
+    argparser = _argparse.ArgumentParser(
+        prog=prog, usage=usage, description=desc, epilog=epilog,
+        add_help=False, formatter_class=_SmartFormatter)
+
+    pos_arggroup = argparser.add_argument_group(
+        'Positional arguments')
+    pos_arggroup.add_argument(
+        'server', metavar='server', nargs='?',
+        help='R|Host name or url of the WBEM server in this format:\n'
+             '    [{scheme}://]{host}[:{port}]\n'
+             '- scheme: Defines the protocol to use;\n'
+             '    - "https" for HTTPs protocol\n'
+             '    - "http" for HTTP protocol.\n'
+             '  Default: "https".\n'
+             '- host: Defines host name as follows:\n'
+             '     - short or fully qualified DNS hostname,\n'
+             '     - literal IPV4 address(dotted)\n'
+             '     - literal IPV6 address (RFC 3986) with zone\n'
+             '       identifier extensions(RFC 6874)\n'
+             '       supporting "-" or %%25 for the delimiter.\n'
+             '- port: Defines the WBEM server port to be used\n'
+             '  Defaults:\n'
+             '     - HTTP  - 5988\n'
+             '     - HTTPS - 5989\n')
+
+    server_arggroup = argparser.add_argument_group(
+        'Server related options',
+        'Specify the WBEM server namespace and timeout')
+    server_arggroup.add_argument(
+        '-n', '--namespace', dest='namespace', metavar='namespace',
+        default='root/cimv2',
+        help='R|Default namespace in the WBEM server for operation\n'
+             'requests when namespace option not supplied with\n'
+             'operation request.\n'
+             'Default: %(default)s')
+    server_arggroup.add_argument(
+        '-t', '--timeout', dest='timeout', metavar='timeout', type=int,
+        default=None,
+        help='R|Timeout of the completion of WBEM Server operation\n'
+             'in seconds(integer between 0 and 300).\n'
+             'Default: No timeout')
+
+    server_arggroup.add_argument(
+        '-c', '--classname', dest='classname', metavar='classname',
+        default='CIM_ManagedElement',
+        help='R|Classname in the WBEM server for operation\n'
+             'request.\n'
+             'Default: %(default)s')
+
+    security_arggroup = argparser.add_argument_group(
+        'Connection security related options',
+        'Specify user name and password or certificates and keys')
+    security_arggroup.add_argument(
+        '-u', '--user', dest='user', metavar='user',
+        help='R|User name for authenticating with the WBEM server.\n'
+             'Default: No user name.')
+    security_arggroup.add_argument(
+        '-p', '--password', dest='password', metavar='password',
+        help='R|Password for authenticating with the WBEM server.\n'
+             'Default: Will be prompted for, if user name\nspecified.')
+    security_arggroup.add_argument(
+        '-nvc', '--no-verify-cert', dest='no_verify_cert',
+        action='store_true',
+        help='Client will not verify certificate returned by the WBEM'
+             ' server (see cacerts). This bypasses the client-side'
+             ' verification of the server identity, but allows'
+             ' encrypted communication with a server for which the'
+             ' client does not have certificates.')
+    security_arggroup.add_argument(
+        '--cacerts', dest='ca_certs', metavar='cacerts',
+        help='R|File or directory containing certificates that will be\n'
+             'matched against a certificate received from the WBEM\n'
+             'server. Set the --no-verify-cert option to bypass\n'
+             'client verification of the WBEM server certificate.\n')
+
+    security_arggroup.add_argument(
+        '--certfile', dest='cert_file', metavar='certfile',
+        help='R|Client certificate file for authenticating with the\n'
+             'WBEM server. If option specified the client attempts\n'
+             'to execute mutual authentication.\n'
+             'Default: Simple authentication.')
+    security_arggroup.add_argument(
+        '--keyfile', dest='key_file', metavar='keyfile',
+        help='R|Client private key file for authenticating with the\n'
+             'WBEM server. Not required if private key is part of the\n'
+             'certfile option. Not allowed if no certfile option.\n'
+             'Default: No client key file. Client private key should\n'
+             'then be part  of the certfile')
+
+    general_arggroup = argparser.add_argument_group(
+        'General options')
+    general_arggroup.add_argument(
+        '-v', '--verbose', dest='verbose',
+        action='store_true', default=False,
+        help='Print more messages while processing')
+
+    general_arggroup.add_argument(
+        '-m', '--MaxObjectCount', dest='max_object_count',
+        metavar='MaxObjectCount', default=100,
+        help='R|Maximum object count in pull responses.\n'
+             'Default: 100.')
+
+    add_nullable_boolean_argument(
+        general_arggroup, 'usepull',
+        help_='Use Pull Operations.  If --usepull, pull will be used. If'
+              ' --nousepull will execute Enumerate operation. Default is'
+              ' `None` where the system decides.')
+    general_arggroup.add_argument(
+        '-h', '--help', action='help',
+        help='Show this help message and exit')
+
+    return argparser
+
+def parse_cmdline(argparser_):
+    """ Parse the command line.  This tests for any required args"""
+
+    opts = argparser_.parse_args()
+
+    if not opts.server:
+        argparser_.error('No WBEM server specified')
+        return None
+    return opts
+
+def main():
+    """
+        Get arguments and call the execution function
+    """
+    prog = sys.argv[0]
+
+    arg_parser = create_parser(prog)
+
+    opts = parse_cmdline(arg_parser)
+
+    print('Parameters: server=%s\n username=%s\n namespace=%s\n'
+          ' classname=%s\n max_pull_size=%s\n use_pull=%s' %
+          (opts.server, opts.user, opts.namespace, opts.classname,
+           opts.max_object_count, opts.usepull))
+
+    # call method to connect to the server
+    conn = WBEMConnection(opts.server, (opts.user, opts.password),
+                          default_namespace=opts.namespace,
+                          no_verification=True,
+                          use_pull_operations=opts.usepull)
+
+    #Call method to create iterator
+    instances = []
+    try:
+        iter_instances = conn.IterEnumerateInstances(
+            opts.classname,
+            MaxObjectCount=opts.max_object_count)
+
+        # generate instances with
+        for instance in iter_instances:
+            print(' %s %s' % (type(instances), type(instance)))
+            instances.append(instance)
+            print('\npath=%s\n%s' % (instance.path, instance.tomof()))
+
+    # handle exceptions
+    except CIMError as ce:
+        print('Operation Failed: CIMError: code=%s, Description=%s' %
+              (ce.status_code_name, ce.status_description))
+        sys.exit(1)
+    except Error as err:
+        print ("Operation failed: %s" % err)
+        sys.exit(1)
+
+    inst_paths = [inst.path for inst in instances]
+
+    paths = []
+    try:
+        iter_paths = conn.IterEnumerateInstancePaths(
+            opts.classname,
+            MaxObjectCount=opts.max_object_count)
+
+        # generate instances with
+        for path in iter_paths:
+            print('path=%s' % path)
+            paths.append(path)
+
+        if len(paths) != len(paths):
+            print('Error path and enum response sizes different enum=%s path=%s'
+                  % (len(paths), len(paths)))
+        for path in paths:
+            found = False
+            for inst_path in inst_paths:                
+                if path == inst_path:
+                    found = True
+                    break
+                else:
+                    print('No match \n%s\n%s' %(path, inst_path))
+            if not found:
+                print('Path %s not found in insts' % path)
+    # handle exceptions
+    except CIMError as ce:
+        print('Operation Failed: CIMError: code=%s, Description=%s' %
+              (ce.status_code_name, ce.status_description))
+        sys.exit(1)
+    except Error as err:
+        print ("Operation failed: %s" % err)
+        sys.exit(1)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -2130,20 +2130,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         _validateIterCommonParams(MaxObjectCount, OperationTimeout)
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
-                method='IterEnumerateInstancePaths',
-                ClassName=ClassName,
-                namespace=namespace,
-                FilterQueryLanguage=FilterQueryLanguage,
-                FilterQuery=FilterQuery,
-                OperationTimeout=OperationTimeout,
-                ContinueOnError=ContinueOnError,
-                MaxObjectCount=MaxObjectCount,
-                **extra)
-
         # Common variable for pull result tuple used by pulls and finally:
+
         pull_result = None
         try:                # try / finally block to allow iter.close()
             if (self._use_enum_path_pull_operations is None or

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -38,7 +38,7 @@ they should be used from the ``pywbem`` namespace.
 
 # This module is meant to be safe for 'import *'.
 
-__all__ = ['ENFORCE_INTEGER_RANGE']
+__all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT']
 
 #: Enforce the allowable value range for CIM integer types (e.g.
 #: :class:`~pywbem.Uint8`). For details, see the :class:`~pywbem.CIMInt` base
@@ -50,3 +50,13 @@ __all__ = ['ENFORCE_INTEGER_RANGE']
 #:   out of range works in pywbem. Note that a WBEM server may or may not
 #:   reject such out-of-range values.
 ENFORCE_INTEGER_RANGE = True
+
+#: Default setting for the MaxObjectCount attribute for all of the
+#: WBEMConnection:Iter... operations.
+#: If this attribute is not specified on a request such as
+#: IterEnumerateInstance this value will be used as the value for
+#: MaxObjectCount.
+#: Note that this does not necessarily optimize the performance of these
+#: operations.
+
+DEFAULT_ITER_MAXOBJECTCOUNT = 1000

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -4760,6 +4760,7 @@ class IterAssociatorInstances(PegasusServerTestBase):
             self.run_enum_test(path, MaxObjectCount=100)
 
 
+# TODO confirm that this should be pegasus
 class IterAssociatorInstancePaths(PegasusServerTestBase):
     """Test IterAssociatorInstancePaths methods"""
 
@@ -4925,6 +4926,118 @@ class IterAssociatorInstancePaths(PegasusServerTestBase):
         # all instances
         for path in inst_paths:
             self.run_enumpath_test(path, MaxObjectCount=100)
+
+
+class IterQueryInstances(PegasusServerTestBase):
+
+    def test_simple_iter_queryinstances(self):
+        try:
+            # Simplest invocation
+
+            result = self.cimcall(self.conn.IterQueryInstances,
+                                  'WQL',
+                                  'Select * from %s' % TEST_CLASS,
+                                  MaxObjectCount=100)
+            self.assertEqual(result.query_result_class, None)
+            count = 0
+            for inst in result.generator:
+                count += 1
+                self.assertTrue(isinstance(inst, CIMInstance))
+
+            self.assertTrue(count != 0)
+
+            self.assertEqual(self.conn._use_enum_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_enum_path_pull_operations, None)
+            self.assertEqual(self.conn._use_ref_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_ref_path_pull_operations, None)
+            self.assertEqual(self.conn._use_assoc_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_assoc_path_pull_operations, None)
+            self.assertEqual(self.conn._use_query_pull_operations, True)
+
+        except CIMError as ce:
+            if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
+                    " support OpenQueryInstances for this query")
+            if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
+                    " server doesn't support WQL for ExecQuery")
+            else:
+                raise
+
+    def test_zeroopen_pullexecquery(self):
+        try:
+
+            # Simplest invocation
+            result = self.cimcall(self.conn.IterQueryInstances,
+                                  'WQL',
+                                  'Select * from %s' % TEST_CLASS)
+
+            self.assertEqual(result.query_result_class, None)
+            count = 0
+            for inst in result.generator:
+                count += 1
+                self.assertTrue(isinstance(inst, CIMInstance))
+            self.assertTrue(count != 0)
+
+            self.assertEqual(self.conn._use_enum_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_enum_path_pull_operations, None)
+            self.assertEqual(self.conn._use_ref_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_ref_path_pull_operations, None)
+            self.assertEqual(self.conn._use_assoc_inst_pull_operations, None)
+            self.assertEqual(self.conn._use_assoc_path_pull_operations, None)
+            self.assertEqual(self.conn._use_query_pull_operations, True)
+
+        except CIMError as ce:
+            if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
+                    " support OpenQueryInstances for this query")
+            if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
+                    " server doesn't support WQL for ExecQuery")
+            else:
+                raise
+
+    def test_original_execquery(self):
+        """Set to use original operation and retry request"""
+        try:
+            # Force a new setup to set the use_pull_operations False.
+            self.setUp(use_pull_operations=False)
+
+            # Simplest invocation
+            result = self.cimcall(self.conn.IterQueryInstances,
+                                  'WQL',
+                                  'Select * from %s' % TEST_CLASS)
+
+            self.assertEqual(result.query_result_class, None)
+            count = 0
+            for inst in result.generator:
+                count += 1
+                self.assertTrue(isinstance(inst, CIMInstance))
+            self.assertTrue(count != 0)
+
+            self.assertEqual(self.conn._use_enum_inst_pull_operations, False)
+            self.assertEqual(self.conn._use_enum_path_pull_operations, False)
+            self.assertEqual(self.conn._use_ref_inst_pull_operations, False)
+            self.assertEqual(self.conn._use_ref_path_pull_operations, False)
+            self.assertEqual(self.conn._use_assoc_inst_pull_operations, False)
+            self.assertEqual(self.conn._use_assoc_path_pull_operations, False)
+            self.assertEqual(self.conn._use_query_pull_operations, False)
+
+        except CIMError as ce:
+            if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
+                    " support OpenQueryInstances for this query")
+            if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
+                raise AssertionError(
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
+                    " server doesn't support WQL for ExecQuery")
+            else:
+                raise
 
 
 RECEIVED_INDICATION_COUNT = 0

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -2376,8 +2376,7 @@ class InvokeMethod(ClientTest):
                               class_name,
                               [('indicationSendCount',
                                 Uint32(0))])
-
-        self.assertEqual(result[0], 1)
+        self.assertEqual(result[0], 0)
 
         # TODO: Call with empty arrays
 
@@ -3503,7 +3502,7 @@ class PegasusTestEmbeddedInstance(PegasusServerTestBase, RegexpMixin):
                     print('======%s XML=====\n%s' % (inst.path, str_xml))
 
                 # confirm general characteristics of mof output
-                self.assertRegex(
+                self.assertRegexpMatches(
                     str_mof, r"instance of Test_CLITestEmbeddedClass {")
                 self.assertRegexpContains(
                     str_mof,
@@ -3611,7 +3610,7 @@ class PyWBEMServerClass(PegasusServerTestBase):
 
         if self.is_pegasus_server():
             self.assertEqual(server.brand, 'OpenPegasus')
-            self.assertRegex(server.version, r"^2\.1[0-7]\.[0-7]$")
+            self.assertRegexpMatches(server.version, r"^2\.1[0-7]\.[0-7]$")
         else:
             # Do not know what server it is so just display
             print("Brand: %s" % server.brand)
@@ -4108,8 +4107,6 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
 
         This is a common function used by other tests in this class.
         """
-        if namespace is not None:
-            namespace = namespace.encode('utf-8')
 
         # execute iterator operation
         generator = self.cimcall(self.conn.IterEnumerateInstancePaths,
@@ -4152,6 +4149,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
         # it.
         orig_paths = self.cimcall(self.conn.EnumerateInstanceNames, ClassName,
                                   namespace=namespace)
+        self.assertPathsValid(result.paths, namespace=namespace)
 
         self.assertPathsEqual(pulled_paths, orig_paths, ignore_host=True)
 
@@ -5320,7 +5318,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             # confirm structure of the name element without any id components
             # NOTE: The uuid from uuid4 is actually 36 char but not we made it
             # 30-40 in case format changes in future.
-            self.assertRegex(
+            self.assertRegexpMatches(
                 filter_path.keybindings['Name'],
                 r'^pywbemfilter:owned:fred2:MyfilterId:[0-9a-f-]{30,40}\Z')
             subscriptions = sub_mgr.add_subscriptions(server_id,
@@ -5411,7 +5409,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             self.assertEqual(len(owned_filter_paths), 1)
             for path in owned_filter_paths:
                 name = path.keybindings['Name']
-                self.assertRegex(
+                self.assertRegexpMatches(
                     name,
                     r'^pywbemfilter:owned:pegTestListener:fred:' +
                     r'[0-9a-f-]{30,40}\Z')
@@ -5423,7 +5421,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
                 query_language="DMTF:CQL", filter_id='test_id_attributes1')
             filter_path2 = filter2.path
 
-            self.assertRegex(
+            self.assertRegexpMatches(
                 filter_path2.keybindings['Name'],
                 r'^pywbemfilter:owned:pegTestListener:test_id_attributes1:' +
                 r'[0-9a-f-]{30,40}\Z')
@@ -5434,7 +5432,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
                 query_language="DMTF:CQL", filter_id='test_id_attributes2')
             filter_path3 = filter3.path
 
-            self.assertRegex(
+            self.assertRegexpMatches(
                 filter_path3.keybindings['Name'],
                 r'^pywbemfilter:owned:pegTestListener:test_id_attributes2:' +
                 r'[0-9a-f-]{30,40}\Z')
@@ -5517,7 +5515,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             self.assertEqual(len(owned_filter_paths), 1)
             for path in owned_filter_paths:
                 name = path.keybindings['Name']
-                self.assertRegex(
+                self.assertRegexpMatches(
                     name,
                     r'^pywbemfilter:owned:pegTestMgr:fred:[0-9a-f-]{30,40}\Z')
             self.assertTrue(filter_path in owned_filter_paths)

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -843,12 +843,17 @@ def result_tuple(value, tc_name):
             instance, eos, context
             or
             paths, eos, context
+        For openqueryinstances it returns a named tuple with 4 elements
+        in place of 3
     """
-
     if isinstance(value, dict):
         # test for both paths and instances.
         objs = None
-        result = namedtuple("exp_result", ["instances", "eos", "context"])
+        if "query_result_class" in value:
+            result = namedtuple("exp_result", ["instances", "eos", "context",
+                                               "query_result_class"])
+        else:
+            result = namedtuple("exp_result", ["instances", "eos", "context"])
 
         # either path or instances should be in value
         if "instances" in value:
@@ -858,7 +863,6 @@ def result_tuple(value, tc_name):
                 raise AssertionError("WBEMConnection operation method "
                                      "result is not as expected. Both "
                                      "'instances' and 'paths' component.")
-
         elif "paths" in value:
             paths = value["paths"]
             objs = obj(paths, tc_name)
@@ -868,7 +872,12 @@ def result_tuple(value, tc_name):
                                  "is not as expected. No 'instances' "
                                  "or 'paths' component.")
 
-        return result(objs, value["eos"], value["context"])
+        # if query_result_class in value, add it to result
+        if "query_result_class" in value:
+            return result(objs, value["eos"], value["context"],
+                          value["query_result_class"])
+        else:
+            return result(objs, value["eos"], value["context"])
 
     else:
         raise AssertionError("WBEMConnection operation invalid tuple "

--- a/testsuite/testclient/openqueryinstances.yaml
+++ b/testsuite/testclient/openqueryinstances.yaml
@@ -1,0 +1,255 @@
+- name: OpenQueryInstances1
+  description: OpenQueryInstances request. returns eos=true, etc. and instances. Successful
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: OpenQueryInstances
+      MaxObjectCount: 100
+      FilterQuery: Select * from CIM_ComputerSystem
+      FilterQueryLanguage: WQL
+      ContinueOnError: null
+      OperationTimeout: null
+      namespace: null
+      ReturnQueryResultClass: null
+  pywbem_response:
+    pullresult:
+        context: null
+        eos: True
+        query_result_class: null
+        instances:
+              - pywbem_object: CIMInstance
+                classname: PG_ComputerSystem
+                properties:
+                  powermanagementcapabilities:
+                    pywbem_object: CIMProperty
+                    name: PowerManagementCapabilities
+                    value:
+                    - 1
+                    type: uint16
+                    reference_class: null
+                    embedded_object: null
+                    is_array: true
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  creationclassname:
+                    pywbem_object: CIMProperty
+                    name: CreationClassName
+                    value: PG_ComputerSystem
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  operationalstatus:
+                    pywbem_object: CIMProperty
+                    name: OperationalStatus
+                    value:
+                    - 2
+                    type: uint16
+                    reference_class: null
+                    embedded_object: null
+                    is_array: true
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  powerstate:
+                    pywbem_object: CIMProperty
+                    name: PowerState
+                    value: 1
+                    type: uint16
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  name:
+                    pywbem_object: CIMProperty
+                    name: Name
+                    value: sheldon
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  nameformat:
+                    pywbem_object: CIMProperty
+                    name: NameFormat
+                    value: Other
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  description:
+                    pywbem_object: CIMProperty
+                    name: Description
+                    value: 'Linux version 3.13.0-105-generic (buildd@lgw01-59) (gcc version
+                      4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #152-Ubuntu SMP Fri Dec 2 15:37:11
+                      UTC 2016'
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  powermanagementsupported:
+                    pywbem_object: CIMProperty
+                    name: PowerManagementSupported
+                    value: false
+                    type: boolean
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  caption:
+                    pywbem_object: CIMProperty
+                    name: Caption
+                    value: Computer System
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  elementname:
+                    pywbem_object: CIMProperty
+                    name: ElementName
+                    value: Computer System
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+                  status:
+                    pywbem_object: CIMProperty
+                    name: Status
+                    value: OK
+                    type: string
+                    reference_class: null
+                    embedded_object: null
+                    is_array: false
+                    array_size: null
+                    class_origin: null
+                    propagated: null
+                    qualifiers: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: OpenQueryInstances
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenQueryInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="FilterQuery">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="FilterQueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="OpenQueryInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Description"  TYPE="string">
+      <VALUE>Linux version 3.13.0-105-generic (buildd@lgw01-59) (gcc version 4.8.4
+      (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #152-Ubuntu SMP Fri Dec 2 15:37:11 UTC 2016</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>
+      </VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'


### PR DESCRIPTION
**STATUS 11 Dec:** for review: All functions implemented along with a _use... parameter for each.  Removed the method to set use_pull_operations.  Some initial code for these operations is now in run_cim operations but have more work there.  I have not yet sorted out how to test this through mock yet. First goal is complete test with run_cimoperations.py I have at least a day of adding tests just in run_cim_operations.py

Added almost all basic tests (except invoke method) to run_cimoperations.py so we are exercising at least the main paths. Working now to try to get them into mock but still trying to sort out how to handle the generate response(probably use it to drive a for loop)

**Discussion:** The IterQueryInstances works but want to discuss the fact that what I did is a hack. Using generators has a number of limitations, specifically it is not easy to create results that return the generator type and some other entity.  I created a class that is returned and has two properties, the query_result_class (on None) and the generator object.

However, making the chain so that I can feed this return class from the pull responses proved difficutltso for now I get all and then return them IterQueryInstancesReturn. The alternative is another class wrapping the whole implementation of IterQueryInstances so that we could wrap multiple levels of generators and I ran out of time.


**DISCUSSION:** restructure with iter function in separate class: See last comment for my conclusion after implementing. **CONCLUSION:** Agreed not to do this

There is also a sample program in examples right now.  The example does execute but is incomplete.

Known Questions:
2. One of the inefficiencies of this is that for every connection we go through the pull dance first try pull and then if pull fails, non-pull. For scripts, where there is just one connection, this is not a real problem. However,  it does assume that the user makes a WBEMConnection with a WEBServer and keeps using it to be efficient. No solution. This is just a note for now.
