### PR TITLE
Fixes #512: Add flake8 as lint test to the make and setup.py.

### DIFF
--- a/flake8.rc
+++ b/flake8.rc
@@ -1,0 +1,32 @@
+[flake8]
+max_line_length = 80
+
+exclude =
+    .git,
+    .tox,
+    __pycache__,
+    *.pyc,
+    attic,
+    packaging,
+    build_doc,
+    docs,
+    dist,
+    pywbem.egg-info,
+    
+ignore =
+    # Ignore extra blank lines
+    E302,
+    # the backslash is redundant between brackets
+    E502,
+    # E303 too many blank lines
+    E303,
+    # E265 block comment should start with #
+    E265,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # E261 at least two spaces before inline comment
+    E261,
+    # E203 whitespace before ':'
+    E203,
+    # E231 missing whitespace after ':'
+    E231

--- a/setup.py
+++ b/setup.py
@@ -363,6 +363,7 @@ def main():
             "astroid" if sys.version_info[0:2] == (2, 7) else None,
             "pylint" if sys.version_info[0:2] == (2, 7) else None,
             "mock",
+            'flake8',
             "pbr", # needed by mock
             "twine", # needed for upload to Pypi
         ],


### PR DESCRIPTION
Adds flake8 as lint tool to setup.py and makefile. 
It is executed as a component of check:. However
whereas pylint is python 2 only, flake8 is both
python2 and python 3.

Includes a first rc file. The rc file was created primarily to reduce those minor warnings, etc.
that are found many times.  This reduces the size of the file from about
140k to 40 k for the moment. One change to the config file was to set the line length to 80 from 79 because apparently we have pylint set to 80 so this does not show extra warnings like that.
All of the excluded warnings are documented in the pyflake8.log with comments defining what
is being warned.

Note that this does NOT include any of the many flake8 extra plugins.
