### PR TITLE
Cleanup of flake8 and pylint issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,30 +17,37 @@ exclude =
 #disable_noqa
     
 ignore =
+    # E126 continuation line over-indented for hanging indent
+    # Currently does not appear to match our style
+    E126,
+    # E127 continuation line over-indented for visual indent.
+    # Disabled because does not appear to match pylint rules
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # E261 at least two spaces before inline comment
+    # Not sure it matches our style and generates many of these messages
+    E261,
+    # E265 block comment should start with '# '
+    # over 100 of these messages right now
+    E265,
     # E302 expected 2 blank lines, found 1. Too many right now, 400+
     E302,
     # E303 too many blank lines
     E303,
-    # E265 block comment should start with #
-    E265,
-    # E128 continuation line under-indented for visual indent
-    E128,
-    # E261 at least two spaces before inline comment
-    E261,
-    # E502 the backslash is redundant between brackets. Remove when cleaner
-    # Right now about 500 of these
-    E502,
     # W391 Blank line at end of file
+    # Many of our files have this so ignore for now
     W391,
-    # E127 continuation line over-indented for visual indent.
-    # Disabled because does not appear to match pylint rules
-    E127,
-    # W391 blank line at end of file
-    W391,
-    # E126 continuation line over-indented for hanging indent
-    # Currently does not appear to match our style
-    E126,
     # D400  First line should end with a period (not 'd')
     # Defines docstring format for first line. Too many for now
-    D400
+    D400,
+    # E402 module level import not at top of file
+    # This occurs primarily because of conditonal imports including six
+    # ex. if six...
+    E402,
+    # E502 the backslash is redundant between brackets. Remove when cleaner
+    # Right now about 500 of these messages
+    E502,  
+    # E265 block comment should start with #
+    E562
     

--- a/os_setup.py
+++ b/os_setup.py
@@ -255,7 +255,7 @@ def _assert_system_dict(dist, attr, value):
                 elif isinstance(distro_item, string_types):
                     # The distro refers to another distro
                     referenced_distro = distro_item
-                    if not referenced_distro in distro_dict:
+                    if referenced_distro not in distro_dict:
                         raise DistutilsSetupError(
                             "'%s' attribute: Referenced distribution does not "\
                             "exist in distribution dictionary "\
@@ -1260,7 +1260,7 @@ class YumInstaller(OSInstaller):
             return (False, False, None)
 
         info = out.splitlines()[-1].strip("\n").split()
-        if not info[0].startswith(pkg_name+"."):
+        if not info[0].startswith(pkg_name + "."):
             raise DistutilsSetupError(
                 "Unexpected output from command '%s':\n%s%s" %\
                 (cmd, out, err))

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -31,24 +31,23 @@ It supports Python 2 and Python 3.
 from __future__ import absolute_import
 
 import sys
-
-from .cim_types import *
-from .cim_constants import *
-from .cim_operations import *
-from .cim_obj import *
-from .tupleparse import *
-from .cim_http import *
-from .exceptions import *
-from ._server import *
-from ._subscription_manager import *
-from ._listener import *
-from ._recorder import *
-from .config import *
+from .cim_types import *  # noqa: F403,F401
+from .cim_constants import *  # noqa: F403,F401
+from .cim_operations import *  # noqa: F403,F401
+from .cim_obj import *  # noqa: F403,F401
+from .tupleparse import *  # noqa: F403,F401
+from .cim_http import *  # noqa: F403,F401
+from .exceptions import *  # noqa: F403,F401
+from ._server import *  # noqa: F403,F401
+from ._subscription_manager import *  # noqa: F403,F401
+from ._listener import *  # noqa: F403,F401
+from ._recorder import *  # noqa: F403,F401
+from .config import *  # noqa: F403,F401
 
 from ._version import __version__
 
-_python_m = sys.version_info[0]
-_python_n = sys.version_info[1]
+_python_m = sys.version_info[0]  # pylint: disable=invalid-name
+_python_n = sys.version_info[1]  # pylint: disable=invalid-name
 if _python_m == 2 and _python_n < 6:
     raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
 elif _python_m == 3 and _python_n < 4:

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -98,7 +98,7 @@ from .cim_constants import CIM_ERR_NOT_SUPPORTED, \
                            CIM_ERR_INVALID_PARAMETER, _statuscode2name
 from .tupleparse import parse_cim
 from .tupletree import dom_to_tupletree
-from .exceptions import ParseError, VersionError, Error
+from .exceptions import ParseError, VersionError
 
 
 # CIM-XML protocol related versions implemented by the WBEM listener.
@@ -392,8 +392,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                             str(status_code),
                             status_desc,
                             error_insts),
-                        ),
-                    ),
+                        ),  # noqa: E123
+                    ),  # noqa: E123
                 msgid, IMPLEMENTED_PROTOCOL_VERSION),
             IMPLEMENTED_CIM_VERSION, IMPLEMENTED_DTD_VERSION)
 
@@ -424,7 +424,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 cim_xml.SIMPLEEXPRSP(
                     cim_xml.EXPMETHODRESPONSE(
                         methodname),
-                    ),
+                    ),  # noqa: E123
                 msgid, IMPLEMENTED_PROTOCOL_VERSION),
             IMPLEMENTED_CIM_VERSION, IMPLEMENTED_DTD_VERSION)
         resp_body = '<?xml version="1.0" encoding="utf-8" ?>\n' + \

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -394,7 +394,8 @@ class WBEMServer(object):
         Example for a 2-hop traversal:
 
         * central class: ``"CIM_Sensor"``
