### PR TITLE
Fixes #500: Correct var used before setting issue

### DIFF
--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -506,11 +506,11 @@ class WBEMSubscriptionManager(object):
             return
 
         server = self._get_server(server_id)
-        server.conn.DeleteInstance(dest_path)
 
         # Here destination_paths will contain only a single path entry.
         # Assign to internal variable for clarity
         dest_path = destination_paths
+        server.conn.DeleteInstance(dest_path)
         paths = self._owned_destination_paths[server_id]
         for i, path in enumerate(paths):
             if path == dest_path:


### PR DESCRIPTION
Corrected just plain code error.  Meant that remove subscription does not actually remove subscription from server.

Think I need to do more through indication test since the test should have caught this.  But will make that part of general cleanup

Note that this is actually a BUG and should go into version 0.9.1.  However, we probably have a few days since I would not expect much use of the new code immediatly.