### PR TITLE
For 0.9: Fixed compatibility issue with Error; Clarified CIMError; Added exceptions unit test

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,15 @@ Bug fixes
 * Fixed the use of a variable before it was set in the `remove_destinations()`
   method of class `WBEMSubscriptionManager`.
 
+* Fixed a compatibility issue relative to pywbem 0.7.0, where the
+  `pywbem.Error` class was no longer available in the `pywbem.cim_http`
+  namespace. It has been made available in that namespace again, for
+  compatibility reasons. Note that using sub-namespaces of the `pywbem`
+  namespace such as `pywbem.cim_http` has been deprecated in pywbem 0.8.0.
+
+* Fixed a documentation issue where the description of `CIMError` was not
+  clear that the exception object itself can be accessed by index and slice.
+
 
 pywbem v0.9.0
 -------------

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -51,8 +51,9 @@ from six.moves import http_client as httplib
 from six.moves import urllib
 
 from .cim_obj import CIMClassName, CIMInstanceName, _ensure_unicode, \
-                    _ensure_bytes
-from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
+                     _ensure_bytes
+from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError, \
+                        Error
 
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -144,16 +144,32 @@ class CIMError(Error):
     This exception indicates that the WBEM server returned an error response
     with a CIM status code. Derived from :exc:`~pywbem.Error`.
 
-    A :class:`CIMError` exception object can be accessed by index and slice and
-    will delegate such access to its :attr:`~pywbem.CIMError.args` instance
-    variable.
-    For example, the numeric CIM status code of a :class:`CIMError` object can
-    be accessed in any of these ways::
+    In Python 2, any :class:`py:Exception` object can be accessed by index
+    and slice and will delegate such access to its :attr:`Exception.args`
+    instance variable. In Python 3, that ability has been removed.
+
+    In its version 0.9, pywbem has added the
+    :attr:`~pywbem.CIMError.status_code` and
+    :attr:`~pywbem.CIMError.status_description` properties.
+
+    With all these variations, the following approach for accessesing the CIM
+    status code a :class:`CIMError` object works for all pywbem versions since
+    0.7.0 and for Python 2 and 3::
 
         except CIMError as exc:
-            status_code = exc.status_code  # access by property
-            status_code = exc[0]           # access the object by index
-            status_code = exc.args[0]      # access the args attribute by index
+            status_code = exc.args[0]
+
+    The following approach is recommended when using pywbem 0.9 or newer, and
+    it works for Python 2 and 3::
+
+        except CIMError as exc:
+            status_code = exc.status_code
+
+    The following approach is limited to Python 2 and will not work on
+    Python 3, and is therefore not recommended::
+
+        except CIMError as exc:
+            status_code = exc[0]
     """
 
     def __init__(self, status_code, status_description=None):

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -144,9 +144,16 @@ class CIMError(Error):
     This exception indicates that the WBEM server returned an error response
     with a CIM status code. Derived from :exc:`~pywbem.Error`.
 
-    The `args` attribute is a `tuple(status_code, status_description)`.
+    A :class:`CIMError` exception object can be accessed by index and slice and
+    will delegate such access to its :attr:`~pywbem.CIMError.args` instance
+    variable.
+    For example, the numeric CIM status code of a :class:`CIMError` object can
+    be accessed in any of these ways::
 
-    The `message` attribute is not set.
+        except CIMError as exc:
+            status_code = exc.status_code  # access by property
+            status_code = exc[0]           # access the object by index
+            status_code = exc.args[0]      # access the args attribute by index
     """
 
     def __init__(self, status_code, status_description=None):
@@ -157,7 +164,11 @@ class CIMError(Error):
 
           status_description (:term:`string`): CIM status description text
             returned by the server, representing a human readable message