-        * scoping path: ``["CIM_AssociatedSensor", "CIM_Fan", "CIM_SystemDevice"]``
+        * scoping path: ``["CIM_AssociatedSensor", "CIM_Fan", \
+                           "CIM_SystemDevice"]``
         * scoping class: ``"CIM_ComputerSystem"``
 
         Parameters:
@@ -752,7 +753,8 @@ class ValueMapping(object):
     ::
 
         [ValueMap{ "0", "2..4", "..6", "7..", "9", ".." },
-         Values{ "zero", "two-four", "five-six", "seven-eight", "nine", "unclaimed"}]
+         Values{ "zero", "two-four", "five-six", "seven-eight", "nine", \
+             "unclaimed"}]
         uint16 MyProp;
 
     The following code will create a value mapping for this property and will
@@ -760,9 +762,12 @@ class ValueMapping(object):
 
     ::
 
-        >>> vm = pywbem.ValueMapping.for_property(server, namespace, classname, "MyProp")
-        >>> for value in range(0, 12):
-        >>>    print("value: %s, Values string: %r" % (value, vm.tovalues(value))
+        vm = pywbem.ValueMapping.for_property(server, namespace, classname,\
+                "MyProp")
+        for value in range(0, 12):
+            print("value: %s, Values string: %r" % (value, vm.tovalues(value))
+
+        Results:
         value: 0, Values string: 'zero'
         value: 1, Values string: 'unclaimed'
         value: 2, Values string: 'two-four'

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -148,10 +148,9 @@ import uuid
 import six
 
 from ._server import WBEMServer
-from ._version import __version__
 from .cim_obj import CIMInstance, CIMInstanceName
 from .cim_http import parse_url
-from .cim_constants import CIM_ERR_NOT_FOUND
+from .cim_constants import CIM_ERR_FAILED
 from .exceptions import CIMError
 
 # CIM model classnames for subscription components

--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -33,6 +33,7 @@ namespace and should be used from there.
 """
 
 # disable flake8 tests for no whitespace before : and line too long
+# for this file because of special formatting in the file.
 # flake8: noqa: E203, E501
 
 # This module is meant to be safe for 'import *'.

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -52,8 +52,7 @@ from six.moves import urllib
 
 from .cim_obj import CIMClassName, CIMInstanceName, _ensure_unicode, \
                      _ensure_bytes
-from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError, \
-                        Error
+from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
 
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -65,7 +64,8 @@ if six.PY2 and not _ON_RTD:  # RTD has no swig to install M2Crypto
     SocketErrors = (socket.error, socket.sslerror)
 else:
     import ssl as SSL                  # pylint: disable=wrong-import-position
-    from ssl import SSLError, CertificateError # pylint: disable=wrong-import-position
+    # pylint: disable=wrong-import-position
+    from ssl import SSLError, CertificateError
     _HAVE_M2CRYPTO = False
     #pylint: disable=invalid-name
     SocketErrors = (socket.error,)
@@ -168,18 +168,17 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
 
         self._timeout = timeout
         self._http_conn = http_conn
-        self._retrytime = 5     # time in seconds after which a retry of the
-                                # socket shutdown is scheduled if the socket
-                                # is not yet on the connection when the
-                                # timeout expires initially.
+        # time in seconds after which a retry of socket shutdown is scheduled
+        # if the socket is not yet connected when timeout expires
+        self._retrytime = 5
+
         self._timer = None      # the timer object
         self._ts1 = None        # timestamp when timer was started
-        self._shutdown = None   # flag indicating that the timer handler has
-                                # shut down the socket
+        self._shutdown = None   # flag indicating timer handler shutdown socket
         return
 
     def __enter__(self):
-        if self._timeout != None:
+        if self._timeout is not None:
             self._timer = threading.Timer(self._timeout,
                                           HTTPTimeout.timer_expired, [self])
             self._timer.start()
@@ -188,7 +187,7 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
         return
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self._timeout != None:
+        if self._timeout is not None:
             self._timer.cancel()
             if self._shutdown:
                 # If the timer handler has shut down the socket, we
@@ -213,7 +212,7 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
         So we do not guarantee in all cases that the overall operation times
         out after the specified timeout.
         """
-        if self._http_conn.sock != None:
+        if self._http_conn.sock is not None:
             self._shutdown = True
             self._http_conn.sock.shutdown(socket.SHUT_RDWR)
         else:
@@ -313,7 +312,7 @@ def parse_url(url, allow_defaults=True):
     if matches:
         # It is an IPv6 address
         host = matches.group(1)
-        if matches.group(2) != None:
+        if matches.group(2) is not None:
             # The zone index is present
             host += "%" + matches.group(2)
 
@@ -662,9 +661,8 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                  timeout=timeout)
     else:
         if url.startswith('http'):
-            client = HTTPConnection(host=host,  # pylint: disable=redefined-variable-type
-                                    port=port,
-                                    timeout=timeout)
+            # pylint: disable=redefined-variable-type
+            client = HTTPConnection(host=host, port=port, timeout=timeout)
         else:
             if url.startswith('file:'):
                 url_ = url[5:]
@@ -799,7 +797,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                     nonce_begin = auth_chal.index('"',
                                                                   nonce_idx)
                                     nonce_end = auth_chal.index('"',
-                                                                nonce_begin+1)
+                                                                nonce_begin + 1)
                                     nonce = auth_chal[nonce_begin + 1:nonce_end]
                                     cookie_idx = auth_chal.index('cookiefile=')
                                     cookie_begin = auth_chal.index('"',

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -161,7 +161,8 @@ class NocaseDict(object):
                 self.update(args[0])
             elif isinstance(args[0], NocaseDict):
                 # Initialize from another NocaseDict object
-                self._data = args[0]._data.copy() # pylint: disable=protected-access
+                # pylint: disable=protected-access
+                self._data = args[0]._data.copy()
             elif args[0] is None:
                 # Leave empty
                 pass
@@ -267,7 +268,7 @@ class NocaseDict(object):
 
         The key is looked up case-insensitively.
         """
-        if not key in self:
+        if key not in self:
             self[key] = default
         return self[key]
 
@@ -397,7 +398,7 @@ class NocaseDict(object):
         The keys are looked up case-insensitively.
         """
         for key, self_value in self.iteritems():
-            if not key in other:
+            if key not in other:
                 return False
             other_value = other[key]
             try:
@@ -616,8 +617,8 @@ def _makequalifiers(qualifiers, indent):
     if len(qualifiers) == 0:
         return ''
 
-    return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent+2).\
-        join([q.tomof(indent+2) for q in sorted(qualifiers.values())]))
+    return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent + 2).\
+        join([q.tomof(indent + 2) for q in sorted(qualifiers.values())]))
 
 def _indent_str(indent):
     """
@@ -2368,7 +2369,7 @@ class CIMProperty(_CIMComparisonMixin):
                         'reference', None, type_, 'type', msg)
                 elif type_ is not None:
                     # Leave type as specified, but check it for validity
-                    dummy_type_obj = type_from_name(type_)
+                    dummy_type_obj = type_from_name(type_)  # noqa: F841
                 else:
                     raise ValueError('Cannot infer type of simple ' \
                                      'property %r that is Null' % name)
@@ -2424,7 +2425,8 @@ class CIMProperty(_CIMComparisonMixin):
             else: # type is specified and value is not Null
                 # Make sure the value is of the corresponding Python type.
                 _type_obj = type_from_name(type_)
-                value = _type_obj(value)  # pylint: disable=redefined-variable-type
+                # pylint: disable=redefined-variable-type
+                value = _type_obj(value)
                 msg = 'Property %r has a simple typed value ' \
                       'and specifies CIM data type %r' % (name, type_)
                 embedded_object = _intended_value(
@@ -2537,7 +2539,8 @@ class CIMProperty(_CIMComparisonMixin):
                     value = value.tocimxml().toxml()
                 else:
                     value = atomic_to_cim_xml(value)
-                value = cim_xml.VALUE(value) # pylint: disable=redefined-variable-type
+                # pylint: disable=redefined-variable-type
+                value = cim_xml.VALUE(value)
 
             return cim_xml.PROPERTY(
                 self.name,

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -29,6 +29,7 @@ a WBEM server.
 All WBEM operations defined in :term:`DSP0200` can be issued across this connection.
 Each method of this class corresponds directly to a WBEM operation.
 
+# noqa: E501
 ==========================================================  ==============================================================
 WBEMConnection method                                       Purpose
 ==========================================================  ==============================================================
@@ -115,7 +116,7 @@ from collections import namedtuple
 
 import six
 from . import cim_xml
-from .cim_constants import DEFAULT_NAMESPACE
+from .cim_constants import DEFAULT_NAMESPACE, CIM_ERR_INVALID_PARAMETER
 from .cim_types import CIMType, CIMDateTime, atomic_to_cim_xml
 from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, \
                      CIMClassName, NocaseDict, _ensure_unicode, tocimxml, \
@@ -125,7 +126,6 @@ from .tupleparse import parse_cim
 from .tupletree import dom_to_tupletree
 from .exceptions import Error, ParseError, AuthError, ConnectionError, \
                         TimeoutError, CIMError
-from .cim_constants import *  # pylint: disable=wildcard-import
 
 __all__ = ['WBEMConnection', 'PegasusUDSConnection', 'SFCBUDSConnection',
            'OpenWBEMUDSConnection']
@@ -1483,7 +1483,7 @@ class WBEMConnection(object):
                 if p[2] is None:
                     valid_result = True
                 elif isinstance(p[2], six.string_types) and \
-                    p[2].lower() in ['true', 'false']:
+                    p[2].lower() in ['true', 'false']:  # noqa: E125
                     valid_result = True if p[2].lower() == 'true' else False
                     end_of_sequence = valid_result
 
@@ -3836,16 +3836,19 @@ class WBEMConnection(object):
                     'ModifiedInstance parameter must have path attribute set')
             if ModifiedInstance.path.classname is None:
                 raise ValueError(
-                    'ModifiedInstance parameter must have classname set in path')
+                    'ModifiedInstance parameter must have classname set in '
+                    ' path')
             if ModifiedInstance.classname is None:
                 raise ValueError(
                     'ModifiedInstance parameter must have classname set in ' \
                     'instance')
 
-            namespace = self._iparam_namespace_from_objectname(ModifiedInstance.path)
+            namespace = self._iparam_namespace_from_objectname(
+                ModifiedInstance.path)
 
             # Strip off host and namespace to avoid producing an INSTANCEPATH or
-            # LOCALINSTANCEPATH element instead of the desired INSTANCENAME element.
+            # LOCALINSTANCEPATH element instead of the desired INSTANCENAME
+            # element.
             instance = ModifiedInstance.copy()
             instance.path.namespace = None
             instance.path.host = None
@@ -4578,8 +4581,8 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-            This parameter has been deprecated in :term:`DSP0200`. Clients cannot
-            rely on it being implemented by WBEM servers.
+            This parameter has been deprecated in :term:`DSP0200`. Clients
+            cannot rely on it being implemented by WBEM servers.
 
           IncludeClassOrigin (:class:`py:bool`):
             Indicates that class origin information is to be included on each

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -120,6 +120,7 @@ class _CIMComparisonMixin(object): # pylint: disable=too-few-public-methods
 
     @staticmethod
     def __ordering_deprecated():
+        """Deprecated warning for pywbem CIM Objects"""
         warnings.warn(
             "Ordering comparisons for pywbem CIM objects are deprecated",
             DeprecationWarning)
@@ -344,8 +345,10 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         elif isinstance(dtarg, timedelta):
             self.__timedelta = dtarg
         elif isinstance(dtarg, CIMDateTime):
-            self.__datetime = dtarg.__datetime   # pylint: disable=protected-access
-            self.__timedelta = dtarg.__timedelta # pylint: disable=protected-access
+            # pylint: disable=protected-access
+            self.__datetime = dtarg.__datetime
+            # pylint: disable=protected-access
+            self.__timedelta = dtarg.__timedelta
         else:
             raise TypeError('dtarg argument "%s" has an invalid type: %s '\
                             '(expected datetime, timedelta, string, or '\
@@ -367,7 +370,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
                 self.__datetime.utcoffset() is not None:
             offset = self.__datetime.utcoffset().seconds / 60
             if self.__datetime.utcoffset().days == -1:
-                offset = -(60*24 - offset)
+                offset = -((60 * 24) - offset)
         return offset
 
     @property
@@ -606,8 +609,8 @@ class Sint8(CIMInt):
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
     cimtype = 'sint8'
-    minvalue = -2**(8-1)
-    maxvalue = 2**(8-1) - 1
+    minvalue = -2 ** (8 - 1)
+    maxvalue = 2 ** (8 - 1) - 1
 
 class Uint16(CIMInt):
     """
