### PR TITLE
Fixes #550: Pin GitPython at 2.0.8 due to issues on Python 2.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -357,7 +357,11 @@ def main():
             "pytest>=2.4",
             "pytest-cov",
             "Sphinx>=1.3",
-            "GitPython>=2.0.6",
+            # Pinning GitPython to 2.0.8 max, due to its use of unittest.case
+            # which is not available on Python 2.6.
+            # TODO: Track resolution of GitPython issue #540:
+            #       https://github.com/gitpython-developers/GitPython/issues/540
+            "GitPython==2.0.8",
             "sphinx-git",
             "httpretty",
             "lxml",


### PR DESCRIPTION
Please review.