### PR TITLE
Added support for Windows CI on Appveyor service - currently disabled.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+
+environment:
+  matrix:
+    - PYTHON: C:\Python27
+      PYTHON_VERSION: 2.7.8
+      PYTHON_ARCH: 32
+
+install:
+
+  # Add Windows Registry entries for Python
+  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+
+  # Add Python
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+
+  ## Install InnoSetup - disabled because it is not needed
+  #- choco install -y InnoSetup
+  #- set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+
+  ## Install pip - disabled because pip is already installed
+  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
+  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+
+  # Add CygWin
+  - set PATH=C:\cygwin\bin;%PATH%
+
+  # Examine the environment
+  - dir C:\
+  - cd
+  - dir
+  #- set
+
+  # TODO: Install OS-level prereq packages:
+  # - prereqs for pip install of lxml:
+  #   - libxml2 from http://xmlsoft.org/sources/win32/
+  #   - libxslt from http://xmlsoft.org/sources/win32/
+  #   - zlib developer files from http://gnuwin32.sourceforge.net/packages/zlib.htm
+  #   - libiconv developer files from http://gnuwin32.sourceforge.net/packages/libiconv.htm
+  #     and copy libiconv.lib to iconv.lib in PCbuild.
+
+  # Install tox
+  - pip install tox==2.0.0
+
+  # Verify that the commands used in tox.ini are available
+  - tox --version
+  - make --version
+  - pip --version
+  - python --version
+
+  # Verify that the commands used in makefile are available
+  - sh --version
+  - bash --version
+  - rm --version
+  - mv --version
+  #- mkdir --version
+  - xargs --version
+  - grep --version
+  - sed --version
+  - tar --version
+  - find --version
+
+build: false # Not a C# project, build stuff at the test step instead.
+
+before_test:
+
+test_script:
+  # the actual test command is disabled for now.
+  - echo tox -e pywin
+

--- a/makefile
+++ b/makefile
@@ -4,18 +4,14 @@
 # Supported platforms for this makefile:
 #   Linux
 #   OS-X
-#   Windows (with CygWin)
+#   Windows (with CygWin, MinGW, etc.)
 #
-# Basic prerequisites for running this makefile:
-#   bash, sh
-#   rm, find, xargs, grep, sed, tar
+# Prerequisite commands for this makefile:
+#   make
+#   bash, sh, rm, mv, mkdir, echo
+#   find, xargs, grep, sed, tar
 #   python (Some active Python version, virtualenv is supported)
 #   pip (in the active Python environment)
-#
-# Additional prerequisites for development and for running some parts of this
-# makefile will be installed by 'make develop'.
-#
-# Prerequisites for usage will be installed by 'make install'.
 # ------------------------------------------------------------------------------
 
 # Determine OS platform make runs on

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,15 @@ whitelist_externals =
     tox
     make
     pip
+    python
 
 commands =
     tox --version
+    python --version
     pip list
     pip install --upgrade pip
-    make clobber
+    python uninstall_pbr_on_py26.py
+    pip list
     make develop
     pip list
     make check
@@ -42,6 +45,10 @@ basepython = python3.4
 
 [testenv:py35]
 basepython = python3.5
+
+[testenv:pywin]
+basepython = {env:PYTHON:}\python.exe
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE
 
 #[testenv:flake8]
 #deps =


### PR DESCRIPTION
This one must be merged in order to fix the current failures of the Appveyor service.

Details:
- Added appveyor.yml file, loosely based upon the one from the distro project.
- Added pywin environment to tox.ini file.
- Removed `make clobber` from commands in tox.ini file.
- Added uninistall of pbr on py26 to commands in tox.ini file.
- Improved description in makefile about prereqs.
- Disabled the tox command in appveyor.yml file, for now, to fix the TODOs (OS-level prereqs for Windows).