@@ -626,8 +629,8 @@ class Sint16(CIMInt):
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
     cimtype = 'sint16'
-    minvalue = -2**(16-1)
-    maxvalue = 2**(16-1) - 1
+    minvalue = -2 ** (16 - 1)
+    maxvalue = 2 ** (16 - 1) - 1
 
 class Uint32(CIMInt):
     """
@@ -637,7 +640,7 @@ class Uint32(CIMInt):
     """
     cimtype = 'uint32'
     minvalue = 0
-    maxvalue = 2**32 - 1
+    maxvalue = 2 ** 32 - 1
 
 class Sint32(CIMInt):
     """
@@ -646,8 +649,8 @@ class Sint32(CIMInt):
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
     cimtype = 'sint32'
-    minvalue = -2**(32-1)
-    maxvalue = 2**(32-1) - 1
+    minvalue = -2 ** (32 - 1)
+    maxvalue = 2 ** (32 - 1) - 1
 
 class Uint64(CIMInt):
     """
@@ -657,7 +660,7 @@ class Uint64(CIMInt):
     """
     cimtype = 'uint64'
     minvalue = 0
-    maxvalue = 2**64 - 1
+    maxvalue = 2 ** 64 - 1
 
 class Sint64(CIMInt):
     """
@@ -666,8 +669,8 @@ class Sint64(CIMInt):
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
     cimtype = 'sint64'
