### PR TITLE
Fixed logic errors in pycmp compatibility check tool.

### DIFF
--- a/tools/pycmp_0.7.0.sh
+++ b/tools/pycmp_0.7.0.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Simply invoke this script in root directory of the repo, without any args
 
+opts=$*
+
 version="0.7.0"
 distfile="dist/pywbem-0.7/pywbem-${version}.tar.gz"
 
@@ -36,6 +38,6 @@ rm $tmpdir/pywbem/wbemcli.py # cannot be imported, in 0.7.0
 # twisted is needed for pywbem/twisted_client.py
 pip install twisted
 
-$pycmp -e $tmpdir/pywbem pywbem >$reportfile
+$pycmp -e -i $opts $tmpdir/pywbem pywbem >$reportfile
 
 echo "Success: Generated report: $reportfile"


### PR DESCRIPTION
Please review.

The pycmp tool is only for the developers of pywbem. To see the tool in action, run the `tools/pycmp_0.7.0.sh` shell script and look at the generated `pycmp*.log` file, which reports the compatibility of the external API of pywbem between the work directory and 0.7.0.