-            describing the error.
+            describing the error. `None`, if the server did not return
+            a description text.
+
+        :ivar args: A tuple(status_code, status_description) set from the
+              corresponding init arguments.
         """
         self.args = (status_code, status_description)
 
@@ -184,7 +195,11 @@ class CIMError(Error):
 
         If the server did not return a description, a short default text for
         the CIM status code is returned. If the CIM status code is invalid,
-        the string ``"Invalid status code <code>"`` is returned."""
+        the string ``"Invalid status code <code>"`` is returned.
+
+        Note that ``args[1]`` is always the ``status_description`` init
+        argument, without defaulting it to a standard text in case of `None`.
+        """
         return self.args[1] or _statuscode2string(self.status_code)
 
     def __str__(self):

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+
+"""
+Test exceptions module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import six
+import pytest
+
+from pywbem import Error, ConnectionError, AuthError, HTTPError, \
+                   TimeoutError, ParseError, VersionError, CIMError
+
+def _assert_subscription(exc):
+
+    # Access by subscription is only supported in Python 2:
+    if six.PY2:
+        assert exc[:] == exc.args
+        for i, _ in enumerate(exc.args):
+            assert exc[i] == exc.args[i]
+            assert exc[i:] == exc.args[i:]
+            assert exc[0:i] == exc.args[0:i]
+    else:
+        try:
+            _ = exc[:]
+        except TypeError:
+            pass
+        else:
+            assert False, "Access by slice did not fail in Python 3"
+        for i, _ in enumerate(exc.args):
+            try:
+                _ = exc[i]
+            except TypeError:
+                pass
+            else:
+                assert False, "Access by index did not fail in Python 3"
+
+# The exception classes for which the simple test should be done:
+@pytest.fixture(params=[
+    Error, ConnectionError, AuthError, TimeoutError, ParseError, VersionError
+], scope='module')
+def simple_class(request):
+    return request.param
+
+# The init arguments for the simple exception classes:
+@pytest.fixture(params=[
+    (),
+    ('foo',),
+    ('foo', 42),
+], scope='module')
+def simple_args(request):
+    return request.param
+
+def test_simple(simple_class, simple_args):
+
+    exc = simple_class(*simple_args)
+
+    # exc has no len()
+    assert len(exc.args) == len(simple_args)
+    for i, _ in enumerate(simple_args):
+        assert exc.args[i] == simple_args[i]
+        assert exc.args[i:] == simple_args[i:]
+        assert exc.args[0:i] == simple_args[0:i]
+        assert exc.args[:] == simple_args[:]
+
+    _assert_subscription(exc)
+
+# The init arguments for the HTTPError exception class:
+@pytest.fixture(params=[
+    # (status, reason, cimerror=None, cimdetails={})
+    (200, 'OK'),
+    (404, 'Not Found', 'instance xyz not found'),
+    (404, 'Not Found', 'instance xyz not found', 'foo'),
+], scope='module')
+def httperror_args(request):
+    return request.param
+
+def test_httperror(httperror_args):
+
+    exc = HTTPError(*httperror_args)
+
+    assert exc.status == httperror_args[0]
+    assert exc.reason == httperror_args[1]
+    if len(httperror_args) < 3:
+        assert exc.cimerror == None  # default value
+    else:
+        assert exc.cimerror == httperror_args[2]
+    if len(httperror_args) < 4:
+        assert exc.cimdetails == {}  # default value (set in init)
+    else:
+        assert exc.cimdetails == httperror_args[3]
+
+    assert exc.args[0] == exc.status
+    assert exc.args[1] == exc.reason
+    assert exc.args[2] == exc.cimerror
+    assert exc.args[3] == exc.cimdetails
+    assert len(exc.args) == 4
+
+    _assert_subscription(exc)
+
+# The CIM status codes for the CIMError exception class:
+@pytest.fixture(params=[
+    # (code, name)
+    # Note: We don't test the exact default description text.
+    # Note: name = None means that the status code is invalid.
+    (0, None),
+    (1, 'CIM_ERR_FAILED'),
+    (2, 'CIM_ERR_ACCESS_DENIED'),
+    (3, 'CIM_ERR_INVALID_NAMESPACE'),
+    (4, 'CIM_ERR_INVALID_PARAMETER'),
+    (5, 'CIM_ERR_INVALID_CLASS'),
+    (6, 'CIM_ERR_NOT_FOUND'),
+    (7, 'CIM_ERR_NOT_SUPPORTED'),
+    (8, 'CIM_ERR_CLASS_HAS_CHILDREN'),
+    (9, 'CIM_ERR_CLASS_HAS_INSTANCES'),
+    (10, 'CIM_ERR_INVALID_SUPERCLASS'),
+    (11, 'CIM_ERR_ALREADY_EXISTS'),
+    (12, 'CIM_ERR_NO_SUCH_PROPERTY'),
+    (13, 'CIM_ERR_TYPE_MISMATCH'),
+    (14, 'CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED'),
+    (15, 'CIM_ERR_INVALID_QUERY'),
+    (16, 'CIM_ERR_METHOD_NOT_AVAILABLE'),
+    (17, 'CIM_ERR_METHOD_NOT_FOUND'),
+    (18, None),
+    (19, None),
+    (20, 'CIM_ERR_NAMESPACE_NOT_EMPTY'),
+    (21, 'CIM_ERR_INVALID_ENUMERATION_CONTEXT'),
+    (22, 'CIM_ERR_INVALID_OPERATION_TIMEOUT'),
+    (23, 'CIM_ERR_PULL_HAS_BEEN_ABANDONED'),
+    (24, 'CIM_ERR_PULL_CANNOT_BE_ABANDONED'),
+    (25, 'CIM_ERR_FILTERED_ENUMERATION_NOT_SUPPORTED'),
+    (26, 'CIM_ERR_CONTINUATION_ON_ERROR_NOT_SUPPORTED'),
+    (27, 'CIM_ERR_SERVER_LIMITS_EXCEEDED'),
+    (28, 'CIM_ERR_SERVER_IS_SHUTTING_DOWN'),
+    (29, None),
+    (30, None),
+], scope='module')
+def status_tuple(request):
+    return request.param
+
+def test_cimerror_1(status_tuple):
+
+    status_code = status_tuple[0]
+    status_code_name = status_tuple[1]
+
+    invalid_code_name = 'Invalid status code %s' % status_code
+    invalid_code_desc = 'Invalid status code %s' % status_code
+
+    exc = CIMError(status_code)
+
+    assert exc.status_code == status_code
+    if status_code_name is None:
+        assert exc.status_description == invalid_code_desc
+        assert exc.status_code_name == invalid_code_name
+    else:
+        assert isinstance(exc.status_description, six.string_types)
+        assert exc.status_code_name == status_code_name
+
+    assert exc.args[0] == exc.status_code
+    assert exc.args[1] is None
+    assert len(exc.args) == 2
+
+    _assert_subscription(exc)
+
+def test_cimerror_2(status_tuple):
+
+    status_code = status_tuple[0]
+    status_code_name = status_tuple[1]
+
+    invalid_code_name = 'Invalid status code %s' % status_code
+    invalid_code_desc = 'Invalid status code %s' % status_code
+
+    input_desc = 'foo'
+
+    exc = CIMError(status_code, input_desc)
+
+    assert exc.status_code == status_code
+    assert exc.status_description == input_desc
+    if status_code_name is None:
+        assert exc.status_code_name == invalid_code_name
+    else:
+        assert exc.status_code_name == status_code_name
+
+    assert exc.args[0] == exc.status_code
+    assert exc.args[1] == input_desc
+    assert len(exc.args) == 2
+
+    _assert_subscription(exc)


### PR DESCRIPTION
This PR rolls back the fix for issue #511 into the 0.9 fix stream.

Details:
- Added the `pywbem.Error` base exception class to the `pywbem.cim_http` namespace where it existed in 0.7.0, for compatibility reasons.
- In the description of `CIMError`, clarified that accessing the exception object itself by index or slice will be delegated to its `args` instance variable.
- In the description of `CIMError`, clarified that `args[1]` is the *input* status description, not the value of the `status_description` property. The difference is that the latter defaults to a standard text if it is
  not provided as input, but `args[1]` does not (for compatibility reasons).
- Added a unit testcase `test_exceptions.py` for the exceptions module.