-    minvalue = -2**(64-1)
-    maxvalue = 2**(64-1) - 1
+    minvalue = -2 ** (64 - 1)
+    maxvalue = 2 ** (64 - 1) - 1
 
 # CIM float types
 

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -131,7 +131,7 @@ def _pcdata_nodes(pcdata):
     if _CDATA_ESCAPING and isinstance(pcdata, six.string_types) and \
        (pcdata.find("<") >= 0 or \
         pcdata.find(">") >= 0 or \
-        pcdata.find("&") >= 0):
+        pcdata.find("&") >= 0):  # noqa: E129
 
         # In order to support nesting of CDATA sections, we represent pcdata
         # that already contains CDATA sections by multiple new CDATA sections
@@ -161,8 +161,8 @@ def _pcdata_nodes(pcdata):
     else:
         # The following automatically uses XML entity references
         # for escaping.
-        # pylint: disable=redefined-variable-type
-        node = _text(pcdata)
+
+        node = _text(pcdata) # pylint: disable=redefined-variable-type
 
         nodelist.append(node)
 
@@ -335,7 +335,7 @@ class QUALIFIER_DECLARATION(CIMElement):
             if is_array:
                 xval = VALUE_ARRAY(value)
             else:
-                xval = VALUE(value)
+                xval = VALUE(value) # pylint: disable=redefined-variable-type
             self.appendOptionalChild(xval)
 
 class SCOPE(CIMElement):

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -157,7 +157,7 @@ reserved = {
     'toinstance': 'TOINSTANCE',
     'translatable': 'TRANSLATABLE',
     'true': 'TRUE',
-    }
+    }  # noqa: E123
 
 tokens = list(reserved.values()) + [
     'IDENTIFIER',
@@ -740,6 +740,7 @@ def p_classDeclaration(p):
             else: # superclass
                 superclass = p[4]
                 cfl = p[6]
+    # pylint: disable=redefined-variable-type
     quals = dict([(x.name, x) for x in quals])
     methods = {}
     props = {}
@@ -1030,6 +1031,7 @@ def p_referenceDeclaration(p):
         pname = p[2]
         if len(p) == 5:
             dv = p[3]
+    # pylint: disable=redefined-variable-type
     quals = dict([(x.name, x) for x in quals])
     p[0] = CIMProperty(pname, dv, type='reference',
                        reference_class=cname, qualifiers=quals)
@@ -1054,6 +1056,7 @@ def p_methodDeclaration(p):
         mname = p[3]
         if p[5] != ')':
             paramlist = p[5]
+    # pylint: disable=redefined-variable-type
     params = dict([(param.name, param) for param in paramlist])
     quals = dict([(q.name, q) for q in quals])
     p[0] = CIMMethod(mname, return_type=dt, parameters=params,
@@ -1236,7 +1239,7 @@ def _fixStringValue(s):
             while j < 4:
                 c = s[i + j]
                 c = c.upper()
-                if not c.isdigit() and not c in 'ABCDEF':
+                if not c.isdigit() and c not in 'ABCDEF':
                     break
                 hexc <<= 4
                 if c.isdigit():
@@ -1344,7 +1347,7 @@ def _build_flavors(p, flist, qualdecl=None):
     flavors = {}
     if ('disableoverride' in flist and 'enableoverride' in flist) \
         or \
-        ('restricted' in flist and 'tosubclass' in flist):
+        ('restricted' in flist and 'tosubclass' in flist):  # noqa: E125
 
         raise MOFParseError(parser_token=p, msg="Conflicting flavors are" \
                             "invalid")
@@ -1609,9 +1612,7 @@ def p_identifier(p):
                   | TOSUBCLASS
                   | TOINSTANCE
                   | TRANSLATABLE
-                  """
-                  #| ASSOCIATION
-                  #| INDICATION
+    """
     p[0] = p[1]
 
 def p_empty(p):
@@ -1989,8 +1990,8 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         # TODO 2016/03 AM: Dubious stmt above.
         if cc.superclass:
             try:
-                dummy_super = self.GetClass(cc.superclass, LocalOnly=True,
-                                            IncludeQualifiers=False)
+                _ = self.GetClass(cc.superclass, LocalOnly=True,  # noqa: F841
+                                  IncludeQualifiers=False)
             except CIMError as ce:
                 if ce.args[0] == CIM_ERR_NOT_FOUND:
                     ce.args = (CIM_ERR_INVALID_SUPERCLASS, cc.superclass)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ from distutils.errors import DistutilsSetupError
 # unloading and subsequent garbage collection causing the error.
 if sys.version_info[0:2] == (2, 6):
     try:
-        import multiprocessing # pylint: disable=unused-import
+        # pylint: disable=unused-import
+        import multiprocessing  # noqa: F401
     except ImportError:
         pass
 

--- a/testsuite/compat_args.py
+++ b/testsuite/compat_args.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-#
-# Test compatibility when changing *args and **kwargs to named args.
-#
+"""
+    Test compatibility when changing *args and **kwargs to named args.
+"""
 
 import sys
 
-def func_old_args(a, b=None, *args):
+def func_old_args(a, b=None, *args): # pylint: disable=invalid-name
     """Old function, defined with *args."""
 
     # We extract a specific optional parameter from *args
@@ -16,7 +16,7 @@ def func_old_args(a, b=None, *args):
 
     return a, b, c
 
-def func_old_kwargs(a, b=None, **kwargs):
+def func_old_kwargs(a, b=None, **kwargs): # pylint: disable=invalid-name
     """Old function, defined with **kwargs."""
 
     # We extract a specific optional parameter from **kwargs
@@ -27,7 +27,7 @@ def func_old_kwargs(a, b=None, **kwargs):
 
     return a, b, c
 
-def func_new(a, b=None, c=None):
+def func_new(a, b=None, c=None): # pylint: disable=invalid-name
     """New function, replacing any of the old functions."""
 
     return a, b, c
@@ -87,6 +87,7 @@ def test_func_kwargs(func_kwargs):
 
 
 def main():
+    """Main function calls the test functs"""
 
     print("Python version %s" % sys.version)
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -85,7 +85,7 @@ class ClientTest(unittest.TestCase):
         # and unittest enables these warnings.
         if not six.PY2:
             #pylint: disable=ResourceWarning, undefined-variable
-            warnings.simplefilter("ignore", ResourceWarning)  # NOQA
+            warnings.simplefilter("ignore", ResourceWarning)
 
         self.log('setup connection {} ns {}'.format(self.system_url,
                                                     self.namespace))
@@ -885,8 +885,9 @@ class PullEnumerateInstances(ClientTest):
             insts_pulled.extend(result.instances)
 
         # get with EnumInstances and compare returns
-        insts_enum = self.cimcall(self.conn.EnumerateInstances, TOP_CLASS)
-
+        insts_enum = \
+            self.cimcall(self.conn.EnumerateInstances, TOP_CLASS)  # noqa: F841
+        # TODO finish the compare
 
 
     def test_bad_namespace(self):
@@ -2463,7 +2464,7 @@ class PegasusServerTestBase(ClientTest):
             if self.verbose:
                 print('Namespaces:')
                 for n in namespaces:
-                    print ('  %s' % (n))
+                    print('  %s' % (n))
 
             return namespaces
 
@@ -3713,7 +3714,7 @@ TEST_LIST = [
     'PegasusTestEmbeddedInstance',
     'PegasusInteropTest',
     'PegasusTestEmbeddedInstance'
-    ]
+    ]  # noqa: E123
 
 
 def parse_args(argv_):

--- a/testsuite/run_operationtimeouts.py
+++ b/testsuite/run_operationtimeouts.py
@@ -25,9 +25,7 @@ from getpass import getpass
 
 import six
 
-from pywbem.cim_constants import *
 from pywbem import WBEMConnection, Uint32, ConnectionError, TimeoutError
-
 
 # Identity of the OpenPegasus namespace, class, and method that implements
 # the delayed response. NOTE: This is only available on OpenPegasus 2.15+.
@@ -171,7 +169,7 @@ class ServerTimeoutTest(ClientTest):
                 err_flag = "Timeout when timeout matches delay"
 
         # This exception terminates the test if stop_on_err set.
-        except Exception as ec:      #pylint: disable=broad-except
+        except Exception as ec:      # pylint: disable=broad-except
             err_flag = "Test Failed.General Exception"
             request_result = 2
             if self.stop_on_err:
@@ -334,7 +332,7 @@ if __name__ == '__main__':
         print("  host: %s" % args['host'])
         print("  username: %s" % args['username'])
         if args['password'] is not None:
-            print("  password: %s" % ("*"*len(args['password'])))
+            print("  password: %s" % ("*" * len(args['password'])))
         print("  maxtimeout: %s" % args['maxtimeout'])
         print("  verbose: %s" % args['verbose'])
         print("  stopOnErr: %s" % args['stopOnErr'])

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -113,7 +113,7 @@ class DictTest(unittest.TestCase):
     interface, such as class `CIMInstance` that provides a dictionary interface
     for its properties.
     """
-
+    # pylint: disable=too-many-branches
     def runtest_dict(self, obj, exp_dict):
         """
         Treat obj as a dict and run dictionary tests, and compare the
@@ -135,7 +135,7 @@ class DictTest(unittest.TestCase):
             self.assertEqual(obj[swapcase2(key)], exp_dict[key])
 
         try:
-            dummy_val = obj['Cheepy']
+            dummy_val = obj['Cheepy']  # noqa: F841
         except KeyError:
             pass
         else:
@@ -155,15 +155,15 @@ class DictTest(unittest.TestCase):
 
         # Test has_key()
 
-        self.assertTrue(obj.has_key(new_key))
-        self.assertTrue(obj.has_key(swapcase2(new_key)))
+        self.assertTrue(obj.has_key(new_key))  # noqa: W601
+        self.assertTrue(obj.has_key(swapcase2(new_key)))  # noqa: W601
 
         # Test __delitem__()
 
         del obj[swapcase2(new_key)]
 
-        self.assertTrue(not obj.has_key(new_key))
-        self.assertTrue(not obj.has_key(swapcase2(new_key)))
+        self.assertTrue(not obj.has_key(new_key))  # noqa: W601
+        self.assertTrue(not obj.has_key(swapcase2(new_key)))  # noqa: W601
 
         # Test __len__()
 
@@ -1006,7 +1006,7 @@ class CIMInstanceEquality(unittest.TestCase):
                                                    [Uint8(1), Uint8(2)]),
                          'ref': CIMProperty('ref',
                                             CIMInstanceName('CIM_Bar'))})
