### PR TITLE
fixes #542 redundant backslash flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -44,10 +44,7 @@ ignore =
     # E402 module level import not at top of file
     # This occurs primarily because of conditonal imports including six
     # ex. if six...
-    E402,
-    # E502 the backslash is redundant between brackets. Remove when cleaner
-    # Right now about 500 of these messages
-    E502,  
+    E402, 
     # E265 block comment should start with #
     E562
     

--- a/os_setup.py
+++ b/os_setup.py
@@ -225,14 +225,14 @@ def _assert_system_dict(dist, attr, value):
     system_dict = value
     if not isinstance(system_dict, dict):
         raise DistutilsSetupError(
-            "'%s' attribute: Value must be a dictionary of systems "\
+            "'%s' attribute: Value must be a dictionary of systems "
             "(got type %s)" % (attr, type(system_dict))
         )
     for system in system_dict:
         if not isinstance(system, string_types):
             raise DistutilsSetupError(
-                "'%s' attribute: Key in system dictionary must be a string "\
-                "(got key %r of type %s)" %\
+                "'%s' attribute: Key in system dictionary must be a string "
+                "(got key %r of type %s)" %
                 (attr, system, type(system))
             )
         system_item = system_dict[system]
@@ -242,9 +242,9 @@ def _assert_system_dict(dist, attr, value):
             for distro in distro_dict:
                 if not isinstance(distro, string_types):
                     raise DistutilsSetupError(
-                        "'%s' attribute: Key in distribution dictionary must "\
-                        "be a string "\
-                        "(for system '%s', got key %r of type %s)" %\
+                        "'%s' attribute: Key in distribution dictionary must "
+                        "be a string "
+                        "(for system '%s', got key %r of type %s)" %
                         (attr, system, distro, type(distro))
                     )
                 distro_item = distro_dict[distro]
@@ -257,16 +257,16 @@ def _assert_system_dict(dist, attr, value):
                     referenced_distro = distro_item
                     if referenced_distro not in distro_dict:
                         raise DistutilsSetupError(
-                            "'%s' attribute: Referenced distribution does not "\
-                            "exist in distribution dictionary "\
-                            "(for system '%s' distro '%s', got "\
-                            "referenced distro '%s')" %\
+                            "'%s' attribute: Referenced distribution does not "
+                            "exist in distribution dictionary "
+                            "(for system '%s' distro '%s', got "
+                            "referenced distro '%s')" %
                             (attr, system, distro, referenced_distro)
                         )
                 else:
                     raise DistutilsSetupError(
-                        "Invalid type %s for value in distribution dictionary "\
-                        ": %r" %\
+                        "Invalid type %s for value in distribution dictionary "
+                        ": %r" %
                         (type(distro_item), distro_item)
                     )
         elif isinstance(system_item, list):
@@ -275,9 +275,9 @@ def _assert_system_dict(dist, attr, value):
             _assert_req_list(dist, attr, req_list)
         else:
             raise DistutilsSetupError(
-                "'%s' attribute: Value in system dictionary must be "\
-                "a dictionary of distributions or a list "\
-                "(for system '%s', got type %s)" %\
+                "'%s' attribute: Value in system dictionary must be "
+                "a dictionary of distributions or a list "
+                "(for system '%s', got type %s)" %
                 (attr, system, type(system_item))
             )
 
@@ -301,15 +301,15 @@ def _assert_req_list(dist, attr, value): # pylint: disable=unused-argument
             for single_req in req:
                 if not isinstance(single_req, string_types):
                     raise DistutilsSetupError(
-                        "'%s' attribute: Requirement list must contain "\
-                        "strings (got list item %r of type %s)" % \
+                        "'%s' attribute: Requirement list must contain "
+                        "strings (got list item %r of type %s)" %
                         (attr, single_req, type(single_req))
                     )
         elif not isinstance(req, (string_types, types.FunctionType,
                                   type(None))):
             raise DistutilsSetupError(
-                "'%s' attribute: Requirement must be a string, a function, "\
-                "or None (got requirement %r of type %s)" % \
+                "'%s' attribute: Requirement must be a string, a function, "
+                "or None (got requirement %r of type %s)" %
                 (attr, req, type(req))
             )
 
@@ -351,7 +351,7 @@ class install_os(BaseOsCommand): # pylint: disable=invalid-name
         """
 
         if self.verbose:
-            print("install_os: Installing prerequisite OS packages for "\
+            print("install_os: Installing prerequisite OS packages for "
                   "platform: %s" % self.installer.platform)
 
         self.installer.install_system(
@@ -385,7 +385,7 @@ class develop_os(BaseOsCommand): # pylint: disable=invalid-name
         """
 
         if self.verbose:
-            print("develop_os: Installing prerequisite OS packages for "\
+            print("develop_os: Installing prerequisite OS packages for "
                   "platform: %s" % self.installer.platform)
 
         self.installer.install_system(
@@ -637,7 +637,7 @@ class BaseInstaller(object):
             return pkg_name, req_list
         else:
             raise DistutilsSetupError(
-                "%s package requirement has an invalid syntax: %r" %\
+                "%s package requirement has an invalid syntax: %r" %
                 (self.env, pkg_req)
             )
 
@@ -665,14 +665,14 @@ class BaseInstaller(object):
                          req_string)
             if m is None:
                 raise DistutilsSetupError(
-                    "Version requirement has an invalid syntax: %r" %\
+                    "Version requirement has an invalid syntax: %r" %
                     req_string
                 )
             req_op = m.group(1)
             req_version_info = m.group(2).split(".")
             if len(req_version_info) > len(version_info):
                 raise DistutilsSetupError(
-                    "Version requirement specifies too many version number "\
+                    "Version requirement specifies too many version number "
                     "components for the actual package: %r" % req_string
                 )
             if req_op == '<':
@@ -701,7 +701,7 @@ class BaseInstaller(object):
                     return False
             else:
                 raise DistutilsSetupError(
-                    "Version requirement has an invalid syntax: %r" %\
+                    "Version requirement has an invalid syntax: %r" %
                     req_string
                 )
         return True
@@ -803,7 +803,7 @@ class PythonInstaller(BaseInstaller):
             success = False
             for single_req in req:
                 if verbose:
-                    print("Processing requirement choice item: %s" %\
+                    print("Processing requirement choice item: %s" %
                           single_req)
                 pkg_name, version_reqs = self.parse_pkg_req(single_req)
                 installed = self.ensure_installed(
@@ -813,7 +813,7 @@ class PythonInstaller(BaseInstaller):
                     break
             if not success:
                 if verbose:
-                    print("No package of Python package req choice is "\
+                    print("No package of Python package req choice is "
                           "available in Pypi: %s" % req)
                 self.record_error(req, None, self.MSG_PKG_NOT_IN_REPOS)
         else: # requirements string
@@ -907,7 +907,7 @@ class PythonInstaller(BaseInstaller):
 
         if inst_sufficient:
             if verbose:
-                print("Installed Python package version is sufficient: "\
+                print("Installed Python package version is sufficient: "
                       "%s %s" % (pkg_name, inst_version))
             return True
 
@@ -917,7 +917,7 @@ class PythonInstaller(BaseInstaller):
         if not avail:
             if not ignore:
                 if verbose:
-                    print("Python package is not available in Pypi: %s" %\
+                    print("Python package is not available in Pypi: %s" %
                           (pkg_name,))
                 self.record_error(pkg_name, version_reqs,
                                   self.MSG_PKG_NOT_IN_REPOS)
@@ -926,8 +926,8 @@ class PythonInstaller(BaseInstaller):
         if not avail_sufficient:
             if not ignore:
                 if verbose:
-                    print("Python package is available in Pypi, but its "\
-                          "versions are not sufficient: %s" %\
+                    print("Python package is available in Pypi, but its "
+                          "versions are not sufficient: %s" %
                           (pkg_name,))
                 self.record_error(pkg_name, version_reqs,
                                   self.MSG_PKG_NOT_IN_REPOS)
@@ -1011,7 +1011,7 @@ class OSInstaller(BaseInstaller):
                     self.install_reqlist(req_list, dry_run, verbose)
                 else:
                     raise DistutilsSetupError(
-                        "Invalid type %s for system entry: %r" %\
+                        "Invalid type %s for system entry: %r" %
                         (type(system_item), system_item)
                     )
 
@@ -1040,7 +1040,7 @@ class OSInstaller(BaseInstaller):
                 self.install_distro(distro, distro_dict, dry_run, verbose)
             else:
                 raise DistutilsSetupError(
-                    "Invalid type %s for distro entry: %r" %\
+                    "Invalid type %s for distro entry: %r" %
                     (type(distro_item), distro_item)
                 )
 
@@ -1080,7 +1080,7 @@ class OSInstaller(BaseInstaller):
             success = False
             for single_req in req:
                 if verbose:
-                    print("Processing requirement choice item: %s" %\
+                    print("Processing requirement choice item: %s" %
                           single_req)
                 pkg_name, version_reqs = self.parse_pkg_req(single_req)
                 installed = self.ensure_installed(
@@ -1090,7 +1090,7 @@ class OSInstaller(BaseInstaller):
                     break
             if not success:
                 if verbose:
-                    print("No package of OS package req choice is "\
+                    print("No package of OS package req choice is "
                           "available in the repos: %s" % req)
                 self.record_error(req, None, self.MSG_PKG_NOT_IN_REPOS)
         else: # requirements string
@@ -1165,7 +1165,7 @@ class OSInstaller(BaseInstaller):
 
         if inst_sufficient:
             if verbose:
-                print("Installed OS package version is sufficient: "\
+                print("Installed OS package version is sufficient: "
                       "%s %s" % (pkg_name, inst_version))
             return True
 
@@ -1175,7 +1175,7 @@ class OSInstaller(BaseInstaller):
         if not avail:
             if not ignore:
                 if verbose:
-                    print("OS package is not available in repos: %s" %\
+                    print("OS package is not available in repos: %s" %
                           (pkg_name,))
                 self.record_error(pkg_name, version_reqs,
                                   self.MSG_PKG_NOT_IN_REPOS)
@@ -1184,8 +1184,8 @@ class OSInstaller(BaseInstaller):
         if not avail_sufficient:
             if not ignore:
                 if verbose:
-                    print("OS package is available in repos, but its "\
-                          "versions are not sufficient: %s" %\
+                    print("OS package is available in repos, but its "
+                          "versions are not sufficient: %s" %
                           (pkg_name,))
                 self.record_error(pkg_name, version_reqs,
                                   self.MSG_PKG_NOT_IN_REPOS)
@@ -1238,7 +1238,7 @@ class YumInstaller(OSInstaller):
         info = out.splitlines()[-1].strip("\n").split()
         if not info[0].startswith(pkg_name + "."):
             raise DistutilsSetupError(
-                "Unexpected output from command '%s':\n%s%s" %\
+                "Unexpected output from command '%s':\n%s%s" %
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
@@ -1262,7 +1262,7 @@ class YumInstaller(OSInstaller):
         info = out.splitlines()[-1].strip("\n").split()
         if not info[0].startswith(pkg_name + "."):
             raise DistutilsSetupError(
-                "Unexpected output from command '%s':\n%s%s" %\
+                "Unexpected output from command '%s':\n%s%s" %
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
@@ -1309,7 +1309,7 @@ class AptInstaller(OSInstaller):
                         if line.startswith("Version:")][0]
         if status_line != "Status: install ok installed":
             raise DistutilsSetupError(
-                "Unexpected status output from command '%s':\n"\
+                "Unexpected status output from command '%s':\n"
                 "%s%s" % (cmd, out, err))
         version = version_line.split()[1].split("-")[0]
         if ":" in version:
@@ -1378,7 +1378,7 @@ class ZypperInstaller(OSInstaller):
         info = out.splitlines()[-1].strip("\n").split()
         if not info[0].startswith(pkg_name + "."):
             raise DistutilsSetupError(
-                "Unexpected output from command '%s':\n%s%s" %\
+                "Unexpected output from command '%s':\n%s%s" %
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
@@ -1530,13 +1530,13 @@ def import_setuptools(min_version="12.0"):
     else:
         if setuptools.__version__.split(".") < min_version.split("."):
             raise DistutilsSetupError(
-                "The required version of setuptools (>=%s) is not available, "\
-                "and can't be\n"\
-                "installed while this script is running. Please install the "\
-                "required version\n"\
-                "first, using:\n"\
-                "\n"\
-                "    pip install --upgrade 'setuptools>=%s'\n" %\
+                "The required version of setuptools (>=%s) is not available, "
+                "and can't be\n"
+                "installed while this script is running. Please install the "
+                "required version\n"
+                "first, using:\n"
+                "\n"
+                "    pip install --upgrade 'setuptools>=%s'\n" %
                 (min_version, min_version)
             )
 

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -119,12 +119,12 @@ SUPPORTED_PROTOCOL_VERSION_STR = '1.x'
 # to the valid characters for tokens, but does its job in parsing tokens
 # and q values.
 TOKEN_QUALITY_FINDALL_PATTERN = re.compile(
-    r'([^;, ]+)' \
-    r'(?:; *q=([01](?:\.[0-9]*)?))?' \
+    r'([^;, ]+)'
+    r'(?:; *q=([01](?:\.[0-9]*)?))?'
     r'(?:, *)?')
 TOKEN_CHARSET_FINDALL_PATTERN = re.compile(
-    r'([^;, ]+)' \
-    r'(?:; *charset="?([^";, ]*)"?)?' \
+    r'([^;, ]+)'
+    r'(?:; *charset="?([^";, ]*)"?)?'
     r'(?:, *)?')
 
 __all__ = ['WBEMListener', 'callback_interface']
@@ -208,8 +208,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         accept = self.headers.get('Accept', 'text/xml')
         if accept not in ('text/xml', 'application/xml', '*/*'):
             self.send_http_error(406, 'header-mismatch',
-                                 'Invalid Accept header value: %s ' \
-                                 '(need text/xml, application/xml or */*)' % \
+                                 'Invalid Accept header value: %s '
+                                 '(need text/xml, application/xml or */*)' %
                                  accept)
             return
 
@@ -224,8 +224,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     break
         if not found:
             self.send_http_error(406, 'header-mismatch',
-                                 'Invalid Accept-Charset header value: %s ' \
-                                 '(need UTF-8 or *)' % \
+                                 'Invalid Accept-Charset header value: %s '
+                                 '(need UTF-8 or *)' %
                                  accept_charset)
             return
 
@@ -250,8 +250,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                         break
         if not identity_acceptable:
             self.send_http_error(406, 'header-mismatch',
-                                 'Invalid Accept-Encoding header value: %s ' \
-                                 '(need Identity to be acceptable)' % \
+                                 'Invalid Accept-Encoding header value: %s '
+                                 '(need Identity to be acceptable)' %
                                  accept_encoding)
             return
 
@@ -263,7 +263,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         accept_range = self.headers.get('Accept-Range', None)
         if accept_range is not None:
             self.send_http_error(406, 'header-mismatch',
-                                 'Accept-Range header is not permitted %s' % \
+                                 'Accept-Range header is not permitted %s' %
                                  accept_range)
             return
 
@@ -283,9 +283,9 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     break
         if not found:
             self.send_http_error(406, 'header-mismatch',
-                                 'Invalid Content-Type header value: %s ' \
-                                 '(need text/xml or application/xml with ' \
-                                 'charset=utf-8 or empty)' % \
+                                 'Invalid Content-Type header value: %s '
+                                 '(need text/xml or application/xml with '
+                                 'charset=utf-8 or empty)' %
                                  content_type)
             return
 
@@ -293,8 +293,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         content_encoding = self.headers.get('Content-Encoding', 'identity')
         if content_encoding.lower() != 'identity':
             self.send_http_error(406, 'header-mismatch',
-                                 'Invalid Content-Encoding header value: ' \
-                                 '%s (listener supports only identity)' % \
+                                 'Invalid Content-Encoding header value: '
+                                 '%s (listener supports only identity)' %
                                  content_encoding)
             return
 
@@ -331,8 +331,8 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if len(params) != 1 or 'NewIndication' not in params:
                 self.send_error_response(msgid, methodname,
                                          CIM_ERR_INVALID_PARAMETER,
-                                         'Expecting one parameter ' \
-                                         'NewIndication, got %s' % \
+                                         'Expecting one parameter '
+                                         'NewIndication, got %s' %
                                          ','.join(params.keys()))
                 return
 
@@ -341,7 +341,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if not isinstance(indication_inst, CIMInstance):
                 self.send_error_response(msgid, methodname,
                                          CIM_ERR_INVALID_PARAMETER,
-                                         'NewIndication parameter is not ' \
+                                         'NewIndication parameter is not '
                                          'a CIM instance, but %r' %
                                          indication_inst)
                 return
@@ -372,7 +372,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             for header, value in headers:
                 self.send_header(header, value)
         self.end_headers()
-        self.log('%s: HTTP status %s; CIMError: %s, ' \
+        self.log('%s: HTTP status %s; CIMError: %s, '
                  'CIMErrorDetails: %s',
                  (self._get_log_prefix(), http_code, cim_error,
                   cim_error_details),
@@ -486,34 +486,34 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         tup_tree = parse_cim(dom_to_tupletree(request_dom))
 
         if tup_tree[0] != 'CIM':
-            raise ParseError('Expecting CIM element, got %s' % \
+            raise ParseError('Expecting CIM element, got %s' %
                              tup_tree[0])
         dtd_version = tup_tree[1]['DTDVERSION']
         if not re.match(SUPPORTED_DTD_VERSION_PATTERN, dtd_version):
-            raise VersionError('DTD version %s not supported. ' \
-                               'Supported versions are: %s' % \
+            raise VersionError('DTD version %s not supported. '
+                               'Supported versions are: %s' %
                                (dtd_version, SUPPORTED_DTD_VERSION_STR))
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'MESSAGE':
-            raise ParseError('Expecting MESSAGE element, got %s' % \
+            raise ParseError('Expecting MESSAGE element, got %s' %
                              tup_tree[0])
         msgid = tup_tree[1]['ID']
         protocol_version = tup_tree[1]['PROTOCOLVERSION']
         if not re.match(SUPPORTED_PROTOCOL_VERSION_PATTERN, protocol_version):
-            raise VersionError('Protocol version %s not supported. ' \
-                               'Supported versions are: %s' % \
+            raise VersionError('Protocol version %s not supported. '
+                               'Supported versions are: %s' %
                                (protocol_version,
                                 SUPPORTED_PROTOCOL_VERSION_STR))
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'SIMPLEEXPREQ':
-            raise ParseError('Expecting SIMPLEEXPREQ element, got %s' % \
+            raise ParseError('Expecting SIMPLEEXPREQ element, got %s' %
                              tup_tree[0])
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'EXPMETHODCALL':
-            raise ParseError('Expecting EXPMETHODCALL element, ' \
+            raise ParseError('Expecting EXPMETHODCALL element, '
                              'got %s' % tup_tree[0])
 
         methodname = tup_tree[1]['NAME']
@@ -630,7 +630,7 @@ class WBEMListener(object):
         elif http_port is None:
             self._http_port = http_port
         else:
-            raise TypeError("Invalid type for http_port: %s" % \
+            raise TypeError("Invalid type for http_port: %s" %
                             type(http_port))
 
         if isinstance(https_port, six.integer_types):
@@ -640,7 +640,7 @@ class WBEMListener(object):
         elif https_port is None:
             self._https_port = https_port
         else:
-            raise TypeError("Invalid type for https_port: %s" % \
+            raise TypeError("Invalid type for https_port: %s" %
                             type(https_port))
 
         if self._https_port is not None:
@@ -858,7 +858,7 @@ class WBEMListener(object):
             try:
                 callback(indication, host)
             except Exception as exc:
-                self.logger.log(logging.ERROR, "Indication delivery callback "\
+                self.logger.log(logging.ERROR, "Indication delivery callback "
                                 "function raised %s: %s",
                                 exc.__class__.__name__, exc)
 

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -62,12 +62,12 @@ def _represent_ordereddict(dump, tag, mapping, flow_style=None):
     for item_key, item_value in mapping:
         node_key = dump.represent_data(item_key)
         node_value = dump.represent_data(item_value)
-        if not (isinstance(node_key, yaml.ScalarNode) \
-           and not node_key.style):
-            best_style = False
-        if not (isinstance(node_value, yaml.ScalarNode) \
-           and not node_value.style):
-            best_style = False
+        if not (isinstance(node_key, yaml.ScalarNode) and
+                not node_key.style):
+                    best_style = False    # pylint: disable=bad-indentation
+        if not (isinstance(node_value, yaml.ScalarNode) and
+                not node_value.style):
+                    best_style = False    # pylint: disable=bad-indentation
         value.append((node_key, node_value))
     if flow_style is None:
         if dump.default_flow_style is not None:
@@ -576,6 +576,6 @@ class TestClientRecorder(BaseOperationRecorder):
             ret['translatable'] = self.toyaml(obj.translatable)
             return ret
         else:
-            raise TypeError("Invalid type in TestClientRecorder.toyaml(): " \
+            raise TypeError("Invalid type in TestClientRecorder.toyaml(): "
                             "%s %s" % (obj.__class__.__name__, type(obj)))
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -156,7 +156,7 @@ class WBEMServer(object):
             Connection to the WBEM server.
         """
         if not isinstance(conn, WBEMConnection):
-            raise TypeError("conn argument of WBEMServer must be a " \
+            raise TypeError("conn argument of WBEMServer must be a "
                             "WBEMConnection object")
         self._conn = conn
         self._interop_ns = None
@@ -305,7 +305,7 @@ class WBEMServer(object):
             self._determine_profiles()
         return self._profiles
 
-    def get_selected_profiles(self, registered_org=None, registered_name=None, \
+    def get_selected_profiles(self, registered_org=None, registered_name=None,
                     registered_version=None):
         """
         List of management profiles advertised by the WBEM server and
@@ -348,7 +348,7 @@ class WBEMServer(object):
             if (registered_org is None or registered_org == inst_org) and \
                     (registered_name is None or registered_name == inst_name) \
                     and \
-                    (registered_version is None or \
+                    (registered_version is None or
                     registered_version == inst_version):
                 rtn.append(inst)
         return rtn
@@ -437,7 +437,7 @@ class WBEMServer(object):
             TypeError: profile_path must be a CIMInstanceName.
         """
         if not isinstance(profile_path, CIMInstanceName):
-            raise TypeError("profile_path must be a CIMInstanceName, but is " \
+            raise TypeError("profile_path must be a CIMInstanceName, but is "
                             "a %s" % type(profile_path))
 
         # Try GetCentralInstances() method:
@@ -456,7 +456,7 @@ class WBEMServer(object):
                 raise
         else:
             if ret_val != 0:
-                raise ValueError("GetCentralInstances() implemented but " \
+                raise ValueError("GetCentralInstances() implemented but "
                                  "failed with rc=%s" % ret_val)
             return out_params['CentralInstances']
 
@@ -472,9 +472,9 @@ class WBEMServer(object):
         if central_class is None or \
            scoping_class is None or \
            scoping_path is None:
-            raise ValueError("No central instances found after applying "\
-                             "GetCentralInstances and central class " \
-                             "methodologies, and parameters for scoping " \
+            raise ValueError("No central instances found after applying "
+                             "GetCentralInstances and central class "
+                             "methodologies, and parameters for scoping "
                              "class methodology were not specified")
 
         # Go up one level on the profile side
@@ -513,8 +513,8 @@ class WBEMServer(object):
                 ResultClass=central_class)
             if len(ci_paths) == 0:
                 # At least one central instance for each scoping instance
-                raise ValueError("No central instances found traversing down " \
-                                 "across %s to %s" % \
+                raise ValueError("No central instances found traversing down "
+                                 "across %s to %s" %
                                  (assoc_class, central_class))
             total_ci_paths.extend(ci_paths)
 
@@ -569,7 +569,7 @@ class WBEMServer(object):
         if interop_ns is None:
             # Exhausted the possible namespaces
             raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Interop namespace could not be determined " \
+                           "Interop namespace could not be determined "
                            "(tried %s)" % self.INTEROP_NAMESPACES)
         self._interop_ns = interop_ns
 
@@ -649,7 +649,7 @@ class WBEMServer(object):
         if ns_insts is None:
             # Exhausted the possible class names
             raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Namespace class could not be determined " \
+                           "Namespace class could not be determined "
                            "(tried %s)" % self.NAMESPACE_CLASSNAMES)
         self._namespace_classname = ns_classname
         self._namespaces = [inst['Name'] for inst in ns_insts]
@@ -676,8 +676,8 @@ class WBEMServer(object):
             "CIM_ObjectManager", namespace=self.interop_ns)
         if len(cimom_insts) != 1:
             raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Unexpected number of CIM_ObjectManager " \
-                           "instances: %s " % \
+                           "Unexpected number of CIM_ObjectManager "
+                           "instances: %s " %
                            [i['ElementName'] for i in cimom_insts])
         cimom_inst = cimom_insts[0]
         element_name = cimom_inst['ElementName']
@@ -1013,7 +1013,7 @@ class ValueMapping(object):
         cimtype = type_from_name(typename)
 
         if not issubclass(cimtype, CIMInt):
-            raise TypeError("The CIM element is not integer-typed: %s" % \
+            raise TypeError("The CIM element is not integer-typed: %s" %
                             typename)
 
         vm = ValueMapping()
@@ -1087,7 +1087,7 @@ class ValueMapping(object):
         """
 
         if not isinstance(element_value, (six.integer_types, CIMInt)):
-            raise TypeError("Element value is not an integer type: %s" % \
+            raise TypeError("Element value is not an integer type: %s" %
                             type(element_value))
 
         # try single value
@@ -1106,6 +1106,6 @@ class ValueMapping(object):
         if self._unclaimed is not None:
             return self._unclaimed
 
-        raise ValueError("Element value outside of the set defined by " \
+        raise ValueError("Element value outside of the set defined by "
                          "ValueMap: %r" % element_value)
 

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -206,11 +206,11 @@ class WBEMSubscriptionManager(object):
             self._subscription_manager_id = subscription_manager_id
         elif isinstance(subscription_manager_id, six.string_types):
             if ':' in subscription_manager_id:
-                raise ValueError("Subscription manager ID contains ':': %s" % \
+                raise ValueError("Subscription manager ID contains ':': %s" %
                                  subscription_manager_id)
             self._subscription_manager_id = subscription_manager_id
         else:
-            raise TypeError("Invalid type for subscription manager ID: %r" % \
+            raise TypeError("Invalid type for subscription manager ID: %r" %
                             subscription_manager_id)
 
     def __repr__(self):
@@ -273,11 +273,11 @@ class WBEMSubscriptionManager(object):
         """
 
         if not isinstance(server, WBEMServer):
-            raise TypeError("Server argument of add_server() must be a " \
+            raise TypeError("Server argument of add_server() must be a "
                             "WBEMServer object")
         server_id = server.url
         if server_id in self._servers:
-            raise ValueError("WBEM server already known by listener: %s" % \
+            raise ValueError("WBEM server already known by listener: %s" %
                              server_id)
 
         # Create dictionary entries for this server
@@ -821,7 +821,7 @@ class WBEMSubscriptionManager(object):
 
         # Validate that owned flag and owned status of path matches
         if not owned and filter_path in self._owned_filter_paths[server_id]:
-            raise ValueError("Not-owned subscription cannot be created on "\
+            raise ValueError("Not-owned subscription cannot be created on "
                              "owned filter: %s" % filter_path)
 
         for dest_path in destination_paths:
@@ -829,8 +829,8 @@ class WBEMSubscriptionManager(object):
             # Validate that owned flag and owned status of paths match
             if not owned and \
                dest_path in self._owned_destination_paths[server_id]:
-                raise ValueError("Not-owned subscription cannot be created "\
-                                 "on owned listener destination: %s" % \
+                raise ValueError("Not-owned subscription cannot be created "
+                                 "on owned listener destination: %s" %
                                  dest_path)
 
             sub_path = _create_subscription(server, dest_path, filter_path)
@@ -1004,7 +1004,7 @@ def _create_destination(server, dest_url, subscription_manager_id=None):
     dest_path = server.conn.CreateInstance(dest_inst)
     return dest_path
 
-def _create_filter(server, source_namespace, query, query_language, \
+def _create_filter(server, source_namespace, query, query_language,
                    subscription_manager_id=None, filter_id=None):
     """
     Create a :term:`dynamic indication filter` instance in the Interop
@@ -1074,8 +1074,8 @@ def _create_filter(server, source_namespace, query, query_language, \
     if subscription_manager_id is not None:
         sub_mgr_id = '%s:' % (subscription_manager_id)
 
-    filter_inst['Name'] = 'pywbemfilter:%s%s%s' % (sub_mgr_id, \
-                                                   filter_id_, \
+    filter_inst['Name'] = 'pywbemfilter:%s%s%s' % (sub_mgr_id,
+                                                   filter_id_,
                                                    uuid.uuid4())
     filter_inst['SourceNamespace'] = source_namespace
     filter_inst['Query'] = query

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -124,7 +124,7 @@ DEFAULT_PORT_HTTPS = 5989       # default port for https
 
 #: Default directory paths for looking up CA certificates.
 DEFAULT_CA_CERT_PATHS = \
-     ['/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt', \
+     ['/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
       '/etc/ssl/certs', '/etc/ssl/certificates']
 
 def get_default_ca_cert_paths():
@@ -197,7 +197,7 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
                 duration = ts2 - self._ts1
                 duration_sec = (float(duration.microseconds) / 1000000) +\
                                duration.seconds + (duration.days * 24 * 3600)
-                raise TimeoutError("The client timed out and closed the "\
+                raise TimeoutError("The client timed out and closed the "
                                    "socket after %.0fs." % duration_sec)
         return False # re-raise any other exceptions
 
@@ -614,7 +614,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 socket_af = socket.AF_UNIX
             except AttributeError:
                 raise ConnectionError(
-                    'file URLs not supported on %s platform due '\
+                    'file URLs not supported on %s platform due '
                     'to missing AF_UNIX support' % platform.system())
             self.sock = socket.socket(socket_af, socket.SOCK_STREAM)
             self.sock.connect(self.uds_path)
@@ -753,11 +753,11 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 except SocketErrors as exc:
                     if exc.args[0] == errno.ECONNRESET:
                         if debug:
-                            print("Debug: Ignoring socket error ECONNRESET " \
+                            print("Debug: Ignoring socket error ECONNRESET "
                                   "(connection reset) returned by server.")
                     elif exc.args[0] == errno.EPIPE:
                         if debug:
-                            print("Debug: Ignoring socket error EPIPE " \
+                            print("Debug: Ignoring socket error EPIPE "
                                   "(broken pipe) returned by server.")
                     else:
                         raise ConnectionError("Socket error: %s" % exc)
@@ -784,9 +784,9 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                     uid = os.getuid()
                                 except AttributeError:
                                     raise AuthError(
-                                        "OWLocal authorization for OpenWbem "\
-                                        "server not supported on %s platform "\
-                                        "due to missing os.getuid()" % \
+                                        "OWLocal authorization for OpenWbem "
+                                        "server not supported on %s platform "
+                                        "due to missing os.getuid()" %
                                         platform.system())
                                 local_auth_header = ('Authorization',
                                                      'OWLocal uid="%d"' % uid)
@@ -811,13 +811,13 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                     file_hndl.close()
                                     local_auth_header = (
                                         'Authorization',
-                                        'OWLocal nonce="%s", cookie="%s"' % \
+                                        'OWLocal nonce="%s", cookie="%s"' %
                                         (nonce, cookie))
                                     continue
                                 except Exception as exc:
                                     if debug:
-                                        print("Debug: Ignoring exception %s " \
-                                              "in OpenWBEM auth challenge " \
+                                        print("Debug: Ignoring exception %s "
+                                              "in OpenWBEM auth challenge "
                                               "processing." % exc)
                                     local_auth_header = None
                                     continue
@@ -832,7 +832,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                     file_hndl.close()
                                     local_auth_header = (
                                         'PegasusAuthorization',
-                                        'Local "%s:%s:%s"' % \
+                                        'Local "%s:%s:%s"' %
                                         (locallogin, _file, cookie))
                                     continue
                             except ValueError:
@@ -867,11 +867,11 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 # See http://bugs.python.org/issue8450.
                 if exc.line is None or exc.line.strip().strip("'") in \
                                        ('', 'None'):
-                    raise ConnectionError("The server closed the "\
-                        "connection without returning any data, or the "\
+                    raise ConnectionError("The server closed the "
+                        "connection without returning any data, or the "
                         "client timed out")
                 else:
-                    raise ConnectionError("The server returned a bad "\
+                    raise ConnectionError("The server returned a bad "
                         "HTTP status line: %r" % exc.line)
             except httplib.IncompleteRead as exc:
                 raise ConnectionError("HTTP incomplete read: %s" % exc)

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -618,7 +618,7 @@ def _makequalifiers(qualifiers, indent):
         return ''
 
     return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent + 2).
-        join([q.tomof(indent+2) for q in sorted(qualifiers.values())]))
+        join([q.tomof(indent + 2) for q in sorted(qualifiers.values())]))
 
 def _indent_str(indent):
     """
@@ -2325,8 +2325,8 @@ class CIMProperty(_CIMComparisonMixin):
                 embedded_object = _intended_value(
                     None, None, embedded_object, 'embedded_object', msg)
             elif type_ == 'datetime':
-                value = [CIMDateTime(val) if val is not None
-                         and not isinstance(val, CIMDateTime)
+                value = [CIMDateTime(val) if val is not None and
+                         not isinstance(val, CIMDateTime)
                          else val for val in value]
                 msg = 'Array property %r specifies CIM data type %r' % \
                       (name, type_)

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -168,11 +168,11 @@ class NocaseDict(object):
                 pass
             else:
                 raise TypeError(
-                    "Invalid type for NocaseDict initialization: %s (%s)" % \
+                    "Invalid type for NocaseDict initialization: %s (%s)" %
                     (args[0].__class__.__name__, type(args[0])))
         elif len(args) > 1:
             raise TypeError(
-                "Too many positional arguments for NocaseDict initialization: "\
+                "Too many positional arguments for NocaseDict initialization: "
                 "%s (1 allowed)" % len(args))
 
         # Step 2: Add any keyword arguments
@@ -208,7 +208,7 @@ class NocaseDict(object):
         Raises `TypeError` if the specified key does not have string type.
         """
         if not isinstance(key, six.string_types):
-            raise TypeError('NocaseDict key %s must be string type, ' \
+            raise TypeError('NocaseDict key %s must be string type, '
                             'but is %s' % (key, builtin_type(key)))
         k = key.lower()
         self._data[k] = (key, value)
@@ -484,7 +484,7 @@ def _intended_value(intended, unspecified, actual, name, msg):
         elif actual in intended:
             return actual
         else:
-            raise ValueError(msg + ", but specifies %s=%r (must be one of %r)"\
+            raise ValueError(msg + ", but specifies %s=%r (must be one of %r)"
                              % (name, actual, intended))
     else:
         if actual == unspecified:
@@ -492,7 +492,7 @@ def _intended_value(intended, unspecified, actual, name, msg):
         elif actual == intended:
             return actual
         else:
-            raise ValueError(msg + ", but specifies %s=%r (must be %r)"\
+            raise ValueError(msg + ", but specifies %s=%r (must be %r)"
                              % (name, actual, intended))
 
 def cmpname(name1, name2):
@@ -617,8 +617,8 @@ def _makequalifiers(qualifiers, indent):
     if len(qualifiers) == 0:
         return ''
 
-    return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent + 2).\
-        join([q.tomof(indent + 2) for q in sorted(qualifiers.values())]))
+    return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent + 2).
+        join([q.tomof(indent+2) for q in sorted(qualifiers.values())]))
 
 def _indent_str(indent):
     """
@@ -896,7 +896,7 @@ class CIMInstanceName(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMInstanceName):
-            raise TypeError("other must be CIMInstanceName, but is: %s" %\
+            raise TypeError("other must be CIMInstanceName, but is: %s" %
                             type(other))
         return (cmpname(self.host, other.host) or
                 cmpname(self.namespace, other.namespace) or
@@ -1053,7 +1053,7 @@ class CIMInstanceName(_CIMComparisonMixin):
         if isinstance(self.keybindings, str):
 
             # This cannot happen; self.keybindings is always a NocaseDict:
-            raise TypeError("Unexpected: keybindings has string type: %s" % \
+            raise TypeError("Unexpected: keybindings has string type: %s" %
                             repr(self.keybindings))
 
             # TODO: Remove this old code after verifying that it works.
@@ -1068,7 +1068,7 @@ class CIMInstanceName(_CIMComparisonMixin):
         elif builtin_type(self.keybindings) in six.integer_types + (float,):
 
             # This cannot happen; self.keybindings is always a NocaseDict:
-            raise TypeError("Unexpected: keybindings has numeric type: %s" % \
+            raise TypeError("Unexpected: keybindings has numeric type: %s" %
                             repr(self.keybindings))
 
             # TODO: Remove this old code after verifying that it works.
@@ -1108,7 +1108,7 @@ class CIMInstanceName(_CIMComparisonMixin):
                     type_ = 'string'
                     value = _ensure_unicode(key_bind[1])
                 else:
-                    raise TypeError('Invalid keybinding type for keybinding '\
+                    raise TypeError('Invalid keybinding type for keybinding '
                             '%s: %s' % (key_bind[0], builtin_type(key_bind[1])))
 
                 kbs.append(cim_xml.KEYBINDING(
@@ -1120,7 +1120,7 @@ class CIMInstanceName(_CIMComparisonMixin):
         else:
 
             # This cannot happen; self.keybindings is always a NocaseDict:
-            raise TypeError("Unexpected: keybindings has type: %s" % \
+            raise TypeError("Unexpected: keybindings has type: %s" %
                             repr(self.keybindings))
 
             # TODO: Remove this old code after verifying that it works.
@@ -1276,7 +1276,7 @@ class CIMInstance(_CIMComparisonMixin):
         # TODO: Add support for accepting qualifiers as plain dict
         self.path = path
         if property_list is not None:
-            self.property_list = [_ensure_unicode(x).lower() \
+            self.property_list = [_ensure_unicode(x).lower()
                 for x in property_list]
         else:
             self.property_list = None
@@ -1301,7 +1301,7 @@ class CIMInstance(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMInstance):
-            raise TypeError("other must be CIMInstance, but is: %s" %\
+            raise TypeError("other must be CIMInstance, but is: %s" %
                             type(other))
         return (cmpname(self.classname, other.classname) or
                 cmpitem(self.path, other.path) or
@@ -1346,7 +1346,7 @@ class CIMInstance(_CIMComparisonMixin):
         # pylint: disable=unidiomatic-typecheck
         if builtin_type(value) in six.integer_types + (float,):
             raise TypeError(
-                "Type of numeric value for a property must be a "\
+                "Type of numeric value for a property must be a "
                 "CIM data type, but is %s" % builtin_type(value))
 
         if self.property_list is not None and key.lower() not in \
@@ -1381,7 +1381,7 @@ class CIMInstance(_CIMComparisonMixin):
         result = CIMInstance(self.classname)
         result.properties = self.properties.copy()
         result.qualifiers = self.qualifiers.copy()
-        result.path = (self.path is not None and \
+        result.path = (self.path is not None and
                        [self.path.copy()] or [None])[0]
 
         return result
@@ -1636,7 +1636,7 @@ class CIMClassName(_CIMComparisonMixin):
 
         if not isinstance(classname, six.string_types):
             raise TypeError(
-                "classname argument has an invalid type: %s "\
+                "classname argument has an invalid type: %s "
                 "(expected string)" % builtin_type(classname))
 
         # TODO: There are some odd restrictions on what a CIM
@@ -1667,7 +1667,7 @@ class CIMClassName(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMClassName):
-            raise TypeError("other must be CIMClassName, but is: %s" %\
+            raise TypeError("other must be CIMClassName, but is: %s" %
                             type(other))
         return (cmpname(self.host, other.host) or
                 cmpname(self.namespace, other.namespace) or
@@ -1870,7 +1870,7 @@ class CIMClass(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMClass):
-            raise TypeError("other must be CIMClass, but is: %s" %\
+            raise TypeError("other must be CIMClass, but is: %s" %
                             type(other))
         return (cmpname(self.classname, other.classname) or
                 cmpname(self.superclass, other.superclass) or
@@ -2255,11 +2255,11 @@ class CIMProperty(_CIMComparisonMixin):
         # General checks:
 
         if embedded_object not in (None, 'instance', 'object'):
-            raise ValueError('Property %r specifies an invalid ' \
+            raise ValueError('Property %r specifies an invalid '
                              'embedded_object=%r' % (name, embedded_object))
 
         if is_array not in (None, True, False):
-            raise ValueError('Property %r specifies an invalid ' \
+            raise ValueError('Property %r specifies an invalid '
                              'is_array=%r' % (name, is_array))
 
         # Set up is_array
@@ -2267,19 +2267,19 @@ class CIMProperty(_CIMComparisonMixin):
         if isinstance(value, (list, tuple)):
             is_array = _intended_value(
                 True, None, is_array, 'is_array',
-                'Property %r has a value that is an array (%s)' % \
+                'Property %r has a value that is an array (%s)' %
                 (name, builtin_type(value)))
         elif value is not None: # Scalar value
             is_array = _intended_value(
                 False, None, is_array, 'is_array',
-                'Property %r has a value that is a scalar (%s)' % \
+                'Property %r has a value that is a scalar (%s)' %
                 (name, builtin_type(value)))
         else: # Null value
             if is_array is None:
                 is_array = False # For compatibility with old default
 
         if not is_array and array_size is not None:
-            raise ValueError('Scalar property %r specifies array_size=%r ' \
+            raise ValueError('Scalar property %r specifies array_size=%r '
                              '(must be None)' % (name, array_size))
 
         # Determine type, embedded_object, and reference_class attributes.
@@ -2302,8 +2302,8 @@ class CIMProperty(_CIMComparisonMixin):
                     dummy_type_obj = type_from_name(type_)
                 else:
                     raise ValueError(
-                        'Cannot infer type of array property %r that is ' \
-                        'Null, empty, or has Null as its first element' % \
+                        'Cannot infer type of array property %r that is '
+                        'Null, empty, or has Null as its first element' %
                         name)
             elif isinstance(value[0], CIMInstance):
                 msg = 'Array property %r contains CIMInstance values' % name
@@ -2325,7 +2325,7 @@ class CIMProperty(_CIMComparisonMixin):
                 embedded_object = _intended_value(
                     None, None, embedded_object, 'embedded_object', msg)
             elif type_ == 'datetime':
-                value = [CIMDateTime(val) if val is not None \
+                value = [CIMDateTime(val) if val is not None
                          and not isinstance(val, CIMDateTime)
                          else val for val in value]
                 msg = 'Array property %r specifies CIM data type %r' % \
@@ -2371,7 +2371,7 @@ class CIMProperty(_CIMComparisonMixin):
                     # Leave type as specified, but check it for validity
                     dummy_type_obj = type_from_name(type_)  # noqa: F841
                 else:
-                    raise ValueError('Cannot infer type of simple ' \
+                    raise ValueError('Cannot infer type of simple '
                                      'property %r that is Null' % name)
             elif isinstance(value, CIMInstanceName):
                 msg = 'Property %r has a CIMInstanceName value with ' \
@@ -2700,7 +2700,7 @@ class CIMProperty(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMProperty):
-            raise TypeError("other must be CIMProperty, but is: %s" %\
+            raise TypeError("other must be CIMProperty, but is: %s" %
                             type(other))
         return (cmpname(self.name, other.name) or
                 cmpitem(self.value, other.value) or
@@ -2854,7 +2854,7 @@ class CIMMethod(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMMethod):
-            raise TypeError("other must be CIMMethod, but is: %s" %\
+            raise TypeError("other must be CIMMethod, but is: %s" %
                             type(other))
         return (cmpname(self.name, other.name) or
                 cmpitem(self.qualifiers, other.qualifiers) or
@@ -3116,7 +3116,7 @@ class CIMParameter(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMParameter):
-            raise TypeError("other must be CIMParameter, but is: %s" %\
+            raise TypeError("other must be CIMParameter, but is: %s" %
                             type(other))
         return (cmpname(self.name, other.name) or
                 cmpitem(self.type, other.type) or
@@ -3494,7 +3494,7 @@ class CIMQualifier(_CIMComparisonMixin):
         # pylint: disable=unidiomatic-typecheck
         if builtin_type(value) in six.integer_types + (float,):
             raise TypeError(
-                "Type of numeric value for a qualifier must be a "\
+                "Type of numeric value for a qualifier must be a "
                 "CIM data type, but is %s" % builtin_type(value))
 
         self.value = value
@@ -3512,7 +3512,7 @@ class CIMQualifier(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMQualifier):
-            raise TypeError("other must be CIMQualifier, but is: %s" %\
+            raise TypeError("other must be CIMQualifier, but is: %s" %
                             type(other))
         return (cmpname(self.name, other.name) or
                 cmpitem(self.type, other.type) or
@@ -3880,7 +3880,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         if self is other:
             return 0
         if not isinstance(other, CIMQualifierDeclaration):
-            raise TypeError("other must be CIMQualifierDeclaration, "\
+            raise TypeError("other must be CIMQualifierDeclaration, "
                             "but is: %s" % type(other))
         return (cmpname(self.name, other.name) or
                 cmpitem(self.type, other.type) or
@@ -4066,7 +4066,7 @@ def tocimxml(value):
     try:
         return cim_xml.VALUE_ARRAY([tocimxml(v) for v in value])
     except TypeError:
-        raise ValueError("Can't convert %s (%s) to CIM XML" % \
+        raise ValueError("Can't convert %s (%s) to CIM XML" %
                      (value, builtin_type(value)))
 
 
@@ -4104,7 +4104,7 @@ def tocimxmlstr(value, indent=None):
         elif isinstance(indent, six.integer_types):
             indent = ' ' * indent
         else:
-            raise TypeError("Type of indent must be string or integer, " \
+            raise TypeError("Type of indent must be string or integer, "
                             "but is: %s" % type(indent))
         xml_str = xml_elem.toprettyxml(indent=indent)
     # xml_str is a unicode string if required based upon its content.
@@ -4290,7 +4290,7 @@ def tocimobj(type_, value):
                     cl_name, s, k = partition(key, '.')
                     if s:
                         if cl_name != classname:
-                            raise ValueError('Invalid object path: "%s"' % \
+                            raise ValueError('Invalid object path: "%s"' %
                                              value)
                         key = k
                     val = val.strip()
@@ -4308,7 +4308,7 @@ def tocimobj(type_, value):
                                 try:
                                     val = CIMDateTime(val)
                                 except ValueError:
-                                    raise ValueError('Invalid key binding: %s'\
+                                    raise ValueError('Invalid key binding: %s'
                                             % val)
 
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -269,7 +269,7 @@ def check_utf8_xml_chars(utf8_xml, meaning):
     context_after = 16     # number of chars to print after any bad chars
 
     if not isinstance(utf8_xml, six.binary_type):
-        raise TypeError("utf8_xml parameter is not a byte string, "\
+        raise TypeError("utf8_xml parameter is not a byte string, "
                         "but has type %s" % type(utf8_xml))
 
     # Check for ill-formed UTF-8 sequences. This needs to be done
@@ -697,7 +697,7 @@ class WBEMConnection(object):
                 self.default_namespace, self.x509, self.verify_callback,
                 self.ca_certs, self.no_verification, self.timeout)
 
-    def imethodcall(self, methodname, namespace, response_params_rqd=None, \
+    def imethodcall(self, methodname, namespace, response_params_rqd=None,
                     **params):
         """
         This is a low-level method that is used by the operation-specific
@@ -718,7 +718,7 @@ class WBEMConnection(object):
                                  response_params_rqd=response_params_rqd,
                                  **params)
 
-    def _imethodcall(self, methodname, namespace, response_params_rqd=None, \
+    def _imethodcall(self, methodname, namespace, response_params_rqd=None,
                      **params):
         """
         Perform an intrinsic CIM-XML operation.
@@ -732,7 +732,7 @@ class WBEMConnection(object):
 
         # Create parameter list
 
-        plist = [cim_xml.IPARAMVALUE(x[0], tocimxml(x[1])) \
+        plist = [cim_xml.IPARAMVALUE(x[0], tocimxml(x[1]))
                  for x in params.items() if x[1] is not None]
 
         # Build XML request
@@ -835,16 +835,16 @@ class WBEMConnection(object):
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'SIMPLERSP':
-            raise ParseError('Expecting SIMPLERSP element, got %s' %\
+            raise ParseError('Expecting SIMPLERSP element, got %s' %
                              tup_tree[0])
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'IMETHODRESPONSE':
-            raise ParseError('Expecting IMETHODRESPONSE element, got %s' %\
+            raise ParseError('Expecting IMETHODRESPONSE element, got %s' %
                              tup_tree[0])
 
         if tup_tree[1]['NAME'] != methodname:
-            raise ParseError('Expecting attribute NAME=%s, got %s' %\
+            raise ParseError('Expecting attribute NAME=%s, got %s' %
                              (methodname, tup_tree[1]['NAME']))
         tup_tree = tup_tree[2]
 
@@ -868,7 +868,7 @@ class WBEMConnection(object):
             #expect either ERROR | IRETURNVALUE*
             err = tup_tree[0]
             if err[0] != 'IRETURNVALUE':
-                raise ParseError('Expecting IRETURNVALUE element, got %s' \
+                raise ParseError('Expecting IRETURNVALUE element, got %s'
                                  % err[0])
             return tup_tree
 
@@ -1083,11 +1083,11 @@ class WBEMConnection(object):
         tt = tt[2]
 
         if tt[0] != 'METHODRESPONSE':
-            raise ParseError('Expecting METHODRESPONSE element, got %s' %\
+            raise ParseError('Expecting METHODRESPONSE element, got %s' %
                              tt[0])
 
         if tt[1]['NAME'] != methodname:
-            raise ParseError('Expecting attribute NAME=%s, got %s' %\
+            raise ParseError('Expecting attribute NAME=%s, got %s' %
                              (methodname, tt[1]['NAME']))
         tt = tt[2]
 
@@ -1115,7 +1115,7 @@ class WBEMConnection(object):
         elif obj is None:
             namespace = obj
         else:
-            raise TypeError('Expecting None (for default), or a namespace ' \
+            raise TypeError('Expecting None (for default), or a namespace '
                             'string, got: %s' % type(obj))
         if namespace is None:
             namespace = self.default_namespace
@@ -1137,8 +1137,8 @@ class WBEMConnection(object):
         elif obj is None:
             namespace = obj
         else:
-            raise TypeError('Expecting None (for default), a class name ' \
-                            'string, a CIMClassName object, or a ' \
+            raise TypeError('Expecting None (for default), a class name '
+                            'string, a CIMClassName object, or a '
                             'CIMInstanceName object, got: %s' % type(obj))
         if namespace is None:
             namespace = self.default_namespace
@@ -1159,8 +1159,8 @@ class WBEMConnection(object):
         elif objectname is None:
             pass
         else:
-            raise TypeError('Expecting None, a classname string, a ' \
-                            'CIMClassName or CIMInstanceName object, ' \
+            raise TypeError('Expecting None, a classname string, a '
+                            'CIMClassName or CIMInstanceName object, '
                             'got: %s' % type(objectname))
         return objectname
 
@@ -1178,7 +1178,7 @@ class WBEMConnection(object):
         elif classname is None:
             pass
         else:
-            raise TypeError('Expecting None, a classname string or a ' \
+            raise TypeError('Expecting None, a classname string or a '
                             'CIMClassName object, got: %s' % type(classname))
         return classname
 
@@ -1194,7 +1194,7 @@ class WBEMConnection(object):
         elif instancename is None:
             pass
         else:
-            raise TypeError('Expecting None or a CIMInstanceName object, ' \
+            raise TypeError('Expecting None or a CIMInstanceName object, '
                             'got: %s' % type(instancename))
         return instancename
 
@@ -3840,7 +3840,7 @@ class WBEMConnection(object):
                     ' path')
             if ModifiedInstance.classname is None:
                 raise ValueError(
-                    'ModifiedInstance parameter must have classname set in ' \
+                    'ModifiedInstance parameter must have classname set in '
                     'instance')
 
             namespace = self._iparam_namespace_from_objectname(

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1498,7 +1498,7 @@ class WBEMConnection(object):
                 rtn_objects = p[2]
 
         if not valid_result:
-            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence " \
+            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence "
                            "or EnumerationContext required")
 
         # convert enum context if eos is True

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -306,7 +306,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         dtarg = _ensure_unicode(dtarg)
         if isinstance(dtarg, six.text_type):
             date_pattern = re.compile(
-                r'^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.' \
+                r'^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.'
                 r'(\d{6})([+|-])(\d{3})')
             srch_result = date_pattern.search(dtarg)
             if srch_result is not None:
@@ -321,8 +321,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
                                                int(parts[6]),
                                                MinutesFromUTC(offset))
                 except ValueError as exc:
-                    raise ValueError('dtarg argument "%s" has invalid field '\
-                                     'values for CIM datetime timestamp '\
+                    raise ValueError('dtarg argument "%s" has invalid field '
+                                     'values for CIM datetime timestamp '
                                      'format: %s' % (dtarg, exc))
             else:
                 tv_pattern = re.compile(
@@ -338,7 +338,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
                                                  seconds=int(parts[3]),
                                                  microseconds=int(parts[4]))
                 else:
-                    raise ValueError('dtarg argument "%s" has an invalid CIM '\
+                    raise ValueError('dtarg argument "%s" has an invalid CIM '
                                      'datetime format' % dtarg)
         elif isinstance(dtarg, datetime):
             self.__datetime = dtarg
@@ -350,8 +350,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
             # pylint: disable=protected-access
             self.__timedelta = dtarg.__timedelta
         else:
-            raise TypeError('dtarg argument "%s" has an invalid type: %s '\
-                            '(expected datetime, timedelta, string, or '\
+            raise TypeError('dtarg argument "%s" has an invalid type: %s '
+                            '(expected datetime, timedelta, string, or '
                             'CIMDateTime)' % (dtarg, type(dtarg)))
 
     @property
@@ -580,7 +580,7 @@ class CIMInt(CIMType, _Longint):
         value = _Longint(*args, **kwargs)
         if config.ENFORCE_INTEGER_RANGE:
             if value > cls.maxvalue or value < cls.minvalue:
-                raise ValueError("Integer value %s is out of range for CIM " \
+                raise ValueError("Integer value %s is out of range for CIM "
                                  "datatype %s" % (value, cls.cimtype))
         # The value needs to be processed here, because int/long is unmutable
         return super(CIMInt, cls).__new__(cls, *args, **kwargs)
@@ -725,7 +725,7 @@ def cimtype(obj):
         return cimtype(obj[0])
     if isinstance(obj, (datetime, timedelta)):
         return 'datetime'
-    raise TypeError("Type %s of this object is not a CIM data type: %r" % \
+    raise TypeError("Type %s of this object is not a CIM data type: %r" %
                     (type(obj), obj))
 
 _TYPE_FROM_NAME = {

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -129,8 +129,8 @@ def _pcdata_nodes(pcdata):
     nodelist = []
 
     if _CDATA_ESCAPING and isinstance(pcdata, six.string_types) and \
-       (pcdata.find("<") >= 0 or \
-        pcdata.find(">") >= 0 or \
+       (pcdata.find("<") >= 0 or
+        pcdata.find(">") >= 0 or
         pcdata.find("&") >= 0):  # noqa: E129
 
         # In order to support nesting of CDATA sections, we represent pcdata

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -382,7 +382,7 @@ class MOFParseError(Error):
         ret_str = 'MOFParseError: '
         if self.lineno is not None:
             ret_str += '%s:%s: %smsg=%s\n%s' % \
-                         (self.file, self.lineno, self.column, self.msg, \
+                         (self.file, self.lineno, self.column, self.msg,
                           self.context)
         else:
             ret_str += '%s' % self.msg
@@ -610,7 +610,7 @@ def p_mp_createClass(p):
         try:
             p.parser.handle.ModifyClass(cc, ns)
         except CIMError as ce:
-            p.parser.log('Error Modifying class %s: %s, %s' % \
+            p.parser.log('Error Modifying class %s: %s, %s' %
                          (cc.classname, ce.args[0], ce.args[1]))
 
 def p_mp_createInstance(p):
@@ -623,19 +623,19 @@ def p_mp_createInstance(p):
     except CIMError as ce:
         if ce.args[0] == CIM_ERR_ALREADY_EXISTS:
             if p.parser.verbose:
-                p.parser.log('Instance of class %s already exist.  ' \
+                p.parser.log('Instance of class %s already exist.  '
                              'Modifying...' % inst.classname)
             try:
                 p.parser.handle.ModifyInstance(inst)
             except CIMError as ce:
                 if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
                     if p.parser.verbose:
-                        p.parser.log('ModifyInstance not supported.  ' \
-                                     'Deleting instance of %s: %s' % \
+                        p.parser.log('ModifyInstance not supported.  '
+                                     'Deleting instance of %s: %s' %
                                      (inst.classname, inst.path))
                     p.parser.handle.DeleteInstance(inst.path)
                     if p.parser.verbose:
-                        p.parser.log('Creating instance of %s.' % \
+                        p.parser.log('Creating instance of %s.' %
                                      inst.classname)
                     p.parser.handle.CreateInstance(inst)
         else:
@@ -660,7 +660,7 @@ def p_mp_setQualifier(p):
             p.parser.handle.SetQualifier(qualdecl)
         elif ce.args[0] == CIM_ERR_NOT_SUPPORTED:
             if p.parser.verbose:
-                p.parser.log('Qualifier %s already exists.  Deleting...' % \
+                p.parser.log('Qualifier %s already exists.  Deleting...' %
                              qualdecl.name)
             p.parser.handle.DeleteQualifier(qualdecl.name)
             if p.parser.verbose:
@@ -1349,7 +1349,7 @@ def _build_flavors(p, flist, qualdecl=None):
         or \
         ('restricted' in flist and 'tosubclass' in flist):  # noqa: E125
 
-        raise MOFParseError(parser_token=p, msg="Conflicting flavors are" \
+        raise MOFParseError(parser_token=p, msg="Conflicting flavors are"
                             "invalid")
 
     if qualdecl is not None:
@@ -1546,7 +1546,7 @@ def p_instanceDeclaration(p):
             inst.properties[pname] = pprop
         except ValueError as ve:
             ce = CIMError(CIM_ERR_INVALID_PARAMETER,
-                          'Invalid value for property %s: %s' % \
+                          'Invalid value for property %s: %s' %
                           (pname, str(ve)))
             ce.file_line = (p.parser.file, p.lexer.lineno)
             raise ce

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -197,17 +197,18 @@ def one_child(tup_tree, acceptable):
     k = kids(tup_tree)
 
     if len(k) != 1:
-        raise ParseError('In element %s with attributes %s, expected '\
-                'just one child element %s, but got child elements %s' %\
-                (name(tup_tree), attrs(tup_tree), acceptable,
-                 [t[0] for t in k]))
+        raise ParseError('In element %s with attributes %s, expected just '
+                         'one child element %s, but got child elements %s' %
+                         (name(tup_tree), attrs(tup_tree), acceptable,
+                          [t[0] for t in k]))
 
     child = k[0]
 
     if name(child) not in acceptable:
-        raise ParseError('In element %s with attributes %s, expected one '\
-                'child element %s, but got child element %s' %\
-                (name(tup_tree), attrs(tup_tree), acceptable, name(child)))
+        raise ParseError('In element %s with attributes %s, expected one '
+                         'child element %s, but got child element %s' %
+                         (name(tup_tree), attrs(tup_tree), acceptable,
+                          name(child)))
 
     return parse_any(child)
 
@@ -219,9 +220,10 @@ def optional_child(tup_tree, allowed):
     k = kids(tup_tree)
 
     if len(k) > 1:
-        raise ParseError('In element %s with attributes %s, expected zero or '\
-                'one child element %s, but got child elements %s' %\
-                (name(tup_tree), attrs(tup_tree), allowed, [t[0] for t in k]))
+        raise ParseError('In element %s with attributes %s, expected zero or '
+                         'one child element %s, but got child elements %s' %
+                         (name(tup_tree), attrs(tup_tree), allowed,
+                          [t[0] for t in k]))
     elif len(k) == 1:
         return one_child(tup_tree, allowed)
     else:
@@ -238,9 +240,11 @@ def list_of_various(tup_tree, acceptable):
 
     for child in kids(tup_tree):
         if name(child) not in acceptable:
-            raise ParseError('In element %s with attributes %s, expected zero '\
-                    'or more child elements %s, but got child element %s' %\
-                    (name(tup_tree), attrs(tup_tree), acceptable, name(child)))
+            raise ParseError('In element %s with attributes %s, expected zero '
+                             'or more child elements %s, but got child element '
+                             ' %s' %
+                             (name(tup_tree), attrs(tup_tree), acceptable,
+                              name(child)))
         result.append(parse_any(child))
 
     return result
@@ -274,16 +278,17 @@ def list_of_same(tup_tree, acceptable):
 
     a_child = name(kid[0])
     if a_child not in acceptable:
-        raise ParseError('In element %s with attributes %s, expected '\
-                'child elements %s, but got child element %s' %\
-                (name(tup_tree), attrs(tup_tree), acceptable, a_child))
+        raise ParseError('In element %s with attributes %s, expected '
+                         'child elements %s, but got child element %s' %
+                         (name(tup_tree), attrs(tup_tree), acceptable,
+                          a_child))
     result = []
     for child in kid:
         if name(child) != a_child:
-            raise ParseError('In element %s with attributes %s, expected '\
-                    'sequence of only child elements %s, but got child '\
-                    'element %s' % (name(tup_tree), attrs(tup_tree), a_child, \
-                     name(child)))
+            raise ParseError('In element %s with attributes %s, expected '
+                             'sequence of only child elements %s, but got child'
+                             ' element %s' % (name(tup_tree), attrs(tup_tree),
+                                              a_child, name(child)))
         result.append(parse_any(child))
 
     return result
@@ -1059,7 +1064,7 @@ def parse_property(tup_tree):
         val = unpack_value(tup_tree)
     except ValueError as exc:
         msg = str(exc)
-        raise ParseError('Cannot parse value for property "%s": %s' %\
+        raise ParseError('Cannot parse value for property "%s": %s' %
                          (attrl['NAME'], msg))
 
     embedded_object = None
@@ -1407,7 +1412,7 @@ def parse_methodcall(tup_tree):
                ['LOCALCLASSPATH', 'LOCALINSTANCEPATH', 'PARAMVALUE'])
     path = list_of_matching(tup_tree, ['LOCALCLASSPATH', 'LOCALINSTANCEPATH'])
     if len(path) != 1:
-        raise ParseError('Expecting one of LOCALCLASSPATH or ' \
+        raise ParseError('Expecting one of LOCALCLASSPATH or '
                          'LOCALINSTANCEPATH, got %r' % path)
     path = path[0]
     params = list_of_matching(tup_tree, ['PARAMVALUE'])
@@ -1773,7 +1778,7 @@ def unpack_value(tup_tree):
     if len(raw_val) == 0:
         return None
     elif len(raw_val) > 1:
-        raise ParseError('more than one VALUE or VALUE.ARRAY under %s' % \
+        raise ParseError('more than one VALUE or VALUE.ARRAY under %s' %
                          name(tup_tree))
 
     raw_val = raw_val[0]

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def _check_get_swig(swig_min_version, verbose):
     Returns True if it needs to be installed/updated.
     """
     if verbose:
-        print("Testing for availability of Swig >=%s in PATH..." %\
+        print("Testing for availability of Swig >=%s in PATH..." %
               swig_min_version)
     get_swig = False
     rc, out, _ = shell("which swig")
@@ -94,12 +94,12 @@ def _check_get_swig(swig_min_version, verbose):
         swig_version = m.group(1)
         if swig_version.split(".") < swig_min_version.split("."):
             if verbose:
-                print("Installed Swig version is too old: %s; "\
+                print("Installed Swig version is too old: %s; "
                       "need to get Swig" % swig_version)
             get_swig = True
         else:
             if verbose:
-                print("Installed Swig version is sufficient: %s" %\
+                print("Installed Swig version is sufficient: %s" %
                       swig_version)
     return get_swig
 
@@ -163,7 +163,7 @@ def install_swig(installer, dry_run, verbose):
             swig_install_root = "/usr"
 
             if verbose:
-                print("Installing prerequisite OS-level packages for building "\
+                print("Installing prerequisite OS-level packages for building "
                       "Swig...")
 
             swig_prereq_pkg_dict = {
@@ -212,37 +212,37 @@ def install_swig(installer, dry_run, verbose):
 
             if dry_run:
                 if verbose:
-                    print("Dry-running: Building Swig version %s from "\
-                          "downloaded source, and installing to %s tree" %\
+                    print("Dry-running: Building Swig version %s from "
+                          "downloaded source, and installing to %s tree" %
                           (swig_build_version, swig_install_root))
             else:
                 if verbose:
-                    print("Building Swig version %s from "\
-                          "downloaded source, and installing to %s tree" %\
+                    print("Building Swig version %s from "
+                          "downloaded source, and installing to %s tree" %
                           (swig_build_version, swig_install_root))
 
                 if os.path.exists(swig_dir):
                     if verbose:
-                        print("Removing previously downloaded Swig directory: "\
+                        print("Removing previously downloaded Swig directory: "
                               "%s" % swig_dir)
                     shutil.rmtree(swig_dir)
 
                 if verbose:
                     print("Downloading Swig source archive: %s" % swig_tar_file)
                 shell_check(
-                    "wget -q -O %s http://sourceforge.net/projects/swig/files"\
-                    "/swig/%s/%s/download" %\
+                    "wget -q -O %s http://sourceforge.net/projects/swig/files"
+                    "/swig/%s/%s/download" %
                     (swig_tar_file, swig_dir, swig_tar_file), display=True)
                 if verbose:
                     print("Unpacking Swig source archive: %s" % swig_tar_file)
                 shell_check("tar -xf %s" % swig_tar_file, display=True)
 
                 if verbose:
-                    print("Configuring Swig build process for installing to "\
+                    print("Configuring Swig build process for installing to "
                           "%s tree..." % swig_install_root)
-                shell_check(["sh", "-c", "cd %s; ./configure --prefix=%s" %\
-                            (swig_dir, swig_install_root)],
-                            display=True)
+                shell_check(["sh", "-c", "cd %s; ./configure --prefix=%s" %
+                             (swig_dir, swig_install_root)],
+                              display=True)
 
                 if verbose:
                     print("Building Swig...")
@@ -255,7 +255,7 @@ def install_swig(installer, dry_run, verbose):
                             display=True)
 
                 if verbose:
-                    print("Done downloading, building and installing Swig "\
+                    print("Done downloading, building and installing Swig "
                           "version %s" % swig_build_version)
 
 
@@ -281,7 +281,7 @@ def build_moftab(verbose):
     if rc != 0:
         # Because this does not work on pip, the best compromise is to
         # tolerate a failure:
-        print("Warning: build_moftab.py failed with rc=%s; the PyWBEM " \
+        print("Warning: build_moftab.py failed with rc=%s; the PyWBEM "
               "LEX/YACC table modules may be rebuilt on first use" % rc)
 
 def main():
@@ -516,7 +516,7 @@ def main():
                 raise
         else:
             break
-        print("Warning: Retrying setup() because %s was raised: %s" % \
+        print("Warning: Retrying setup() because %s was raised: %s" %
               (exc.__class__.__name__, exc))
 
     if 'install' in sys.argv or 'develop' in sys.argv:

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -129,7 +129,7 @@ class ClientTest(unittest.TestCase):
         try:
             result = fn(*pargs, **kwargs)
         except Exception as exc:
-            self.log('Operation %s failed with %s: %s\n' % \
+            self.log('Operation %s failed with %s: %s\n' %
                      (fn.__name__, exc.__class__.__name__, str(exc)))
             last_request = self.conn.last_request or self.conn.last_raw_request
             self.log('Request:\n\n%s\n' % last_request)
@@ -188,7 +188,7 @@ class ClientTest(unittest.TestCase):
                     self.assertIsInstance(prop, CIMProperty)
 
 
-    def assertInstanceNameValid(self, path, includes_namespace=True, \
+    def assertInstanceNameValid(self, path, includes_namespace=True,
                                 includes_keybindings=True,
                                 namespace=None):
         """
@@ -270,7 +270,7 @@ class ClientTest(unittest.TestCase):
                 self.fail("Instance Lists do not match")
             else:
                 for inst2 in insts2:
-                    if self.pathsEqual(inst1.path, inst2.path, \
+                    if self.pathsEqual(inst1.path, inst2.path,
                                        ignorehost=ignorehost):
 
                         self.assertTrue(isinstance(inst2, CIMInstance))
@@ -495,7 +495,7 @@ class EnumerateInstances(ClientTest):
                     print('ClassPropertyName=%s' % p.name)
 
         if cls_property_count != inst_property_count:
-            print('ERROR: classproperty_count %s != inst_property_count %s' % \
+            print('ERROR: classproperty_count %s != inst_property_count %s' %
                   (cls_property_count, inst_property_count))
             for p in cls.properties.values():
                 print('ClassPropertyName=%s' % p.name)
@@ -540,7 +540,7 @@ class EnumerateInstances(ClientTest):
                     print('ClassPropertyName=%s' % p.name)
 
         if cls_property_count != inst_property_count:
-            print('ERROR: classproperty_count %s != inst_property_count %s' % \
+            print('ERROR: classproperty_count %s != inst_property_count %s' %
                   (cls_property_count, inst_property_count))
             for p in cls.properties.values():
                 print('ClassPropertyName=%s' % p.name)
@@ -590,7 +590,7 @@ class EnumerateInstances(ClientTest):
                 self.assertTrue(inst_property_count == len(inst.properties))
 
         if property_count != inst_property_count:
-            print('\nERROR: cls property_count %s != inst_property_count %s' % \
+            print('\nERROR: cls property_count %s != inst_property_count %s' %
                   (property_count, inst_property_count))
             for p in cls.properties.values():
                 print('ClassPropertyName=%s' % p.name)
@@ -1056,8 +1056,8 @@ class PullEnumerateInstancePaths(ClientTest):
         paths_enum = self.cimcall(self.conn.EnumerateInstanceNames, TEST_CLASS)
 
         if (len(paths_pulled) != len(paths_enum)):
-            print('ERROR result.paths len %s ne paths_enum len %s' %  \
-                (len(paths_pulled), len(paths_enum)))
+            print('ERROR result.paths len %s ne paths_enum len %s' %
+                  (len(paths_pulled), len(paths_enum)))
 
         self.assertTrue(len(paths_pulled) == len(paths_enum))
         # TODO add test to confirm they are the same
@@ -1149,7 +1149,7 @@ class PullEnumerateInstancePaths(ClientTest):
         if diff == 0:
             self.assertPathsEqual(paths_pulled, paths_enum, ignorehost=True)
         elif paths_pulled / diff < 10:
-            print('Return diff count %s of total %s ignored' % \
+            print('Return diff count %s of total %s ignored' %
                   (diff, paths_pulled))
         else:
             self.fail('Issues with pull vs non-pull responses')
@@ -1542,11 +1542,11 @@ class PullQueryInstances(ClientTest):
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't" \
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
                     " support OpenQueryInstances for this query")
             if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM" \
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
                     " server doesn't support WQL for ExecQuery")
             else:
                 raise
@@ -1576,11 +1576,11 @@ class PullQueryInstances(ClientTest):
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't" \
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
                     " support OpenQueryInstances for this query")
             if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM" \
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
                     " server doesn't support WQL for ExecQuery")
             else:
                 raise
@@ -1606,11 +1606,11 @@ class ExecQuery(ClientTest):
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't" \
+                    "CIM_ERR_NOT_SUPPORTED: The WBEM server doesn't"
                     " support ExecQuery for this query")
             if ce.args[0] == CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
                 raise AssertionError(
-                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM" \
+                    "CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: The WBEM"
                     " server doesn't support WQL for ExecQuery")
             else:
                 raise
@@ -3721,7 +3721,7 @@ def parse_args(argv_):
     argv = list(argv_)
 
     if len(argv) <= 1:
-        print('Error: No arguments specified; Call with --help or -h for '\
+        print('Error: No arguments specified; Call with --help or -h for '
               'usage.')
         sys.exit(2)
     elif argv[1] == '--help' or argv[1] == '-h':
@@ -3729,41 +3729,41 @@ def parse_args(argv_):
         print('Test program for CIM operations.')
         print('')
         print('Usage:')
-        print('    %s [GEN_OPTS] URL [USERNAME%%PASSWORD [UT_OPTS '\
+        print('    %s [GEN_OPTS] URL [USERNAME%%PASSWORD [UT_OPTS '
               '[UT_CLASS ...]]] ' % argv[0])
         print('')
         print('Where:')
         print('    GEN_OPTS            General options (see below).')
-        print('    URL                 URL of the target WBEM server.\n'\
-              '                        http:// or https:// prefix'\
+        print('    URL                 URL of the target WBEM server.\n'
+              '                        http:// or https:// prefix'
               '                        defines ssl usage')
-        print('    USERNAME            Userid used to log into '\
-              '                        WBEM server.\n' \
+        print('    USERNAME            Userid used to log into '
+              '                        WBEM server.\n'
               '                        Requests user input if not supplied')
-        print('    PASSWORD            Password used to log into '\
-              '                        WBEM server.\n' \
+        print('    PASSWORD            Password used to log into '
+              '                        WBEM server.\n'
               '                        Requests user input if not supplier')
         print('    -nvc                Do not verify server certificates.')
         print('    --cacerts           File/dir with ca certificate(s).')
         print('    --yamlfile yamlfile  Test_client YAML file to be recorded.')
 
         print('    UT_OPTS             Unittest options (see below).')
-        print('    UT_CLASS            Name of testcase class (e.g. '\
+        print('    UT_CLASS            Name of testcase class (e.g. '
               '                        EnumerateInstances).')
         print('')
         print('General options[GEN_OPTS]:')
         print('    --help, -h          Display this help text.')
-        print('    -n NAMESPACE        Use this CIM namespace instead of '\
+        print('    -n NAMESPACE        Use this CIM namespace instead of '
               'default: %s' % DEFAULT_NAMESPACE)
-        print('    -t TIMEOUT          Use this timeout (in seconds)'\
+        print('    -t TIMEOUT          Use this timeout (in seconds)'
               '                        instead of no timeout')
-        print('    -v                  Verbose output which includes:\n' \
-              '                          - connection details,\n' \
+        print('    -v                  Verbose output which includes:\n'
+              '                          - connection details,\n'
               '                          - details of tests')
-        print('    -d                  Debug flag for extra displays:\n' \
+        print('    -d                  Debug flag for extra displays:\n'
               '                          - xml input and output,\n')
-        print('    -l                  Do long running tests. If not set, ' \
-              '                        skips a number of tests that take a ' \
+        print('    -l                  Do long running tests. If not set, '
+              '                        skips a number of tests that take a '
               '                        long time to run')
         print('    -hl                 List of individual tests')
 
@@ -3771,7 +3771,7 @@ def parse_args(argv_):
         print('Examples:')
         print('    %s https://9.10.11.12 username%%password' % argv[0])
         print('    %s https://myhost -v username%%password' % argv[0])
-        print('    %s http://localhost -v username%%password' \
+        print('    %s http://localhost -v username%%password'
               ' GetQualifier' % argv[0])
 
         print('------------------------')

--- a/testsuite/run_operationtimeouts.py
+++ b/testsuite/run_operationtimeouts.py
@@ -142,7 +142,7 @@ class ServerTimeoutTest(ClientTest):
             if delay > timeout:
                 err_flag = "Timeout Error: delay gt timeout"
                 if self.stop_on_err:
-                    self.fail('should not get good response for %delay > %s' % \
+                    self.fail('should not get good response for %delay > %s' %
                               (delay, timeout))
             if delay == timeout:
                 err_flag = "Good when timeout matches delay"
@@ -163,7 +163,7 @@ class ServerTimeoutTest(ClientTest):
             if delay < timeout:
                 err_flag = 'Error. delay < timeout'
                 if self.stop_on_err:
-                    self.fail('should not get timeout for %delay < %s' % \
+                    self.fail('should not get timeout for %delay < %s' %
                               (delay, timeout))
             if delay == timeout:
                 err_flag = "Timeout when timeout matches delay"
@@ -228,7 +228,7 @@ def parse_args(argv_):
     argv = list(argv_)
 
     if len(argv) <= 1:
-        print('Error: No arguments specified; Call with --help or -h for '\
+        print('Error: No arguments specified; Call with --help or -h for '
               'usage.')
         sys.exit(2)
     elif argv[1] == '--help' or argv[1] == '-h':
@@ -241,29 +241,29 @@ def parse_args(argv_):
         print('Complete test is in a single unittest function')
         print('')
         print('Usage:')
-        print('    %s [GEN_OPTS] URL [USERNAME%%PASSWORD [UT_OPTS '\
+        print('    %s [GEN_OPTS] URL [USERNAME%%PASSWORD [UT_OPTS '
               '[UT_CLASS ...]]] ' % argv[0])
         print('')
         print('Where:')
         print('    GEN_OPTS            General options (see below).')
-        print('    HOST                Name of the target WBEM server.\n'\
-              '                        No Scheme prefix\n'\
+        print('    HOST                Name of the target WBEM server.\n'
+              '                        No Scheme prefix\n'
               '                        defines ssl usage')
-        print('    USERNAME            Userid used to log into\n'\
-              '                        WBEM server.\n' \
+        print('    USERNAME            Userid used to log into\n'
+              '                        WBEM server.\n'
               '                        Requests user input if not supplied')
-        print('    PASSWORD            Password used to log into\n'\
-              '                        WBEM server.\n' \
+        print('    PASSWORD            Password used to log into\n'
+              '                        WBEM server.\n'
               '                        Requests user input if not supplier')
         print('')
         print('General options[GEN_OPTS]:')
         print('    --help, -h          Display this help text.')
-        print('    -t MAXTIMEOUT       Maximum timout value in sec. to test.\n'\
+        print('    -t MAXTIMEOUT       Maximum timout value in sec. to test.\n'
               '                        default is 20 sec.')
-        print('    -v                  Verbose output which includes\n' \
+        print('    -v                  Verbose output which includes\n'
               '                        result of each test.')
-        print('    -s                  Stop test on first timeout error.\n' \
-              '                        Otherwise errors in timeout are just\n' \
+        print('    -s                  Stop test on first timeout error.\n'
+              '                        Otherwise errors in timeout are just\n'
               '                        reported. Other errors stop test.')
         print('    -d                  Debug flag for extra displays')
 

--- a/testsuite/test_cim_http.py
+++ b/testsuite/test_cim_http.py
@@ -23,13 +23,13 @@ class Parse_url(unittest.TestCase):  # pylint: disable=invalid-name
         host, port, ssl = cim_http.parse_url(url)
 
         self.assertEqual(host, exp_host,
-                         "Unexpected host: %r, expected: %r" %\
+                         "Unexpected host: %r, expected: %r" %
                          (host, exp_host))
         self.assertEqual(port, exp_port,
-                         "Unexpected port: %r, expected: %r" %\
+                         "Unexpected port: %r, expected: %r" %
                          (port, exp_port))
         self.assertEqual(ssl, exp_ssl,
-                         "Unexpected ssl: %r, expected: %r" %\
+                         "Unexpected ssl: %r, expected: %r" %
                          (ssl, exp_ssl))
 
     def _run_single_defaults_false(self, url, exp_host, exp_port, exp_ssl):
@@ -41,13 +41,13 @@ class Parse_url(unittest.TestCase):  # pylint: disable=invalid-name
         host, port, ssl = cim_http.parse_url(url, allow_defaults=False)
 
         self.assertEqual(host, exp_host,
-                         "Unexpected host: %r, expected: %r" %\
+                         "Unexpected host: %r, expected: %r" %
                          (host, exp_host))
         self.assertEqual(port, exp_port,
-                         "Unexpected port: %r, expected: %r" %\
+                         "Unexpected port: %r, expected: %r" %
                          (port, exp_port))
         self.assertEqual(ssl, exp_ssl,
-                         "Unexpected ssl: %r, expected: %r" %\
+                         "Unexpected ssl: %r, expected: %r" %
                          (ssl, exp_ssl))
 
     def test_all(self):

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -64,34 +64,34 @@ class ValidateTest(unittest.TestCase):
             validate_xml(xml_str,
                          dtd_directory=os.path.relpath(_MODULE_PATH),
                          root_elem=root_elem),
-            'DTD validation of CIM-XML for %s object failed\n'\
-            '  Required XML root element: %s\n'\
+            'DTD validation of CIM-XML for %s object failed\n'
+            '  Required XML root element: %s\n'
             '  Generated CIM-XML: %s' % (type(obj), root_elem, xml_str))
 
         xml_str2 = obj.tocimxmlstr()
         self.assertTrue(isinstance(xml_str2, six.text_type),
-                        'XML string returned by tocimxmlstr() is not ' \
+                        'XML string returned by tocimxmlstr() is not '
                         'a unicode type, but: %s' % type(xml_str2))
         self.assertEqual(xml_str2, xml_str,
-                         'XML string returned by tocimxmlstr() is not ' \
+                         'XML string returned by tocimxmlstr() is not '
                          'equal to tocimxml().toxml().')
 
         xml_pretty_str = obj.tocimxml().toprettyxml(indent='    ')
         xml_pretty_str2 = obj.tocimxmlstr(indent='    ')
         self.assertTrue(isinstance(xml_pretty_str2, six.text_type),
-                        'XML string returned by tocimxmlstr() is not ' \
+                        'XML string returned by tocimxmlstr() is not '
                         'a unicode type, but: %s' % type(xml_pretty_str2))
         self.assertEqual(xml_pretty_str2, xml_pretty_str,
-                         'XML string returned by tocimxmlstr(indent) is not ' \
+                         'XML string returned by tocimxmlstr(indent) is not '
                          'equal to tocimxml().toprettyxml(indent).')
 
         xml_pretty_str = obj.tocimxml().toprettyxml(indent='  ')
         xml_pretty_str2 = obj.tocimxmlstr(indent=2)
         self.assertTrue(isinstance(xml_pretty_str2, six.text_type),
-                        'XML string returned by tocimxmlstr() is not ' \
+                        'XML string returned by tocimxmlstr() is not '
                         'a unicode type, but: %s' % type(xml_pretty_str2))
         self.assertEqual(xml_pretty_str2, xml_pretty_str,
-                         'XML string returned by tocimxmlstr(indent) is not ' \
+                         'XML string returned by tocimxmlstr(indent) is not '
                          'equal to tocimxml().toprettyxml(indent).')
 
 def swapcase2(text):
@@ -139,8 +139,8 @@ class DictTest(unittest.TestCase):
         except KeyError:
             pass
         else:
-            self.fail('KeyError not thrown when accessing undefined key '\
-                      '\'Cheepy\'\n'\
+            self.fail('KeyError not thrown when accessing undefined key '
+                      '\'Cheepy\'\n'
                       'Object: %r' % obj)
 
         # Test __setitem__()
@@ -238,8 +238,8 @@ class DictTest(unittest.TestCase):
                              default_value)
         except Exception as exc:
             self.fail('%s thrown in exception-free get() when accessing '
-                      'undefined key %s\n'\
-                      'Object: %r' % \
+                      'undefined key %s\n'
+                      'Object: %r' %
                       (exc.__class__.__name__, invalid_propname, obj))
 
         # Test update()
@@ -731,8 +731,8 @@ class InitCIMInstance(unittest.TestCase):
                 pass
             else:
                 self.fail('TypeError not raised for invalid value %s '
-                          '(type %s) for property of unspecified type\n'\
-                          'Instance properties: %r' %\
+                          '(type %s) for property of unspecified type\n'
+                          'Instance properties: %r' %
                           (num_value, type(num_value), inst.properties))
 
         # Check that initialization with string values for boolean types
@@ -750,9 +750,9 @@ class InitCIMInstance(unittest.TestCase):
             except TypeError:
                 pass
             else:
-                self.fail('TypeError not raised for invalid value \'TRUE\' '\
-                          '(type string) for property of type boolean'\
-                          'Instance properties: %r' %\
+                self.fail('TypeError not raised for invalid value \'TRUE\' '
+                          '(type string) for property of type boolean'
+                          'Instance properties: %r' %
                           (inst.properties,))
 
         # Initialize with some qualifiers
@@ -918,9 +918,9 @@ class CIMInstanceDict(DictTest):
         except TypeError:
             pass
         else:
-            self.fail('TypeError not raised for invalid value 43 '\
-                      '(type int) for property of unspecified type'\
-                      'Instance properties: %r' %\
+            self.fail('TypeError not raised for invalid value 43 '
+                      '(type int) for property of unspecified type'
+                      'Instance properties: %r' %
                       (obj.properties,))
 
         obj['Foo'] = Uint32(43)
@@ -1191,15 +1191,15 @@ class CIMInstanceToMOF(unittest.TestCase):
             r"(?:\s*(\w+)\s*=\s*.*;){4,4}" # just match the general syntax
             r"\s*\}\s*;\s*$", imof)
         if m is None:
-            self.fail("Invalid MOF generated.\n"\
-                      "Instance: %r\n"\
+            self.fail("Invalid MOF generated.\n"
+                      "Instance: %r\n"
                       "Generated MOF: %r" % (i, imof))
 
         # search for one property
         s = re.search(r"\n\s*MyRef\s*=\s*CIM_Bar;\n", imof)
         if s is None:
-            self.fail("Invalid MOF generated. No MyRef.\n"\
-                      "Instance: %r\n"\
+            self.fail("Invalid MOF generated. No MyRef.\n"
+                      "Instance: %r\n"
                       "Generated MOF: %r" % (i, imof))
 
 class CIMInstanceWithEmbeddedInstToMOF(unittest.TestCase):
@@ -1240,16 +1240,16 @@ class CIMInstanceWithEmbeddedInstToMOF(unittest.TestCase):
             imof)
 
         if m is None:
-            self.fail("Invalid MOF generated.\n"\
-                      "Instance: %r\n"\
+            self.fail("Invalid MOF generated.\n"
+                      "Instance: %r\n"
                       "Generated MOF: %r" % (i, imof))
 
         # search for the CIM_Embedded instance.
         s = re.search(r"CIM_Embedded", imof)
 
         if s is None:
-            self.fail("Invalid MOF embedded generated.\n"\
-                      "Instance: %r\n"\
+            self.fail("Invalid MOF embedded generated.\n"
+                      "Instance: %r\n"
                       "Generated MOF: %r" % (i, imof))
         # TODO this test only catchs existence of the embedded instance
 
@@ -2414,11 +2414,11 @@ class CIMClassPropertyWithValueToMOF(unittest.TestCase, RegexpMixin):
         self.assertRegexpContains(imof, r"\n\s*uint8\s+MyUint8\s+=\s+99;")
         self.assertRegexpContains(imof, r"\n\s*uint16\s+MyUint16\s+=\s+999;")
         self.assertRegexpContains(imof, r"\n\s*uint32\s+MyUint32\s+=\s+12345;")
-        self.assertRegexpContains(imof, r"\n\s*sint32\s+MySint32\s+=\s+" \
+        self.assertRegexpContains(imof, r"\n\s*sint32\s+MySint32\s+=\s+"
                                         r"-12345;")
-        self.assertRegexpContains(imof, r"\n\s*datetime\s+Mydatetime\s+=\s+" \
+        self.assertRegexpContains(imof, r"\n\s*datetime\s+Mydatetime\s+=\s+"
                                         r"\"12345678224455.654321:000\";")
-        self.assertRegexpContains(imof, r"\n\s*string\s+MyStr\s+=\s+" \
+        self.assertRegexpContains(imof, r"\n\s*string\s+MyStr\s+=\s+"
                                         r"\"This is a test\";")
 
         self.assertRegexpContains(imof, r"\n\};")
@@ -2550,9 +2550,9 @@ class CIMClassWQualToMOF(unittest.TestCase):
         # predefine qualifiers, params
         pquals = {'ModelCorresponse': CIMQualifier('ModelCorrespondense',
                                                    'BlahBlahClass'),
-                  'Description': CIMQualifier('Description', "This is a" \
-                                               " description for a property" \
-                                               " that serves no purpose" \
+                  'Description': CIMQualifier('Description', "This is a"
+                                               " description for a property"
+                                               " that serves no purpose"
                                                " but is multiline.")}
         pquals2 = {'ValueMap': CIMQualifier('ValueMap',
                                             ["0", "1", "2", "3", "4",
@@ -2578,7 +2578,7 @@ class CIMClassWQualToMOF(unittest.TestCase):
             'CIM_Foo', superclass='CIM_Bar',
             qualifiers={'Abstract': CIMQualifier('Abstract', True),
                         'Description': CIMQualifier('Description',
-                                                    'This is a class ' \
+                                                    'This is a class '
                                                     'description')},
 
             properties={'InstanceID': CIMProperty('InstanceID', None,
@@ -2613,32 +2613,32 @@ class CIMClassWQualToMOF(unittest.TestCase):
         # match first line for [Abstract (True),
         m = re.match(r"^\s*\[Abstract", clmof)
         if m is None:
-            self.fail("Invalid MOF generated. First line\n"\
-                      "Class: %r\n"\
+            self.fail("Invalid MOF generated. First line\n"
+                      "Class: %r\n"
                       "Generated MOF: \n%s" % (cl, clmof))
 
         # search for class CIM_Foo: CIM_Bar {
         s = re.search(r"\s*class\s+CIM_Foo\s*:\s*CIM_Bar\s*\{", clmof)
 
         if s is None:
-            self.fail("Invalid MOF generated. Class name line.\n"\
-                      "Class: %r\n"\
+            self.fail("Invalid MOF generated. Class name line.\n"
+                      "Class: %r\n"
                       "Generated MOF: \n%s" % (cl, clmof))
 
         # search for EmbeddedInstance ("My_Embedded")]
         s = re.search(r"\s*EmbeddedInstance\s+\(\"My_Embedded\"\)\]", clmof)
 
         if s is None:
-            self.fail("Invalid MOF generated. EmbeddedInstance.\n"\
-                      "Class: %r\n"\
+            self.fail("Invalid MOF generated. EmbeddedInstance.\n"
+                      "Class: %r\n"
                       "Generated MOF: \n%s" % (cl, clmof))
 
         # search for 'string MyEmbedded;'
         s = re.search(r"\s*string\s+MyEmbedded;", clmof)
 
         if s is None:
-            self.fail("Invalid MOF generated. property string MyEmbedded.\n"\
-                      "Class: %r\n"\
+            self.fail("Invalid MOF generated. property string MyEmbedded.\n"
+                      "Class: %r\n"
                       "Generated MOF: \n%s" % (cl, clmof))
 
 
@@ -2672,7 +2672,7 @@ class CIMClassWoQualifiersToMof(unittest.TestCase, RegexpMixin):
 
         # search for class CIM_Foo: CIM_Bar {
         self.assertRegexpContains(clmof,
-                                  r"^\s*class\s+CIM_FooNoQual\s*:\s*" \
+                                  r"^\s*class\s+CIM_FooNoQual\s*:\s*"
                                   r"CIM_Bar\s*\{")
 
         # match method Delete,
@@ -3134,7 +3134,7 @@ class ToCIMObj(unittest.TestCase):
 
         path = cim_obj.tocimobj(
             'reference',
-            "Acme_User.uid=33,OSName=\"acmeunit\"," \
+            "Acme_User.uid=33,OSName=\"acmeunit\","
             "SystemName=\"UnixHost\"")
         self.assertTrue(isinstance(path, CIMInstanceName))
         self.assertTrue(path.namespace is None)
@@ -3174,7 +3174,7 @@ class ToCIMObj(unittest.TestCase):
 
         path = cim_obj.tocimobj(
             'reference',
-            '//./root/default:LogicalDisk.SystemName="acme",' \
+            '//./root/default:LogicalDisk.SystemName="acme",'
             'LogicalDisk.Drive="C"')
         self.assertTrue(isinstance(path, CIMInstanceName))
         self.assertEqual(path.namespace, 'root/default')

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -32,7 +32,7 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
             check_utf8_xml_chars(utf8_xml, "Test XML")
         except ParseError as exc:
             if self.VERBOSE:
-                print("Verify manually: Input XML: %r, ParseError: %s" %\
+                print("Verify manually: Input XML: %r, ParseError: %s" %
                       (utf8_xml, exc))
             self.assertFalse(expected_ok,
                              "ParseError unexpectedly raised: %s" % exc)
@@ -53,7 +53,7 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
 
         # invalid XML characters
         if self.VERBOSE:
-            print("From here on, the only expected exception is ParseError "\
+            print("From here on, the only expected exception is ParseError "
                   "for invalid XML characters...")
         self._run_single(b'<V>a\bb</V>', False)
         self._run_single(b'<V>a\x08b</V>', False)
@@ -64,7 +64,7 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
 
         # correctly encoded but ill-formed UTF-8
         if self.VERBOSE:
-            print("From here on, the only expected exception is ParseError "\
+            print("From here on, the only expected exception is ParseError "
                   "for ill-formed UTF-8 Byte sequences...")
         # combo of U+D800,U+DD22:
         self._run_single(b'<V>a\xED\xA0\x80\xED\xB4\xA2b</V>', False)
@@ -76,7 +76,7 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
 
         # incorrectly encoded UTF-8
         if self.VERBOSE:
-            print("From here on, the only expected exception is ParseError "\
+            print("From here on, the only expected exception is ParseError "
                   "for invalid UTF-8 Byte sequences...")
         # incorrect 1-byte sequence:
         self._run_single(b'<V>a\x80b</V>', False)

--- a/testsuite/test_cim_xml.py
+++ b/testsuite/test_cim_xml.py
@@ -101,7 +101,7 @@ class CIMXMLTest(unittest.TestCase):
                 exp_xml_str = self.xml_str[i]
                 if exp_xml_str is not None:
                     self.assertEqual(act_xml_str, exp_xml_str,
-                                     "CIM-XML fragment to be tested: %r" %\
+                                     "CIM-XML fragment to be tested: %r" %
                                      act_xml_str)
 
 

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -106,9 +106,9 @@ def obj(value, tc_name):
             try:
                 ctor_call = getattr(pywbem, ctor_name)
             except AttributeError:
-                raise ClientTestError("Error in definition of testcase %s: "\
-                                      "Unknown type specified in " \
-                                      "'pywbem_object' attribute: %s" % \
+                raise ClientTestError("Error in definition of testcase %s: "
+                                      "Unknown type specified in "
+                                      "'pywbem_object' attribute: %s" %
                                       (tc_name, ctor_name))
             ctor_args = {}
             for arg_name in value:
@@ -143,7 +143,7 @@ def tc_getattr(tc_name, dict_, key, default=-1):
     except (KeyError, IndexError):
         if default != -1:
             return default
-        raise ClientTestError("Error in definition of testcase %s: "\
+        raise ClientTestError("Error in definition of testcase %s: "
                               "'%s' attribute missing" % (tc_name, key))
     return value
 
@@ -162,7 +162,7 @@ def tc_getattr_list(tc_name, dict_, key, default=-1):
     except KeyError:
         if default != -1:
             return default
-        raise ClientTestError("Error in definition of testcase %s: "\
+        raise ClientTestError("Error in definition of testcase %s: "
                               "'%s' attribute missing" % (tc_name, key))
     return value
 
@@ -450,7 +450,7 @@ class ClientTest(unittest.TestCase):
         if not checker.check_output(ns_act, ns_exp, 0):
             diff = checker.output_difference(doctest.Example("", ns_exp),
                                              ns_act, 0)
-            raise AssertionError("XML is not as expected in %s: %s" % \
+            raise AssertionError("XML is not as expected in %s: %s" %
                                  (entity, diff))
 
     def test_all(self):
@@ -522,8 +522,8 @@ class ClientTest(unittest.TestCase):
                 try:
                     callback_func = getattr(Callback(), callback_name)
                 except AttributeError:
-                    raise ClientTestError("Error in testcase %s: Unknown "\
-                                          "exception callback specified: %s" % \
+                    raise ClientTestError("Error in testcase %s: Unknown "
+                                          "exception callback specified: %s" %
                                           (tc_name, callback_name))
                 params = {
                     "body": callback_func
@@ -566,8 +566,8 @@ class ClientTest(unittest.TestCase):
             op_call = getattr(conn, op_name)
 
         except AttributeError as exc:
-            raise ClientTestError("Error in definition of testcase %s: "\
-                                  "Unknown operation name: %s" %\
+            raise ClientTestError("Error in definition of testcase %s: "
+                                  "Unknown operation name: %s" %
                                   (tc_name, op_name))
 
         # Invoke the PyWBEM operation to be tested
@@ -602,19 +602,19 @@ class ClientTest(unittest.TestCase):
                                      None)
 
         if exp_pull_result and exp_result:
-            raise ClientTestError("Error in definition of testcase %s: "\
-                                  "result and pull result attributes "\
+            raise ClientTestError("Error in definition of testcase %s: "
+                                  "result and pull result attributes "
                                   "are exclusive.")
 
         if exp_exception is not None and exp_result is not None:
-            raise ClientTestError("Error in definition of testcase %s: "\
-                                  "'result' and 'exception' attributes in "\
-                                  "'pywbem_result' are not compatible." %\
+            raise ClientTestError("Error in definition of testcase %s: "
+                                  "'result' and 'exception' attributes in "
+                                  "'pywbem_result' are not compatible." %
                                   tc_name)
         if exp_cim_status != 0 and exp_result is not None:
-            raise ClientTestError("Error in definition of testcase %s: "\
-                                  "'result' and 'cim_status' attributes in "\
-                                  "'pywbem_result' are not compatible." %\
+            raise ClientTestError("Error in definition of testcase %s: "
+                                  "'result' and 'cim_status' attributes in "
+                                  "'pywbem_result' are not compatible." %
                                   tc_name)
 
         if exp_cim_status != 0:
@@ -622,26 +622,26 @@ class ClientTest(unittest.TestCase):
 
         if exp_exception is not None:
             if raised_exception is None:
-                raise AssertionError("Testcase %s: A %s exception was "\
-                                     "expected to be raised by PyWBEM "\
-                                     "operation %s, but no exception was "\
-                                     "actually raised." %\
+                raise AssertionError("Testcase %s: A %s exception was "
+                                     "expected to be raised by PyWBEM "
+                                     "operation %s, but no exception was "
+                                     "actually raised." %
                                      (tc_name, exp_exception, op_name))
             elif raised_exception.__class__.__name__ != exp_exception:
-                raise AssertionError("Testcase %s: A %s exception was "\
-                                     "expected to be raised by PyWBEM "\
-                                     "operation %s, but a different "\
-                                     "exception was actually raised:\n"\
-                                     "%s\n" %\
+                raise AssertionError("Testcase %s: A %s exception was "
+                                     "expected to be raised by PyWBEM "
+                                     "operation %s, but a different "
+                                     "exception was actually raised:\n"
+                                     "%s\n" %
                                      (tc_name, exp_exception, op_name,
                                       raised_traceback_str))
         else:
             if raised_exception is not None:
-                raise AssertionError("Testcase %s: No exception was "\
-                                     "expected to be raised by PyWBEM "\
-                                     "operation %s, but an exception was "\
-                                     "actually raised:\n"\
-                                     "%s\n" %\
+                raise AssertionError("Testcase %s: No exception was "
+                                     "expected to be raised by PyWBEM "
+                                     "operation %s, but an exception was "
+                                     "actually raised:\n"
+                                     "%s\n" %
                                      (tc_name, op_name, raised_traceback_str))
 
         # Validate HTTP request produced by PyWBEM
@@ -653,14 +653,14 @@ class ClientTest(unittest.TestCase):
                             "HTTP request is empty")
             exp_verb = tc_getattr(tc_name, exp_http_request, "verb")
             self.assertEqual(http_request.method, exp_verb,
-                             "Verb in HTTP request is: %s (expected: %s)" % \
+                             "Verb in HTTP request is: %s (expected: %s)" %
                              (http_request.method, exp_verb))
             exp_headers = tc_getattr(tc_name, exp_http_request, "headers", {})
             for header_name in exp_headers:
                 self.assertEqual(http_request.headers[header_name],
                                  exp_headers[header_name],
-                                 "Value of %s header in HTTP request is: %s " \
-                                 "(expected: %s)" % \
+                                 "Value of %s header in HTTP request is: %s "
+                                 "(expected: %s)" %
                                  (header_name,
                                   http_request.headers[header_name],
                                   exp_headers[header_name]))
@@ -691,7 +691,7 @@ class ClientTest(unittest.TestCase):
                 print("Details for the following assertion error:")
                 print("- Expected result type: %s" % type(exp_result_obj))
                 print("- Actual result type: %s" % type(result))
-                raise AssertionError("PyWBEM CIM result type is not" \
+                raise AssertionError("PyWBEM CIM result type is not"
                                      " as expected.")
 
             # The testcase can only specify dicts but not NocaseDicts, so we
@@ -713,7 +713,7 @@ class ClientTest(unittest.TestCase):
                 print("- Actual result: %s" % repr(result))
                 if conn.debug:
                     print("- HTTP response data: %r" % conn.last_raw_reply)
-                raise AssertionError("WBEMConnection operation method result " \
+                raise AssertionError("WBEMConnection operation method result "
                                      "is not as expected.")
 
         # if this is a pull result, compare the components of expected
@@ -724,58 +724,58 @@ class ClientTest(unittest.TestCase):
             # Length should be the same
             if len(result) != len(exp_pull_result_obj):
                 print("Details for the following assertion error:")
-                print("- Expected pull_result tuple size: %s" % \
+                print("- Expected pull_result tuple size: %s" %
                       len(exp_pull_result_obj))
                 print("- Actual result len: %s" % len(result))
-                raise AssertionError("PyWBEM CIM result type is not" \
+                raise AssertionError("PyWBEM CIM result type is not"
                                      " as expected.")
             #eos is required result
             if result.eos != exp_pull_result_obj.eos:
                 print("Details for the following assertion error:")
-                print("- Expected pull result.eos: %r" % \
+                print("- Expected pull result.eos: %r" %
                       exp_pull_result_obj.eos)
                 print("- Actual pull result.eos: %r" % result.eos)
                 if conn.debug:
                     print("- HTTP response data: %r" % conn.last_raw_reply)
-                raise AssertionError("WBEMConnection operation method result " \
+                raise AssertionError("WBEMConnection operation method result "
                                      "is not as expected.")
 
             # context is required result
             if result.context != exp_pull_result_obj.context:
                 print("Details for the following assertion error:")
-                print("- Expected pull result.context: %r" % \
+                print("- Expected pull result.context: %r" %
                     exp_pull_result_obj.context)
                 print("- Actual pull result.context: %r" % result.context)
                 if conn.debug:
                     print("- HTTP response data: %r" % conn.last_raw_reply)
-                raise AssertionError("WBEMConnection operation method result " \
+                raise AssertionError("WBEMConnection operation method result "
                                      "is not as expected.")
 
             if "instances" in exp_pull_result:
                 if result.instances != exp_pull_result_obj.instances:
                     # TODO 2016/07 AM: Improve the presentation of the diff.
                     print("Details for the following assertion error:")
-                    print("- Expected pull result: %r" % \
+                    print("- Expected pull result: %r" %
                           exp_pull_result_obj.instances)
                     print("- Actual pull result: %r" % result.instances)
                     if conn.debug:
                         print("- HTTP response data: %r" % conn.last_raw_reply)
-                    raise AssertionError("WBEMConnection operation method " \
+                    raise AssertionError("WBEMConnection operation method "
                                          "result is not as expected.")
             elif "paths" in exp_pull_result:
                 if result.paths != exp_pull_result_obj.paths:
                     # TODO 2016/07 AM: Improve the presentation of the diff.
                     print("Details for the following assertion error:")
-                    print("- Expected pull result: %r" % \
+                    print("- Expected pull result: %r" %
                           exp_pull_result_obj.paths)
                     print("- Actual pull result: %r" % result.paths)
                     if conn.debug:
                         print("- HTTP response data: %r" % conn.last_raw_reply)
-                    raise AssertionError("WBEMConnection operation method " \
+                    raise AssertionError("WBEMConnection operation method "
                                          "result is not as expected.")
             else:
-                raise AssertionError("WBEMConnection operation method result " \
-                     "is not as expected. No 'instances' " \
+                raise AssertionError("WBEMConnection operation method result "
+                     "is not as expected. No 'instances' "
                      "or 'paths' component.")
 
             # TODO redo as indexed loop to compare all items.
@@ -803,8 +803,8 @@ def result_tuple(value, tc_name):
             instances = value["instances"]
             objs = obj(instances, tc_name)
             if 'paths' in value:
-                raise AssertionError("WBEMConnection operation method " \
-                                     "result is not as expected. Both " \
+                raise AssertionError("WBEMConnection operation method "
+                                     "result is not as expected. Both "
                                      "'instances' and 'paths' component.")
 
         elif "paths" in value:
@@ -812,14 +812,14 @@ def result_tuple(value, tc_name):
             objs = obj(paths, tc_name)
             result = namedtuple("result", ["paths", "eos", "context"])
         else:
-            raise AssertionError("WBEMConnection operation method result " \
-                                 "is not as expected. No 'instances' " \
+            raise AssertionError("WBEMConnection operation method result "
+                                 "is not as expected. No 'instances' "
                                  "or 'paths' component.")
 
         return result(objs, value["eos"], value["context"])
 
     else:
-        raise AssertionError("WBEMConnection operation invalid tuple " \
+        raise AssertionError("WBEMConnection operation invalid tuple "
                                  "definition.")
 
 

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -82,7 +82,7 @@ def setUpModule():
         zf = ZipFile(tfo, 'r')
         nlist = zf.namelist()
         for i in range(0, len(nlist)):
-            sys.stdout.write('\rUnpacking %s: %d%% ' % \
+            sys.stdout.write('\rUnpacking %s: %d%% ' %
                              (mofbname, 100 * (i + 1) / len(nlist)))
             sys.stdout.flush()
             file_ = nlist[i]
@@ -445,7 +445,7 @@ class TestInstCompile(MOFTest, CIMObjectMixin):
                 #self.assertEqual(i['peo'], None)
                 #self.assertEqual(i['pei'], None)
             else:
-                self.fail('Cannot find required instance k1=%s, k2=%s' % \
+                self.fail('Cannot find required instance k1=%s, k2=%s' %
                           (i['k1'], i['k2']))
 
 
@@ -777,41 +777,41 @@ class BaseTestLexer(unittest.TestCase):
                 if isinstance(exp_token, LexErrorToken):
                     # We expect an error
                     if self.last_error_t is None:
-                        self.fail("t_error() was not called as expected, " \
+                        self.fail("t_error() was not called as expected, "
                                   "actual token: %r" % act_token)
                     else:
                         self.assertTrue(
-                            self.last_error_t.type == exp_token.type and \
+                            self.last_error_t.type == exp_token.type and
                             self.last_error_t.value == exp_token.value,
-                            "t_error() was called with an unexpected " \
-                            "token: %r (expected: %r)" % \
+                            "t_error() was called with an unexpected "
+                            "token: %r (expected: %r)" %
                             (self.last_error_t, exp_token))
                 else:
                     # We do not expect an error
                     if self.last_error_t is not None:
                         self.fail(
-                            "t_error() was unexpectedly called with " \
+                            "t_error() was unexpectedly called with "
                             "token: %r" % self.last_error_t)
                     else:
                         self.assertTrue(
                             act_token.type == exp_token.type,
-                            "Unexpected token type: %s (expected: %s) " \
-                            "in token: %r" % \
+                            "Unexpected token type: %s (expected: %s) "
+                            "in token: %r" %
                             (act_token.type, exp_token.type, act_token))
                         self.assertTrue(
                             act_token.value == exp_token.value,
-                            "Unexpected token value: %s (expected: %s) " \
-                            "in token: %r" % \
+                            "Unexpected token value: %s (expected: %s) "
+                            "in token: %r" %
                             (act_token.value, exp_token.value, act_token))
                         self.assertTrue(
                             act_token.lineno == exp_token.lineno,
-                            "Unexpected token lineno: %s (expected: %s) " \
-                            "in token: %r" % \
+                            "Unexpected token lineno: %s (expected: %s) "
+                            "in token: %r" %
                             (act_token.lineno, exp_token.lineno, act_token))
                         self.assertTrue(
                             act_token.lexpos == exp_token.lexpos,
-                            "Unexpected token lexpos: %s (expected: %s) " \
-                            "in token: %r" % \
+                            "Unexpected token lexpos: %s (expected: %s) "
+                            "in token: %r" %
                             (act_token.lexpos, exp_token.lexpos, act_token))
 
 class TestLexerSimple(BaseTestLexer):

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -285,21 +285,21 @@ class TestEqual(BaseTest):
         for test_dict, relation, comment in test_dicts:
             if relation == 'eq':
                 self.assertDictEqual(test_dict, base_dict,
-                                     "Expected test_dict == base_dict:\n" \
-                                     "  test case: %s\n" \
-                                     "  test_dict: %r\n" \
-                                     "  base_dict: %r" % \
+                                     "Expected test_dict == base_dict:\n"
+                                     "  test case: %s\n"
+                                     "  test_dict: %r\n"
+                                     "  base_dict: %r" %
                                      (comment, test_dict, base_dict))
             elif relation == 'ne':
                 self.assertDictNotEqual(test_dict, base_dict,
-                                        "Expected test_dict != base_dict:\n" \
-                                        "  test case: %s\n" \
-                                        "  test_dict: %r\n" \
-                                        "  base_dict: %r" % \
+                                        "Expected test_dict != base_dict:\n"
+                                        "  test case: %s\n"
+                                        "  test_dict: %r\n"
+                                        "  base_dict: %r" %
                                         (comment, test_dict, base_dict))
             else:
-                raise AssertionError("Internal Error: Invalid relation %s" \
-                                     "specified in testcase: %s" % \
+                raise AssertionError("Internal Error: Invalid relation %s"
+                                     "specified in testcase: %s" %
                                      (relation, comment))
 
     def test_all(self):

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -35,7 +35,7 @@ class TupleTest(unittest.TestCase):
         # Assert that the before and after objects should be equal
 
         self.assertEqual(obj, result,
-                         '\nbefore: %s\nafter:  %s' %\
+                         '\nbefore: %s\nafter:  %s' %
                          (xml, result.tocimxml().toxml()))
 
 class RawXMLTest(unittest.TestCase):
@@ -123,14 +123,14 @@ class ParseCIMClass(TupleTest):
                                      translatable=False),
                         'Description':
                         CIMQualifier('Description',
-                                     'CIM_CollectionInSystem is an ' \
-                                     'association used to establish a ' \
-                                     'parent-child relationship between a ' \
-                                     'collection and an \'owning\' System ' \
-                                     'such as an AdminDomain or '\
-                                     'ComputerSystem. A single collection '\
-                                     'should not have both a ' \
-                                     'CollectionInOrganization and a ' \
+                                     'CIM_CollectionInSystem is an '
+                                     'association used to establish a '
+                                     'parent-child relationship between a '
+                                     'collection and an \'owning\' System '
+                                     'such as an AdminDomain or '
+                                     'ComputerSystem. A single collection '
+                                     'should not have both a '
+                                     'CollectionInOrganization and a '
                                      'CollectionInSystem association.',
                                      translatable=True)},
             properties={'Parent':

--- a/testsuite/test_valuemapping.py
+++ b/testsuite/test_valuemapping.py
@@ -41,7 +41,7 @@ class TestAll(unittest.TestCase):
         try:
             vm.tovalues(value)
         except ValueError as exc:
-            if re.match("Element value outside of the set defined by " \
+            if re.match("Element value outside of the set defined by "
                         "ValueMap.*", str(exc)) is None:
                 self.fail("ValueError has unexpected text: %s" % str(exc))
         else:

--- a/testsuite/unittest_extensions.py
+++ b/testsuite/unittest_extensions.py
@@ -29,8 +29,8 @@ class RegexpMixin(object):
           """
         if not re.search(pattern, text):
             raise AssertionError(
-                "String text does not contain regexp pattern\n"\
-                "    text:    %r\n"\
+                "String text does not contain regexp pattern\n"
+                "    text:    %r\n"
                 "    pattern: %r" % (text, pattern))
 
     def assertRegexpMatches(self, text, pattern, msg=None):
@@ -49,8 +49,8 @@ class RegexpMixin(object):
           """
         if not re.match(pattern, text):
             raise AssertionError(
-                "String text does not match regexp pattern\n"\
-                "    text:    %r\n"\
+                "String text does not match regexp pattern\n"
+                "    text:    %r\n"
                 "    pattern: %r" % (text, pattern))
 
 class FileMixin(object):
@@ -183,47 +183,47 @@ class CIMObjectMixin(object):
 
         self.assertEqual(
             act_property.name, exp_property.name,
-            "%s (dict key), name attribute: %s (expected: %s)" % \
+            "%s (dict key), name attribute: %s (expected: %s)" %
             (context,
              act_property.name, exp_property.name))
         self.assertEqual(
             act_property.value, exp_property.value,
-            "%s, value attribute: %s (expected: %s)" % \
+            "%s, value attribute: %s (expected: %s)" %
             (context,
              act_property.value, exp_property.value))
         self.assertEqual(
             act_property.type, exp_property.type,
-            "%s, type attribute: %s (expected: %s)" % \
+            "%s, type attribute: %s (expected: %s)" %
             (context,
              act_property.type, exp_property.type))
         self.assertEqual(
             act_property.reference_class, exp_property.reference_class,
-            "%s, reference_class attribute: %s (expected: %s)" % \
+            "%s, reference_class attribute: %s (expected: %s)" %
             (context,
              act_property.reference_class, exp_property.reference_class))
         self.assertEqual(
             act_property.embedded_object, exp_property.embedded_object,
-            "%s, embedded_object attribute: %s (expected: %s)" % \
+            "%s, embedded_object attribute: %s (expected: %s)" %
             (context,
              act_property.embedded_object, exp_property.embedded_object))
         self.assertEqual(
             act_property.is_array, exp_property.is_array,
-            "%s, is_array attribute: %s (expected: %s)" % \
+            "%s, is_array attribute: %s (expected: %s)" %
             (context,
              act_property.is_array, exp_property.is_array))
         self.assertEqual(
             act_property.array_size, exp_property.array_size,
-            "%s, array_size attribute: %s (expected: %s)" % \
+            "%s, array_size attribute: %s (expected: %s)" %
             (context,
              act_property.array_size, exp_property.array_size))
         self.assertEqual(
             act_property.class_origin, exp_property.class_origin,
-            "%s, class_origin attribute: %s (expected: %s)" % \
+            "%s, class_origin attribute: %s (expected: %s)" %
             (context,
              act_property.class_origin, exp_property.class_origin))
         self.assertEqual(
             act_property.propagated, exp_property.propagated,
-            "%s, propagated attribute: %s (expected: %s)" % \
+            "%s, propagated attribute: %s (expected: %s)" %
             (context,
              act_property.propagated, exp_property.propagated))
         self.assertEqualQualifiers(
@@ -237,22 +237,22 @@ class CIMObjectMixin(object):
 
         self.assertEqual(
             act_method.name, exp_method.name,
-            "%s (dict key), name attribute: %s (expected: %s)" % \
+            "%s (dict key), name attribute: %s (expected: %s)" %
             (context,
              act_method.name, exp_method.name))
         self.assertEqual(
             act_method.return_type, exp_method.return_type,
-            "%s, return_type attribute: %s (expected: %s)" % \
+            "%s, return_type attribute: %s (expected: %s)" %
             (context,
              act_method.return_type, exp_method.return_type))
         self.assertEqual(
             act_method.class_origin, exp_method.class_origin,
-            "%s, class_origin attribute: %s (expected: %s)" % \
+            "%s, class_origin attribute: %s (expected: %s)" %
             (context,
              act_method.class_origin, exp_method.class_origin))
         self.assertEqual(
             act_method.propagated, exp_method.propagated,
-            "%s, propagated attribute: %s methodmethod (expected: %s)" % \
+            "%s, propagated attribute: %s methodmethod (expected: %s)" %
             (context,
              act_method.propagated, exp_method.propagated))
         self.assertEqualParameters(
@@ -269,27 +269,27 @@ class CIMObjectMixin(object):
 
         self.assertEqual(
             act_parameter.name, exp_parameter.name,
-            "%s (dict key), name attribute: %s (expected: %s)" % \
+            "%s (dict key), name attribute: %s (expected: %s)" %
             (context,
              act_parameter.name, exp_parameter.name))
         self.assertEqual(
             act_parameter.type, exp_parameter.type,
-            "%s, type attribute: %s (expected: %s)" % \
+            "%s, type attribute: %s (expected: %s)" %
             (context,
              act_parameter.type, exp_parameter.type))
         self.assertEqual(
             act_parameter.reference_class, exp_parameter.reference_class,
-            "%s, reference_class attribute: %s (expected: %s)" % \
+            "%s, reference_class attribute: %s (expected: %s)" %
             (context,
              act_parameter.reference_class, exp_parameter.reference_class))
         self.assertEqual(
             act_parameter.is_array, exp_parameter.is_array,
-            "%s, is_array attribute: %s (expected: %s)" % \
+            "%s, is_array attribute: %s (expected: %s)" %
             (context,
              act_parameter.is_array, exp_parameter.is_array))
         self.assertEqual(
             act_parameter.array_size, exp_parameter.array_size,
-            "%s, array_size attribute: %s (expected: %s)" % \
+            "%s, array_size attribute: %s (expected: %s)" %
             (context,
              act_parameter.array_size, exp_parameter.array_size))
         self.assertEqualQualifiers(
@@ -303,42 +303,42 @@ class CIMObjectMixin(object):
 
         self.assertEqual(
             act_qualifier.name, exp_qualifier.name,
-            "%s (dict key), name attribute: %s (expected: %s)" % \
+            "%s (dict key), name attribute: %s (expected: %s)" %
             (context,
              act_qualifier.name, exp_qualifier.name))
         self.assertEqual(
             act_qualifier.value, exp_qualifier.value,
-            "%s, value attribute: %s (expected: %s)" % \
+            "%s, value attribute: %s (expected: %s)" %
             (context,
              act_qualifier.value, exp_qualifier.value))
         self.assertEqual(
             act_qualifier.type, exp_qualifier.type,
-            "%s, type attribute: %s (expected: %s)" % \
+            "%s, type attribute: %s (expected: %s)" %
             (context,
              act_qualifier.type, exp_qualifier.type))
         self.assertEqual(
             act_qualifier.propagated, exp_qualifier.propagated,
-            "%s, propagated attribute: %s (expected: %s)" % \
+            "%s, propagated attribute: %s (expected: %s)" %
             (context,
              act_qualifier.propagated, exp_qualifier.propagated))
         self.assertEqual(
             act_qualifier.overridable, exp_qualifier.overridable,
-            "%s, overridable attribute: %s (expected: %s)" % \
+            "%s, overridable attribute: %s (expected: %s)" %
             (context,
              act_qualifier.overridable, exp_qualifier.overridable))
         self.assertEqual(
             act_qualifier.tosubclass, exp_qualifier.tosubclass,
-            "%s, tosubclass attribute: %s (expected: %s)" % \
+            "%s, tosubclass attribute: %s (expected: %s)" %
             (context,
              act_qualifier.tosubclass, exp_qualifier.tosubclass))
         self.assertEqual(
             act_qualifier.toinstance, exp_qualifier.toinstance,
-            "%s, toinstance attribute: %s (expected: %s)" % \
+            "%s, toinstance attribute: %s (expected: %s)" %
             (context,
              act_qualifier.toinstance, exp_qualifier.toinstance))
         self.assertEqual(
             act_qualifier.translatable, exp_qualifier.translatable,
-            "%s, translatable attribute: %s (expected: %s)" % \
+            "%s, translatable attribute: %s (expected: %s)" %
             (context,
              act_qualifier.translatable, exp_qualifier.translatable))
 


### PR DESCRIPTION
Ready for review

Removes a large number of flake8 messages.  Also fixed a few formatting issues noted by pylint but this did not really change pylint message count much.  Note that the current number of messages from flake8 is about the same but we now enabled the E502 error (there were over 400 of them)

This is completely aesthetic but makes the code cleaner.

the flake 8 message log summary is now:

3     E131 continuation line unaligned for hanging indent
33    E501 line too long (115 > 80 characters)
1     F401 '._version.__version__' imported but unused
2     F821 undefined name 'ResourceWarning'
1     F841 local variable 'insts_enum' is assigned to but never used
2     W601 .has_key() is deprecated, use 'in'


A number of these I just do not know how to resolve because of the way flake8 works..  In particular the line_too long messages are primarily a) table in cim_operations which is completely within a comment b) some long lines in documentation due to the specification of attribute typing that must go on a single line.

Since the standard way to ignore issues in flake 8 is to put on the same line '  # noqa Exxx' this does not work within docstrings.