### PR TITLE
fixes #401: Modify run_cimoperations.py to rename yaml file before each test

### DIFF
--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 # pylint: disable=missing-docstring,superfluous-parens,no-self-use
 import sys
+import os.path
 import threading
 from datetime import timedelta
 import unittest
@@ -3862,6 +3863,15 @@ if __name__ == '__main__':
 
         if args['long_running'] is True:
             SKIP_LONGRUNNING_TEST = False
+
+    # if yamlfile exists rename it to yamlfile.bak
+    if args['yamlfile']:
+        yamlfile_name = args['yamlfile']
+        if os.path.isfile(yamlfile_name):
+            backupfile_name = '%s.bak' % yamlfile_name
+            if os.path.isfile(backupfile_name):
+                os.remove(backupfile_name)
+            os.rename(yamlfile_name, backupfile_name)
 
     # Note: unittest options are defined in separate args after
     # the url argument.


### PR DESCRIPTION
Please Review

Issue #401 brought up the question of whether we should clean out the yaml file before each use (with some other issues).  However, the conclusion is that there is not an issue in the recorder itself since it starts with an open file.



Previously run_cimoperations.py  just appended to an existing file making the tests messy.  Note that the issue itself now requires no change to _recorder.py

I used this pr to fix the yaml file lifecycle in run_cimoperations.py  and as an easy way to close the issue.  I don't think there is any issue with the r_recorder itself but we were not cleaning out the old yaml file in cim_operations so added code to create a backup if the file exists so we start each run_cim_operations.py test with an empty yaml file.

Note that this does not create a separate file for each test but one file for the complete execution of the test program.