-            )
+            )  # noqa: E123
 
 class CIMInstanceCompare(unittest.TestCase):
     """
@@ -1387,6 +1387,7 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
                   'sint8', 'sint16', 'sint32', 'sint64']
     _REAL_TYPES = ['real32', 'real64']
 
+    # pylint: disable=too-many-branches
     def test_all(self):
 
         quals = {'Key': CIMQualifier('Key', True)}
@@ -2605,7 +2606,7 @@ class CIMClassWQualToMOF(unittest.TestCase):
                      'FooMethod': CIMMethod('FooMethod', 'uint32',
                                             parameters=params,
                                             qualifiers=mquals)}
-            )
+            )  # noqa: E123
 
         clmof = cl.tomof()
 
@@ -2659,12 +2660,12 @@ class CIMClassWoQualifiersToMof(unittest.TestCase, RegexpMixin):
                                                type='uint8'),
                         'MyUint16': CIMProperty('MyUint16', None,
                                                 type='uint16'),
-                       },
+                       },  # noqa: E124
             methods={'Delete': CIMMethod('Delete', 'uint32'),
                      'FooMethod': CIMMethod('FooMethod', 'uint32',
                                             parameters=params)
-                    }
-            )
+                    }  # noqa: E124
+            )  # noqa: E123
 
         # Generate the mof. Does not really test result
         clmof = cl.tomof()
@@ -2963,9 +2964,9 @@ class CIMParameterEquality(unittest.TestCase):
                                          reference_class='CIM_Foo'),
                             CIMParameter('RefParam', 'reference',
                                          reference_class='CIM_Foo',
-                                         qualifiers=
-                                         {'Key': CIMQualifier('Key',
-                                                              True)}))
+                                         qualifiers={'Key': CIMQualifier('Key',
+                                                                         True)})
+                           )  # noqa: E124
 
         # Reference array parameters
 

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -70,8 +70,9 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
         self._run_single(b'<V>a\xED\xA0\x80\xED\xB4\xA2b</V>', False)
         # combo of U+D800,U+DD22 and combo of U+D800,U+DD23:
         # pylint: disable=line-too-long
-        self._run_single(b'<V>a\xED\xA0\x80\xED\xB4\xA2b\xED\xA0\x80\xED\xB4\xA3</V>',
-                         False)
+        self._run_single(
+            b'<V>a\xED\xA0\x80\xED\xB4\xA2b\xED\xA0\x80\xED\xB4\xA3</V>',
+            False)
 
         # incorrectly encoded UTF-8
         if self.VERBOSE:

--- a/testsuite/test_cim_xml.py
+++ b/testsuite/test_cim_xml.py
@@ -73,12 +73,12 @@ class CIMXMLTest(unittest.TestCase):
 
     def setUp(self):
 
-        self.xml = []       # List of test cases, each list item being an
-                            # xml.dom.minidom node representing some element
-                            # from the CIM-XML payload.
+        # List of test cases, each list item being an xml.dom.minidom node
+        # representing some element from the CIM-XML payload.
+        self.xml = []
 
-        self.xml_str = []   # List of expected XML strings resulting from each
-                            # test case.
+        # List of expected XML strings resulting from each test case.
+        self.xml_str = []
 
     @staticmethod
     def validate(xml, expectedResult=0):

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -196,23 +196,23 @@ class Callback(object):
     """
 
     @staticmethod
