### PR TITLE
Added Appveyor CI and Coveralls support for 0.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - make clobber
   - pip list
   - make develop
+  - pip install python-coveralls
   - pip list
 
 # commands to run builds & tests
@@ -28,3 +29,5 @@ script:
   - make builddoc
   - make test
 
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-[![Test on master](https://img.shields.io/travis/pywbem/pywbem/master.svg?style=plastic&label=test%20on%20master)](https://travis-ci.org/pywbem/pywbem/branches)
+
 [![PyPI version](https://img.shields.io/pypi/v/pywbem.svg?style=plastic&label=PyPI%20version)](https://pypi.python.org/pypi/pywbem)
+[![Travis Test](https://img.shields.io/travis/pywbem/pywbem/master.svg?style=plastic&label=Travis%20Test)](https://travis-ci.org/pywbem/pywbem/branches)
+[![Appveyor Test](https://img.shields.io/appveyor/ci/andy-maier/pywbem.svg?style=plastic&label=Appveyor%20Test)](https://ci.appveyor.com/project/andy-maier/pywbem)
+[![Coverage](https://img.shields.io/coveralls/pywbem/pywbem.svg?style=plastic&label=Coverage)](https://coveralls.io/r/pywbem/pywbem?branch=master)
 
 About this project
 ------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+
+environment:
+  matrix:
+    - PYTHON: C:\Python27
+      PYTHON_VERSION: 2.7.8
+      PYTHON_ARCH: 32
+
+install:
+
+  # Add Windows Registry entries for Python
+  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+
+  # Add Python
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+
+  ## Install InnoSetup - disabled because it is not needed
+  #- choco install -y InnoSetup
+  #- set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+
+  ## Install pip - disabled because pip is already installed
+  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
+  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+
+  # Add CygWin
+  - set PATH=C:\cygwin\bin;%PATH%
+
+  # Examine the environment
+  - dir C:\
+  - cd
+  - dir
+  #- set
+
+  # TODO: Install OS-level prereq packages:
+  # - prereqs for pip install of lxml:
+  #   - libxml2 from http://xmlsoft.org/sources/win32/
+  #   - libxslt from http://xmlsoft.org/sources/win32/
+  #   - zlib developer files from http://gnuwin32.sourceforge.net/packages/zlib.htm
+  #   - libiconv developer files from http://gnuwin32.sourceforge.net/packages/libiconv.htm
+  #     and copy libiconv.lib to iconv.lib in PCbuild.
+
+  # Install tox
+  - pip install tox==2.0.0
+
+  # Verify that the commands used in tox.ini are available
+  - tox --version
+  - make --version
+  - pip --version
+  - python --version
+
+  # Verify that the commands used in makefile are available
+  - sh --version
+  - bash --version
+  - rm --version
+  - mv --version
+  #- mkdir --version
+  - xargs --version
+  - grep --version
+  - sed --version
+  - tar --version
+  - find --version
+
+build: false # Not a C# project, build stuff at the test step instead.
+
+before_test:
+
+test_script:
+  # the actual test command is disabled for now.
+  - echo tox -e pywin
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,22 @@
 environment:
   matrix:
     - PYTHON: C:\Python27
-      PYTHON_VERSION: 2.7.8
+      PYTHON_VERSION: 2.7.12
       PYTHON_ARCH: 32
 
 install:
 
-  # Add Windows Registry entries for Python
-  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
-  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  # Examine the environment
+  - echo %PATH%
+  - echo %INCLUDE%
+  - echo %LIB%
+  - choco source list
+  - dir C:\
+  - dir
 
   # Add Python
+  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   ## Install InnoSetup - disabled because it is not needed
@@ -25,19 +31,91 @@ install:
   # Add CygWin
   - set PATH=C:\cygwin\bin;%PATH%
 
-  # Examine the environment
-  - dir C:\
-  - cd
-  - dir
-  #- set
+  ## Disabled: The following is an attempt to install the lxml installation
+  ## prereqs with choco. The lxml installation currently fails with unresolved
+  ## symbols at the link step. Reported the issue to the Appveyor Problems forum:
+  ## http://help.appveyor.com/discussions/problems/5330-pip-install-lxml-fails-with-missing-symbols
+  ##
+  ## Install OS-level prereqs for lxml installation: libxml2, libxslt, zlib,
+  ## libiconv (needs iconv.lib).
+  #- choco source add -n=nuget -s="https://www.nuget.org/api/v2/"
+  #- set PATH=C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\VC\Bin;%PATH%
+  #- choco install -y -v libxml2
+  #- set INCLUDE=C:\ProgramData\chocolatey\lib\libxml2\build\native\include;%INCLUDE%
+  #- set _LIB_XML2=C:\ProgramData\chocolatey\lib\libxml2\build\native\lib\v110\Win32\Release\static\cdecl
+  #- set LIB=%_LIB_XML2%;%LIB%
+  #- dir %_LIB_XML2%
+  #- dumpbin /symbols %_LIB_XML2%\libxml2.lib
+  #- dumpbin /exports %_LIB_XML2%\libxml2.lib
+  #- choco install -y -v libxslt
+  #- set INCLUDE=C:\ProgramData\chocolatey\lib\libxslt\build\native\include;%INCLUDE%
+  #- set _LIB_XSLT=C:\ProgramData\chocolatey\lib\libxslt\build\native\lib\v110\Win32\Release\static
+  #- set LIB=%_LIB_XSLT%;%LIB%
+  #- dir %_LIB_XSLT%
+  #- choco install -y -v zlib
+  #- set INCLUDE=C:\ProgramData\chocolatey\lib\zlib.v120.windesktop.msvcstl.dyn.rt-dyn\build\native\include;%INCLUDE%
+  #- set _LIB_ZLIB=C:\ProgramData\chocolatey\lib\zlib.v120.windesktop.msvcstl.dyn.rt-dyn\lib\native\v120\windesktop\msvcstl\dyn\rt-dyn\Win32\Release
+  #- set LIB=%_LIB_ZLIB%;%LIB%
+  #- dir %_LIB_ZLIB%
+  #- choco install -y -v libiconv
+  #- set INCLUDE=C:\ProgramData\chocolatey\lib\libiconv\build\native\include;%INCLUDE%
+  #- set _LIB_ICONV=C:\ProgramData\chocolatey\lib\libiconv\build\native\lib\v110\Win32\Release\static\cdecl
+  #- set LIB=%_LIB_ICONV%;%LIB%
+  #- copy %_LIB_ICONV%\libiconv.lib %_LIB_ICONV%\iconv.lib 
+  #- dir %_LIB_ICONV%
+  #- find c:/ProgramData/chocolatey -name "*.h"
+  #- find c:/ProgramData/chocolatey -name "*.lib"
+  #- find c:/ProgramData/chocolatey -name "*.dll"
 
-  # TODO: Install OS-level prereq packages:
-  # - prereqs for pip install of lxml:
-  #   - libxml2 from http://xmlsoft.org/sources/win32/
-  #   - libxslt from http://xmlsoft.org/sources/win32/
-  #   - zlib developer files from http://gnuwin32.sourceforge.net/packages/zlib.htm
-  #   - libiconv developer files from http://gnuwin32.sourceforge.net/packages/libiconv.htm
-  #     and copy libiconv.lib to iconv.lib in PCbuild.
+  # Install OS-level prereqs for lxml installation: libxml2, libxslt, zlib,
+  # libiconv (needs iconv.lib). This approach uses the binary libraries
+  # that are linked from the lxml site.
+
+  - echo set _PWD=%%%%~dp0>tmp_prereq_dir.bat
+  - call tmp_prereq_dir.bat
+  - rm tmp_prereq_dir.bat
+
+  - set _PREREQ_DIR=prereqs
+  - set _PREREQ_ABSDIR=%_PWD%%_PREREQ_DIR%
+  - echo Installing lxml prereqs into %_PREREQ_ABSDIR%
+  - mkdir %_PREREQ_DIR%
+
+  - set _PKGFILE=libxml2-2.7.8.win32.zip
+  - set _PKGDIR=libxml2-2.7.8.win32
+  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  - set _PKGFILE=libxslt-1.1.26.win32.zip
+  - set _PKGDIR=libxslt-1.1.26.win32
+  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  - set _PKGFILE=zlib-1.2.5.win32.zip
+  - set _PKGDIR=zlib-1.2.5
+  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  - set _PKGFILE=iconv-1.9.2.win32.zip
+  - set _PKGDIR=iconv-1.9.2.win32
+  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  - find %_PREREQ_DIR%
+  - echo %PATH%
+  - echo %INCLUDE%
+  - echo %LIB%
 
   # Install tox
   - pip install tox==2.0.0
@@ -65,6 +143,5 @@ build: false # Not a C# project, build stuff at the test step instead.
 before_test:
 
 test_script:
-  # the actual test command is disabled for now.
-  - echo tox -e pywin
+  - tox -e pywin
 

--- a/testsuite/test_indicationlistener.py
+++ b/testsuite/test_indicationlistener.py
@@ -233,9 +233,10 @@ class TestIndications(unittest.TestCase):
         """Test sending 100 indications"""
         self.send_indications(100, 5001, None)
 
-    def test_send_1000(self):
-        """Test sending 1000 indications"""
-        self.send_indications(1000, 5002, None)
+    # Disabled the following test, because in some environments it takes 30min.
+    #def test_send_1000(self):
+    #    """Test sending 1000 indications"""
+    #    self.send_indications(1000, 5002, None)
 
 #    This test takes about 60 seconds and so is disabled for now
 #    def test_send_10000(self):

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,15 @@ whitelist_externals =
     tox
     make
     pip
+    python
 
 commands =
     tox --version
+    python --version
     pip list
     pip install --upgrade pip
-    make clobber
+    python uninstall_pbr_on_py26.py
+    pip list
     make develop
     pip list
     make check
@@ -42,6 +45,10 @@ basepython = python3.4
 
 [testenv:py35]
 basepython = python3.5
+
+[testenv:pywin]
+basepython = {env:PYTHON:}\python.exe
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE
 
 #[testenv:flake8]
 #deps =

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ basepython = python3.5
 
 [testenv:pywin]
 basepython = {env:PYTHON:}\python.exe
-passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB
 
 #[testenv:flake8]
 #deps =


### PR DESCRIPTION
Please review.

This PR rolls the Appveyor changes from PR #525 into v0.9.
In addition, this PR adds support for the Coveralls service to v0.9.