-    def socket_ssl(request, uri, headers): #pylint: disable=unused-argument
+    def socket_ssl(request, uri, headers): # pylint: disable=unused-argument
         """HTTPretty callback function that raises an arbitrary
         SSLError."""
         raise SSLError(1, "Arbitrary SSL error.")
 
     @staticmethod
-    def socket_104(request, uri, headers): #pylint: disable=unused-argument
+    def socket_104(request, uri, headers): # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.error 104."""
         raise socket.error(104, "Connection reset by peer.")
 
     @staticmethod
-    def socket_32(request, uri, headers): #pylint: disable=unused-argument
+    def socket_32(request, uri, headers): # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.error 32."""
         raise socket.error(32, "Broken pipe.")
 
     @staticmethod
-    def socket_timeout(request, uri, headers): #pylint: disable=unused-argument
+    def socket_timeout(request, uri, headers): # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.timeout error.
            The socket.timeout is just a string, no status.
         """
@@ -450,7 +450,7 @@ class ClientTest(unittest.TestCase):
         if not checker.check_output(ns_act, ns_exp, 0):
             diff = checker.output_difference(doctest.Example("", ns_exp),
                                              ns_act, 0)
-            raise AssertionError("XML is not as expected in %s: %s"%\
+            raise AssertionError("XML is not as expected in %s: %s" % \
                                  (entity, diff))
 
     def test_all(self):
@@ -523,7 +523,7 @@ class ClientTest(unittest.TestCase):
                     callback_func = getattr(Callback(), callback_name)
                 except AttributeError:
                     raise ClientTestError("Error in testcase %s: Unknown "\
-                                          "exception callback specified: %s"%\
+                                          "exception callback specified: %s" % \
                                           (tc_name, callback_name))
                 params = {
                     "body": callback_func
@@ -575,7 +575,7 @@ class ClientTest(unittest.TestCase):
             result = op_call(**op_args)
             raised_exception = None
 
-        except Exception as exc:      #pylint: disable=broad-except
+        except Exception as exc:      # pylint: disable=broad-except
             raised_exception = exc
             stringio = six.StringIO()
             traceback.print_exc(file=stringio)
@@ -704,6 +704,7 @@ class ClientTest(unittest.TestCase):
                     NocaseDict(exp_result_obj[1])
                 )
             else:
+                # pylint: disable=redefined-variable-type
                 _exp_result_obj = exp_result_obj
             if result != _exp_result_obj:
                 # TODO 2016/07 AM: Improve the presentation of the difference

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -30,7 +30,7 @@ def _assert_subscription(exc):
             assert False, "Access by slice did not fail in Python 3"
         for i, _ in enumerate(exc.args):
             try:
-                _ = exc[i]
+                _ = exc[i]  # noqa: F841
             except TypeError:
                 pass
             else:
@@ -83,7 +83,7 @@ def test_httperror(httperror_args):
     assert exc.status == httperror_args[0]
     assert exc.reason == httperror_args[1]
     if len(httperror_args) < 3:
-        assert exc.cimerror == None  # default value
+        assert exc.cimerror is None  # default value
     else:
         assert exc.cimerror == httperror_args[2]
     if len(httperror_args) < 4:
@@ -169,7 +169,7 @@ def test_cimerror_2(status_tuple):
     status_code_name = status_tuple[1]
 
     invalid_code_name = 'Invalid status code %s' % status_code
-    invalid_code_desc = 'Invalid status code %s' % status_code
+    _invalid_code_desc = 'Invalid status code %s' % status_code  # noqa: F841
 
     input_desc = 'foo'
 

--- a/testsuite/test_indicationlistener.py
+++ b/testsuite/test_indicationlistener.py
@@ -83,7 +83,7 @@ def create_indication_data(msg_id, sequence_number, delta_time, protocol_ver):
 
     data = {'sequence_number': sequence_number, 'delta_time': delta_time,
             'protocol_ver': protocol_ver, 'msg_id': msg_id}
-    return data_template%data
+    return data_template % data
 
 def send_indication(url, headers, payload, verbose):
     """Send a single indication using Python requests"""
@@ -215,7 +215,7 @@ class TestIndications(unittest.TestCase):
 
         endtime = timer.elapsed_sec()
         print('Sent %s in %s sec or %.2f ind/sec' % (send_count, endtime,
-                                                     (send_count/endtime)))
+                                                     (send_count / endtime)))
 
         self.assertEqual(send_count, RCV_COUNT,
                          'Mismatch between sent and rcvd')

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -70,7 +70,7 @@ def setUpModule():
         ppct = -1
         for data in ufo:
             offset += len(data)
-            pct = 100 * offset/clen
+            pct = 100 * offset / clen
             if pct > ppct:
                 ppct = pct
                 sys.stdout.write('\rDownloading %s: %d%% ' % (mofbname, pct))
@@ -82,8 +82,8 @@ def setUpModule():
         zf = ZipFile(tfo, 'r')
         nlist = zf.namelist()
         for i in range(0, len(nlist)):
-            sys.stdout.write('\rUnpacking %s: %d%% ' % (mofbname,
-                                                        100*(i+1)/len(nlist)))
+            sys.stdout.write('\rUnpacking %s: %d%% ' % \
+                             (mofbname, 100 * (i + 1) / len(nlist)))
             sys.stdout.flush()
             file_ = nlist[i]
             dfile = os.path.join(SCHEMA_DIR, file_)

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -60,7 +60,7 @@ class TestInit(unittest.TestCase):
 
         # Initialise from iterable and kwargs
 
-        dic = NocaseDict([('Dog', 'Cat'),], Budgie='Fish')
+        dic = NocaseDict([('Dog', 'Cat'), ], Budgie='Fish')
         self.assertTrue(len(dic) == 2)
         self.assertTrue(dic['Dog'] == 'Cat' and dic['Budgie'] == 'Fish')
 

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -152,9 +152,9 @@ class ParseCIMClass(TupleTest):
                             qualifiers={'Key':
                                         CIMQualifier('Key', True,
                                                      overridable=False)}
-                            )
-                       }
-            ))
+                            )  # noqa: E123
+                       }  # noqa: E124
+            ))  # noqa: E123
 
 # TODO 2/16 KS: Extend to all property data types.
 class ParseCIMProperty(TupleTest):


### PR DESCRIPTION
Ready for review.  I may have one more change today.

Cleans up a number of flake8 issues. This reduces the flake8 count from
about 200 to about 50 messages.

Currently the flake8 message summary is as follows:
```
3     E131 continuation line unaligned for hanging indent
33    E501 line too long (115 > 80 characters)
1     F401 '._version.__version__' imported but unused
8     F821 undefined name 'basestring'
1     F841 local variable 'insts_enum' is assigned to but never used
2     W601 .has_key() is deprecated, use 'in'
```
the E501 cover two issues:

1. A bunch of long lines in cim_operations.py in the table but we do not want to exclude this from the whole module.  flake8 has an issue with trying to ignore selected groups of code and further these are all in a comment and that causes further issues for flake8 since its only ignore mechanisms are:

    ignore this line: # noqa: Fxxx

    ignore for this file # flake8: noqa: Fxxx

2. E131 - in setup.py in a very complex statement 

3. F841 - An issue that I am in process of fixing

4. W601 - I think this is our has_key rather than python

With all of the warnings turned off the flake 8 message summary is:
```
55    E127 continuation line over-indented for visual indent
39    E128 continuation line under-indented for visual indent
3     E131 continuation line unaligned for hanging indent
108   E261 at least two spaces before inline comment
107   E265 block comment should start with '# '
485   E302 expected 2 blank lines, found 1
115   E303 too many blank lines (2)
13    E402 module level import not at top of file
85    E501 line too long (115 > 80 characters)
454   E502 the backslash is redundant between brackets
14    F401 '.cim_types.*' imported but unused
12    F403 'from .cim_types import *' used; unable to detect undefined names
2     F821 undefined name 'ResourceWarning'
6     F841 local variable 'dummy_type_obj' is assigned to but never used
15    W391 blank line at end of file
2     W601 .has_key() is deprecated, use 'in'
```

