### PR TITLE
ERROR IN THIS PR Cancel: Fix formatting issue with argparse epilog

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,34 +17,4 @@ exclude =
 #disable_noqa
     
 ignore =
-    # E126 continuation line over-indented for hanging indent
-    # Currently does not appear to match our style
-    E126,
-    # E127 continuation line over-indented for visual indent.
-    # Disabled because does not appear to match pylint rules
-    E127,
-    # E128 continuation line under-indented for visual indent
-    E128,
-    # E261 at least two spaces before inline comment
-    # Not sure it matches our style and generates many of these messages
-    E261,
-    # E265 block comment should start with '# '
-    # over 100 of these messages right now
-    E265,
-    # E302 expected 2 blank lines, found 1. Too many right now, 400+
-    E302,
-    # E303 too many blank lines
-    E303,
-    # W391 Blank line at end of file
-    # Many of our files have this so ignore for now
-    W391,
-    # D400  First line should end with a period (not 'd')
-    # Defines docstring format for first line. Too many for now
-    D400,
-    # E402 module level import not at top of file
-    # This occurs primarily because of conditonal imports including six
-    # ex. if six...
-    E402, 
-    # E265 block comment should start with #
-    E562
-    
+

--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -71,6 +71,9 @@ General options:
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Examples: wbemcli https://localhost:15345 -n vendor -u sheldon -p penny -
-(https localhost, port=15345, namespace=vendor user=sheldon password=penny)
-wbemcli http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
+Examples:
+  wbemcli https://localhost:15345 -n vendor -u sheldon -p penny
+          - (https localhost, port=15345, namespace=vendor user=sheldon
+         password=penny)
+
+  wbemcli http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)

--- a/makefile
+++ b/makefile
@@ -308,13 +308,12 @@ else
 	@echo 'Info: Pylint requires Python 2.7; skipping this step on Python $(python_version)'
 endif
 
-# TODO: Once flake8 has no more errors, remove the dash "-"
 flake8.log: makefile $(flake8_rc_file) $(flake8_py_files)
 ifeq ($(python_mn_version),26)
 	@echo 'Info: Flake8 requires Python 2.7 or Python 3; skipping this step on Python $(python_version)'
 else
 	rm -f flake8.log
-	-bash -c "set -o pipefail; PYTHONPATH=. flake8 --statistics --config=$(flake8_rc_file) $(flake8_py_files) 2>&1 |tee flake8.tmp.log"
+	bash -c "set -o pipefail; PYTHONPATH=. flake8 --statistics --config=$(flake8_rc_file) $(flake8_py_files) 2>&1 |tee flake8.tmp.log"
 	mv -f flake8.tmp.log flake8.log
 	@echo 'Done: Created flake8 log file: $@'
 endif

--- a/os_setup.py
+++ b/os_setup.py
@@ -166,14 +166,14 @@ import pip
 
 # Some types to avoid dependency on "six" package during installation.
 if sys.version_info[0] == 2:
-    string_types = basestring,      # pylint: disable=invalid-name
-    text_type = unicode             # pylint: disable=invalid-name
-    binary_type = str               # pylint: disable=invalid-name
+    string_types = basestring,      # pylint: disable=invalid-name # noqa: F821
+    text_type = unicode             # pylint: disable=invalid-name # noqa: F821
+    binary_type = str               # pylint: disable=invalid-name # noqa: F821
     from xmlrpclib import ServerProxy as xmlrpc_ServerProxy
 else:
-    string_types = str,             # pylint: disable=invalid-name
-    text_type = str                 # pylint: disable=invalid-name
-    binary_type = bytes             # pylint: disable=invalid-name
+    string_types = str,             # pylint: disable=invalid-name # noqa: F821
+    text_type = str                 # pylint: disable=invalid-name # noqa: F821
+    binary_type = bytes             # pylint: disable=invalid-name # noqa: F821
     from xmlrpc.client import ServerProxy as xmlrpc_ServerProxy
 
 
@@ -208,6 +208,7 @@ class OsDistribution(Distribution):
 
         # Distribution is an old-style class in Python 2.6:
         Distribution.__init__(self, attrs)
+
 
 def _assert_system_dict(dist, attr, value):
     """Validate the value of the 'install_os_requires' and
@@ -281,7 +282,8 @@ def _assert_system_dict(dist, attr, value):
                 (attr, system, type(system_item))
             )
 
-def _assert_req_list(dist, attr, value): # pylint: disable=unused-argument
+
+def _assert_req_list(dist, attr, value):  # pylint: disable=unused-argument
     """Validate the value of a requirements list (e.g. the 'develop_requires'
     attribute, or the requirement lists for a distro or system in the
     'install_os_requires' attribute).
@@ -330,7 +332,7 @@ class BaseOsCommand(Command):
         pass
 
 
-class install_os(BaseOsCommand): # pylint: disable=invalid-name
+class install_os(BaseOsCommand):  # pylint: disable=invalid-name
     """Setuptools/distutils command class for installing OS packages
     in 'normal mode', i.e. when the user specifies the 'install_os' command.
     """
@@ -363,7 +365,8 @@ class install_os(BaseOsCommand): # pylint: disable=invalid-name
                 "Errors occurred (see previous messages)"
             )
 
-class develop_os(BaseOsCommand): # pylint: disable=invalid-name
+
+class develop_os(BaseOsCommand):  # pylint: disable=invalid-name
     """Setuptools/distutils command class for installing OS packages for
     'development mode', i.e. when the user specifies the 'develop_os' command.
     """
@@ -399,7 +402,8 @@ class develop_os(BaseOsCommand): # pylint: disable=invalid-name
                 "Errors occurred (see previous messages)"
             )
 
-class develop(_develop): # pylint: disable=invalid-name
+
+class develop(_develop):  # pylint: disable=invalid-name
     """Setuptools/distutils command class extending the setuptools 'develop'
     command with the ability to process the 'develop_requires' attribute
     of the setup() function.
@@ -457,6 +461,7 @@ def _linux_distribution():
     )
     return distro
 
+
 class BaseInstaller(object):
     """Base class for installing OS packages and Python packages."""
 
@@ -500,7 +505,6 @@ class BaseInstaller(object):
 
         self.userid = getpass.getuser()
         self.env = None
-
 
     def do_install(self, pkg_name, version_reqs=None, dry_run=False,
                    reinstall=False):
@@ -630,9 +634,9 @@ class BaseInstaller(object):
                 for req in req_string.split(','):
                     req = req.strip()
                     if len(req) == 0:
-                        continue # ignore empty requirements
+                        continue  # ignore empty requirements
                     if req[0] not in "<=>!":
-                        req = '==' + req # add default operator
+                        req = '==' + req  # add default operator
                     req_list.append(req)
             return pkg_name, req_list
         else:
@@ -654,7 +658,7 @@ class BaseInstaller(object):
           <op><version> (e.g. '>=1.0').
         """
         if not req_list:
-            return True # no requirement -> version always matches
+            return True  # no requirement -> version always matches
 
         if not isinstance(req_list, (list, tuple)):
             req_list = list(req_list)
@@ -751,13 +755,14 @@ class BaseInstaller(object):
                 msg = "Error: The following %s packages are not in the "\
                       "repositories or do not have a sufficient version "\
                       "there and need to be obtained otherwise:\n"\
-                       "    %s" %\
-                       (self.env, "\n    ".join(pkg_reqs))
+                      "    %s" %\
+                      (self.env, "\n    ".join(pkg_reqs))
             else:
                 raise DistutilsSetupError(
                     "Internal Error: Unexpected message ID: %s" % msg_id
                 )
             print(msg)
+
 
 class PythonInstaller(BaseInstaller):
     """Support for installing Python packages."""
@@ -794,7 +799,7 @@ class PythonInstaller(BaseInstaller):
               printed.
         """
         if req is None:
-            pass # ignore
+            pass  # ignore
         elif isinstance(req, types.FunctionType):
             req(self, dry_run, verbose)
         elif isinstance(req, (list, tuple)):  # requirements choice
@@ -816,7 +821,7 @@ class PythonInstaller(BaseInstaller):
                     print("No package of Python package req choice is "
                           "available in Pypi: %s" % req)
                 self.record_error(req, None, self.MSG_PKG_NOT_IN_REPOS)
-        else: # requirements string
+        else:  # requirements string
             if verbose:
                 print("Processing Python package requirement: %s" % req)
             pkg_name, version_reqs = self.parse_pkg_req(req)
@@ -863,7 +868,7 @@ class PythonInstaller(BaseInstaller):
                         if line.startswith("Version:")][0]
         version = version_line.split()[1]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, version)
 
     def is_available(self, pkg_name, version_reqs=None):
@@ -964,7 +969,7 @@ class OSInstaller(BaseInstaller):
             platform_installer = self.installers[self.platform]
             return platform_installer()
         except KeyError:
-            return self # limited function, i.e. it cannot install
+            return self  # limited function, i.e. it cannot install
 
     def supported(self):
         """Determine whether this operating system platform is supported for
@@ -977,9 +982,9 @@ class OSInstaller(BaseInstaller):
         if self.system == "Linux":
             # TODO: Using sudo may ask for the sudo password. Find a better
             #       way of testing for authorization to install packages.
-            #rc, _, _ = shell("sudo echo ok")
-            #authorized = (rc == 0)
-            authorized = True # For now...
+            # rc, _, _ = shell("sudo echo ok")
+            # authorized = (rc == 0)
+            authorized = True  # For now...
         else:
             authorized = True
         return authorized
@@ -1071,7 +1076,7 @@ class OSInstaller(BaseInstaller):
               printed.
         """
         if req is None:
-            pass # ignore
+            pass  # ignore
         elif isinstance(req, types.FunctionType):
             req(self, dry_run, verbose)
         elif isinstance(req, (list, tuple)):  # requirements choice
@@ -1093,7 +1098,7 @@ class OSInstaller(BaseInstaller):
                     print("No package of OS package req choice is "
                           "available in the repos: %s" % req)
                 self.record_error(req, None, self.MSG_PKG_NOT_IN_REPOS)
-        else: # requirements string
+        else:  # requirements string
             if verbose:
                 print("Processing OS package requirement: %s" % req)
             pkg_name, version_reqs = self.parse_pkg_req(req)
@@ -1242,7 +1247,7 @@ class YumInstaller(OSInstaller):
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, version)
 
     def is_available(self, pkg_name, version_reqs=None):
@@ -1266,8 +1271,9 @@ class YumInstaller(OSInstaller):
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, [version])
+
 
 class AptInstaller(OSInstaller):
     """Installer for apt tool (e.g. Debian, Ubuntu)."""
@@ -1316,7 +1322,7 @@ class AptInstaller(OSInstaller):
             version = version.split(":")[1]
             # TODO: Add support for epoch number in the version
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, version)
 
     def is_available(self, pkg_name, version_reqs=None):
@@ -1338,8 +1344,9 @@ class AptInstaller(OSInstaller):
                         if line.startswith("Version:")][0]
         version = version_line.split()[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, [version])
+
 
 class ZypperInstaller(OSInstaller):
     """Installer for zypper tool (e.g. SLES, openSUSE)."""
@@ -1382,7 +1389,7 @@ class ZypperInstaller(OSInstaller):
                 (cmd, out, err))
         version = info[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, version)
 
     def is_available(self, pkg_name, version_reqs=None):
@@ -1405,8 +1412,9 @@ class ZypperInstaller(OSInstaller):
         version_line = version_lines[0]
         version = version_line.split()[1].split("-")[0]
         version_sufficient = self.version_matches_req(version, version_reqs) \
-                             if version_reqs else True
+            if version_reqs else True
         return (True, version_sufficient, [version])
+
 
 def shell(command, display=False, ignore_notfound=False):
     """Execute a shell command and return its return code, stdout and stderr.
@@ -1465,6 +1473,7 @@ def shell(command, display=False, ignore_notfound=False):
 
     return p.returncode, stdout, stderr
 
+
 def shell_check(command, display=False, exp_rc=0):
     """Execute a shell command, check if its return code is 0, and if not,
     raise an exception.
@@ -1500,6 +1509,7 @@ def shell_check(command, display=False, exp_rc=0):
             "%s returns rc=%d: %s" % (command[0], rc, msg))
 
     return out
+
 
 def import_setuptools(min_version="12.0"):
     """Import the `setuptools` package.
@@ -1539,4 +1549,3 @@ def import_setuptools(min_version="12.0"):
                 "    pip install --upgrade 'setuptools>=%s'\n" %
                 (min_version, min_version)
             )
-

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -44,7 +44,7 @@ from ._listener import *  # noqa: F403,F401
 from ._recorder import *  # noqa: F403,F401
 from .config import *  # noqa: F403,F401
 
-from ._version import __version__
+from ._version import __version__  # noqa: F401
 
 _python_m = sys.version_info[0]  # pylint: disable=invalid-name
 _python_n = sys.version_info[1]  # pylint: disable=invalid-name
@@ -52,4 +52,3 @@ if _python_m == 2 and _python_n < 6:
     raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
 elif _python_m == 3 and _python_n < 4:
     raise RuntimeError('On Python 3, pywbem requires Python 3.4 or higher')
-

--- a/pywbem/_cliutils.py
+++ b/pywbem/_cliutils.py
@@ -48,4 +48,3 @@ class SmartFormatter(argparse.HelpFormatter):
         if text.startswith('R|'):
             return text[2:].splitlines()
         return argparse.HelpFormatter._split_lines(self, text, width)
-

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -73,7 +73,7 @@ creates a listener and displays any indications it receives, in MOF format.
 
 import re
 import logging
-try: # Python 2.7+
+try:  # Python 2.7+
     from logging import NullHandler
 except ImportError:
     class NullHandler(logging.Handler):
@@ -94,8 +94,8 @@ from . import cim_xml
 from ._version import __version__
 from .cim_obj import CIMInstance, _ensure_unicode
 from .cim_operations import check_utf8_xml_chars
-from .cim_constants import CIM_ERR_NOT_SUPPORTED, \
-                           CIM_ERR_INVALID_PARAMETER, _statuscode2name
+from .cim_constants import CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_PARAMETER, \
+    _statuscode2name
 from .tupleparse import parse_cim
 from .tupletree import dom_to_tupletree
 from .exceptions import ParseError, VersionError
@@ -149,52 +149,52 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """
         self.send_http_error(405, headers=[('Allow', 'POST')])
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_OPTIONS(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_HEAD(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_GET(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_PUT(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_PATCH(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_DELETE(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_TRACE(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_CONNECT(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_M_POST(self):
         """Invalid method for listener"""
         self.invalid_method()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def do_POST(self):
         """
         This method will be called for each POST request to one of the
@@ -479,7 +479,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 check_utf8_xml_chars(request_str, "CIM-XML export message")
             except ParseError:
                 raise
-            raise ParseError(msg) # data from previous exception
+            raise ParseError(msg)  # data from previous exception
 
         # Parse response
 
@@ -570,7 +570,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             (__version__, self.server_version, self.sys_version)
 
 
-#pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes
 class WBEMListener(object):
     """
     A WBEM listener.
@@ -780,7 +780,7 @@ class WBEMListener(object):
                 server = ThreadedHTTPServer((self._host, self._http_port),
                                             ListenerRequestHandler)
 
-                #pylint: disable=attribute-defined-outside-init
+                # pylint: disable=attribute-defined-outside-init
                 server.listener = self
                 thread = threading.Thread(target=server.serve_forever)
                 thread.daemon = True  # Exit server thread upon main thread exit
@@ -797,7 +797,7 @@ class WBEMListener(object):
                 server = ThreadedHTTPServer((self._host, self._https_port),
                                             ListenerRequestHandler)
 
-                #pylint: disable=attribute-defined-outside-init
+                # pylint: disable=attribute-defined-outside-init
                 server.listener = self
                 server.socket = ssl.wrap_socket(server.socket,
                                                 certfile=self._certfile,
@@ -881,6 +881,7 @@ class WBEMListener(object):
         if callback not in self._callbacks:
             self._callbacks.append(callback)
 
+
 def callback_interface(indication, host):
     # pylint: disable=unused-argument
     """
@@ -903,4 +904,3 @@ def callback_interface(indication, host):
           callback function is called.
     """
     raise NotImplementedError
-

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -29,8 +29,8 @@ import yaml
 import six
 
 from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
-                     CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
-                     CIMQualifierDeclaration, NocaseDict
+    CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
+    CIMQualifierDeclaration, NocaseDict
 from .cim_types import CIMInt, CIMFloat, CIMDateTime
 from .exceptions import CIMError
 
@@ -38,7 +38,7 @@ __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
            'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse']
 
 if six.PY2:
-    _Longint = long
+    _Longint = long  # noqa: F821
 else:
     _Longint = int
 
@@ -104,6 +104,7 @@ class OpArgs(OpArgs_tuple):
 
 OpResult_tuple = namedtuple("OpResult_tuple", ["ret", "exc"])
 
+
 class OpResult(OpResult_tuple):
     """
     A named tuple representing the result of the invocation of a
@@ -132,6 +133,7 @@ class OpResult(OpResult_tuple):
 HttpRequest_tuple = namedtuple("HttpRequest_tuple",
                                ["version", "url", "target", "method", "headers",
                                 "payload"])
+
 
 class HttpRequest(HttpRequest_tuple):
     """
@@ -173,6 +175,7 @@ class HttpRequest(HttpRequest_tuple):
 HttpResponse_tuple = namedtuple("HttpResponse_tuple",
                                 ["version", "status", "reason", "headers",
                                  "payload"])
+
 
 class HttpResponse(HttpResponse_tuple):
     """
@@ -404,7 +407,7 @@ class TestClientRecorder(BaseOperationRecorder):
         if http_request is not None:
             tc_http_request['verb'] = http_request.method
             tc_http_request['url'] = TestClientRecorder.TESTCASE_URL + \
-                                     http_request.target
+                http_request.target
             tc_request_headers = OrderedDict()
             if http_request.headers is not None:
                 for hdr_name in http_request.headers:
@@ -578,4 +581,3 @@ class TestClientRecorder(BaseOperationRecorder):
         else:
             raise TypeError("Invalid type in TestClientRecorder.toyaml(): "
                             "%s %s" % (obj.__class__.__name__, type(obj)))
-

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -105,8 +105,7 @@ import re
 import six
 
 from .cim_constants import CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_CLASS, \
-                           CIM_ERR_METHOD_NOT_AVAILABLE, \
-                           CIM_ERR_NOT_SUPPORTED, CIM_ERR_NOT_FOUND
+    CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_NOT_SUPPORTED, CIM_ERR_NOT_FOUND
 from .exceptions import CIMError
 from .cim_obj import CIMInstanceName, NocaseDict
 from .cim_types import CIMInt, type_from_name
@@ -306,7 +305,7 @@ class WBEMServer(object):
         return self._profiles
 
     def get_selected_profiles(self, registered_org=None, registered_name=None,
-                    registered_version=None):
+                              registered_version=None):
         """
         List of management profiles advertised by the WBEM server and
         filtered by the input parameters for registered_org, registered_name,
@@ -344,18 +343,17 @@ class WBEMServer(object):
             inst_name = inst['RegisteredName']
             inst_version = inst['RegisteredVersion']
 
-            #pylint: disable=too-many-boolean-expressions
+            # pylint: disable=too-many-boolean-expressions
             if (registered_org is None or registered_org == inst_org) and \
                     (registered_name is None or registered_name == inst_name) \
                     and \
                     (registered_version is None or
-                    registered_version == inst_version):
+                     registered_version == inst_version):
                 rtn.append(inst)
         return rtn
 
     def get_central_instances(self, profile_path, central_class=None,
                               scoping_class=None, scoping_path=None):
-        # pylint: disable=line-too-long
         """
         Determine the central instances for a management profile, and return
         their instance paths as a list of :class:`~pywbem.CIMInstanceName`
@@ -727,7 +725,6 @@ class WBEMServer(object):
 
 
 class ValueMapping(object):
-    # pylint: disable=line-too-long
     """
     A utility class that translates the values of a corresponding integer-typed
     CIM element (property, method, parameter) that is qualified with the
@@ -1004,7 +1001,7 @@ class ValueMapping(object):
             ValueError: No Values qualifier defined.
             ValueError: Invalid ValueMap entry.
             TypeError: The CIM element is not integer-typed.
-        """
+        """  # noqa: E501
 
         # pylint: disable=protected-access
 
@@ -1062,7 +1059,6 @@ class ValueMapping(object):
         return self._element_obj
 
     def tovalues(self, element_value):
-        # pylint: disable=line-too-long
         """
         Return the Values string for an element value, based on the ValueMap /
         Values qualifiers of the corresponding CIM element.
@@ -1108,4 +1104,3 @@ class ValueMapping(object):
 
         raise ValueError("Element value outside of the set defined by "
                          "ValueMap: %r" % element_value)
-

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -164,6 +164,7 @@ DEFAULT_QUERY_LANGUAGE = 'WQL'
 
 __all__ = ['WBEMSubscriptionManager']
 
+
 class WBEMSubscriptionManager(object):
     """
     A class for managing subscriptions for CIM indications in a WBEM server.
@@ -171,7 +172,7 @@ class WBEMSubscriptionManager(object):
     """
 
     def __init__(self, subscription_manager_id=None):
-        #pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         """
         Parameters:
 
@@ -305,7 +306,7 @@ class WBEMSubscriptionManager(object):
         this_host = getfqdn()
 
         dest_name_pattern = re.compile(
-            r'^pywbemdestination:owned:%s:[^:]*$' %
+            r'^pywbemdestination:owned:%s:%s:[^:]*$' %
             (this_host, self._subscription_manager_id))
         dest_inst_paths = server.conn.EnumerateInstanceNames(
             DESTINATION_CLASSNAME, namespace=server.interop_ns)
@@ -396,7 +397,7 @@ class WBEMSubscriptionManager(object):
             # This depends on server.url same as server_id
             self.remove_server(server.url)
 
-    #pylint: disable=line-too-long
+    # pylint: disable=line-too-long
     def add_listener_destinations(self, server_id, listener_urls, owned=True):
         """
         Register WBEM listeners to be the target of indications sent by a
@@ -561,7 +562,7 @@ class WBEMSubscriptionManager(object):
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError(CIM_ERR_FAILED) if there are referencing subscriptions.
-        """
+        """  # noqa: E501
 
         # if list, recursively call this remove subscriptions for each entry
         if isinstance(destination_paths, list):
@@ -597,7 +598,7 @@ class WBEMSubscriptionManager(object):
                    query_language=DEFAULT_QUERY_LANGUAGE,
                    owned=True,
                    filter_id=None):
-        #pylint: disable=line-too-long
+        # pylint: disable=line-too-long
         """
         Add a :term:`dynamic indication filter` to a WBEM server, by creating
         an indication filter instance (of CIM class "CIM_IndicationFilter") in
@@ -875,7 +876,7 @@ class WBEMSubscriptionManager(object):
         Raises:
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
         # validate server_id
         server = self._get_server(server_id)
 
@@ -986,7 +987,7 @@ class WBEMSubscriptionManager(object):
         Raises:
 
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         # if list, recursively call this remove subscriptions for each entry
         if isinstance(sub_paths, list):
@@ -1007,6 +1008,7 @@ class WBEMSubscriptionManager(object):
             if path == sub_path:
                 del sub_path_list[i]
                 # continue to end of list to pick up any duplicates
+
 
 def _create_destination(server, dest_url, subscription_manager_id, owned):
     """
@@ -1069,6 +1071,7 @@ def _create_destination(server, dest_url, subscription_manager_id, owned):
     dest_path = server.conn.CreateInstance(dest_inst)
     return dest_path
 
+
 def _create_filter(server, source_namespace, query, query_language,
                    subscription_manager_id, filter_id, owned):
     """
@@ -1129,14 +1132,15 @@ def _create_filter(server, source_namespace, query, query_language,
     filter_inst['SystemName'] = this_host
     # TODO: We should not set the `Name` property of filters, because it
     # needs to be user-defined. See issue #540.
-    filter_inst['Name'] = 'pywbemfilter:%s:%s:%s:%s' % (ownership,
-                          subscription_manager_id, filter_id, uuid.uuid4())
+    filter_inst['Name'] = 'pywbemfilter:%s:%s:%s:%s' % \
+        (ownership, subscription_manager_id, filter_id, uuid.uuid4())
     filter_inst['SourceNamespace'] = source_namespace
     filter_inst['Query'] = query
     filter_inst['QueryLanguage'] = query_language
 
     filter_path = server.conn.CreateInstance(filter_inst)
     return filter_path
+
 
 def _create_subscription(server, dest_path, filter_path):
     """

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -32,4 +32,3 @@ Version of the pywbem package.
 #:   PyPI)
 #: * "M.N.U": The final M.N.U release
 __version__ = '0.10.0.dev0'
-

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -51,7 +51,7 @@ from six.moves import http_client as httplib
 from six.moves import urllib
 
 from .cim_obj import CIMClassName, CIMInstanceName, _ensure_unicode, \
-                     _ensure_bytes
+    _ensure_bytes
 from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
 
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
@@ -60,17 +60,18 @@ if six.PY2 and not _ON_RTD:  # RTD has no swig to install M2Crypto
     from M2Crypto import SSL           # pylint: disable=wrong-import-position
     from M2Crypto.Err import SSLError  # pylint: disable=wrong-import-position
     _HAVE_M2CRYPTO = True
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     SocketErrors = (socket.error, socket.sslerror)
 else:
     import ssl as SSL                  # pylint: disable=wrong-import-position
     # pylint: disable=wrong-import-position
     from ssl import SSLError, CertificateError
     _HAVE_M2CRYPTO = False
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     SocketErrors = (socket.error,)
 
 __all__ = ['DEFAULT_CA_CERT_PATHS']
+
 
 def create_pywbem_ssl_context():
     """ Create an SSL context based on what is commonly accepted as the
@@ -106,14 +107,14 @@ def create_pywbem_ssl_context():
 
         # Variable settings per SSL create_default_context. These are what
         # the function above sets for Python 3.4
-        #context = SSLContext(PROTOCOL_SSLv23)
-        #context.options |= OP_NO_SSLv2
-        #context.options |= OP_NO_SSLv3
-        #context.options |= getattr(SSL, "OP_NO_COMPRESSION", 0)
-        #context.options |= getattr(SSL, "OP_CIPHER_SERVER_PREFERENCE", 0)
-        #context.options |= getattr(SSL, "OP_SINGLE_DH_USE", 0)
-        #context.options |= getattr(SSL, "OP_SINGLE_ECDH_USE", 0)
-        #context.set_ciphers(_RESTRICTED_SERVER_CIPHERS)
+        # context = SSLContext(PROTOCOL_SSLv23)
+        # context.options |= OP_NO_SSLv2
+        # context.options |= OP_NO_SSLv3
+        # context.options |= getattr(SSL, "OP_NO_COMPRESSION", 0)
+        # context.options |= getattr(SSL, "OP_CIPHER_SERVER_PREFERENCE", 0)
+        # context.options |= getattr(SSL, "OP_SINGLE_DH_USE", 0)
+        # context.options |= getattr(SSL, "OP_SINGLE_ECDH_USE", 0)
+        # context.set_ciphers(_RESTRICTED_SERVER_CIPHERS)
 
     return context
 
@@ -124,8 +125,9 @@ DEFAULT_PORT_HTTPS = 5989       # default port for https
 
 #: Default directory paths for looking up CA certificates.
 DEFAULT_CA_CERT_PATHS = \
-     ['/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
-      '/etc/ssl/certs', '/etc/ssl/certificates']
+    ['/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
+     '/etc/ssl/certs', '/etc/ssl/certificates']
+
 
 def get_default_ca_cert_paths():
     """Return the list of default certificate paths defined for this
@@ -195,11 +197,11 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
                 # exceptions that may be pending.
                 ts2 = datetime.now()
                 duration = ts2 - self._ts1
-                duration_sec = (float(duration.microseconds) / 1000000) +\
-                               duration.seconds + (duration.days * 24 * 3600)
+                duration_sec = (float(duration.microseconds) / 1000000) + \
+                    duration.seconds + (duration.days * 24 * 3600)
                 raise TimeoutError("The client timed out and closed the "
                                    "socket after %.0fs." % duration_sec)
-        return False # re-raise any other exceptions
+        return False  # re-raise any other exceptions
 
     def timer_expired(self):
         """
@@ -221,6 +223,7 @@ class HTTPTimeout(object):  # pylint: disable=too-few-public-methods
             self._timer = threading.Timer(self._retrytime,
                                           HTTPTimeout.timer_expired, [self])
             self._timer.start()
+
 
 def parse_url(url, allow_defaults=True):
     """Return a tuple of ``(host, port, ssl)`` from the URL specified in the
@@ -318,6 +321,7 @@ def parse_url(url, allow_defaults=True):
 
     return host, port, ssl
 
+
 def get_default_ca_certs():
     """
     Try to find out system path with ca certificates. This path is cached and
@@ -331,6 +335,7 @@ def get_default_ca_certs():
         else:
             get_default_ca_certs._path = None
     return get_default_ca_certs._path
+
 
 # pylint: disable=too-many-branches,too-many-statements,too-many-arguments
 def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
@@ -490,7 +495,6 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 # Another change is that we do not pass the timeout value
                 # on to the socket call, because that does not work with
                 # M2Crypto.
-
 
                 if sys.version_info[0:2] >= (2, 7):
                     # the source_address parameter was added in Python 2.7
@@ -845,7 +849,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                         pgdetails_hdr = response.getheader('PGErrorDetail',
                                                            None)
                         if pgdetails_hdr is not None:
-                            #pylint: disable=too-many-function-args
+                            # pylint: disable=too-many-function-args
                             cimdetails['PGErrorDetail'] = \
                                 urllib.parse.unquote(pgdetails_hdr)
                         raise HTTPError(response.status, response.reason,
@@ -866,13 +870,13 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 # (e.g. because the server went down).
                 # See http://bugs.python.org/issue8450.
                 if exc.line is None or exc.line.strip().strip("'") in \
-                                       ('', 'None'):
-                    raise ConnectionError("The server closed the "
-                        "connection without returning any data, or the "
-                        "client timed out")
+                        ('', 'None'):
+                    raise ConnectionError("The server closed the connection "
+                                          "without returning any data, or the "
+                                          "client timed out")
                 else:
-                    raise ConnectionError("The server returned a bad "
-                        "HTTP status line: %r" % exc.line)
+                    raise ConnectionError("The server returned a bad HTTP "
+                                          "status line: %r" % exc.line)
             except httplib.IncompleteRead as exc:
                 raise ConnectionError("HTTP incomplete read: %s" % exc)
             except httplib.NotConnected as exc:

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -59,7 +59,7 @@ in detail in this documentation.
 
 Deprecated: In v0.9.0, support for comparing two NocaseDict instances with the
 ``>``, ``>``, ``<=``, ``>=`` operators has been deprecated.
-"""
+"""  # noqa: E501
 # pylint: enable=line-too-long
 # Note: When used before module docstrings, Pylint scopes the disable statement
 #       to the whole rest of the file, so we need an enable statement.
@@ -72,18 +72,18 @@ from datetime import datetime, timedelta
 import warnings
 
 import six
+
+from . import cim_xml
+from .cim_types import _CIMComparisonMixin, type_from_name, cimtype, \
+    atomic_to_cim_xml, CIMType, CIMDateTime, Uint8, Sint8, Uint16, Sint16, \
+    Uint32, Sint32, Uint64, Sint64, Real32, Real64
+
 if six.PY2:
     # pylint: disable=wrong-import-order
     from __builtin__ import type as builtin_type
 else:
     # pylint: disable=wrong-import-order
     from builtins import type as builtin_type  # pylint: disable=import-error
-
-from . import cim_xml
-from .cim_types import _CIMComparisonMixin, type_from_name, \
-                       cimtype, atomic_to_cim_xml, CIMType, \
-                       CIMDateTime, Uint8, Sint8, Uint16, Sint16, Uint32, \
-                       Sint32, Uint64, Sint64, Real32, Real64
 
 __all__ = ['CIMClassName', 'CIMProperty', 'CIMInstanceName', 'CIMInstance',
            'CIMClass', 'CIMMethod', 'CIMParameter', 'CIMQualifier',
@@ -93,8 +93,9 @@ __all__ = ['CIMClassName', 'CIMProperty', 'CIMInstanceName', 'CIMInstance',
 MOF_INDENT = 4
 MAX_MOF_LINE = 79   # use 79 because comma separator sometimes runs over
 
-# pylint: disable=too-many-lines
+
 class NocaseDict(object):
+    # pylint: disable=too-many-lines
     """
     Yet another implementation of a case-insensitive dictionary.
 
@@ -387,7 +388,7 @@ class NocaseDict(object):
         not copied).
         """
         result = NocaseDict()
-        result._data = self._data.copy() # pylint: disable=protected-access
+        result._data = self._data.copy()  # pylint: disable=protected-access
         return result
 
     def __eq__(self, other):
@@ -405,7 +406,7 @@ class NocaseDict(object):
                 if not self_value == other_value:
                     return False
             except TypeError:
-                return False # not comparable -> considered not equal
+                return False  # not comparable -> considered not equal
         return len(self) == len(other)
 
     def __ne__(self, other):
@@ -460,6 +461,7 @@ class NocaseDict(object):
         self.__ordering_deprecated()
         return (self < other) or (self == other)
 
+
 def _intended_value(intended, unspecified, actual, name, msg):
     """
     Return the intended value if the actual value is unspecified or has
@@ -480,7 +482,7 @@ def _intended_value(intended, unspecified, actual, name, msg):
 
     if isinstance(intended, (tuple, list)):
         if actual == unspecified:
-            return intended[0] # the default
+            return intended[0]  # the default
         elif actual in intended:
             return actual
         else:
@@ -494,6 +496,7 @@ def _intended_value(intended, unspecified, actual, name, msg):
         else:
             raise ValueError(msg + ", but specifies %s=%r (must be %r)"
                              % (name, actual, intended))
+
 
 def cmpname(name1, name2):
     """
@@ -524,6 +527,7 @@ def cmpname(name1, name2):
     else:
         return 1
 
+
 def cmpitem(item1, item2):
     """
     Compare two items (CIM values, CIM objects, or NocaseDict objects) for
@@ -547,6 +551,7 @@ def cmpitem(item1, item2):
         return 0
     return 1
 
+
 def _convert_unicode(obj):
     """
     Convert the input object into a Unicode string (`unicode`for Python 2,
@@ -562,6 +567,7 @@ def _convert_unicode(obj):
         return obj.decode("utf-8")
     return six.text_type(obj)
 
+
 def _ensure_unicode(obj):
     """
     Return the input object, ensuring that a byte string is decoded into a
@@ -573,6 +579,7 @@ def _ensure_unicode(obj):
     if isinstance(obj, six.binary_type):
         return obj.decode("utf-8")
     return obj
+
 
 def _convert_bytes(obj):
     """
@@ -589,6 +596,7 @@ def _convert_bytes(obj):
         return obj.encode("utf-8")
     return six.binary_type(obj)
 
+
 def _ensure_bytes(obj):
     """
     Return the input object, ensuring that a Unicode string is decoded into a
@@ -600,6 +608,7 @@ def _ensure_bytes(obj):
     if isinstance(obj, six.text_type):
         return obj.encode("utf-8")
     return obj
+
 
 def _makequalifiers(qualifiers, indent):
     """
@@ -613,12 +622,12 @@ def _makequalifiers(qualifiers, indent):
 
       indent (:term:`integer): Indent level for this set of qualifiers.
     """
-
     if len(qualifiers) == 0:
         return ''
+    qual_list = [q.tomof(indent + 2) for q in sorted(qualifiers.values())]
+    qual_str = ',\n '.ljust(indent + 2).join(qual_list)
+    return '%s[%s]' % (_indent_str(indent), qual_str)
 
-    return '%s[%s]' % (_indent_str(indent), ',\n '.ljust(indent + 2).
-        join([q.tomof(indent + 2) for q in sorted(qualifiers.values())]))
 
 def _indent_str(indent):
     """
@@ -626,6 +635,7 @@ def _indent_str(indent):
     that defines number of spaces to indent. Used to format MOF output
     """
     return ' '.ljust(indent, ' ')
+
 
 def mofstr(strvalue, indent=MOF_INDENT, maxline=MAX_MOF_LINE):
     # Note: This is a raw docstring because it shows many backslashes, and
@@ -700,11 +710,12 @@ def mofstr(strvalue, indent=MOF_INDENT, maxline=MAX_MOF_LINE):
 
     # Escape \b, \t, \n, \f, \r
     # Note, the Python escape sequences happen to be the same as in MOF
-    escaped_str = escaped_str.replace('\b', '\\b').\
-                              replace('\t', '\\t').\
-                              replace('\n', '\\n').\
-                              replace('\f', '\\f').\
-                              replace('\r', '\\r')
+    escaped_str = escaped_str.\
+        replace('\b', '\\b').\
+        replace('\t', '\\t').\
+        replace('\n', '\\n').\
+        replace('\f', '\\f').\
+        replace('\r', '\\r')
 
     # Escape remaining control characters (U+0001...U+001F), skipping
     # U+0008, U+0009, U+000A, U+000C, U+000D that are already handled.
@@ -715,32 +726,33 @@ def mofstr(strvalue, indent=MOF_INDENT, maxline=MAX_MOF_LINE):
     #         c = six.unichr(cp)
     #         esc = '\\x%04X' % cp
     #         escaped_str = escaped_str.replace(c, esc)
-    escaped_str = escaped_str.replace(u'\u0001', '\\x0001').\
-                              replace(u'\u0002', '\\x0002').\
-                              replace(u'\u0003', '\\x0003').\
-                              replace(u'\u0004', '\\x0004').\
-                              replace(u'\u0005', '\\x0005').\
-                              replace(u'\u0006', '\\x0006').\
-                              replace(u'\u0007', '\\x0007').\
-                              replace(u'\u000B', '\\x000B').\
-                              replace(u'\u000E', '\\x000E').\
-                              replace(u'\u000F', '\\x000F').\
-                              replace(u'\u0010', '\\x0010').\
-                              replace(u'\u0011', '\\x0011').\
-                              replace(u'\u0012', '\\x0012').\
-                              replace(u'\u0013', '\\x0013').\
-                              replace(u'\u0014', '\\x0014').\
-                              replace(u'\u0015', '\\x0015').\
-                              replace(u'\u0016', '\\x0016').\
-                              replace(u'\u0017', '\\x0017').\
-                              replace(u'\u0018', '\\x0018').\
-                              replace(u'\u0019', '\\x0019').\
-                              replace(u'\u001A', '\\x001A').\
-                              replace(u'\u001B', '\\x001B').\
-                              replace(u'\u001C', '\\x001C').\
-                              replace(u'\u001D', '\\x001D').\
-                              replace(u'\u001E', '\\x001E').\
-                              replace(u'\u001F', '\\x001F')
+    escaped_str = escaped_str.\
+        replace(u'\u0001', '\\x0001').\
+        replace(u'\u0002', '\\x0002').\
+        replace(u'\u0003', '\\x0003').\
+        replace(u'\u0004', '\\x0004').\
+        replace(u'\u0005', '\\x0005').\
+        replace(u'\u0006', '\\x0006').\
+        replace(u'\u0007', '\\x0007').\
+        replace(u'\u000B', '\\x000B').\
+        replace(u'\u000E', '\\x000E').\
+        replace(u'\u000F', '\\x000F').\
+        replace(u'\u0010', '\\x0010').\
+        replace(u'\u0011', '\\x0011').\
+        replace(u'\u0012', '\\x0012').\
+        replace(u'\u0013', '\\x0013').\
+        replace(u'\u0014', '\\x0014').\
+        replace(u'\u0015', '\\x0015').\
+        replace(u'\u0016', '\\x0016').\
+        replace(u'\u0017', '\\x0017').\
+        replace(u'\u0018', '\\x0018').\
+        replace(u'\u0019', '\\x0019').\
+        replace(u'\u001A', '\\x001A').\
+        replace(u'\u001B', '\\x001B').\
+        replace(u'\u001C', '\\x001C').\
+        replace(u'\u001D', '\\x001D').\
+        replace(u'\u001E', '\\x001E').\
+        replace(u'\u001F', '\\x001F')
 
     # Escape single and double quote
     escaped_str = escaped_str.replace('"', '\\"')
@@ -770,6 +782,7 @@ def mofstr(strvalue, indent=MOF_INDENT, maxline=MAX_MOF_LINE):
 
     ret_str = ('\n' + _is).join(ret_str_list)
     return ret_str
+
 
 def moftype(cim_type, refclass):
     """
@@ -1109,7 +1122,8 @@ class CIMInstanceName(_CIMComparisonMixin):
                     value = _ensure_unicode(key_bind[1])
                 else:
                     raise TypeError('Invalid keybinding type for keybinding '
-                            '%s: %s' % (key_bind[0], builtin_type(key_bind[1])))
+                                    '%s: %s' %
+                                    (key_bind[0], builtin_type(key_bind[1])))
 
                 kbs.append(cim_xml.KEYBINDING(
                     key_bind[0],
@@ -1277,7 +1291,7 @@ class CIMInstance(_CIMComparisonMixin):
         self.path = path
         if property_list is not None:
             self.property_list = [_ensure_unicode(x).lower()
-                for x in property_list]
+                                  for x in property_list]
         else:
             self.property_list = None
 
@@ -2269,14 +2283,14 @@ class CIMProperty(_CIMComparisonMixin):
                 True, None, is_array, 'is_array',
                 'Property %r has a value that is an array (%s)' %
                 (name, builtin_type(value)))
-        elif value is not None: # Scalar value
+        elif value is not None:  # Scalar value
             is_array = _intended_value(
                 False, None, is_array, 'is_array',
                 'Property %r has a value that is a scalar (%s)' %
                 (name, builtin_type(value)))
-        else: # Null value
+        else:  # Null value
             if is_array is None:
-                is_array = False # For compatibility with old default
+                is_array = False  # For compatibility with old default
 
         if not is_array and array_size is not None:
             raise ValueError('Scalar property %r specifies array_size=%r '
@@ -2285,7 +2299,7 @@ class CIMProperty(_CIMComparisonMixin):
         # Determine type, embedded_object, and reference_class attributes.
         # Make sure value is CIM-typed.
 
-        if is_array: # Array property
+        if is_array:  # Array property
             if reference_class is not None:
                 raise ValueError(
                     'Array property %r cannot specify reference_class' % name)
@@ -2339,16 +2353,16 @@ class CIMProperty(_CIMComparisonMixin):
                       'with no CIM data type specified' % name
                 embedded_object = _intended_value(
                     None, None, embedded_object, 'embedded_object', msg)
-            else: # type is specified and value (= entire array) is not Null
+            else:  # type is specified and value (= entire array) is not Null
                 # Make sure the array elements are of the corresponding Python
                 # type.
                 value = [type_from_name(type_)(val) if val is not None
                          else val for val in value]
                 msg = 'Array property %r contains simple typed values ' \
-                        'and specifies CIM data type %r' % (name, type_)
+                      'and specifies CIM data type %r' % (name, type_)
                 embedded_object = _intended_value(
                     None, None, embedded_object, 'embedded_object', msg)
-        else: # Scalar property
+        else:  # Scalar property
             if value is None:
                 # Try to infer from embedded_object, reference_class, and type
                 if embedded_object == 'instance':
@@ -2422,7 +2436,7 @@ class CIMProperty(_CIMComparisonMixin):
                     None, None, embedded_object, 'embedded_object', msg)
                 reference_class = _intended_value(
                     None, None, reference_class, 'reference_class', msg)
-            else: # type is specified and value is not Null
+            else:  # type is specified and value is not Null
                 # Make sure the value is of the corresponding Python type.
                 _type_obj = type_from_name(type_)
                 # pylint: disable=redefined-variable-type
@@ -3385,7 +3399,7 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that this information is not available.
     """
 
-    #pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
     def __init__(self, name, value, type=None, propagated=None,
                  overridable=None, tosubclass=None, toinstance=None,
                  translatable=None):
@@ -3655,7 +3669,8 @@ class CIMQualifier(_CIMComparisonMixin):
                 mof = '%s (%s)' % (self.name, val)
         return mof
 
-#pylint: disable=too-many-instance-attributes
+
+# pylint: disable=too-many-instance-attributes
 class CIMQualifierDeclaration(_CIMComparisonMixin):
     """
 
@@ -4067,7 +4082,7 @@ def tocimxml(value):
         return cim_xml.VALUE_ARRAY([tocimxml(v) for v in value])
     except TypeError:
         raise ValueError("Can't convert %s (%s) to CIM XML" %
-                     (value, builtin_type(value)))
+                         (value, builtin_type(value)))
 
 
 def tocimxmlstr(value, indent=None):
@@ -4111,7 +4126,7 @@ def tocimxmlstr(value, indent=None):
     return _ensure_unicode(xml_str)
 
 
-#pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
+# pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
 def tocimobj(type_, value):
     """
     Return a CIM object representing the specified value and
@@ -4250,7 +4265,7 @@ def tocimobj(type_, value):
                 return (str_arg, '', '')
             return (str_arg[:idx], seq, str_arg[idx + len(seq):])
 
-    if type_ == 'reference': # pylint: disable=too-many-nested-blocks
+    if type_ == 'reference':  # pylint: disable=too-many-nested-blocks
         # pylint: disable=too-many-return-statements,too-many-branches
         # TODO doesn't handle double-quoting, as in refs to refs.  Example:
         # r'ex_composedof.composer="ex_sampleClass.label1=9921,' +
@@ -4280,7 +4295,7 @@ def tocimobj(type_, value):
             key_bindings = {}
             while tail:
                 head, sep, tail = partition(tail, ',')
-                if head.count('"') == 1: # quoted string contains comma
+                if head.count('"') == 1:  # quoted string contains comma
                     tmp, sep, tail = partition(tail, '"')
                     head = '%s,%s' % (head, tmp)
                     tail = partition(tail, ',')[2]
@@ -4309,8 +4324,7 @@ def tocimobj(type_, value):
                                     val = CIMDateTime(val)
                                 except ValueError:
                                     raise ValueError('Invalid key binding: %s'
-                                            % val)
-
+                                                     % val)
 
                     key_bindings[key] = val
             return CIMInstanceName(classname, host=host, namespace=nm_space,
@@ -4326,4 +4340,3 @@ def byname(nlist):
     Convert a list of named objects into a map indexed by name
     """
     return dict([(x.name, x) for x in nlist])
-

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -118,14 +118,13 @@ import six
 from . import cim_xml
 from .cim_constants import DEFAULT_NAMESPACE, CIM_ERR_INVALID_PARAMETER
 from .cim_types import CIMType, CIMDateTime, atomic_to_cim_xml
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, \
-                     CIMClassName, NocaseDict, _ensure_unicode, tocimxml, \
-                     tocimobj
+from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
+    NocaseDict, _ensure_unicode, tocimxml, tocimobj
 from .cim_http import get_object_header, wbem_request
 from .tupleparse import parse_cim
 from .tupletree import dom_to_tupletree
 from .exceptions import Error, ParseError, AuthError, ConnectionError, \
-                        TimeoutError, CIMError
+    TimeoutError, CIMError
 
 __all__ = ['WBEMConnection', 'PegasusUDSConnection', 'SFCBUDSConnection',
            'OpenWBEMUDSConnection']
@@ -135,7 +134,7 @@ __all__ = ['WBEMConnection', 'PegasusUDSConnection', 'SFCBUDSConnection',
 
 # openenumerateInstances, OpenAssociators, etc and PullInstanceWithPath
 # responses
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 pull_path_result_tuple = namedtuple("pull_path_result_tuple",
                                     ["paths", "eos", "context"])
 
@@ -170,6 +169,7 @@ def _check_classname(val):
     """
     if not isinstance(val, six.string_types):
         raise ValueError("string expected for classname, not %r" % val)
+
 
 def check_utf8_xml_chars(utf8_xml, meaning):
     """
@@ -661,7 +661,6 @@ class WBEMConnection(object):
         self.last_reply = None
         self.operation_recorder = None
 
-
     def __str__(self):
         """
         Return a short representation of the :class:`~pywbem.WBEMConnection`
@@ -815,12 +814,12 @@ class WBEMConnection(object):
                 if parsing_error:
                     # We did not catch it in the check function, but
                     # minidom.parseString() failed.
-                    raise ParseError(msg) # data from previous exception
+                    raise ParseError(msg)  # data from previous exception
 
         if self.debug:
             pretty_reply = reply_dom.toprettyxml(indent='  ')
             self.last_reply = re.sub(r'>( *[\r\n]+)+( *)<', r'>\n\2<',
-                                     pretty_reply) # remove extra empty lines
+                                     pretty_reply)  # remove extra empty lines
 
         # Parse response
 
@@ -865,7 +864,7 @@ class WBEMConnection(object):
                 raise CIMError(code, err[1]['DESCRIPTION'])
             raise CIMError(code, 'Error code %s' % err[1]['CODE'])
         if response_params_rqd is None:
-            #expect either ERROR | IRETURNVALUE*
+            # expect either ERROR | IRETURNVALUE*
             err = tup_tree[0]
             if err[0] != 'IRETURNVALUE':
                 raise ParseError('Expecting IRETURNVALUE element, got %s'
@@ -1059,12 +1058,12 @@ class WBEMConnection(object):
                 if parsing_error:
                     # We did not catch it in the check function, but
                     # minidom.parseString() failed.
-                    raise ParseError(msg) # data from previous exception
+                    raise ParseError(msg)  # data from previous exception
 
         if self.debug:
             pretty_reply = reply_dom.toprettyxml(indent='  ')
             self.last_reply = re.sub(r'>( *[\r\n]+)+( *)<', r'>\n\2<',
-                                     pretty_reply) # remove extra empty lines
+                                     pretty_reply)  # remove extra empty lines
 
         # Parse response
 
@@ -1292,7 +1291,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return instancenames
 
-
     def EnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                            DeepInheritance=None, IncludeQualifiers=None,
                            IncludeClassOrigin=None, PropertyList=None,
@@ -1449,7 +1447,7 @@ class WBEMConnection(object):
 
             # TODO ks 6/16 would the setattr be faster?
             # TODO: ks 6/16 should we check before setting?
-            #[setattr(i.path, 'namespace', namespace) for i in instances]
+            # [setattr(i.path, 'namespace', namespace) for i in instances]
             for instance in instances:
                 instance.path.namespace = namespace
 
@@ -1464,7 +1462,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return instances
 
-
     @staticmethod
     def _get_rslt_params(result, namespace):
         """Common processing for pull results to separate
@@ -1472,7 +1469,7 @@ class WBEMConnection(object):
            Returns tuple of entities in IRETURNVALUE, end_of_sequence,
            and enumeration_context)
         """
-        #TODO ks 6/16 make this None???
+        # TODO ks 6/16 make this None???
         rtn_objects = []
         end_of_sequence = False
         enumeration_context = None
@@ -1708,7 +1705,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(result_tuple, None)
                 self.operation_recorder.record_staged()
             return result_tuple
-
 
     def OpenEnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                                DeepInheritance=None, IncludeQualifiers=None,
@@ -1982,7 +1978,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     def OpenReferenceInstancePaths(self, InstanceName, ResultClass=None,
                                    Role=None,
                                    FilterQueryLanguage=None, FilterQuery=None,
@@ -2191,7 +2186,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(result_tuple, None)
                 self.operation_recorder.record_staged()
             return result_tuple
-
 
     def OpenReferenceInstances(self, InstanceName, ResultClass=None,
                                Role=None, IncludeQualifiers=None,
@@ -2407,7 +2401,7 @@ class WBEMConnection(object):
 
         try:
 
-            #TODO ks 6/16 Limit to instance name. No classname allowed.
+            # TODO ks 6/16 Limit to instance name. No classname allowed.
             namespace = self._iparam_namespace_from_objectname(InstanceName)
             instancename = self._iparam_instancename(InstanceName)
 
@@ -2441,7 +2435,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(result_tuple, None)
                 self.operation_recorder.record_staged()
             return result_tuple
-
 
     def OpenAssociatorInstancePaths(self, InstanceName, AssocClass=None,
                                     ResultClass=None, Role=None,
@@ -2671,7 +2664,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(result_tuple, None)
                 self.operation_recorder.record_staged()
             return result_tuple
-
 
     def OpenAssociatorInstances(self, InstanceName, AssocClass=None,
                                 ResultClass=None, Role=None, ResultRole=None,
@@ -2942,7 +2934,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     def OpenQueryInstances(self, FilterQueryLanguage, FilterQuery,
                            namespace=None, ReturnQueryResultClass=None,
                            OperationTimeout=None, ContinueOnError=None,
@@ -3134,7 +3125,7 @@ class WBEMConnection(object):
             insts, eos, enum_ctxt = self._get_rslt_params(result, namespace)
 
             query_result_class = _GetQueryRsltClass(result) if \
-                                 ReturnQueryResultClass else None
+                ReturnQueryResultClass else None
 
             result_tuple = pull_query_result_tuple(insts, eos, enum_ctxt,
                                                    query_result_class)
@@ -3149,7 +3140,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(result_tuple, None)
                 self.operation_recorder.record_staged()
             return result_tuple
-
 
     def PullInstancesWithPath(self, context, MaxObjectCount,
                               **extra):
@@ -3288,7 +3278,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
 
@@ -3421,7 +3410,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     def PullInstances(self, context, MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
         """
@@ -3550,7 +3538,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     def CloseEnumeration(self, context, **extra):
         # pylint: disable=invalid-name
         """
@@ -3613,7 +3600,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(None, None)
                 self.operation_recorder.record_staged()
             return
-
 
     def GetInstance(self, InstanceName, LocalOnly=None, IncludeQualifiers=None,
                     IncludeClassOrigin=None, PropertyList=None, **extra):
@@ -3748,7 +3734,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return instance
 
-
     def ModifyInstance(self, ModifiedInstance, IncludeQualifiers=None,
                        PropertyList=None, **extra):
         # pylint: disable=invalid-name,line-too-long
@@ -3872,7 +3857,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return
 
-
     def CreateInstance(self, NewInstance, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
@@ -3975,7 +3959,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return instancename
 
-
     def DeleteInstance(self, InstanceName, **extra):
         # pylint: disable=invalid-name
         """
@@ -4037,7 +4020,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(None, None)
                 self.operation_recorder.record_staged()
             return
-
 
     #
     # Association operations
@@ -4189,7 +4171,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(objects, None)
                 self.operation_recorder.record_staged()
             return objects
-
 
     def Associators(self, ObjectName, AssocClass=None, ResultClass=None,
                     Role=None, ResultRole=None, IncludeQualifiers=None,
@@ -4387,7 +4368,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return objects
 
-
     def ReferenceNames(self, ObjectName, ResultClass=None, Role=None, **extra):
         # pylint: disable=invalid-name, line-too-long
         """
@@ -4516,7 +4496,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(objects, None)
                 self.operation_recorder.record_staged()
             return objects
-
 
     def References(self, ObjectName, ResultClass=None, Role=None,
                    IncludeQualifiers=None, IncludeClassOrigin=None,
@@ -4696,7 +4675,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return objects
 
-
     #
     # Method invocation operation
     #
@@ -4849,7 +4827,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return result_tuple
 
-
     #
     # Query operations
     #
@@ -4943,7 +4920,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(instances, None)
                 self.operation_recorder.record_staged()
             return instances
-
 
     #
     # Class operations
@@ -5055,7 +5031,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(classnames, None)
                 self.operation_recorder.record_staged()
             return classnames
-
 
     def EnumerateClasses(self, namespace=None, ClassName=None,
                          DeepInheritance=None, LocalOnly=None,
@@ -5202,7 +5177,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return classes
 
-
     def GetClass(self, ClassName, namespace=None, LocalOnly=None,
                  IncludeQualifiers=None, IncludeClassOrigin=None,
                  PropertyList=None, **extra):
@@ -5329,7 +5303,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return klass
 
-
     def ModifyClass(self, ModifiedClass, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
@@ -5405,7 +5378,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return
 
-
     def CreateClass(self, NewClass, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
@@ -5480,7 +5452,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return
 
-
     def DeleteClass(self, ClassName, namespace=None, **extra):
         # pylint: disable=invalid-name,line-too-long
         """
@@ -5552,7 +5523,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(None, None)
                 self.operation_recorder.record_staged()
             return
-
 
     #
     # Qualifier operations
@@ -5628,7 +5598,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(qualifiers, None)
                 self.operation_recorder.record_staged()
             return qualifiers
-
 
     def GetQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -5706,7 +5675,6 @@ class WBEMConnection(object):
                 self.operation_recorder.record_staged()
             return qualifiername
 
-
     def SetQualifier(self, QualifierDeclaration, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
@@ -5773,7 +5741,6 @@ class WBEMConnection(object):
                 self.operation_recorder.stage_pywbem_result(None, None)
                 self.operation_recorder.record_staged()
             return
-
 
     def DeleteQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -5889,6 +5856,7 @@ def is_subclass(ch, ns, super_class, sub):
                                IncludeClassOrigin=False)
     return False
 
+
 def PegasusUDSConnection(creds=None, **kwargs):
     """ Pegasus specific Unix Domain Socket call. Specific because
         of the location of the file name
@@ -5898,6 +5866,7 @@ def PegasusUDSConnection(creds=None, **kwargs):
     return WBEMConnection('/var/run/tog-pegasus/cimxml.socket', creds,
                           **kwargs)
 
+
 def SFCBUDSConnection(creds=None, **kwargs):
     """ SFCB specific Unix Domain Socket call. Specific because
         of the location of the file name
@@ -5905,6 +5874,7 @@ def SFCBUDSConnection(creds=None, **kwargs):
 
     # pylint: disable=invalid-name
     return WBEMConnection('/tmp/sfcbHttpSocket', creds, **kwargs)
+
 
 def OpenWBEMUDSConnection(creds=None, **kwargs):
     """ Pegasus specific Unix Domain Socket call. Specific because

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -78,7 +78,7 @@ import six
 from . import config
 
 if six.PY2:
-    _Longint = long
+    _Longint = long  # noqa: F821
 else:
     _Longint = int
 
@@ -87,7 +87,8 @@ __all__ = ['MinutesFromUTC', 'CIMType', 'CIMDateTime', 'CIMInt', 'Uint8',
            'Sint8', 'Uint16', 'Sint16', 'Uint32', 'Sint32', 'Uint64', 'Sint64',
            'CIMFloat', 'Real32', 'Real64']
 
-class _CIMComparisonMixin(object): # pylint: disable=too-few-public-methods
+
+class _CIMComparisonMixin(object):  # pylint: disable=too-few-public-methods
     """Mixin class providing default implementations for rich comparison
     operators.
 
@@ -210,7 +211,7 @@ class MinutesFromUTC(tzinfo):
                                                   pywbem.MinutesFromUTC(-300))
     """
 
-    def __init__(self, offset): # pylint: disable=super-init-not-called
+    def __init__(self, offset):  # pylint: disable=super-init-not-called
         """
         Parameters:
 
@@ -224,7 +225,7 @@ class MinutesFromUTC(tzinfo):
         """
         self.__offset = timedelta(minutes=offset)
 
-    def utcoffset(self, dt): # pylint: disable=unused-argument
+    def utcoffset(self, dt):  # pylint: disable=unused-argument
         """
         An implementation of the corresponding base class method
         (see :meth:`py:datetime.tzinfo.utcoffset` for its description),
@@ -239,7 +240,7 @@ class MinutesFromUTC(tzinfo):
         """
         return self.__offset
 
-    def dst(self, dt): # pylint: disable=unused-argument
+    def dst(self, dt):  # pylint: disable=unused-argument
         """
         An implementation of the corresponding base class method,
         (see :meth:`py:datetime.tzinfo.dst` for its description),
@@ -255,7 +256,7 @@ class MinutesFromUTC(tzinfo):
         return timedelta(0)
 
 
-class CIMType(object):       # pylint: disable=too-few-public-methods
+class CIMType(object):  # pylint: disable=too-few-public-methods
     """Base type for all CIM data types defined in this package."""
 
     # Note: __str__() is not needed; the inherited method is used,
@@ -300,7 +301,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
               interval.
             * Another :class:`~pywbem.CIMDateTime` object will be copied.
         """
-        from .cim_obj import _ensure_unicode # defer due to cyclic deps.
+        from .cim_obj import _ensure_unicode  # defer due to cyclic deps.
         self.__timedelta = None
         self.__datetime = None
         dtarg = _ensure_unicode(dtarg)
@@ -488,8 +489,8 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
             minute = (self.timedelta.seconds - hour * 3600) // 60
             second = self.timedelta.seconds - hour * 3600 - minute * 60
             return '%08d%02d%02d%02d.%06d:000' % \
-                    (self.timedelta.days, hour, minute, second,
-                     self.timedelta.microseconds)
+                (self.timedelta.days, hour, minute, second,
+                 self.timedelta.microseconds)
         else:
             offset = self.minutes_from_utc
             sign = '+'
@@ -497,10 +498,10 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
                 sign = '-'
                 offset = -offset
             return '%d%02d%02d%02d%02d%02d.%06d%s%03d' % \
-                   (self.datetime.year, self.datetime.month,
-                    self.datetime.day, self.datetime.hour,
-                    self.datetime.minute, self.datetime.second,
-                    self.datetime.microsecond, sign, offset)
+                (self.datetime.year, self.datetime.month,
+                 self.datetime.day, self.datetime.hour,
+                 self.datetime.minute, self.datetime.second,
+                 self.datetime.microsecond, sign, offset)
 
     def __repr__(self):
         """Return a string representation suitable for debugging."""
@@ -523,7 +524,9 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         return (cmpitem(self.datetime, other.datetime) or
                 cmpitem(self.timedelta, other.timedelta))
 
+
 # CIM integer types
+
 
 class CIMInt(CIMType, _Longint):
     """
@@ -592,6 +595,7 @@ class CIMInt(CIMType, _Longint):
                (self.__class__.__name__, self.cimtype, self.minvalue,
                 self.maxvalue, self)
 
+
 class Uint8(CIMInt):
     """
     A value of CIM data type uint8. Derived from :class:`~pywbem.CIMInt`.
@@ -601,6 +605,7 @@ class Uint8(CIMInt):
     cimtype = 'uint8'
     minvalue = 0
     maxvalue = 2**8 - 1
+
 
 class Sint8(CIMInt):
     """
@@ -612,6 +617,7 @@ class Sint8(CIMInt):
     minvalue = -2 ** (8 - 1)
     maxvalue = 2 ** (8 - 1) - 1
 
+
 class Uint16(CIMInt):
     """
     A value of CIM data type uint16. Derived from :class:`~pywbem.CIMInt`.
@@ -621,6 +627,7 @@ class Uint16(CIMInt):
     cimtype = 'uint16'
     minvalue = 0
     maxvalue = 2**16 - 1
+
 
 class Sint16(CIMInt):
     """
@@ -632,6 +639,7 @@ class Sint16(CIMInt):
     minvalue = -2 ** (16 - 1)
     maxvalue = 2 ** (16 - 1) - 1
 
+
 class Uint32(CIMInt):
     """
     A value of CIM data type uint32. Derived from :class:`~pywbem.CIMInt`.
@@ -641,6 +649,7 @@ class Uint32(CIMInt):
     cimtype = 'uint32'
     minvalue = 0
     maxvalue = 2 ** 32 - 1
+
 
 class Sint32(CIMInt):
     """
@@ -652,6 +661,7 @@ class Sint32(CIMInt):
     minvalue = -2 ** (32 - 1)
     maxvalue = 2 ** (32 - 1) - 1
 
+
 class Uint64(CIMInt):
     """
     A value of CIM data type uint64. Derived from :class:`~pywbem.CIMInt`.
@@ -661,6 +671,7 @@ class Uint64(CIMInt):
     cimtype = 'uint64'
     minvalue = 0
     maxvalue = 2 ** 64 - 1
+
 
 class Sint64(CIMInt):
     """
@@ -672,12 +683,15 @@ class Sint64(CIMInt):
     minvalue = -2 ** (64 - 1)
     maxvalue = 2 ** (64 - 1) - 1
 
+
 # CIM float types
+
 
 class CIMFloat(CIMType, float):
     """
     Base type for real (floating point) CIM data types.
     """
+
 
 class Real32(CIMFloat):
     """
@@ -685,11 +699,13 @@ class Real32(CIMFloat):
     """
     cimtype = 'real32'
 
+
 class Real64(CIMFloat):
     """
     A value of CIM data type real64. Derived from :class:`~pywbem.CIMFloat`.
     """
     cimtype = 'real64'
+
 
 def cimtype(obj):
     """
@@ -728,10 +744,11 @@ def cimtype(obj):
     raise TypeError("Type %s of this object is not a CIM data type: %r" %
                     (type(obj), obj))
 
+
 _TYPE_FROM_NAME = {
     'boolean': bool,
-    'string': six.text_type, # return the preferred type
-    'char16': six.text_type, # return the preferred type
+    'string': six.text_type,  # return the preferred type
+    'char16': six.text_type,  # return the preferred type
     'datetime': CIMDateTime,
     # 'reference' covered at run time
     'uint8': Uint8,
@@ -745,6 +762,7 @@ _TYPE_FROM_NAME = {
     'real32': Real32,
     'real64': Real64,
 }
+
 
 def type_from_name(type_name):
     """
@@ -780,6 +798,7 @@ def type_from_name(type_name):
     except KeyError:
         raise ValueError("Unknown CIM data type name: %r" % type_name)
     return type_obj
+
 
 def atomic_to_cim_xml(obj):
     """
@@ -820,5 +839,5 @@ def atomic_to_cim_xml(obj):
         return u'%.16E' % obj
     elif isinstance(obj, six.string_types):
         return _ensure_unicode(obj)
-    else: # e.g. int
+    else:  # e.g. int
         return _convert_unicode(obj)

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -60,6 +60,7 @@ import six
 
 __all__ = []
 
+
 def _text(data):
     """Return a minidom text node with the specified data string.
 
@@ -87,6 +88,7 @@ def _text(data):
 # You only need to set this to True if the WBEM server has no support for
 # XML-based escaping, but does have support for CDATA-based escaping.
 _CDATA_ESCAPING = False
+
 
 def _pcdata_nodes(pcdata):
     """Return a list of minidom nodes with the properly escaped ``pcdata``
@@ -162,11 +164,12 @@ def _pcdata_nodes(pcdata):
         # The following automatically uses XML entity references
         # for escaping.
 
-        node = _text(pcdata) # pylint: disable=redefined-variable-type
+        node = _text(pcdata)  # pylint: disable=redefined-variable-type
 
         nodelist.append(node)
 
     return nodelist
+
 
 class CIMElement(Element):
     """A base class that has a few bonus helper methods."""
@@ -194,6 +197,7 @@ class CIMElement(Element):
 
 # Root element
 
+
 class CIM(CIMElement):
     """
     The CIM element is the root element of every XML Document that is
@@ -220,6 +224,7 @@ class CIM(CIMElement):
 
 # Object declaration elements
 
+
 class DECLARATION(CIMElement):
     """
     The DECLARATION element defines a set of one or more declarations
@@ -235,6 +240,7 @@ class DECLARATION(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'DECLARATION')
         self.appendChildren(data)
+
 
 class DECLGROUP(CIMElement):
     """
@@ -253,6 +259,7 @@ class DECLGROUP(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'DECLGROUP')
         self.appendChildren(data)
+
 
 class DECLGROUP_WITHNAME(CIMElement):
     # pylint: disable=invalid-name
@@ -273,6 +280,7 @@ class DECLGROUP_WITHNAME(CIMElement):
         Element.__init__(self, 'DECLGROUP.WITHNAME')
         self.appendChildren(data)
 
+
 class DECLGROUP_WITHPATH(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -289,6 +297,7 @@ class DECLGROUP_WITHPATH(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'DECLGROUP.WITHPATH')
         self.appendChildren(data)
+
 
 class QUALIFIER_DECLARATION(CIMElement):
     # pylint: disable=invalid-name
@@ -335,8 +344,9 @@ class QUALIFIER_DECLARATION(CIMElement):
             if is_array:
                 xval = VALUE_ARRAY(value)
             else:
-                xval = VALUE(value) # pylint: disable=redefined-variable-type
+                xval = VALUE(value)  # pylint: disable=redefined-variable-type
             self.appendOptionalChild(xval)
+
 
 class SCOPE(CIMElement):
     """
@@ -374,6 +384,7 @@ class SCOPE(CIMElement):
 
 # Object value elements
 
+
 class VALUE(CIMElement):
     """
     The VALUE element is used to define a single (non-array and
@@ -390,6 +401,7 @@ class VALUE(CIMElement):
         if pcdata is not None:
             self.appendChildren(_pcdata_nodes(pcdata))
 
+
 class VALUE_ARRAY(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -404,6 +416,7 @@ class VALUE_ARRAY(CIMElement):
     def __init__(self, values):
         Element.__init__(self, 'VALUE.ARRAY')
         self.appendChildren(values)
+
 
 class VALUE_REFERENCE(CIMElement):
     # pylint: disable=invalid-name
@@ -422,6 +435,7 @@ class VALUE_REFERENCE(CIMElement):
         Element.__init__(self, 'VALUE.REFERENCE')
         self.appendChild(data)
 
+
 class VALUE_REFARRAY(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -436,6 +450,7 @@ class VALUE_REFARRAY(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'VALUE.REFARRAY')
         self.appendChildren(data)
+
 
 class VALUE_OBJECT(CIMElement):
     # pylint: disable=invalid-name
@@ -452,6 +467,7 @@ class VALUE_OBJECT(CIMElement):
         Element.__init__(self, 'VALUE.OBJECT')
         self.appendChild(data)
 
+
 class VALUE_NAMEDINSTANCE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -467,6 +483,7 @@ class VALUE_NAMEDINSTANCE(CIMElement):
         Element.__init__(self, 'VALUE.NAMEDINSTANCE')
         self.appendChild(instancename)
         self.appendChild(instance)
+
 
 class VALUE_NAMEDOBJECT(CIMElement):
     # pylint: disable=invalid-name
@@ -485,6 +502,7 @@ class VALUE_NAMEDOBJECT(CIMElement):
             self.appendChildren(data)
         else:
             self.appendChild(data)
+
 
 class VALUE_OBJECTWITHLOCALPATH(CIMElement):
     # pylint: disable=invalid-name
@@ -505,6 +523,7 @@ class VALUE_OBJECTWITHLOCALPATH(CIMElement):
         self.appendChild(data1)
         self.appendChild(data2)
 
+
 class VALUE_OBJECTWITHPATH(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -524,6 +543,7 @@ class VALUE_OBJECTWITHPATH(CIMElement):
         self.appendChild(data1)
         self.appendChild(data2)
 
+
 class VALUE_NULL(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -539,6 +559,7 @@ class VALUE_NULL(CIMElement):
         Element.__init__(self, 'VALUE.NULL')
 
 # Object naming and location elements
+
 
 class NAMESPACEPATH(CIMElement):
     # pylint: disable=invalid-name
@@ -556,6 +577,7 @@ class NAMESPACEPATH(CIMElement):
         self.appendChild(host)
         self.appendChild(localnamespacepath)
 
+
 class LOCALNAMESPACEPATH(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -571,6 +593,7 @@ class LOCALNAMESPACEPATH(CIMElement):
     def __init__(self, namespaces):
         Element.__init__(self, 'LOCALNAMESPACEPATH')
         self.appendChildren(namespaces)
+
 
 class HOST(CIMElement):
     # pylint: disable=invalid-name
@@ -588,6 +611,7 @@ class HOST(CIMElement):
         Element.__init__(self, 'HOST')
         self.appendChild(_text(pcdata))
 
+
 class NAMESPACE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -604,6 +628,7 @@ class NAMESPACE(CIMElement):
     def __init__(self, name):
         Element.__init__(self, 'NAMESPACE')
         self.setName(name)
+
 
 class CLASSPATH(CIMElement):
     # pylint: disable=invalid-name
@@ -638,6 +663,7 @@ class LOCALCLASSPATH(CIMElement):
         self.appendChild(localnamespacepath)
         self.appendChild(classname)
 
+
 class CLASSNAME(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -653,6 +679,7 @@ class CLASSNAME(CIMElement):
     def __init__(self, classname):
         Element.__init__(self, 'CLASSNAME')
         self.setName(classname)
+
 
 class INSTANCEPATH(CIMElement):
     # pylint: disable=invalid-name
@@ -671,6 +698,7 @@ class INSTANCEPATH(CIMElement):
         self.appendChild(namespacepath)
         self.appendChild(instancename)
 
+
 class LOCALINSTANCEPATH(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -687,6 +715,7 @@ class LOCALINSTANCEPATH(CIMElement):
         Element.__init__(self, 'LOCALINSTANCEPATH')
         self.appendChild(localpath)
         self.appendChild(instancename)
+
 
 class INSTANCENAME(CIMElement):
     # pylint: disable=invalid-name
@@ -723,6 +752,7 @@ class INSTANCENAME(CIMElement):
             else:
                 self.appendChild(data)
 
+
 class OBJECTPATH(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -737,6 +767,7 @@ class OBJECTPATH(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'OBJECTPATH')
         self.appendChild(data)
+
 
 class KEYBINDING(CIMElement):
     # pylint: disable=invalid-name
@@ -754,6 +785,7 @@ class KEYBINDING(CIMElement):
         Element.__init__(self, 'KEYBINDING')
         self.setName(name)
         self.appendChild(data)
+
 
 class KEYVALUE(CIMElement):
     # pylint: disable=invalid-name
@@ -783,7 +815,9 @@ class KEYVALUE(CIMElement):
         if data is not None:
             self.appendChild(_text(data))
 
+
 # Object definition elements
+
 
 class CLASS(CIMElement):
     # pylint: disable=invalid-name
@@ -813,6 +847,7 @@ class CLASS(CIMElement):
             children.extend(methods)
         self.appendChildren(children)
 
+
 class INSTANCE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -837,6 +872,7 @@ class INSTANCE(CIMElement):
         if properties:
             children.extend(properties)
         self.appendChildren(children)
+
 
 class QUALIFIER(CIMElement):
     # pylint: disable=invalid-name
@@ -885,6 +921,7 @@ class QUALIFIER(CIMElement):
         self.setOptionalAttribute('xml:lang', xml_lang)
 
         self.appendOptionalChild(value)
+
 
 class PROPERTY(CIMElement):
     # pylint: disable=invalid-name
@@ -948,6 +985,7 @@ class PROPERTY(CIMElement):
             self.appendChildren(qualifiers)
         self.appendOptionalChild(value)
 
+
 class PROPERTY_ARRAY(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -998,6 +1036,7 @@ class PROPERTY_ARRAY(CIMElement):
             self.appendChildren(qualifiers)
         self.appendOptionalChild(value_array)
 
+
 class PROPERTY_REFERENCE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1033,6 +1072,7 @@ class PROPERTY_REFERENCE(CIMElement):
         if qualifiers:
             self.appendChildren(qualifiers)
         self.appendOptionalChild(value_reference)
+
 
 class METHOD(CIMElement):
     # pylint: disable=invalid-name
@@ -1074,6 +1114,7 @@ class METHOD(CIMElement):
             children.extend(parameters)
         self.appendChildren(children)
 
+
 class PARAMETER(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1096,6 +1137,7 @@ class PARAMETER(CIMElement):
         if qualifiers:
             self.appendChildren(qualifiers)
 
+
 class PARAMETER_REFERENCE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1117,6 +1159,7 @@ class PARAMETER_REFERENCE(CIMElement):
         self.setOptionalAttribute('REFERENCECLASS', reference_class)
         if qualifiers:
             self.appendChildren(qualifiers)
+
 
 class PARAMETER_ARRAY(CIMElement):
     # pylint: disable=invalid-name
@@ -1142,6 +1185,7 @@ class PARAMETER_ARRAY(CIMElement):
             self.setAttribute('ARRAYSIZE', str(array_size))
         if qualifiers:
             self.appendChildren(qualifiers)
+
 
 class PARAMETER_REFARRAY(CIMElement):
     # pylint: disable=invalid-name
@@ -1169,7 +1213,8 @@ class PARAMETER_REFARRAY(CIMElement):
         if qualifiers:
             self.appendChildren(qualifiers)
 
-class TABLECELL_DECLARATION(CIMElement): # pylint: disable=invalid-name
+
+class TABLECELL_DECLARATION(CIMElement):  # pylint: disable=invalid-name
     # pylint: disable=invalid-name
     """
     The TABLECELL.DECLARATION element describes a TABLECELL that is
@@ -1187,6 +1232,7 @@ class TABLECELL_DECLARATION(CIMElement): # pylint: disable=invalid-name
             SORTPOS          CDATA       #IMPLIED
             SORTDIR        (ASC|DESC)    #IMPLIED>
     """
+
 
 class TABLECELL_REFERENCE(CIMElement):
     # pylint: disable=invalid-name
@@ -1207,6 +1253,7 @@ class TABLECELL_REFERENCE(CIMElement):
             SORTDIR         (ASC|DESC)   #IMPLIED>
      """
 
+
 class TABLEROW_DECLARATION(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1219,6 +1266,7 @@ class TABLEROW_DECLARATION(CIMElement):
                                         | TABLECELL.REFERENCE)*>
     """
 
+
 class TABLE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1230,6 +1278,7 @@ class TABLE(CIMElement):
 
         <!ELEMENT TABLE(TABLEROW.DECLARATION,(TABLEROW)*)>
     """
+
 
 class TABLEROW(CIMElement):
     # pylint: disable=invalid-name
@@ -1244,7 +1293,9 @@ class TABLEROW(CIMElement):
                             VALUE.REFARRAY | VALUE.NULL)*>
     """
 
+
 # Message elements
+
 
 class MESSAGE(CIMElement):
     # pylint: disable=invalid-name
@@ -1269,6 +1320,7 @@ class MESSAGE(CIMElement):
         self.setAttribute('PROTOCOLVERSION', protocol_version)
         self.appendChild(data)
 
+
 class MULTIREQ(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1284,6 +1336,7 @@ class MULTIREQ(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'MULTIREQ')
         self.appendChildren(data)
+
 
 class MULTIEXPREQ(CIMElement):
     # pylint: disable=invalid-name
@@ -1301,6 +1354,7 @@ class MULTIEXPREQ(CIMElement):
         Element.__init__(self, 'MULTIEXPREQ')
         self.appendChildren(data)
 
+
 class SIMPLEREQ(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1317,6 +1371,7 @@ class SIMPLEREQ(CIMElement):
         Element.__init__(self, 'SIMPLEREQ')
         self.appendChild(data)
 
+
 class SIMPLEEXPREQ(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1331,6 +1386,7 @@ class SIMPLEEXPREQ(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'SIMPLEEXPREQ')
         self.appendChild(data)
+
 
 class IMETHODCALL(CIMElement):
     # pylint: disable=invalid-name
@@ -1359,6 +1415,7 @@ class IMETHODCALL(CIMElement):
             self.appendChildren(iparamvalues)
         self.appendOptionalChild(responsedestination)
 
+
 class METHODCALL(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1386,6 +1443,7 @@ class METHODCALL(CIMElement):
             self.appendChildren(paramvalues)
         self.appendOptionalChild(responsedestination)
 
+
 class EXPMETHODCALL(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1405,6 +1463,7 @@ class EXPMETHODCALL(CIMElement):
         self.setName(name)
         if params:
             self.appendChildren(params)
+
 
 class PARAMVALUE(CIMElement):
     # pylint: disable=invalid-name
@@ -1433,6 +1492,7 @@ class PARAMVALUE(CIMElement):
         # See the note on EmbeddedObject in PROPERTY().
         self.appendOptionalChild(data)
 
+
 class IPARAMVALUE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1454,6 +1514,7 @@ class IPARAMVALUE(CIMElement):
         Element.__init__(self, 'IPARAMVALUE')
         self.setName(name)
         self.appendOptionalChild(data)
+
 
 class EXPPARAMVALUE(CIMElement):
     # pylint: disable=invalid-name
@@ -1477,6 +1538,7 @@ class EXPPARAMVALUE(CIMElement):
         self.setOptionalAttribute('PARAMTYPE', param_type)
         self.appendOptionalChild(data)
 
+
 class MULTIRSP(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1493,6 +1555,7 @@ class MULTIRSP(CIMElement):
         Element.__init__(self, 'MULTIRSP')
         self.appendChildren(data)
 
+
 class MULTIEXPRSP(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1508,6 +1571,7 @@ class MULTIEXPRSP(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'MULTIEXPRSP')
         self.appendChildren(data)
+
 
 class SIMPLERSP(CIMElement):
     # pylint: disable=invalid-name
@@ -1526,6 +1590,7 @@ class SIMPLERSP(CIMElement):
         Element.__init__(self, 'SIMPLERSP')
         self.appendChild(data)
 
+
 class SIMPLEEXPRSP(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1541,6 +1606,7 @@ class SIMPLEEXPRSP(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'SIMPLEEXPRSP')
         self.appendChild(data)
+
 
 class METHODRESPONSE(CIMElement):
     # pylint: disable=invalid-name
@@ -1567,6 +1633,7 @@ class METHODRESPONSE(CIMElement):
             else:
                 self.appendChild(data)
 
+
 class EXPMETHODRESPONSE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1587,6 +1654,7 @@ class EXPMETHODRESPONSE(CIMElement):
         self.setName(name)
         self.appendOptionalChild(data)
 
+
 class IMETHODRESPONSE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1606,6 +1674,7 @@ class IMETHODRESPONSE(CIMElement):
         Element.__init__(self, 'IMETHODRESPONSE')
         self.setName(name)
         self.appendOptionalChild(data)
+
 
 class ERROR(CIMElement):
     # pylint: disable=invalid-name
@@ -1630,6 +1699,7 @@ class ERROR(CIMElement):
         if instances:
             self.appendChildren(instances)
 
+
 class RETURNVALUE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1651,6 +1721,7 @@ class RETURNVALUE(CIMElement):
         # See the note on EmbeddedObject in PROPERTY().
         self.appendOptionalChild(data)
 
+
 class IRETURNVALUE(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1671,6 +1742,7 @@ class IRETURNVALUE(CIMElement):
         Element.__init__(self, 'IRETURNVALUE')
         self.appendOptionalChild(data)
 
+
 class RESPONSEDESTINATION(CIMElement):
     # pylint: disable=invalid-name
     """
@@ -1685,6 +1757,7 @@ class RESPONSEDESTINATION(CIMElement):
     def __init__(self, data):
         Element.__init__(self, 'RESPONSEDESTINATON')
         self.appendChild(data)
+
 
 class SIMPLEREQACK(CIMElement):
     # pylint: disable=invalid-name

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -50,4 +50,3 @@ __all__ = ['ENFORCE_INTEGER_RANGE']
 #:   out of range works in pywbem. Note that a WBEM server may or may not
 #:   reject such out-of-range values.
 ENFORCE_INTEGER_RANGE = True
-

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -26,9 +26,11 @@ from .cim_constants import _statuscode2name, _statuscode2string
 __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
            'VersionError', 'ParseError', 'CIMError']
 
+
 class Error(Exception):
     """Base class for pywbem specific exceptions."""
     pass
+
 
 class ConnectionError(Error):
     """This exception indicates a problem with the connection to the WBEM
@@ -36,11 +38,13 @@ class ConnectionError(Error):
     :exc:`~pywbem.Error`."""
     pass
 
+
 class AuthError(Error):
     """This exception indicates an authentication error with the WBEM server,
     either during TLS/SSL handshake, or during HTTP-level authentication.
     Derived from :exc:`~pywbem.Error`."""
     pass
+
 
 class HTTPError(Error):
     """
@@ -123,10 +127,12 @@ class HTTPError(Error):
             ret_str += ", %s: %s" % (key, self.cimdetails[key])
         return ret_str
 
+
 class TimeoutError(Error):
     """This exception indicates that the client timed out waiting for the WBEM
     server. Derived from :exc:`~pywbem.Error`."""
     pass
+
 
 class ParseError(Error):
     """This exception indicates a parsing error with the CIM-XML response
@@ -134,11 +140,13 @@ class ParseError(Error):
     listener. Derived from :exc:`~pywbem.Error`."""
     pass
 
+
 class VersionError(Error):
     """This exception indicates an unsupported CIM, DTD or protocol version
     with the CIM-XML response returned by the WBEM server, or in the CIM-XML
     request sent by the WBEM listener. Derived from :exc:`~pywbem.Error`."""
     pass
+
 
 class CIMError(Error):
     """
@@ -222,4 +230,3 @@ class CIMError(Error):
 
     def __str__(self):
         return "%s: %s" % (self.status_code, self.status_description)
-

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -65,16 +65,14 @@ from abc import ABCMeta, abstractmethod
 import six
 from ply import yacc, lex
 
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, \
-                     CIMProperty, CIMMethod, CIMParameter, \
-                     CIMQualifier, CIMQualifierDeclaration, NocaseDict, \
-                     tocimobj
+from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMProperty, \
+    CIMMethod, CIMParameter, CIMQualifier, CIMQualifierDeclaration, \
+    NocaseDict, tocimobj
 from .cim_operations import WBEMConnection
 from .cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
-                     CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_NAMESPACE, \
-                     CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
-                     CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, \
-                     _statuscode2string
+    CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_NAMESPACE, \
+    CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
+    CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, _statuscode2string
 from .exceptions import Error, CIMError
 
 __all__ = ['MOFParseError', 'MOFWBEMConnection', 'MOFCompiler',
@@ -93,7 +91,7 @@ _lextab = 'moflextab'
 # Directory for _tabmodule and _lextab
 _tabdir = os.path.dirname(os.path.abspath(__file__))
 
-#------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # IMPORTANT NOTE:
 #
@@ -114,7 +112,7 @@ _tabdir = os.path.dirname(os.path.abspath(__file__))
 #
 # The YACC parser functions are all named "p_*".
 #
-#------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 reserved = {
     'any': 'ANY',
@@ -198,10 +196,12 @@ utf8Char = r'(%s)|(%s)|(%s)|(%s)|(%s)|(%s)|(%s)|(%s)' % \
            (utf8_2, utf8_3_1, utf8_3_2, utf8_3_3, utf8_3_4, utf8_4_1,
             utf8_4_2, utf8_4_3)
 
+
 # pylint: disable=unused-argument
 def t_COMMENT(t):
     r'//.*'
     return  # discard token
+
 
 def t_MCOMMENT(t):
     r'/\*(.|\n)*?\*/'
@@ -211,13 +211,16 @@ def t_MCOMMENT(t):
 # These simple tokens must also be defined as functions, in order to control
 # the order of evaluation.
 
+
 def t_floatValue(t):
     r'[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?'
     return t
 
+
 def t_hexValue(t):
     r'[+-]?0[xX][0-9a-fA-F]+'
     return t
+
 
 def t_binaryValue(t):
     r'[+-]?[0-9]+[bB]'
@@ -237,6 +240,7 @@ def t_binaryValue(t):
         t.lexer.skip(len(t.value))
     return t
 
+
 def t_octalValue(t):
     r'[+-]?0[0-9]+'
     # We must match [0-9], and then check the validity of the octal number.
@@ -255,6 +259,7 @@ def t_octalValue(t):
         t.lexer.skip(len(t.value))
     return t
 
+
 # Matching for decimal must be at the end of the other numerics because of
 # the 0. If not at the end, 0 would match at the begin of e.g. an octal value.
 def t_decimalValue(t):
@@ -269,11 +274,13 @@ sChar = r'[^"\\\n\r]|(%s)' % escapeSequence
 
 charvalue_re = r"'(%s)'" % cChar
 
+
 @lex.TOKEN(charvalue_re)
 def t_charValue(t):
     return t
 
 stringvalue_re = r'"(%s)*"' % sChar
+
 
 @lex.TOKEN(stringvalue_re)
 def t_stringValue(t):
@@ -281,10 +288,12 @@ def t_stringValue(t):
 
 identifier_re = r'([a-zA-Z_]|(%s))([0-9a-zA-Z_]|(%s))*' % (utf8Char, utf8Char)
 
+
 @lex.TOKEN(identifier_re)
 def t_IDENTIFIER(t):
     t.type = reserved.get(t.value.lower(), 'IDENTIFIER')
     return t
+
 
 # Define a rule so we can track line numbers
 def t_newline(t):
@@ -382,8 +391,7 @@ class MOFParseError(Error):
         ret_str = 'MOFParseError: '
         if self.lineno is not None:
             ret_str += '%s:%s: %smsg=%s\n%s' % \
-                         (self.file, self.lineno, self.column, self.msg,
-                          self.context)
+                (self.file, self.lineno, self.column, self.msg, self.context)
         else:
             ret_str += '%s' % self.msg
         return ret_str
@@ -426,11 +434,13 @@ def p_error(p):
 def p_mofSpecification(p):
     """mofSpecification : mofProductionList"""
 
+
 # pylint: disable=unused-argument
 def p_mofProductionList(p):
     """mofProductionList : empty
                          | mofProductionList mofProduction
                          """
+
 
 # pylint: disable=unused-argument
 def p_mofProduction(p):
@@ -502,15 +512,13 @@ def _create_ns(p, handle, ns):
         handle.CreateInstance(inst)
 
 
-
-
 def p_mp_createClass(p):
     """mp_createClass : classDeclaration
                       | assocDeclaration
                       | indicDeclaration
                       """
 
-    #pylint: disable=too-many-branches,too-many-statements,too-many-locals
+    # pylint: disable=too-many-branches,too-many-statements,too-many-locals
     ns = p.parser.handle.default_namespace
     cc = p[1]
     try:
@@ -613,6 +621,7 @@ def p_mp_createClass(p):
             p.parser.log('Error Modifying class %s: %s, %s' %
                          (cc.classname, ce.args[0], ce.args[1]))
 
+
 def p_mp_createInstance(p):
     """mp_createInstance : instanceDeclaration"""
     inst = p[1]
@@ -641,6 +650,7 @@ def p_mp_createInstance(p):
         else:
             ce.file_line = (p.parser.file, p.lexer.lineno)
             raise
+
 
 def p_mp_setQualifier(p):
     """mp_setQualifier : qualifierDeclaration"""
@@ -671,6 +681,7 @@ def p_mp_setQualifier(p):
             raise
     p.parser.qualcache[ns][qualdecl.name] = qualdecl
 
+
 def p_compilerDirective(p):
     """compilerDirective : '#' PRAGMA pragmaName '(' pragmaParameter ')'"""
     directive = p[3].lower()
@@ -687,13 +698,16 @@ def p_compilerDirective(p):
 
     p[0] = None
 
+
 def p_pragmaName(p):
     """pragmaName : identifier"""
     p[0] = p[1]
 
+
 def p_pragmaParameter(p):
     """pragmaParameter : stringValue"""
     p[0] = _fixStringValue(p[1])
+
 
 def p_classDeclaration(p):
     # pylint: disable=line-too-long
@@ -705,39 +719,39 @@ def p_classDeclaration(p):
                         | qualifierList CLASS className superClass '{' classFeatureList '}' ';'
                         | qualifierList CLASS className alias '{' classFeatureList '}' ';'
                         | qualifierList CLASS className alias superClass '{' classFeatureList '}' ';'
-                        """
+                        """  # noqa: E501
     superclass = None
     alias = None
     quals = []
     if isinstance(p[1], six.string_types):  # no class qualifiers
         cname = p[2]
-        if p[3][0] == '$': # alias present
+        if p[3][0] == '$':  # alias present
             alias = p[3]
-            if p[4] == '{': # no superclass
+            if p[4] == '{':  # no superclass
                 cfl = p[5]
-            else: # superclass
+            else:  # superclass
                 superclass = p[4]
                 cfl = p[6]
-        else: # no alias
-            if p[3] == '{': # no superclass
+        else:  # no alias
+            if p[3] == '{':  # no superclass
                 cfl = p[4]
-            else: # superclass
+            else:  # superclass
                 superclass = p[3]
                 cfl = p[5]
-    else: # class qualifiers
+    else:  # class qualifiers
         quals = p[1]
         cname = p[3]
-        if p[4][0] == '$': # alias present
+        if p[4][0] == '$':  # alias present
             alias = p[4]
-            if p[5] == '{': # no superclass
+            if p[5] == '{':  # no superclass
                 cfl = p[6]
-            else: # superclass
+            else:  # superclass
                 superclass = p[5]
                 cfl = p[7]
-        else: # no alias
-            if p[4] == '{': # no superclass
+        else:  # no alias
+            if p[4] == '{':  # no superclass
                 cfl = p[5]
-            else: # superclass
+            else:  # superclass
                 superclass = p[4]
                 cfl = p[6]
     # pylint: disable=redefined-variable-type
@@ -755,6 +769,7 @@ def p_classDeclaration(p):
     if alias:
         p.parser.aliases[alias] = p[0]
 
+
 def p_classFeatureList(p):
     """classFeatureList : empty
                         | classFeatureList classFeature
@@ -764,17 +779,19 @@ def p_classFeatureList(p):
     else:
         p[0] = p[1] + [p[2]]
 
+
 def p_assocDeclaration(p):
     # pylint: disable=line-too-long
     """assocDeclaration : '[' ASSOCIATION qualifierListEmpty ']' CLASS className '{' associationFeatureList '}' ';'
                         | '[' ASSOCIATION qualifierListEmpty ']' CLASS className superClass '{' associationFeatureList '}' ';'
                         | '[' ASSOCIATION qualifierListEmpty ']' CLASS className alias '{' associationFeatureList '}' ';'
                         | '[' ASSOCIATION qualifierListEmpty ']' CLASS className alias superClass '{' associationFeatureList '}' ';'
-                        """
+                        """  # noqa: E501
     aqual = CIMQualifier('ASSOCIATION', True, type='boolean')
     # TODO flavor trash.
     quals = [aqual] + p[3]
     p[0] = _assoc_or_indic_decl(quals, p)
+
 
 def p_indicDeclaration(p):
     # pylint: disable=line-too-long
@@ -782,11 +799,12 @@ def p_indicDeclaration(p):
                         | '[' INDICATION qualifierListEmpty ']' CLASS className superClass '{' classFeatureList '}' ';'
                         | '[' INDICATION qualifierListEmpty ']' CLASS className alias '{' classFeatureList '}' ';'
                         | '[' INDICATION qualifierListEmpty ']' CLASS className alias superClass '{' classFeatureList '}' ';'
-                        """
+                        """  # noqa: E501
     iqual = CIMQualifier('INDICATION', True, type='boolean')
     # TODO flavor trash.
     quals = [iqual] + p[3]
     p[0] = _assoc_or_indic_decl(quals, p)
+
 
 def _assoc_or_indic_decl(quals, p):
     """(refer to grammer rules on p_assocDeclaration and p_indicDeclaration)"""
@@ -795,7 +813,7 @@ def _assoc_or_indic_decl(quals, p):
     cname = p[6]
     if p[7] == '{':
         cfl = p[8]
-    elif p[7][0] == '$': # alias
+    elif p[7][0] == '$':  # alias
         alias = p[7]
         if p[8] == '{':
             cfl = p[9]
@@ -820,6 +838,7 @@ def _assoc_or_indic_decl(quals, p):
         p.parser.aliases[alias] = cc
     return cc
 
+
 def p_qualifierListEmpty(p):
     """qualifierListEmpty : empty
                           | qualifierListEmpty ',' qualifier
@@ -828,6 +847,7 @@ def p_qualifierListEmpty(p):
         p[0] = []
     else:
         p[0] = p[1] + [p[3]]
+
 
 def p_associationFeatureList(p):
     """associationFeatureList : empty
@@ -838,21 +858,26 @@ def p_associationFeatureList(p):
     else:
         p[0] = p[1] + [p[2]]
 
+
 def p_className(p):
     """className : identifier"""
     p[0] = p[1]
+
 
 def p_alias(p):
     """alias : AS aliasIdentifier"""
     p[0] = p[2]
 
+
 def p_aliasIdentifier(p):
     """aliasIdentifier : '$' identifier"""
     p[0] = '$%s' % p[2]
 
+
 def p_superClass(p):
     """superClass : ':' className"""
     p[0] = p[2]
+
 
 def p_classFeature(p):
     """classFeature : propertyDeclaration
@@ -861,13 +886,16 @@ def p_classFeature(p):
                     """
     p[0] = p[1]
 
+
 def p_associationFeature(p):
     """associationFeature : classFeature"""
     p[0] = p[1]
 
+
 def p_qualifierList(p):
     """qualifierList : '[' qualifier qualifierListEmpty ']'"""
     p[0] = [p[2]] + p[3]
+
 
 def p_qualifier(p):
     """qualifier : qualifierName
@@ -876,7 +904,7 @@ def p_qualifier(p):
                  | qualifierName qualifierParameter ':' flavorList
                  """
 
-    #pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
     qname = p[1]
     ns = p.parser.handle.default_namespace
     qval = None
@@ -920,11 +948,12 @@ def p_qualifier(p):
         if qualdecl.type == 'boolean':
             qval = True
         else:
-            qval = qualdecl.value # default value
+            qval = qualdecl.value  # default value
     else:
         qval = tocimobj(qualdecl.type, qval)
     p[0] = CIMQualifier(qname, qval, type=qualdecl.type, **flavors)
     # TODO propagated?
+
 
 def p_flavorList(p):
     """flavorList : flavor
@@ -935,6 +964,7 @@ def p_flavorList(p):
     else:
         p[0] = p[1] + [p[2]]
 
+
 def p_qualifierParameter(p):
     """qualifierParameter : '(' constantValue ')'
                           | arrayInitializer
@@ -944,7 +974,8 @@ def p_qualifierParameter(p):
     else:
         p[0] = p[2]
 
-#TODO 8/16 ks Consider complete removed of TOINSTANCE from compiler
+
+# TODO 8/16 ks Consider complete removed of TOINSTANCE from compiler
 def p_flavor(p):
     """flavor : ENABLEOVERRIDE
               | DISABLEOVERRIDE
@@ -954,6 +985,7 @@ def p_flavor(p):
               | TRANSLATABLE
               """
     p[0] = p[1].lower()
+
 
 def p_propertyDeclaration(p):
     """propertyDeclaration : propertyDeclaration_1
@@ -967,35 +999,42 @@ def p_propertyDeclaration(p):
                            """
     p[0] = p[1]
 
+
 def p_propertyDeclaration_1(p):
     """propertyDeclaration_1 : dataType propertyName ';'"""
     p[0] = CIMProperty(p[2], None, type=p[1])
 
+
 def p_propertyDeclaration_2(p):
     """propertyDeclaration_2 : dataType propertyName defaultValue ';'"""
     p[0] = CIMProperty(p[2], p[3], type=p[1])
+
 
 def p_propertyDeclaration_3(p):
     """propertyDeclaration_3 : dataType propertyName array ';'"""
     p[0] = CIMProperty(p[2], None, type=p[1], is_array=True,
                        array_size=p[3])
 
+
 def p_propertyDeclaration_4(p):
     """propertyDeclaration_4 : dataType propertyName array defaultValue ';'"""
     p[0] = CIMProperty(p[2], p[4], type=p[1], is_array=True,
                        array_size=p[3])
+
 
 def p_propertyDeclaration_5(p):
     """propertyDeclaration_5 : qualifierList dataType propertyName ';'"""
     quals = dict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], None, type=p[2], qualifiers=quals)
 
+
 def p_propertyDeclaration_6(p):
     # pylint: disable=line-too-long
-    """propertyDeclaration_6 : qualifierList dataType propertyName defaultValue ';'"""
+    """propertyDeclaration_6 : qualifierList dataType propertyName defaultValue ';'"""  # noqa: E501
     quals = dict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], tocimobj(p[2], p[4]),
                        type=p[2], qualifiers=quals)
+
 
 def p_propertyDeclaration_7(p):
     """propertyDeclaration_7 : qualifierList dataType propertyName array ';'"""
@@ -1003,13 +1042,15 @@ def p_propertyDeclaration_7(p):
     p[0] = CIMProperty(p[3], None, type=p[2], qualifiers=quals,
                        is_array=True, array_size=p[4])
 
+
 def p_propertyDeclaration_8(p):
     # pylint: disable=line-too-long
-    """propertyDeclaration_8 : qualifierList dataType propertyName array defaultValue ';'"""
+    """propertyDeclaration_8 : qualifierList dataType propertyName array defaultValue ';'"""  # noqa: E501
     quals = dict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], tocimobj(p[2], p[5]),
                        type=p[2], qualifiers=quals, is_array=True,
                        array_size=p[4])
+
 
 def p_referenceDeclaration(p):
     # pylint: disable=line-too-long
@@ -1017,10 +1058,10 @@ def p_referenceDeclaration(p):
                             | objectRef referenceName defaultValue ';'
                             | qualifierList objectRef referenceName ';'
                             | qualifierList objectRef referenceName defaultValue ';'
-                            """
+                            """  # noqa: E501
     quals = []
     dv = None
-    if isinstance(p[1], list): # qualifiers
+    if isinstance(p[1], list):  # qualifiers
         quals = p[1]
         cname = p[2]
         pname = p[3]
@@ -1036,13 +1077,14 @@ def p_referenceDeclaration(p):
     p[0] = CIMProperty(pname, dv, type='reference',
                        reference_class=cname, qualifiers=quals)
 
+
 def p_methodDeclaration(p):
     # pylint: disable=line-too-long
     """methodDeclaration : dataType methodName '(' ')' ';'
                          | dataType methodName '(' parameterList ')' ';'
                          | qualifierList dataType methodName '(' ')' ';'
                          | qualifierList dataType methodName '(' parameterList ')' ';'
-                         """
+                         """  # noqa: E501
     paramlist = []
     quals = []
     if isinstance(p[1], six.string_types):  # no quals
@@ -1050,7 +1092,7 @@ def p_methodDeclaration(p):
         mname = p[2]
         if p[4] != ')':
             paramlist = p[4]
-    else: # quals present
+    else:  # quals present
         quals = p[1]
         dt = p[2]
         mname = p[3]
@@ -1064,17 +1106,21 @@ def p_methodDeclaration(p):
     # note: class_origin is set when adding method to class.
     # TODO what to do with propagated?
 
+
 def p_propertyName(p):
     """propertyName : identifier"""
     p[0] = p[1]
+
 
 def p_referenceName(p):
     """referenceName : identifier"""
     p[0] = p[1]
 
+
 def p_methodName(p):
     """methodName : identifier"""
     p[0] = p[1]
+
 
 def p_dataType(p):
     """dataType : DT_UINT8
@@ -1094,9 +1140,11 @@ def p_dataType(p):
                 """
     p[0] = p[1].lower()
 
+
 def p_objectRef(p):
     """objectRef : className REF"""
     p[0] = p[1]
+
 
 def p_parameterList(p):
     """parameterList : parameter
@@ -1107,6 +1155,7 @@ def p_parameterList(p):
     else:
         p[0] = p[1] + [p[3]]
 
+
 def p_parameter(p):
     """parameter : parameter_1
                  | parameter_2
@@ -1114,6 +1163,7 @@ def p_parameter(p):
                  | parameter_4
                  """
     p[0] = p[1]
+
 
 def p_parameter_1(p):
     """parameter_1 : dataType parameterName
@@ -1124,6 +1174,7 @@ def p_parameter_1(p):
         args['is_array'] = True
         args['array_size'] = p[3]
     p[0] = CIMParameter(p[2], p[1], **args)
+
 
 def p_parameter_2(p):
     """parameter_2 : qualifierList dataType parameterName
@@ -1136,6 +1187,7 @@ def p_parameter_2(p):
     quals = dict([(x.name, x) for x in p[1]])
     p[0] = CIMParameter(p[3], p[2], qualifiers=quals, **args)
 
+
 def p_parameter_3(p):
     """parameter_3 : objectRef parameterName
                    | objectRef parameterName array
@@ -1145,6 +1197,7 @@ def p_parameter_3(p):
         args['is_array'] = True
         args['array_size'] = p[3]
     p[0] = CIMParameter(p[2], 'reference', reference_class=p[1], **args)
+
 
 def p_parameter_4(p):
     """parameter_4 : qualifierList objectRef parameterName
@@ -1158,9 +1211,11 @@ def p_parameter_4(p):
     p[0] = CIMParameter(p[3], 'reference', qualifiers=quals,
                         reference_class=p[2], **args)
 
+
 def p_parameterName(p):
     """parameterName : identifier"""
     p[0] = p[1]
+
 
 def p_array(p):
     """array : '[' ']'
@@ -1171,9 +1226,11 @@ def p_array(p):
     else:
         p[0] = p[2]
 
+
 def p_defaultValue(p):
     """defaultValue : '=' initializer"""
     p[0] = p[2]
+
 
 def p_initializer(p):
     """initializer : constantValue
@@ -1181,6 +1238,7 @@ def p_initializer(p):
                    | referenceInitializer
                    """
     p[0] = p[1]
+
 
 def p_arrayInitializer(p):
     """arrayInitializer : '{' constantValueList '}'
@@ -1191,6 +1249,7 @@ def p_arrayInitializer(p):
     else:
         p[0] = p[2]
 
+
 def p_constantValueList(p):
     """constantValueList : constantValue
                          | constantValueList ',' constantValue
@@ -1200,10 +1259,11 @@ def p_constantValueList(p):
     else:
         p[0] = p[1] + [p[3]]
 
+
 def _fixStringValue(s):
     """Clean up string value including special characters, etc."""
 
-    #pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches
     s = s[1:-1]
     rv = ''
     esc = False
@@ -1275,6 +1335,7 @@ def p_constantValue(p):
                      """
     p[0] = p[1]
 
+
 def p_integerValue(p):
     """integerValue : binaryValue
                     | octalValue
@@ -1283,6 +1344,7 @@ def p_integerValue(p):
                     """
     p[0] = int(p[1])
     # TODO deal with non-decimal values.
+
 
 def p_referenceInitializer(p):
     """referenceInitializer : objectHandle
@@ -1299,15 +1361,17 @@ def p_referenceInitializer(p):
     else:
         p[0] = p[1]
 
+
 def p_objectHandle(p):
     """objectHandle : identifier"""
     p[0] = p[1]
+
 
 def p_qualifierDeclaration(p):
     # pylint: disable=line-too-long
     """qualifierDeclaration : QUALIFIER qualifierName qualifierType scope ';'
                             | QUALIFIER qualifierName qualifierType scope defaultFlavor ';'
-                            """
+                            """  # noqa: E501
     qualtype = p[3]
     dt, is_array, array_size, value = qualtype
     qualname = p[2]
@@ -1322,6 +1386,7 @@ def p_qualifierDeclaration(p):
     p[0] = CIMQualifierDeclaration(
         qualname, dt, value=value, is_array=is_array, array_size=array_size,
         scopes=scopes, **flavors)
+
 
 def _build_flavors(p, flist, qualdecl=None):
     """
@@ -1373,6 +1438,7 @@ def _build_flavors(p, flist, qualdecl=None):
 
     return flavors
 
+
 def p_qualifierName(p):
     """qualifierName : identifier
                      | ASSOCIATION
@@ -1380,11 +1446,13 @@ def p_qualifierName(p):
                      """
     p[0] = p[1]
 
+
 def p_qualifierType(p):
     """qualifierType : qualifierType_1
                      | qualifierType_2
                      """
     p[0] = p[1]
+
 
 def p_qualifierType_1(p):
     """qualifierType_1 : ':' dataType array
@@ -1395,6 +1463,7 @@ def p_qualifierType_1(p):
         dv = p[4]
     p[0] = (p[2], True, p[3], dv)
 
+
 def p_qualifierType_2(p):
     """qualifierType_2 : ':' dataType
                        | ':' dataType defaultValue
@@ -1403,6 +1472,7 @@ def p_qualifierType_2(p):
     if len(p) == 4:
         dv = p[3]
     p[0] = (p[2], False, None, dv)
+
 
 def p_scope(p):
     """scope : ',' SCOPE '(' metaElementList ')'"""
@@ -1419,6 +1489,7 @@ def p_scope(p):
         scopes[i] = i in slist
     p[0] = scopes
 
+
 def p_metaElementList(p):
     """metaElementList : metaElement
                        | metaElementList ',' metaElement
@@ -1427,6 +1498,7 @@ def p_metaElementList(p):
         p[0] = [p[1]]
     else:
         p[0] = p[1] + [p[3]]
+
 
 def p_metaElement(p):
     """metaElement : SCHEMA
@@ -1441,6 +1513,7 @@ def p_metaElement(p):
                    | ANY
                    """
     p[0] = p[1].upper()
+
 
 def p_defaultFlavor(p):
     """defaultFlavor : ',' FLAVOR '(' flavorListWithComma ')'"""
@@ -1468,13 +1541,14 @@ def p_flavorListWithComma(p):
     else:
         p[0] = p[1] + [p[3]]
 
+
 def p_instanceDeclaration(p):
     # pylint: disable=line-too-long
     """instanceDeclaration : INSTANCE OF className '{' valueInitializerList '}' ';'
                            | INSTANCE OF className alias '{' valueInitializerList '}' ';'
                            | qualifierList INSTANCE OF className '{' valueInitializerList '}' ';'
                            | qualifierList INSTANCE OF className alias '{' valueInitializerList '}' ';'
-                           """
+                           """  # noqa: E501
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     alias = None
     quals = {}
@@ -1488,7 +1562,7 @@ def p_instanceDeclaration(p):
             alias = p[4]
     else:
         cname = p[4]
-        #quals = p[1] # qualifiers on instances are deprecated -- rightly so.
+        # quals = p[1]  # qualifiers on instances are deprecated -- rightly so.
         if p[5] == '{':
             props = p[6]
         else:
@@ -1555,6 +1629,7 @@ def p_instanceDeclaration(p):
         p.parser.aliases[alias] = inst.path
     p[0] = inst
 
+
 def p_valueInitializerList(p):
     """valueInitializerList : valueInitializer
                             | valueInitializerList valueInitializer
@@ -1579,15 +1654,18 @@ def p_valueInitializer(p):
         val = p[3]
     p[0] = (quals, id_, val)
 
+
 def p_booleanValue(p):
     """booleanValue : FALSE
                     | TRUE
                     """
     p[0] = p[1].lower() == 'true'
 
+
 def p_nullValue(p):
     """nullValue : NULL"""
     p[0] = None
+
 
 def p_identifier(p):
     """identifier : IDENTIFIER
@@ -1615,9 +1693,11 @@ def p_identifier(p):
     """
     p[0] = p[1]
 
+
 def p_empty(p):
     'empty :'
     pass
+
 
 def _find_column(input_, token):
     """
@@ -1633,6 +1713,7 @@ def _find_column(input_, token):
         i -= 1
     column = (token.lexpos - i) + 1
     return column
+
 
 def _get_error_context(input_, token):
     """
@@ -1672,6 +1753,7 @@ def _get_error_context(input_, token):
         i += 1
     lines.append(pointline + pointer)
     return lines
+
 
 @six.add_metaclass(ABCMeta)
 class BaseRepositoryConnection(object):
@@ -1952,7 +2034,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                 self.classes[self.default_namespace][cc.classname] = cc
             except KeyError:
                 self.classes[self.default_namespace] = \
-                        NocaseDict({cc.classname: cc})
+                    NocaseDict({cc.classname: cc})
         if 'LocalOnly' in kwargs and not kwargs['LocalOnly']:
             if cc.superclass:
                 try:
@@ -1970,7 +2052,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                         cc.methods[meth.name] = meth
         return cc
 
-    def ModifyClass(self, *args, **kwargs): # pylint: disable=no-self-use
+    def ModifyClass(self, *args, **kwargs):  # pylint: disable=no-self-use
         """This method is used by the MOF compiler only in the course of
         handling CIM_ERR_ALREADY_EXISTS after trying to create a class.
         Because :meth:`CreateClass` overwrites existing classes, this method
@@ -2006,7 +2088,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
             self.classes[self.default_namespace][cc.classname] = cc
         except KeyError:
             self.classes[self.default_namespace] = \
-                    NocaseDict({cc.classname: cc})
+                NocaseDict({cc.classname: cc})
 
         # TODO: should we see if it exists first with
         # self.conn.GetClass()?  Do we want to create a class
@@ -2069,7 +2151,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
             self.qualifiers[self.default_namespace][qual.name] = qual
         except KeyError:
             self.qualifiers[self.default_namespace] = \
-                    NocaseDict({qual.name: qual})
+                NocaseDict({qual.name: qual})
 
     def DeleteQualifier(self, *args, **kwargs):
         """This method is only invoked by :meth:`rollback` (on the underlying
@@ -2325,6 +2407,7 @@ def _build(verbose=False):
     _yacc(verbose)
     _lex(verbose)
 
+
 def _yacc(verbose=False):
     """Return YACC parser object for the MOF compiler.
 
@@ -2344,6 +2427,7 @@ def _yacc(verbose=False):
                      debuglog=yacc.NullLogger(),
                      errorlog=yacc.PlyLogger(sys.stdout))
 
+
 def _lex(verbose=False):
     """Return LEX analyzer object for the MOF Compiler.
 
@@ -2357,4 +2441,3 @@ def _lex(verbose=False):
                    outputdir=_tabdir,
                    debug=False,
                    errorlog=lex.PlyLogger(sys.stdout))
-

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -82,10 +82,9 @@ from __future__ import absolute_import
 
 import six
 
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, \
-                     CIMClassName, CIMProperty, CIMMethod, \
-                     CIMParameter, CIMQualifier, CIMQualifierDeclaration, \
-                     tocimobj, byname
+from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
+    CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
+    CIMQualifierDeclaration, tocimobj, byname
 from .tupletree import xml_to_tupletree
 from .exceptions import ParseError
 
@@ -127,6 +126,7 @@ def attrs(tup_tree):
 def kids(tup_tree):
     """Return third (children) element of tup_tree"""
     return filter_tuples(tup_tree[2])
+
 
 # pylint: disable=too-many-arguments
 def check_node(tup_tree, nodename, required_attrs=None, optional_attrs=None,
@@ -302,6 +302,7 @@ def notimplemented(tup_tree):
 # Root element
 #
 
+
 def parse_cim(tup_tree):
     """Parse the top level element of CIM/XML message
 
@@ -462,6 +463,7 @@ def parse_value_namedinstance(tup_tree):
 
     return instance
 
+
 def parse_value_instancewithpath(tup_tree):
     """
     The VALUE.INSTANCEWITHPATH is used to define a value that comprises
@@ -483,6 +485,7 @@ def parse_value_instancewithpath(tup_tree):
 
     instance.path = path
     return (instance)
+
 
 def parse_value_namedobject(tup_tree):
     """
@@ -509,6 +512,7 @@ def parse_value_namedobject(tup_tree):
                          kids(tup_tree))
 
     return (name(tup_tree), attrs(tup_tree), _object)
+
 
 # pylint: disable=invalid-name
 def parse_value_objectwithlocalpath(tup_tree):
@@ -537,6 +541,7 @@ def parse_value_objectwithlocalpath(tup_tree):
 
     return (name(tup_tree), attrs(tup_tree), _object)
 
+
 def parse_value_objectwithpath(tup_tree):
     """
       ::
@@ -563,9 +568,11 @@ def parse_value_objectwithpath(tup_tree):
 
     return (name(tup_tree), attrs(tup_tree), _object)
 
+
 #
 # Object naming and locating elements
 #
+
 
 def parse_namespacepath(tup_tree):
     """
@@ -668,6 +675,7 @@ def parse_localclasspath(tup_tree):
 
     return CIMClassName(classname.classname, namespace=localnspath)
 
+
 def parse_classname(tup_tree):
     """Parse a CLASSNAME element and return a CIMClassName.
 
@@ -704,6 +712,7 @@ def parse_instancepath(tup_tree):
 
     return instancename
 
+
 def parse_localinstancepath(tup_tree):
     """Parse a LOCALINSTANCEPATH element:
 
@@ -725,6 +734,7 @@ def parse_localinstancepath(tup_tree):
 
     return instancename
 
+
 def parse_instancename(tup_tree):
     """Parse XML INSTANCENAME into CIMInstanceName object.
 
@@ -734,7 +744,6 @@ def parse_instancename(tup_tree):
         <!ATTLIST INSTANCENAME
             %ClassName;>
     """
-
 
     check_node(tup_tree, 'INSTANCENAME', ['CLASSNAME'])
 
@@ -778,7 +787,6 @@ def parse_objectpath(tup_tree):
     child = one_child(tup_tree, ['INSTANCEPATH', 'CLASSPATH'])
 
     return (name(tup_tree), attrs(tup_tree), child)
-
 
 
 def parse_keybinding(tup_tree):
@@ -843,6 +851,7 @@ def parse_keyvalue(tup_tree):
 #
 # Object definition elements
 #
+
 
 def parse_class(tup_tree):
     """Parse CLASS element returning a CIMClass if the parse
@@ -915,6 +924,7 @@ def parse_instance(tup_tree):
 
     return obj
 
+
 def parse_scope(tup_tree):
     """Parse SCOPE element.
 
@@ -935,6 +945,7 @@ def parse_scope(tup_tree):
                ['CLASS', 'ASSOCIATION', 'REFERENCE', 'PROPERTY', 'METHOD',
                 'PARAMETER', 'INDICATION'], [])
     return dict([(k, v.lower() == 'true') for k, v in attrs(tup_tree).items()])
+
 
 def parse_qualifier_declaration(tup_tree):
     """Parse QUALIFIER.DECLARATION element.
@@ -1230,6 +1241,7 @@ def parse_parameter(tup_tree):
     return CIMParameter(attrl['NAME'], type=attrl['TYPE'],
                         qualifiers=quals)
 
+
 def parse_parameter_reference(tup_tree):
     """
       ::
@@ -1320,6 +1332,7 @@ def parse_parameter_refarray(tup_tree):
 # Message elements
 #
 
+
 def parse_message(tup_tree):
     """
       ::
@@ -1353,6 +1366,7 @@ def parse_multiexpreq(tup_tree):   # pylint: disable=unused-argument
     # TODO: Implement MULTIEXPREQ parser
     raise ParseError('MULTIEXPREQ parser not implemented')
 
+
 def parse_simpleexpreq(tup_tree):
     """
       ::
@@ -1363,6 +1377,7 @@ def parse_simpleexpreq(tup_tree):
     child = one_child(tup_tree, ['EXPMETHODCALL'])
 
     return name(tup_tree), attrs(tup_tree), child
+
 
 def parse_simplereq(tup_tree):
     """
@@ -1429,7 +1444,6 @@ def parse_expmethodcall(tup_tree):
     """
 
     check_node(tup_tree, 'EXPMETHODCALL', ['NAME'], [], ['EXPPARAMVALUE'])
-
 
     params = list_of_matching(tup_tree, ['EXPPARAMVALUE'])
 
@@ -1685,9 +1699,11 @@ def parse_ireturnvalue(tup_tree):
 
     return name(tup_tree), attrs(tup_tree), values
 
+
 #
 # Object naming and locating elements
 #
+
 
 def parse_any(tup_tree):
     """Parse a fragment of XML. This function drives the rest of
@@ -1708,7 +1724,8 @@ def parse_any(tup_tree):
     else:
         return funct_name(tup_tree)
 
-def parse_embeddedObject(val): # pylint: disable=invalid-name
+
+def parse_embeddedObject(val):  # pylint: disable=invalid-name
     """Parse and embedded instance or class and return the
     CIMInstance or CIMClass.
 
@@ -1789,6 +1806,7 @@ def unpack_value(tup_tree):
         return None
     else:
         return tocimobj(valtype, raw_val)
+
 
 def unpack_boolean(data):
     """Unpack a boolean, represented as "TRUE" or "FALSE" in CIM."""

--- a/pywbem/tupletree.py
+++ b/pywbem/tupletree.py
@@ -56,6 +56,7 @@ import six
 
 __all__ = []
 
+
 def dom_to_tupletree(node):
     """Convert a DOM object to a pyRXP-style tuple tree.
 
@@ -78,7 +79,7 @@ def dom_to_tupletree(node):
             contents.append(dom_to_tupletree(child))
         elif child.nodeType == child.TEXT_NODE:
             assert isinstance(child.nodeValue, six.string_types), \
-                   "text node %s is not a string %r" % child
+                "text node %s is not a string %r" % child
             contents.append(child.nodeValue)
         elif child.nodeType == child.CDATA_SECTION_NODE:
             contents.append(child.nodeValue)

--- a/setup.py
+++ b/setup.py
@@ -41,18 +41,18 @@ import subprocess
 import platform
 from distutils.errors import DistutilsSetupError
 
+import os_setup
+from os_setup import shell, shell_check, import_setuptools
+
 # Workaround for Python 2.6 issue https://bugs.python.org/issue15881
 # This causes this module to be referenced and prevents the premature
 # unloading and subsequent garbage collection causing the error.
 if sys.version_info[0:2] == (2, 6):
     try:
         # pylint: disable=unused-import
-        import multiprocessing  # noqa: F401
+        import multiprocessing  # noqa: E402, F401
     except ImportError:
         pass
-
-import os_setup
-from os_setup import shell, shell_check, import_setuptools
 
 if sys.version_info[0] == 2:
     from xmlrpclib import Fault
@@ -60,6 +60,7 @@ else:
     from xmlrpc.client import Fault
 
 _VERBOSE = True
+
 
 def package_version(filename, varname):
     """Return package version string by reading `filename` and retrieving its
@@ -102,6 +103,7 @@ def _check_get_swig(swig_min_version, verbose):
                 print("Installed Swig version is sufficient: %s" %
                       swig_version)
     return get_swig
+
 
 def install_swig(installer, dry_run, verbose):
     """Custom installer function for `os_setup` module.
@@ -240,26 +242,27 @@ def install_swig(installer, dry_run, verbose):
                 if verbose:
                     print("Configuring Swig build process for installing to "
                           "%s tree..." % swig_install_root)
-                shell_check(["sh", "-c", "cd %s; ./configure --prefix=%s" %
-                             (swig_dir, swig_install_root)],
-                              display=True)
+                shell_check(
+                    ["sh", "-c", "cd %s; ./configure --prefix=%s" %
+                     (swig_dir, swig_install_root)], display=True)
 
                 if verbose:
                     print("Building Swig...")
-                shell_check(["sh", "-c", "cd %s; make swig" % swig_dir],
-                            display=True)
+                shell_check(
+                    ["sh", "-c", "cd %s; make swig" % swig_dir], display=True)
 
                 if verbose:
                     print("Installing Swig to %s tree..." % swig_install_root)
-                shell_check(["sh", "-c", "cd %s; sudo make install" % swig_dir],
-                            display=True)
+                shell_check(
+                    ["sh", "-c", "cd %s; sudo make install" % swig_dir],
+                    display=True)
 
                 if verbose:
                     print("Done downloading, building and installing Swig "
                           "version %s" % swig_build_version)
 
 
-def build_moftab(verbose):
+def build_moftab(verbose):  # pylint: disable=unused-argument
     """Generate the moftab modules.
 
     This function is called after the installation of the `pywbem`package
@@ -283,6 +286,7 @@ def build_moftab(verbose):
         # tolerate a failure:
         print("Warning: build_moftab.py failed with rc=%s; the PyWBEM "
               "LEX/YACC table modules may be rebuilt on first use" % rc)
+
 
 def main():
     """Main function of this script."""
@@ -374,23 +378,23 @@ def main():
             "pylint" if sys.version_info[0:2] == (2, 7) else None,
             "mock",
             'flake8',
-            "pbr", # needed by mock
-            "twine", # needed for upload to Pypi
+            "pbr",  # needed by mock
+            "twine",  # needed for upload to Pypi
         ],
         'install_os_requires': {
             # OS-level prereqs for 'install_os' command. Handled by os_setup
             # module.
             'Linux': {
                 'redhat': [
-                    "openssl-devel>=1.0.1", # for M2Crypto installation
+                    "openssl-devel>=1.0.1",  # for M2Crypto installation
                     "gcc-c++>=4.4",         # for building Swig and for running
                                             #   Swig in M2Crypto install
                     install_swig,           # for running Swig in M2Crypto inst.
                     # Python-devel provides Python.h for Swig run.
                     ["python34-devel", "python34u-devel", "python3-devel"] \
-                        if py_version_m_n == "3.4" else \
+                    if py_version_m_n == "3.4" else \
                     ["python35-devel", "python35u-devel", "python3-devel"] \
-                        if py_version_m_n == "3.5" else \
+                    if py_version_m_n == "3.5" else \
                     "python-devel",
                 ],
                 'centos': 'redhat',
@@ -469,7 +473,7 @@ def main():
             'Intended Audience :: Developers',
             'Intended Audience :: System Administrators',
             'License :: OSI Approved :: '\
-                'GNU Lesser General Public License v2 or later (LGPLv2+)',
+            'GNU Lesser General Public License v2 or later (LGPLv2+)',
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.6',

--- a/testsuite/compat_args.py
+++ b/testsuite/compat_args.py
@@ -5,7 +5,8 @@
 
 import sys
 
-def func_old_args(a, b=None, *args): # pylint: disable=invalid-name
+
+def func_old_args(a, b=None, *args):  # pylint: disable=invalid-name
     """Old function, defined with *args."""
 
     # We extract a specific optional parameter from *args
@@ -16,7 +17,8 @@ def func_old_args(a, b=None, *args): # pylint: disable=invalid-name
 
     return a, b, c
 
-def func_old_kwargs(a, b=None, **kwargs): # pylint: disable=invalid-name
+
+def func_old_kwargs(a, b=None, **kwargs):  # pylint: disable=invalid-name
     """Old function, defined with **kwargs."""
 
     # We extract a specific optional parameter from **kwargs
@@ -27,7 +29,8 @@ def func_old_kwargs(a, b=None, **kwargs): # pylint: disable=invalid-name
 
     return a, b, c
 
-def func_new(a, b=None, c=None): # pylint: disable=invalid-name
+
+def func_new(a, b=None, c=None):  # pylint: disable=invalid-name
     """New function, replacing any of the old functions."""
 
     return a, b, c
@@ -58,6 +61,7 @@ def test_func_args(func_args):
     lis = [1, 2, 3]
     a, b, c = func_args(*lis)
     assert (a, b, c) == (1, 2, 3)
+
 
 def test_func_kwargs(func_kwargs):
     """Examine all possible ways to invoke a function defined with **kwargs."""
@@ -103,6 +107,6 @@ def main():
           ' named args.")
     return 0
 
+
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -24,21 +24,17 @@ import six
 from unittest_extensions import RegexpMixin
 
 from pywbem import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
-                   CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_PARAMETER, \
-                   CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, \
-                   CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_INVALID_QUERY, \
-                   CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED, \
-                   CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
-                   CIM_ERR_METHOD_NOT_FOUND, \
-                   DEFAULT_NAMESPACE
+    CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_PARAMETER, \
+    CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, \
+    CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_INVALID_QUERY, \
+    CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED, CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
+    CIM_ERR_METHOD_NOT_FOUND, DEFAULT_NAMESPACE
 
 from pywbem import WBEMConnection, WBEMServer, CIMError, Error, WBEMListener, \
-                   WBEMSubscriptionManager, \
-                   CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
-                   CIMProperty, CIMQualifier, CIMQualifierDeclaration, \
-                   CIMMethod, ValueMapping, \
-                   Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, Sint32, \
-                   Sint64, Real32, Real64, CIMDateTime, TestClientRecorder
+    WBEMSubscriptionManager, CIMInstance, CIMInstanceName, CIMClass, \
+    CIMClassName, CIMProperty, CIMQualifier, CIMQualifierDeclaration, \
+    CIMMethod, ValueMapping, Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, \
+    Sint32, Sint64, Real32, Real64, CIMDateTime, TestClientRecorder
 
 # Test for decorator for unimplemented tests
 # decorator is @unittest.skip(UNIMPLEMENTED)
@@ -71,7 +67,7 @@ class ClientTest(unittest.TestCase):
 
     def setUp(self):
         """Create a connection."""
-        #pylint: disable=global-variable-not-assigned
+        # pylint: disable=global-variable-not-assigned
         global args                 # pylint: disable=invalid-name
 
         self.system_url = args['url']
@@ -84,8 +80,8 @@ class ClientTest(unittest.TestCase):
         # set this because python 3 http libs generate many ResourceWarnings
         # and unittest enables these warnings.
         if not six.PY2:
-            #pylint: disable=ResourceWarning, undefined-variable
-            warnings.simplefilter("ignore", ResourceWarning)
+            # pylint: disable=ResourceWarning, undefined-variable
+            warnings.simplefilter("ignore", ResourceWarning)  # noqa: F821
 
         self.log('setup connection {} ns {}'.format(self.system_url,
                                                     self.namespace))
@@ -109,7 +105,7 @@ class ClientTest(unittest.TestCase):
 
     def tearDown(self):
         """Close the test_client YAML file."""
-        #pylint: disable=global-variable-not-assigned
+        # pylint: disable=global-variable-not-assigned
         global args                 # pylint: disable=invalid-name
 
         if self.yamlfp is not None:
@@ -145,12 +141,10 @@ class ClientTest(unittest.TestCase):
 
         return result
 
-
     def log(self, data_):
         """Display log entry if verbose."""
         if self.verbose:
             print('{}'.format(data_))
-
 
     def assertInstancesValid(self, instances, includes_path=True,
                              prop_count=None, property_list=None):
@@ -187,7 +181,6 @@ class ClientTest(unittest.TestCase):
                     prop = instance.properties[p]
                     self.assertIsInstance(prop, CIMProperty)
 
-
     def assertInstanceNameValid(self, path, includes_namespace=True,
                                 includes_keybindings=True,
                                 namespace=None):
@@ -203,7 +196,6 @@ class ClientTest(unittest.TestCase):
             self.assertTrue(path.keybindings is not None)
         if namespace is not None:
             self.assertTrue(path.namespace == namespace)
-
 
     def assertAssocRefClassRtnValid(self, cls):
         """ Confirm that an associator or Reference class response
@@ -285,7 +277,6 @@ class ClientTest(unittest.TestCase):
                         return
                 self.fail('assertInstancesEqual fail')
 
-
     def assertPathsEqual(self, paths1, paths2, ignorehost=False):
         """ Compare two lists of paths or paths for equality
             assert if they are not the same
@@ -306,9 +297,11 @@ class ClientTest(unittest.TestCase):
                         return
                 self.fail('assertPathsEqual fail')
 
+
 #################################################################
 # Instance provider interface tests
 #################################################################
+
 
 class EnumerateInstanceNames(ClientTest):
 
@@ -352,6 +345,7 @@ class EnumerateInstanceNames(ClientTest):
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_CLASS:
                 raise
+
 
 class EnumerateInstances(ClientTest):
     """Test enumerateInstance variations against the server."""
@@ -424,7 +418,6 @@ class EnumerateInstances(ClientTest):
 
         self.assertInstancesValid(instances)
 
-
     def test_with_localonly(self):
         """Test LocalOnly specifically.
         Open pegasus ignores this one so cannot really test."""
@@ -437,13 +430,12 @@ class EnumerateInstances(ClientTest):
 
         self.display_response(instances)
 
-        #Add specific response tests to the following
+        # Add specific response tests to the following
         instances = self.cimcall(self.conn.EnumerateInstances,
                                  TEST_CLASS,
                                  LocalOnly=False)
 
         self.assertInstancesValid(instances)
-
 
     def test_class_propertylist(self):
         """ Test with propertyList for getClass to confirm property in class.
@@ -458,7 +450,6 @@ class EnumerateInstances(ClientTest):
         if self.verbose:
             for p in cls.properties.values():
                 print('ClassPropertyName=%s' % p.name)
-
 
     def test_instance_propertylist(self):
         """ Test property list on enumerate instances."""
@@ -476,7 +467,6 @@ class EnumerateInstances(ClientTest):
                                  PropertyList=property_list)
 
         self.assertInstancesValid(instances)
-
 
         for i in instances:
             self.assertTrue(len(i.properties) >= cls_property_count)
@@ -504,8 +494,7 @@ class EnumerateInstances(ClientTest):
 
         # TODO Apparently ks 5/16 Pegasus did not implement all properties
         # now in the class
-        #self.assertTrue(property_count == inst_property_count)
-
+        # self.assertTrue(property_count == inst_property_count)
 
     def test_instance_propertylist2(self):
         """ Test property list on enumerate instances."""
@@ -549,7 +538,7 @@ class EnumerateInstances(ClientTest):
 
         # TODO Apparently ks 5/16 Pegasus did not implement all properties
         # now in the class
-        #self.assertTrue(property_count == inst_property_count)
+        # self.assertTrue(property_count == inst_property_count)
 
     def test_deepinheritance(self):
         """Test with deep inheritance set true and then false."""
@@ -597,7 +586,6 @@ class EnumerateInstances(ClientTest):
             for p in instances[0].properties.values():
                 print('InstancePropertyName=%s' % p.name)
 
-
     def test_includequalifiers_true(self):
         """Test Include qualifiers. No detailed added test because
            most servers ignore this."""
@@ -610,7 +598,6 @@ class EnumerateInstances(ClientTest):
 
         self.assertInstancesValid(instances, prop_count=2,
                                   property_list=prop_list)
-
 
     def test_includequalifiers_false(self):
         """ Can only test if works wnen set."""
@@ -625,7 +612,6 @@ class EnumerateInstances(ClientTest):
 
         self.display_response(instances)
 
-
     def test_includeclassorigin(self):
         """test with includeclassorigin."""
         prop_list = [TEST_CLASS_PROPERTY1, TEST_CLASS_PROPERTY2]
@@ -637,7 +623,7 @@ class EnumerateInstances(ClientTest):
         self.assertInstancesValid(instances, prop_count=2,
                                   property_list=prop_list)
 
-        #self.assertTrue(self.instance_classorigin(i, True))
+        # self.assertTrue(self.instance_classorigin(i, True))
 
         instances = self.cimcall(self.conn.EnumerateInstances,
                                  TEST_CLASS,
@@ -647,7 +633,6 @@ class EnumerateInstances(ClientTest):
             self.assertInstancesValid(i, prop_count=2,
                                       property_list=prop_list)
             self.assertTrue(self.instance_classorigin(i, False))
-
 
     def test_nonexistent_namespace(self):
         """ Confirm correct error with nonexistent namespace."""
@@ -662,7 +647,6 @@ class EnumerateInstances(ClientTest):
             if ce.args[0] != CIM_ERR_INVALID_NAMESPACE:
                 raise
 
-
     def test_nonexistent_classname(self):
         """ Confirm correct error with nonexistent classname."""
         try:
@@ -672,7 +656,6 @@ class EnumerateInstances(ClientTest):
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_CLASS:
                 raise
-
 
     def test_invalid_request_parameter(self):
         """Should return error if invalid parameter."""
@@ -685,9 +668,12 @@ class EnumerateInstances(ClientTest):
             if ce.args[0] != CIM_ERR_NOT_SUPPORTED:
                 raise
 
+
 #
 #   Test the Pull Operations
 #
+
+
 class PullEnumerateInstances(ClientTest):
     """
         Tests on OpenEnumerateInstances and corresponding PullInstancesWithPath
@@ -726,7 +712,6 @@ class PullEnumerateInstances(ClientTest):
 
         self.assertInstancesEqual(insts_pulled, insts_enum, ignorehost=True)
 
-
     def test_open_deepinheritance(self):
         """Simple OpenEnumerateInstances but with DeepInheritance set."""
 
@@ -749,7 +734,6 @@ class PullEnumerateInstances(ClientTest):
         self.assertInstancesValid(insts_enum)
 
         self.assertInstancesEqual(insts_pulled, insts_enum, ignorehost=True)
-
 
     def test_open_includequalifiers(self):
         """Simple OpenEnumerateInstances but with IncludeQualifiers set."""
@@ -778,7 +762,6 @@ class PullEnumerateInstances(ClientTest):
 
         self.assertInstancesEqual(insts_pulled, insts_enum, ignorehost=True)
 
-
     def test_open_includeclassorigin(self):
         """Simple OpenEnumerateInstances but with DeepInheritance set."""
 
@@ -802,7 +785,6 @@ class PullEnumerateInstances(ClientTest):
         insts_enum = self.cimcall(self.conn.EnumerateInstances, TEST_CLASS)
 
         self.assertInstancesEqual(insts_pulled, insts_enum, ignorehost=True)
-
 
     def test_open_complete_with_ns(self):
         """Simple call that is complete with just the open and
@@ -829,7 +811,6 @@ class PullEnumerateInstances(ClientTest):
 
         self.assertInstancesEqual(insts_pulled, insts_enum, ignorehost=True)
 
-
     def test_zero_open(self):
         """ Test with default on open. Should return zero instances.
         """
@@ -849,7 +830,6 @@ class PullEnumerateInstances(ClientTest):
 
         self.assertTrue(result.eos is True)
 
-
     def test_close_early(self):
         """"Close enumeration session after initial Open."""
         result = self.cimcall(self.conn.OpenEnumerateInstances, TEST_CLASS)
@@ -865,7 +845,6 @@ class PullEnumerateInstances(ClientTest):
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
                 raise
-
 
     def test_get_onebyone(self):
         """Get instances with MaxObjectCount = 1)."""
@@ -885,10 +864,9 @@ class PullEnumerateInstances(ClientTest):
             insts_pulled.extend(result.instances)
 
         # get with EnumInstances and compare returns
-        insts_enum = \
-            self.cimcall(self.conn.EnumerateInstances, TOP_CLASS)  # noqa: F841
-        # TODO finish the compare
-
+        insts_enum = self.cimcall(  # noqa: F841
+            self.conn.EnumerateInstances, TOP_CLASS)
+        # TODO finish the compare (and remove the noqa F841)
 
     def test_bad_namespace(self):
         """Call with explicit CIM namespace that does not exist."""
@@ -917,8 +895,7 @@ class PullEnumerateInstances(ClientTest):
             if ce.args[0] != CIM_ERR_NOT_SUPPORTED:
                 raise
 
-
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def test_open_invalid_filterquerylanguage(self):
         """Test invalid FilterQueryLanguage parameter."""
         try:
@@ -931,8 +908,7 @@ class PullEnumerateInstances(ClientTest):
         except CIMError as ce:
             self.assertEqual(ce.args[0], CIM_ERR_FAILED)
 
-
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def test_open_invalid_filterquerylanguagewithfilter(self):
         """Test valid filter but invalid FilterQueryLanguage."""
         try:
@@ -946,7 +922,6 @@ class PullEnumerateInstances(ClientTest):
         except CIMError as ce:
             self.assertEqual(ce.args[0],
                              CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED)
-
 
     def test_open_invalid_filterquery(self):
         """Test Invalid FilterQuery."""
@@ -1025,7 +1000,6 @@ class PullEnumerateInstancePaths(ClientTest):
         self.assertTrue(len(paths_pulled) == len(paths_enum))
         # TODO add test for all paths equal
 
-
     def test_open_complete_with_ns(self):
         """Simplest invocation. Everything comes back in
            initial response with end-of-sequence == True
@@ -1062,7 +1036,6 @@ class PullEnumerateInstancePaths(ClientTest):
         self.assertTrue(len(paths_pulled) == len(paths_enum))
         # TODO add test to confirm they are the same
 
-
     def test_bad_namespace(self):
         """Call with explicit CIM namespace that does not exist."""
 
@@ -1075,7 +1048,6 @@ class PullEnumerateInstancePaths(ClientTest):
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_NAMESPACE:
                 raise
-
 
     def test_zero_open(self):
         """ Test for request with MaxObjectCount default on open. This
@@ -1091,7 +1063,6 @@ class PullEnumerateInstancePaths(ClientTest):
                               MaxObjectCount=100)
 
         self.assertTrue(result.eos)
-
 
     def test_close_early(self):
         """"Close enumeration session after initial Open."""
@@ -1154,6 +1125,7 @@ class PullEnumerateInstancePaths(ClientTest):
         else:
             self.fail('Issues with pull vs non-pull responses')
 
+
 class PullReferences(ClientTest):
     """Test OpenReferences and PullInstancesWithPath."""
 
@@ -1162,8 +1134,7 @@ class PullReferences(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
-
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         result = self.cimcall(self.conn.OpenReferenceInstances,
                               inst_name,
@@ -1197,7 +1168,6 @@ class PullReferences(ClientTest):
 
         self.assertInstancesEqual(insts_pulled, insts_enum)
 
-
     @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip test against all instances')
     def test_all_instances_in_ns(self):
         """Simplest invocation. Everything comes back in
@@ -1230,9 +1200,8 @@ class PullReferences(ClientTest):
                 print('References %s count %s' % (pathi, len(insts_enum)))
             self.assertTrue(len(insts_pulled) == len(insts_enum))
 
-            #TODO ks 5/30 2016 add tests here
-            #Do this as a loop for all instances above.
-
+            # TODO ks 5/30 2016 add tests here
+            # Do this as a loop for all instances above.
 
     def test_invalid_instance_name(self):
         """Test with name that is invalid class Expects exception"""
@@ -1256,8 +1225,7 @@ class PullReferencePaths(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
-
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         result = self.cimcall(self.conn.OpenReferenceInstancePaths,
                               inst_name,
@@ -1272,7 +1240,6 @@ class PullReferencePaths(ClientTest):
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
-
 
         for path in result.paths:
             self.assertTrue(isinstance(path, CIMInstanceName))
@@ -1326,8 +1293,9 @@ class PullReferencePaths(ClientTest):
                 print('References %s count %s' % (pathi, len(paths_enum)))
             self.assertTrue(len(paths) == len(paths_enum))
 
-            #TODO ks 5/30 2016 add tests here
-            #Do this as a loop for all instances above.
+            # TODO ks 5/30 2016 add tests here
+            # Do this as a loop for all instances above.
+
 
 class PullAssociators(ClientTest):
     """Test the OpenAssociators and corresponding pull."""
@@ -1338,8 +1306,7 @@ class PullAssociators(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
-
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         result = self.cimcall(self.conn.OpenAssociatorInstances,
                               inst_name,
@@ -1354,7 +1321,6 @@ class PullAssociators(ClientTest):
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
-
 
         for inst in insts_pulled:
             self.assertTrue(isinstance(inst, CIMInstanceName))
@@ -1373,7 +1339,6 @@ class PullAssociators(ClientTest):
             self.assertTrue(i.path.host is not None)
 
         self.assertInstancesEqual(insts_pulled, insts_enum)
-
 
     @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long  all instances test')
     def test_all_instances_in_ns(self):
@@ -1409,9 +1374,8 @@ class PullAssociators(ClientTest):
                 print('Associators %s count %s' % (insts_pulled,
                                                    len(insts_enum)))
             self.assertTrue(len(insts_pulled) == len(insts_enum))
-            #TODO ks 5/30 2016 add tests here
-            #Do this as a loop for all instances above.
-
+            # TODO ks 5/30 2016 add tests here
+            # Do this as a loop for all instances above.
 
     def test_invalid_instance_name(self):
         """Test with name that is invalid class."""
@@ -1437,8 +1401,7 @@ class PullAssociatorPaths(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
-
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         result = self.cimcall(self.conn.OpenAssociatorInstancePaths,
                               inst_name,
@@ -1453,7 +1416,6 @@ class PullAssociatorPaths(ClientTest):
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
-
 
         for path in paths_pulled:
             self.assertTrue(isinstance(path, CIMInstanceName))
@@ -1472,7 +1434,6 @@ class PullAssociatorPaths(ClientTest):
             self.assertTrue(i.host is not None)
 
         self.assertPathsEqual(paths_pulled, paths_enum)
-
 
     @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
     def test_all_instances_in_ns(self):
@@ -1508,8 +1469,9 @@ class PullAssociatorPaths(ClientTest):
             if len(paths_enum) != 0:
                 print('Associator Names %s count %s' % (pathi, len(paths_enum)))
             self.assertTrue(len(paths_pulled) == len(paths_enum))
-            #TODO ks 5/30 2016 add tests here
-            #Do this as a loop for all instances above.
+            # TODO ks 5/30 2016 add tests here
+            # Do this as a loop for all instances above.
+
 
 class PullQueryInstances(ClientTest):
     """Test of openexecquery and pullinstances."""
@@ -1537,7 +1499,7 @@ class PullQueryInstances(ClientTest):
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 
-            #TODO ks extend this test
+            # TODO ks extend this test
 
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
@@ -1550,7 +1512,6 @@ class PullQueryInstances(ClientTest):
                     " server doesn't support WQL for ExecQuery")
             else:
                 raise
-
 
     def test_zeroopen_pullexecquery(self):
         try:
@@ -1585,6 +1546,7 @@ class PullQueryInstances(ClientTest):
             else:
                 raise
 
+
 class ExecQuery(ClientTest):
 
     def test_simple(self):
@@ -1615,7 +1577,6 @@ class ExecQuery(ClientTest):
             else:
                 raise
 
-
     def test_namespace_error(self):
         """Call with explicit CIM namespace that does not exist."""
 
@@ -1630,7 +1591,6 @@ class ExecQuery(ClientTest):
             if ce.args[0] != CIM_ERR_INVALID_NAMESPACE:
                 raise
 
-
     def test_invalid_querylang(self):
         """Test execquery with invalid query_lang parameter."""
         try:
@@ -1643,7 +1603,6 @@ class ExecQuery(ClientTest):
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED:
                 raise
-
 
     def test_invalid_query(self):
         """Test with invalid query syntax."""
@@ -1666,7 +1625,7 @@ class GetInstance(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        name = inst_names[0] # Pick the first returned instance
+        name = inst_names[0]  # Pick the first returned instance
 
         # Simple invocation
 
@@ -1721,7 +1680,7 @@ class GetInstance(ClientTest):
         self.assertTrue(isinstance(obj, CIMInstance))
         self.assertTrue(isinstance(obj.path, CIMInstanceName))
         self.assertTrue(obj.path.namespace == self.namespace)
-        #TODO confirm results.
+        # TODO confirm results.
 
         # Call with IncludeClassOrigin
 
@@ -1732,7 +1691,7 @@ class GetInstance(ClientTest):
         self.assertTrue(isinstance(obj, CIMInstance))
         self.assertTrue(isinstance(obj.path, CIMInstanceName))
         self.assertTrue(obj.path.namespace == self.namespace)
-        #confirm results
+        # confirm results
 
         # Call with IncludeQualifiers and IncludeClassOrigin
 
@@ -1769,14 +1728,13 @@ class GetInstance(ClientTest):
             if ce.args[0] != CIM_ERR_INVALID_NAMESPACE:
                 raise
 
-
     def test_propertylist_tuple(self):
         """ Test property list as tuple instead of list."""
 
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        name = inst_names[0] # Pick the first returned instance
+        name = inst_names[0]  # Pick the first returned instance
 
         obj = self.cimcall(self.conn.GetInstance,
                            name,
@@ -1850,10 +1808,11 @@ class CreateInstance(ClientTest):
 
         try:
             self.cimcall(self.conn.GetInstance(instance.path))
-            #TODO ks 8/16 extend to match the get and create
+            # TODO ks 8/16 extend to match the get and create
         except CIMError as arg:
             if arg == CIM_ERR_NOT_FOUND:
                 pass
+
 
 class ModifyInstance(ClientTest):
 
@@ -1906,6 +1865,7 @@ class ModifyInstance(ClientTest):
 # Method provider interface tests
 #################################################################
 
+
 class InvokeMethod(ClientTest):
 
     def test_all(self):
@@ -1927,7 +1887,7 @@ class InvokeMethod(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        name = inst_names[0] # Pick the first returned instance
+        name = inst_names[0]  # Pick the first returned instance
 
         try:
 
@@ -2014,8 +1974,8 @@ class InvokeMethod(ClientTest):
             self.cimcall(self.conn.InvokeMethod,
                          'FooMethod',
                          TEST_CLASS,
-                         [('Spam', Uint16(1)), ('Ham', Uint16(2))], # Params
-                         Drink=Uint16(3), # begin of **params
+                         [('Spam', Uint16(1)), ('Ham', Uint16(2))],  # Params
+                         Drink=Uint16(3),  # begin of **params
                          Beer=Uint16(4))
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_METHOD_NOT_AVAILABLE:
@@ -2031,6 +1991,7 @@ class InvokeMethod(ClientTest):
 # Associators request interface tests
 #################################################################
 
+
 class Associators(ClientTest):
     """ Tests of the associators instance request operation."""
 
@@ -2041,7 +2002,7 @@ class Associators(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         instances = self.cimcall(self.conn.Associators, inst_name)
 
@@ -2056,7 +2017,6 @@ class Associators(ClientTest):
             self.assertTrue(i.path.host is not None)
 
         # TODO: check return values
-
 
     def test_one_class_associator(self):
         """
@@ -2090,7 +2050,7 @@ class AssociatorNames(ClientTest):
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames,
                                   TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         names = self.cimcall(self.conn.AssociatorNames, inst_name)
 
@@ -2102,7 +2062,6 @@ class AssociatorNames(ClientTest):
 
             self.assertTrue(n.namespace is not None)
             self.assertTrue(n.host is not None)
-
 
     def test_one_class_associatorname(self):
         """Call on class name. Returns CIMClassName.
@@ -2128,6 +2087,7 @@ class AssociatorNames(ClientTest):
             for n in assoc_classnames:
                 self.assertTrue(isinstance(n, CIMClassName))
 
+
 class References(ClientTest):
 
     def test_one_ref(self):
@@ -2136,7 +2096,7 @@ class References(ClientTest):
 
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames, TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         instances = self.cimcall(self.conn.References, inst_name)
 
@@ -2163,6 +2123,7 @@ class References(ClientTest):
             self.assertTrue(isinstance(cl[1], CIMClass))
         # TODO: check return values
 
+
 class ReferenceNames(ClientTest):
 
     def test_one_refname(self):
@@ -2171,7 +2132,7 @@ class ReferenceNames(ClientTest):
 
         inst_names = self.cimcall(self.conn.EnumerateInstanceNames, TEST_CLASS)
         self.assertTrue(len(inst_names) >= 1)
-        inst_name = inst_names[0] # Pick the first returned instance
+        inst_name = inst_names[0]  # Pick the first returned instance
 
         names = self.cimcall(self.conn.ReferenceNames, inst_name)
 
@@ -2198,6 +2159,7 @@ class ReferenceNames(ClientTest):
 # Schema manipulation interface tests
 #################################################################
 
+
 class ClientClassTest(ClientTest):
     """Intermediate class for testing CIMClass instances.
        Class operations subclass from this class"""
@@ -2207,20 +2169,17 @@ class ClientClassTest(ClientTest):
 
         self.assertTrue(isinstance(prop, CIMProperty))
 
-
     def verify_qualifier(self, qualifier):
         """Verify qualifier attributes."""
         self.assertTrue(isinstance(qualifier, CIMQualifier))
         self.assertTrue(qualifier.name)
         self.assertTrue(qualifier.value)
 
-
     def verify_method(self, method):
         """Verify method attributes."""
         self.assertTrue(isinstance(method, CIMMethod))
         # TODO add these tests
-        ##pass
-
+        # #pass
 
     def verify_class(self, cl):
         """Verify simple class attributes."""
@@ -2241,6 +2200,7 @@ class ClientClassTest(ClientTest):
         for m in cl.methods.values():
             self.verify_method(m)
         # TODO validate parameters in methods
+
 
 class EnumerateClassNames(ClientTest):
 
@@ -2282,10 +2242,11 @@ class EnumerateClassNames(ClientTest):
         full_name_list += subname_list
         self.assertTrue(TEST_CLASS in full_name_list,
                         'test class not found')
-        #TODO could we assert some size limit here. Probably Not
+        # TODO could we assert some size limit here. Probably Not
         # since this applies to any server.
         if self.verbose:
             print('end deep inheritance size %s' % len(full_name_list))
+
 
 class EnumerateClasses(ClientClassTest):
 
@@ -2308,8 +2269,9 @@ class EnumerateClasses(ClientClassTest):
             self.assertTrue(isinstance(cl, CIMClass))
             self.verify_class(cl)
 
-        #TODO extend for options of Deepinheritance, LocalOnly,
+        # TODO extend for options of Deepinheritance, LocalOnly,
         # IncludeQualifiers, IncludeClassOrigin
+
 
 class GetClass(ClientClassTest):
     """Test the get Class request operation"""
@@ -2347,7 +2309,7 @@ class GetClass(ClientClassTest):
             if ce.args[0] != CIM_ERR_NOT_FOUND:
                 raise
 
-        #TODO extend for options of Deepinheritance, LocalOnly,
+        # TODO extend for options of Deepinheritance, LocalOnly,
         # IncludeQualifiers, IncludeClassOrigin
 
 
@@ -2357,11 +2319,13 @@ class CreateClass(ClientClassTest):
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class DeleteClass(ClientClassTest):
 
     @unittest.skip(UNIMPLEMENTED)
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class ModifyClass(ClientClassTest):
 
@@ -2372,6 +2336,7 @@ class ModifyClass(ClientClassTest):
 #################################################################
 # Qualifier Declaration provider interface tests
 #################################################################
+
 
 class QualifierDeclClientTest(ClientTest):
     """Base class for QualifierDeclaration tests. Adds specific
@@ -2386,6 +2351,7 @@ class QualifierDeclClientTest(ClientTest):
 
         # TODO expand the verification of qual decls
 
+
 class EnumerateQualifiers(QualifierDeclClientTest):
 
     def test_all(self):
@@ -2394,6 +2360,7 @@ class EnumerateQualifiers(QualifierDeclClientTest):
 
         for qual_decl in qual_decls:
             self.verify_qual_decl(qual_decl)
+
 
 class GetQualifier(QualifierDeclClientTest):
 
@@ -2408,11 +2375,13 @@ class GetQualifier(QualifierDeclClientTest):
             if ce.args[0] != CIM_ERR_NOT_FOUND:
                 raise
 
+
 class SetQualifier(QualifierDeclClientTest):
 
     @unittest.skip(UNIMPLEMENTED)
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class DeleteQualifier(QualifierDeclClientTest):
 
@@ -2424,6 +2393,7 @@ class DeleteQualifier(QualifierDeclClientTest):
 # Query provider interface
 #################################################################
 
+
 class ExecuteQuery(ClientTest):
 
     @unittest.skip(UNIMPLEMENTED)
@@ -2434,6 +2404,7 @@ class ExecuteQuery(ClientTest):
 #################################################################
 # Open pegasus tests
 #################################################################
+
 
 class PegasusServerTestBase(ClientTest):
     """ Common superclass for all tests run against OpenPegasus
@@ -2528,7 +2499,6 @@ class PegasusServerTestBase(ClientTest):
 
         return False
 
-
     def get_interop_namespace(self):
         """Return the namespace used by this pegasus as interop
            If one of the listed namespaces is interop, return
@@ -2599,6 +2569,7 @@ class PegasusServerTestBase(ClientTest):
             for i in profiles:
                 print(i.tomof())
         return profiles
+
 
 class PegasusInteropTest(PegasusServerTestBase):
     """Test for valid interop namespace in a pegasus server."""
@@ -2738,6 +2709,7 @@ class PegasusTestEmbeddedInstance(PegasusServerTestBase, RegexpMixin):
             # TODO Create a new instance on server and test return using
             # getInstance
 
+
 class PyWBEMServerClass(PegasusServerTestBase):
     """
        Test the components of the server class and compare with previous tests
@@ -2768,7 +2740,6 @@ class PyWBEMServerClass(PegasusServerTestBase):
         for n in peg_namespaces:
             self.assertTrue(n in server.namespaces)
 
-
     def test_interop_namespace(self):
         """Confirm that pegasus tests and Server class select same namespace
            as interop namespace.
@@ -2779,7 +2750,6 @@ class PyWBEMServerClass(PegasusServerTestBase):
         peg_interop = self.get_interop_namespace()
 
         self.assertEqual(peg_interop.lower(), server.interop_ns.lower())
-
 
     def test_registered_profiles(self):
         """ Test getting profiles from server class against getting list
@@ -2807,7 +2777,6 @@ class PyWBEMServerClass(PegasusServerTestBase):
                 vers = inst['RegisteredVersion']
                 print("  %s %s Profile %s" % (org, name, vers))
 
-
     def test_get_brand(self):
         """ Get brand info. If pegasus server test for correct response.
             Otherwise display result.
@@ -2822,7 +2791,6 @@ class PyWBEMServerClass(PegasusServerTestBase):
             # Do not know what server it is so just display
             print("Brand: %s" % server.brand)
             print("Server Version:\n  %s" % server.version)
-
 
     def test_indication_profile_info(self):
         """ Get the indications central class."""
@@ -2871,7 +2839,6 @@ class PyWBEMServerClass(PegasusServerTestBase):
                     cls_name = cls.superclass
                 else:
                     self.fail("Could not find CIM_IndicationService")
-
 
     def test_server_profile(self):
         """Test getting the server profile."""
@@ -2981,6 +2948,7 @@ class PyWBEMServerClass(PegasusServerTestBase):
 RECEIVED_INDICATION_COUNT = 0
 COUNTER_LOCK = threading.Lock()
 
+
 # pylint: disable=unused-argument
 def consume_indication(indication, host):
     """This function is called when an indication is received.
@@ -2988,12 +2956,13 @@ def consume_indication(indication, host):
         tests in the PyWBEMListenerClass
     """
 
-    #pylint: disable=global-variable-not-assigned
+    # pylint: disable=global-variable-not-assigned
     global RECEIVED_INDICATION_COUNT
     # increment count.
     COUNTER_LOCK.acquire()
     RECEIVED_INDICATION_COUNT += 1
     COUNTER_LOCK.release()
+
 
 class PyWBEMListenerClass(PyWBEMServerClass):
     """Test the management of indications with the listener class.
@@ -3034,7 +3003,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
         # If success, wait and recheck to be sure no extra indications received.
         if success:
             time.sleep(2)
-            #self.assertEqual(RECEIVED_INDICATION_COUNT, requested_count)
+            # self.assertEqual(RECEIVED_INDICATION_COUNT, requested_count)
         if requested_count != RECEIVED_INDICATION_COUNT:
             print('Error receiving indications. Expected=%s Received=%s' %
                   (requested_count, RECEIVED_INDICATION_COUNT))
@@ -3144,7 +3113,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             for i, dest in enumerate(dests):
                 print('destination %s %s' % (i, dest))
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def test_create_delete_subscription(self):
         """
         Create and delete a server and listener and create an indication.
@@ -3187,8 +3156,8 @@ class PyWBEMListenerClass(PyWBEMServerClass):
 
             # confirm destination instance paths match
             self.assertTrue(len(sub_mgr.get_all_destinations(server_id)) > 0)
-            ##TODO: ks Finish this test completely when we add other changes
-            ##for filter ids
+            # #TODO: ks Finish this test completely when we add other changes
+            # #for filter ids
 
             sub_mgr.remove_subscriptions(server_id, subscription_paths)
             sub_mgr.remove_filter(server_id, filter_path)
@@ -3199,7 +3168,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             my_listener.stop()
             sub_mgr.remove_server(server_id)
 
-        #TODO ks 6/16 add more tests including: multiple subscriptions, filters
+        # TODO ks 6/16 add more tests including: multiple subscriptions, filters
         #     actual indication production, Errors. extend for ssl, test
         #     logging
 
@@ -3598,7 +3567,6 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             subscription_paths_owned = sub_mgr.add_subscriptions(
                 server_id, filter_path_owned)
 
-
             self.confirm_created(sub_mgr, server_id, filter_path_owned,
                                  subscription_paths_owned)
 
@@ -3696,7 +3664,7 @@ TEST_LIST = [
     'ExecQuery',
     'ExecuteQuery',
 
-    #PullOperations
+    # PullOperations
     'PullEnumerateInstancePaths',
     'PullEnumerateInstances',
     'PullAssociators',
@@ -3707,7 +3675,6 @@ TEST_LIST = [
     # TestServerClass
     'PyWBEMServerClass',
     'PyWEBEMListenerClass',
-
 
     # Pegasus only tests
     'PEGASUSCLITestClass',
@@ -3846,8 +3813,11 @@ def parse_args(argv_):
         args_['password'] = getpass()
     return args_, argv
 
-if __name__ == '__main__':
-    args, sys.argv = parse_args(sys.argv) # pylint: disable=invalid-name
+
+def main():
+    global SKIP_LONGRUNNING_TEST
+
+    args, sys.argv = parse_args(sys.argv)  # pylint: disable=invalid-name
     if args['verbose']:
         print("Using WBEM Server:")
         print("  server url: %s" % args['url'])
@@ -3879,3 +3849,5 @@ if __name__ == '__main__':
 
     unittest.main()
 
+if __name__ == '__main__':
+    main()

--- a/testsuite/run_operationtimeouts.py
+++ b/testsuite/run_operationtimeouts.py
@@ -33,11 +33,13 @@ NAMESPACE = 'test/testprovider'
 TESTCLASS = 'Test_CLITestProviderClass'
 TESTMETHOD = 'delayedMethodResponse'
 
+
 class ElapsedTimer(object):
     """
         Set up elapsed time timer. Calculates time between initiation
         and access.
     """
+
     def __init__(self):
         """ Initiate the object with current time"""
         self.start_time = datetime.datetime.now()
@@ -51,14 +53,15 @@ class ElapsedTimer(object):
             point representation of elapsed time in seconds.
         """
         dt = datetime.datetime.now() - self.start_time
-        return ((dt.days * 24 * 3600) + dt.seconds) * 1000  \
-                + dt.microseconds / 1000.0
+        return ((dt.days * 24 * 3600) + dt.seconds) * 1000 + \
+            dt.microseconds / 1000.0
 
     def elapsed_sec(self):
         """ get the elapsed time in seconds. Returns floating
             point representation of time in seconds
         """
         return self.elapsed_ms() / 1000
+
 
 class ClientTest(unittest.TestCase):
     """ Base class that creates a pywbem.WBEMConnection for
@@ -69,7 +72,7 @@ class ClientTest(unittest.TestCase):
 
     def setUp(self):
         """Create a connection."""
-        #pylint: disable=global-variable-not-assigned
+        # pylint: disable=global-variable-not-assigned
         global args                 # pylint: disable=invalid-name
 
         self.host = args['host']
@@ -82,8 +85,8 @@ class ClientTest(unittest.TestCase):
         # set this because python 3 http libs generate many ResourceWarnings
         # and unittest enables these warnings.
         if not six.PY2:
-            #pylint: disable=undefined-variable
-            warnings.simplefilter("ignore", ResourceWarning)
+            # pylint: disable=undefined-variable
+            warnings.simplefilter("ignore", ResourceWarning)  # noqa: F821
 
     def connect(self, url, timeout=None):
 
@@ -101,11 +104,11 @@ class ClientTest(unittest.TestCase):
         self.log('Connected {}'.format(url))
         return conn
 
-
     def log(self, data_):
         """Display log entry if verbose"""
         if self.debug:
             print('{}'.format(data_))
+
 
 class ServerTimeoutTest(ClientTest):
 
@@ -324,8 +327,9 @@ def parse_args(argv_):
         args_['password'] = getpass()
     return args_, argv
 
+
 if __name__ == '__main__':
-    args, sys.argv = parse_args(sys.argv) # pylint: disable=invalid-name
+    args, sys.argv = parse_args(sys.argv)  # pylint: disable=invalid-name
 
     if args['verbose'] in args:
         print("Using WBEM Server:")

--- a/testsuite/test_cim_http.py
+++ b/testsuite/test_cim_http.py
@@ -298,7 +298,6 @@ class Parse_url(unittest.TestCase):  # pylint: disable=invalid-name
         except ValueError:
             pass
 
-
         try:
             self._run_single_defaults_false("://[2001:db8::7348-eth1]:5900",
                                             "2001:db8::7348%eth1",

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -28,10 +28,8 @@ import six
 
 from pywbem import cim_obj, cim_types
 from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
-                   CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
-                   Uint8, Uint16, Uint32, Uint64, \
-                   Sint8, Sint16, Sint32, Sint64,\
-                   Real32, Real64, CIMDateTime
+    CIMProperty, CIMMethod, CIMParameter, CIMQualifier, Uint8, Uint16, Uint32, \
+    Uint64, Sint8, Sint16, Sint32, Sint64, Real32, Real64, CIMDateTime
 from pywbem.cim_obj import NocaseDict
 
 from validate import validate_xml
@@ -58,7 +56,7 @@ class ValidateTest(unittest.TestCase):
             representing the CIM object. `None` means that no test for an
             expected XML root element will happen.
         """
-        global _MODULE_PATH # pylint: disable=global-variable-not-assigned
+        global _MODULE_PATH  # pylint: disable=global-variable-not-assigned
         xml_str = obj.tocimxml().toxml()
         self.assertTrue(
             validate_xml(xml_str,
@@ -94,6 +92,7 @@ class ValidateTest(unittest.TestCase):
                          'XML string returned by tocimxmlstr(indent) is not '
                          'equal to tocimxml().toprettyxml(indent).')
 
+
 def swapcase2(text):
     """Returns text, where every other character has been changed to swap
     its lexical case. For strings that contain at least one letter, the
@@ -106,6 +105,7 @@ def swapcase2(text):
         text_cs += c
         i += 1
     return text_cs
+
 
 class DictTest(unittest.TestCase):
     """
@@ -352,6 +352,7 @@ class InitCIMInstanceName(unittest.TestCase, CIMObjectMixin):
         self.assertCIMInstanceName(obj, 'CIM_Foo', kb4, 'woot.com',
                                    'root/cimv2')
 
+
 class CopyCIMInstanceName(unittest.TestCase, CIMObjectMixin):
     """
     Test the copy() method of `CIMInstanceName` objects.
@@ -378,6 +379,7 @@ class CopyCIMInstanceName(unittest.TestCase, CIMObjectMixin):
 
         self.assertCIMInstanceName(i, 'CIM_Foo', {'InstanceID': '1234'},
                                    'woot.com', 'root/cimv2')
+
 
 class CIMInstanceNameAttrs(unittest.TestCase, CIMObjectMixin):
     """
@@ -407,6 +409,7 @@ class CIMInstanceNameAttrs(unittest.TestCase, CIMObjectMixin):
         self.assertCIMInstanceName(obj, 'CIM_Bar', kb2,
                                    'woom.com', 'root/interop')
 
+
 class CIMInstanceNameDict(DictTest):
     """
     Test the dictionary interface of `CIMInstanceName` objects.
@@ -418,6 +421,7 @@ class CIMInstanceNameDict(DictTest):
         obj = CIMInstanceName('CIM_Foo', kb)
 
         self.runtest_dict(obj, kb)
+
 
 class CIMInstanceNameEquality(unittest.TestCase):
     """
@@ -482,6 +486,7 @@ class CIMInstanceNameEquality(unittest.TestCase):
         self.assertEqual(CIMInstanceName('CIM_Foo', namespace='root/cimv2'),
                          CIMInstanceName('CIM_Foo', namespace='Root/CIMv2'))
 
+
 class CIMInstanceNameCompare(unittest.TestCase):
     """
     Test the ordering comparison of `CIMInstanceName` objects.
@@ -492,6 +497,7 @@ class CIMInstanceNameCompare(unittest.TestCase):
         # TODO Implement ordering comparison test for CIMInstanceName
         raise AssertionError("test not implemented")
 
+
 class CIMInstanceNameSort(unittest.TestCase):
     """
     Test the sorting of `CIMInstanceName` objects.
@@ -501,6 +507,7 @@ class CIMInstanceNameSort(unittest.TestCase):
     def test_all(self):
         # TODO Implement sorting test for CIMInstanceName
         raise AssertionError("test not implemented")
+
 
 class CIMInstanceNameString(unittest.TestCase, RegexpMixin):
     """
@@ -556,6 +563,7 @@ class CIMInstanceNameString(unittest.TestCase, RegexpMixin):
 
         self.assertEqual(str(obj),
                          '//woot.com/root/InterOp:CIM_Foo.InstanceID="1234"')
+
 
 class CIMInstanceNameToXML(ValidateTest):
     """
@@ -644,7 +652,7 @@ class InitCIMInstance(unittest.TestCase):
         props_input = {}
         props_input[1] = {
             'S1': b'Ham',
-            'S2': u'H\u00E4m', # U+00E4 = lower case a umlaut
+            'S2': u'H\u00E4m',  # U+00E4 = lower case a umlaut
             'B': True,
             'UI8': Uint8(42),
             'UI16': Uint16(4216),
@@ -664,7 +672,7 @@ class InitCIMInstance(unittest.TestCase):
             'S1': CIMProperty(name='S1', type='string',
                               value=b'Ham', is_array=False),
             'S2': CIMProperty(name='S2', type='string',
-                              value=u'H\u00E4m', is_array=False), # a umlaut
+                              value=u'H\u00E4m', is_array=False),  # a umlaut
             'B': CIMProperty(name='B', type='boolean',
                              value=True, is_array=False),
             'UI8': CIMProperty(name='UI8', type='uint8',
@@ -696,7 +704,7 @@ class InitCIMInstance(unittest.TestCase):
                                is_array=False),
         }
         props_input[4] = NocaseDict(props_input[3])
-        props_obj = props_input[4] # for all kinds of input
+        props_obj = props_input[4]  # for all kinds of input
 
         for i in props_input:
 
@@ -721,7 +729,7 @@ class InitCIMInstance(unittest.TestCase):
 
         num_values = [42, 42.1]
         if six.PY2:
-            num_values.append(long(42))
+            num_values.append(long(42))  # noqa: F821
         for num_value in num_values:
             try:
                 inst = CIMInstance('CIM_Foo',
@@ -762,7 +770,7 @@ class InitCIMInstance(unittest.TestCase):
         #      e.g. quals_input = {'Key': True}
         quals_input[1] = {'Key': CIMQualifier('Key', True)}
         quals_input[2] = NocaseDict(quals_input[1])
-        quals_obj = quals_input[2] # for all kinds of input
+        quals_obj = quals_input[2]  # for all kinds of input
 
         for i in quals_input:
 
@@ -810,6 +818,7 @@ class InitCIMInstance(unittest.TestCase):
 
         # Note: Tests for initializing CIMInstance with property_list are
         #       handled in class CIMInstancePropertyList.
+
 
 class CopyCIMInstance(unittest.TestCase):
     """
@@ -863,6 +872,7 @@ class CopyCIMInstance(unittest.TestCase):
         self.assertEqual(i.qualifiers['Key'], CIMQualifier('Key', True))
         self.assertEqual(i.path, None)
 
+
 class CIMInstanceAttrs(unittest.TestCase):
     """
     Test that the public data attributes of `CIMInstance` objects can be
@@ -900,6 +910,7 @@ class CIMInstanceAttrs(unittest.TestCase):
         self.assertEqual(obj.qualifiers, quals)
         self.assertEqual(obj.path, path)
 
+
 class CIMInstanceDict(DictTest):
     """Test the Python dictionary interface for CIMInstance."""
 
@@ -924,6 +935,7 @@ class CIMInstanceDict(DictTest):
                       (obj.properties,))
 
         obj['Foo'] = Uint32(43)
+
 
 class CIMInstanceEquality(unittest.TestCase):
     """Test comparing CIMInstance objects."""
@@ -1008,6 +1020,7 @@ class CIMInstanceEquality(unittest.TestCase):
                                             CIMInstanceName('CIM_Bar'))})
             )  # noqa: E123
 
+
 class CIMInstanceCompare(unittest.TestCase):
     """
     Test the ordering comparison of `CIMInstance` objects.
@@ -1018,6 +1031,7 @@ class CIMInstanceCompare(unittest.TestCase):
         # TODO Implement ordering comparison test for CIMInstance
         raise AssertionError("test not implemented")
 
+
 class CIMInstanceSort(unittest.TestCase):
     """
     Test the sorting of `CIMInstance` objects.
@@ -1027,6 +1041,7 @@ class CIMInstanceSort(unittest.TestCase):
     def test_all(self):
         # TODO Implement sorting test for CIMInstance
         raise AssertionError("test not implemented")
+
 
 class CIMInstanceString(unittest.TestCase, RegexpMixin):
     """
@@ -1055,6 +1070,7 @@ class CIMInstanceString(unittest.TestCase, RegexpMixin):
         self.assertRegexpContains(r, 'classname=u?[\'"]CIM_Foo[\'"]')
         self.assertNotEqual(r.find('Name'), -1)
         self.assertNotEqual(r.find('Ref1'), -1)
+
 
 class CIMInstanceToXML(ValidateTest):
     """
@@ -1170,6 +1186,7 @@ class CIMInstanceToXML(ValidateTest):
 
         self.validate(obj, root_elem_CIMInstance_noname)
 
+
 class CIMInstanceToMOF(unittest.TestCase):
     """
     Test that valid MOF is generated for `CIMInstance` objects.
@@ -1188,7 +1205,7 @@ class CIMInstanceToMOF(unittest.TestCase):
         # match first line
         m = re.match(
             r"^\s*instance\s+of\s+CIM_Foo\s*\{"
-            r"(?:\s*(\w+)\s*=\s*.*;){4,4}" # just match the general syntax
+            r"(?:\s*(\w+)\s*=\s*.*;){4,4}"  # just match the general syntax
             r"\s*\}\s*;\s*$", imof)
         if m is None:
             self.fail("Invalid MOF generated.\n"
@@ -1201,6 +1218,7 @@ class CIMInstanceToMOF(unittest.TestCase):
             self.fail("Invalid MOF generated. No MyRef.\n"
                       "Instance: %r\n"
                       "Generated MOF: %r" % (i, imof))
+
 
 class CIMInstanceWithEmbeddedInstToMOF(unittest.TestCase):
     """Test that MOF with valid embedded insance is generated for instance"""
@@ -1269,16 +1287,17 @@ class CIMInstanceUpdatePath(unittest.TestCase):
         i['k1'] = 'key1'
         self.assertEqual(i['k1'], 'key1')
         self.assertTrue('k1' in i)
-        self.assertEqual(i.path['k1'], 'key1') # also updates the path
+        self.assertEqual(i.path['k1'], 'key1')  # also updates the path
 
         i['k2'] = 'key2'
         self.assertEqual(i['k2'], 'key2')
         self.assertTrue('k2' in i)
-        self.assertEqual(i.path['k2'], 'key2') # also updates the path
+        self.assertEqual(i.path['k2'], 'key2')  # also updates the path
 
         i['p1'] = 'prop1'
         self.assertEqual(len(i.path.keybindings), 2)
-        self.assertTrue('p1' not in i.path) # no key, does not update the path
+        self.assertTrue('p1' not in i.path)  # no key, does not update the path
+
 
 class CIMInstancePropertyList(unittest.TestCase):
     """
@@ -1298,12 +1317,12 @@ class CIMInstancePropertyList(unittest.TestCase):
         i['k1'] = 'key1'
         self.assertEqual(i['k1'], 'key1')
         self.assertTrue('k1' in i)
-        self.assertEqual(i.path['k1'], 'key1') # also updates the path
+        self.assertEqual(i.path['k1'], 'key1')  # also updates the path
 
         i['k2'] = 'key2'
         self.assertEqual(i['k2'], 'key2')
         self.assertTrue('k2' in i)
-        self.assertEqual(i.path['k2'], 'key2') # also updates the path
+        self.assertEqual(i.path['k2'], 'key2')  # also updates the path
 
         i['p1'] = 'prop1'
         self.assertEqual(i['p1'], 'prop1')
@@ -1318,7 +1337,8 @@ class CIMInstancePropertyList(unittest.TestCase):
         self.assertTrue('p2' not in i.path)
 
         i['p3'] = 'prop3'
-        self.assertTrue('p3' not in i) # the effect of property list
+        self.assertTrue('p3' not in i)  # the effect of property list
+
 
 class CIMInstanceUpdateExisting(unittest.TestCase):
     """
@@ -1680,7 +1700,7 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
 
         num_values = [42, 42.0]
         if six.PY2:
-            num_values.append(long(42))
+            num_values.append(long(42))  # noqa: F821
         for val in num_values:
             try:
                 CIMProperty('Age', val)
@@ -1945,6 +1965,7 @@ class InitCIMProperty(unittest.TestCase, CIMObjectMixin):
             else:
                 self.fail('ValueError or TypeError not raised')
 
+
 class CopyCIMProperty(unittest.TestCase, CIMObjectMixin):
 
     def test_all(self):
@@ -1960,6 +1981,7 @@ class CopyCIMProperty(unittest.TestCase, CIMObjectMixin):
 
         self.assertCIMProperty(p, 'Spotty', 'Foot', type_='string',
                                qualifiers={})
+
 
 class CIMPropertyAttrs(unittest.TestCase, CIMObjectMixin):
 
@@ -1984,6 +2006,7 @@ class CIMPropertyAttrs(unittest.TestCase, CIMObjectMixin):
         obj = CIMProperty('Foo', v)
         self.assertCIMProperty(obj, 'Foo', v, type_='reference',
                                reference_class='CIM_Bar')
+
 
 class CIMPropertyEquality(unittest.TestCase):
 
@@ -2050,17 +2073,20 @@ class CIMPropertyEquality(unittest.TestCase):
             CIMProperty('Foo', CIMInstanceName('CIM_Foo'),
                         qualifiers={'Key': CIMQualifier('Key', True)}))
 
+
 class CIMPropertyCompare(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class CIMPropertySort(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class CIMPropertyString(unittest.TestCase, RegexpMixin):
 
@@ -2069,6 +2095,7 @@ class CIMPropertyString(unittest.TestCase, RegexpMixin):
         r = repr(CIMProperty('Spotty', 'Foot', type='string'))
 
         self.assertRegexpMatches(r, '^CIMProperty')
+
 
 class CIMPropertyToXML(ValidateTest):
     """Test valid XML is generated for various CIMProperty objects."""
@@ -2136,6 +2163,7 @@ class InitCIMQualifier(unittest.TestCase):
         CIMQualifier('RevisionList', ['1', '2', '3'], propagated=False)
         CIMQualifier('Null', None, 'string')
 
+
 class CopyCIMQualifier(unittest.TestCase):
 
     def test_all(self):
@@ -2149,6 +2177,7 @@ class CopyCIMQualifier(unittest.TestCase):
         c.value = 'eep'
 
         self.assertEqual(q.name, 'Revision')
+
 
 class CIMQualifierAttrs(unittest.TestCase):
     """Test attributes of CIMQualifier object."""
@@ -2174,6 +2203,7 @@ class CIMQualifierAttrs(unittest.TestCase):
         self.assertEqual(q.value, [1, 2, 3])
         self.assertEqual(q.propagated, False)
 
+
 class CIMQualifierEquality(unittest.TestCase):
     """Compare CIMQualifier objects."""
 
@@ -2191,17 +2221,20 @@ class CIMQualifierEquality(unittest.TestCase):
         self.assertNotEqual(CIMQualifier('Null', None, type='string'),
                             CIMQualifier('Null', ''))
 
+
 class CIMQualifierCompare(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class CIMQualifierSort(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class CIMQualifierString(unittest.TestCase, RegexpMixin):
 
@@ -2211,6 +2244,7 @@ class CIMQualifierString(unittest.TestCase, RegexpMixin):
                              propagated=False))
 
         self.assertRegexpContains(s, 'RevisionList')
+
 
 class CIMQualifierToXML(ValidateTest):
 
@@ -2258,6 +2292,7 @@ class InitCIMClass(unittest.TestCase):
 
         CIMClass('CIM_Foo', qualifiers={'Key': CIMQualifier('Key', True)})
 
+
 class CopyCIMClass(unittest.TestCase):
 
     def test_all(self):
@@ -2278,6 +2313,7 @@ class CopyCIMClass(unittest.TestCase):
         self.assertTrue(c.methods['Delete'])
         self.assertTrue(c.qualifiers['Key'])
 
+
 class CIMClassAttrs(unittest.TestCase):
 
     def test_all(self):
@@ -2290,6 +2326,7 @@ class CIMClassAttrs(unittest.TestCase):
         self.assertEqual(obj.qualifiers, {})
         self.assertEqual(obj.methods, {})
         self.assertEqual(obj.qualifiers, {})
+
 
 class CIMClassEquality(unittest.TestCase):
 
@@ -2321,11 +2358,13 @@ class CIMClassEquality(unittest.TestCase):
         self.assertEqual(CIMClass('CIM_Foo', superclass='CIM_Bar'),
                          CIMClass('CIM_Foo', superclass='cim_bar'))
 
+
 class CIMClassCompare(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class CIMClassSort(unittest.TestCase):
 
@@ -2333,12 +2372,14 @@ class CIMClassSort(unittest.TestCase):
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class CIMClassString(unittest.TestCase, RegexpMixin):
 
     def test_all(self):
 
         s = str(CIMClass('CIM_Foo'))
         self.assertRegexpContains(s, 'CIM_Foo')
+
 
 class CIMClassToXML(ValidateTest):
 
@@ -2368,6 +2409,7 @@ class CIMClassToXML(ValidateTest):
                                qualifiers={'Key': CIMQualifier('Key', True)}),
                       root_elem_CIMClass)
 
+
 class CIMClassToMOF(unittest.TestCase, RegexpMixin):
 
     def test_all(self):
@@ -2383,6 +2425,7 @@ class CIMClassToMOF(unittest.TestCase, RegexpMixin):
 
         self.assertRegexpContains(imof, r"\n\s*string\s+InstanceID")
         self.assertRegexpContains(imof, r"\n\};")
+
 
 class CIMClassPropertyWithValueToMOF(unittest.TestCase, RegexpMixin):
 
@@ -2422,6 +2465,7 @@ class CIMClassPropertyWithValueToMOF(unittest.TestCase, RegexpMixin):
                                         r"\"This is a test\";")
 
         self.assertRegexpContains(imof, r"\n\};")
+
 
 class CIMClassToMofArrayProperty(unittest.TestCase, RegexpMixin):
     def test_ArrayDef32(self):
@@ -2484,6 +2528,7 @@ class CIMClassToMofArrayProperty(unittest.TestCase, RegexpMixin):
     # TODO ks apr 16: extend this test for other alternatives for mof output
     # of property parameters.
 
+
 class CIMClassMethodsToMOF(unittest.TestCase, RegexpMixin):
     """Test variations of class method mof output"""
 
@@ -2498,7 +2543,6 @@ class CIMClassMethodsToMOF(unittest.TestCase, RegexpMixin):
         self.assertRegexpContains(imof, r"^\s*class\s+CIM_FooOneMethod\s*\{")
         self.assertRegexpContains(imof, r"\s*uint32\s+Simple\(\);")
         self.assertRegexpContains(imof, r"\n\};",)
-
 
     def test_SimpleMethod(self):
         """Test multiple methods some with parameters"""
@@ -2540,6 +2584,7 @@ class CIMClassMethodsToMOF(unittest.TestCase, RegexpMixin):
         self.assertRegexpContains(imof, r"\n\s*sint32\s+Param4\[9\]\);")
         self.assertRegexpContains(imof, r"\n\};",)
 
+
 class CIMClassWQualToMOF(unittest.TestCase):
     """Generate mof output for a a class with a qualifiers, multiple
        properties and methods
@@ -2551,9 +2596,9 @@ class CIMClassWQualToMOF(unittest.TestCase):
         pquals = {'ModelCorresponse': CIMQualifier('ModelCorrespondense',
                                                    'BlahBlahClass'),
                   'Description': CIMQualifier('Description', "This is a"
-                                               " description for a property"
-                                               " that serves no purpose"
-                                               " but is multiline.")}
+                                              " description for a property"
+                                              " that serves no purpose"
+                                              " but is multiline.")}
         pquals2 = {'ValueMap': CIMQualifier('ValueMap',
                                             ["0", "1", "2", "3", "4",
                                              "5", "6"]),
@@ -2573,7 +2618,7 @@ class CIMClassWQualToMOF(unittest.TestCase):
                                                  "An embedded instance"),
                      'EmbeddedInstance': CIMQualifier('EmbeddedInstance',
                                                       "My_Embedded")}
-        #define the target class
+        # define the target class
         cl = CIMClass(
             'CIM_Foo', superclass='CIM_Bar',
             qualifiers={'Abstract': CIMQualifier('Abstract', True),
@@ -2679,6 +2724,7 @@ class CIMClassWoQualifiersToMof(unittest.TestCase, RegexpMixin):
         self.assertRegexpContains(clmof, r"\n\s*uint32\s+Delete\(\);\n")
         self.assertRegexpContains(clmof, r"\n\};",)
 
+
 class InitCIMMethod(unittest.TestCase):
 
     def test_all(self):
@@ -2693,6 +2739,7 @@ class InitCIMMethod(unittest.TestCase):
                   parameters={'Param1': CIMParameter('Param1', 'uint32'),
                               'Param2': CIMParameter('Param2', 'string')},
                   qualifiers={'Key': CIMQualifier('Key', True)})
+
 
 class CopyCIMMethod(unittest.TestCase):
 
@@ -2717,6 +2764,7 @@ class CopyCIMMethod(unittest.TestCase):
         self.assertTrue(m.parameters['P1'])
         self.assertTrue(m.qualifiers['Key'])
 
+
 class CIMMethodAttrs(unittest.TestCase):
 
     def test_all(self):
@@ -2729,6 +2777,7 @@ class CIMMethodAttrs(unittest.TestCase):
         self.assertEqual(m.return_type, 'uint32')
         self.assertEqual(len(m.parameters), 2)
         self.assertEqual(m.qualifiers, {})
+
 
 class CIMMethodEquality(unittest.TestCase):
 
@@ -2745,17 +2794,20 @@ class CIMMethodEquality(unittest.TestCase):
                                       qualifiers={'Key': CIMQualifier('Key',
                                                                       True)}))
 
+
 class CIMMethodCompare(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class CIMMethodSort(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class CIMMethodString(unittest.TestCase, RegexpMixin):
 
@@ -2765,6 +2817,7 @@ class CIMMethodString(unittest.TestCase, RegexpMixin):
 
         self.assertRegexpContains(s, 'FooMethod')
         self.assertRegexpContains(s, 'uint32')
+
 
 class CIMMethodNoReturn(unittest.TestCase):
     """Test that CIMMethod without return value fails"""
@@ -2776,6 +2829,7 @@ class CIMMethodNoReturn(unittest.TestCase):
 
         except ValueError:
             pass
+
 
 class CIMMethodToXML(ValidateTest):
 
@@ -2830,6 +2884,7 @@ class InitCIMParameter(unittest.TestCase):
                      reference_class='CIM_Foo', array_size=10,
                      qualifiers={'Key': CIMQualifier('Key', True)})
 
+
 class CopyCIMParameter(unittest.TestCase):
 
     def test_all(self):
@@ -2851,6 +2906,7 @@ class CopyCIMParameter(unittest.TestCase):
         self.assertEqual(p.type, 'reference')
         self.assertEqual(p.reference_class, 'CIM_Foo')
         self.assertTrue(p.qualifiers['Key'])
+
 
 class CIMParameterAttrs(unittest.TestCase):
 
@@ -2892,6 +2948,7 @@ class CIMParameterAttrs(unittest.TestCase):
         self.assertEqual(p.array_size, 10)
         self.assertEqual(p.is_array, True)
         self.assertEqual(p.qualifiers, {})
+
 
 class CIMParameterEquality(unittest.TestCase):
 
@@ -3002,17 +3059,20 @@ class CIMParameterEquality(unittest.TestCase):
                                                      CIMQualifier('Key',
                                                                   True)}))
 
+
 class CIMParameterCompare(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
 
+
 class CIMParameterSort(unittest.TestCase):
 
     @unimplemented
     def test_all(self):
         raise AssertionError("test not implemented")
+
 
 class CIMParameterString(unittest.TestCase, RegexpMixin):
 
@@ -3022,6 +3082,7 @@ class CIMParameterString(unittest.TestCase, RegexpMixin):
 
         self.assertRegexpContains(s, 'Param1')
         self.assertRegexpContains(s, 'uint32')
+
 
 class CIMParameterToXML(ValidateTest):
 
@@ -3094,25 +3155,32 @@ class CIMParameterToXML(ValidateTest):
 class InitCIMQualifierDeclaration(unittest.TestCase):
     pass
 
+
 class CopyCIMQualifierDeclaration(unittest.TestCase):
     pass
 
+
 class CIMQualifierDeclarationAttrs(unittest.TestCase):
     pass
+
 
 class CIMQualifierDeclarationEquality(unittest.TestCase):
     # pylint: disable=invalid-name
     pass
 
+
 class CIMQualifierDeclarationCompare(unittest.TestCase):
     # pylint: disable=invalid-name
     pass
 
+
 class CIMQualifierDeclarationSort(unittest.TestCase):
     pass
 
+
 class CIMQualifierDeclarationString(unittest.TestCase):
     pass
+
 
 class CIMQualifierDeclarationToXML(unittest.TestCase):
     pass
@@ -3194,15 +3262,14 @@ class ToCIMObj(unittest.TestCase):
         self.assertEqual(path['key1'], 'John Smith')
         self.assertEqual(path['key2'], 33.3)
 
-
         path = cim_obj.tocimobj(
             'reference',
             "//./root/default:NetworkCard=2")
         # TODO How should pywbem deal with a single, unnamed, keybinding?
-        #self.assertTrue(isinstance(path, CIMInstanceName))
-        #self.assertEqual(path.namespace, 'root/default')
-        #self.assertEqual(path.host, '.')
-        #self.assertEqual(path.classname, 'NetworkCard')
+        # self.assertTrue(isinstance(path, CIMInstanceName))
+        # self.assertEqual(path.namespace, 'root/default')
+        # self.assertEqual(path.host, '.')
+        # self.assertEqual(path.classname, 'NetworkCard')
 
 
 class MofStr(unittest.TestCase):
@@ -3274,15 +3341,15 @@ class MofStr(unittest.TestCase):
         self._run_single('\\n', '"\\\\n"')
         self._run_single('\\f', '"\\\\f"')
         self._run_single('\\r', '"\\\\r"')
-        self._run_single('\\\'', '"\\\\\\\'"') # escape the following quote
-        self._run_single('\\"', '"\\\\\\""') # escape the following quote
+        self._run_single('\\\'', '"\\\\\\\'"')  # escape the following quote
+        self._run_single('\\"', '"\\\\\\""')  # escape the following quote
         self._run_single('c\\bd', '"c\\\\bd"')
         self._run_single('c\\td', '"c\\\\td"')
         self._run_single('c\\nd', '"c\\\\nd"')
         self._run_single('c\\fd', '"c\\\\fd"')
         self._run_single('c\\rd', '"c\\\\rd"')
-        self._run_single('c\\\'d', '"c\\\\\\\'d"') # escape the following quote
-        self._run_single('c\\"d', '"c\\\\\\"d"') # escape the following quote
+        self._run_single('c\\\'d', '"c\\\\\\\'d"')  # escape the following quote
+        self._run_single('c\\"d', '"c\\\\\\"d"')  # escape the following quote
 
         # Backslash followed by MOF-escapable character (are treated separately)
         self._run_single('\\\b', '"\\\\\\b"')
@@ -3333,7 +3400,7 @@ class MofStr(unittest.TestCase):
         # Line break cases
 
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown f jumps over a big brown fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \
@@ -3341,7 +3408,7 @@ class MofStr(unittest.TestCase):
             '    "jumps over a big brown fox"')
 
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown fo jumps over a big brown fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \
@@ -3349,7 +3416,7 @@ class MofStr(unittest.TestCase):
             '    "jumps over a big brown fox"')
 
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown fox jumps over a big brown fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \
@@ -3357,14 +3424,14 @@ class MofStr(unittest.TestCase):
             '    "jumps over a big brown fox"')
 
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown foxx jumps over a big brown fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown foxx "\n' \
             '    "jumps over a big brown fox"')
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown foxxx jumps over a big brown fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \
@@ -3373,7 +3440,7 @@ class MofStr(unittest.TestCase):
 
         # TODO: This may be wrong in that it breaks a word, not between words.
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the_big_brown_fox_jumps_over_a_big_brown_fox_jumps_over_a_big' \
             '_brown_fox_jumps_over a big brown fox', \
             '"the_big_brown_fox_jumps_over_a_big_brown_fox_jumps_over_a_big' \
@@ -3381,7 +3448,7 @@ class MofStr(unittest.TestCase):
             '    "umps_over a big brown fox"')
 
         self._run_single(
-            #|1                                                          |60
+            # |2                                                          |60
             'the big brown fox jumps over a big brown fox jumps over a big' \
             ' brown fox_jumps_over_a_big_brown_fox', \
             '"the big brown fox jumps over a big brown fox jumps over a big' \

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -11,9 +11,11 @@ import unittest
 
 from pywbem.cim_operations import check_utf8_xml_chars, ParseError
 
+
 #################################################################
 # Test check_utf8_xml_chars function
 #################################################################
+
 
 # pylint: disable=invalid-name
 class Test_check_utf8_xml_chars(unittest.TestCase):
@@ -94,4 +96,3 @@ class Test_check_utf8_xml_chars(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/testsuite/test_cim_types.py
+++ b/testsuite/test_cim_types.py
@@ -10,13 +10,13 @@ from datetime import timedelta, datetime
 import pytest
 
 from pywbem import CIMType, CIMInt, CIMFloat, Uint8, Uint16, Uint32, Uint64, \
-                   Sint8, Sint16, Sint32, Sint64, Real32, Real64, CIMDateTime, \
-                   MinutesFromUTC
+    Sint8, Sint16, Sint32, Sint64, Real32, Real64, CIMDateTime, MinutesFromUTC
 
 
 #
 # CIM integer data types
 #
+
 
 @pytest.fixture(params=[
 
@@ -41,6 +41,7 @@ from pywbem import CIMType, CIMInt, CIMFloat, Uint8, Uint16, Uint32, Uint64, \
 ], scope='module')
 def integer_tuple(request):
     return request.param
+
 
 class TestIntegers:
     """
@@ -147,6 +148,7 @@ class TestIntegers:
 # CIM real data types
 #
 
+
 @pytest.fixture(params=[
 
     # Each list item is a tuple of:
@@ -160,6 +162,7 @@ class TestIntegers:
 ], scope='module')
 def real_tuple(request):
     return request.param
+
 
 class TestReals:
     """
@@ -207,6 +210,7 @@ class TestReals:
 #
 # CIM datetime data type
 #
+
 
 @pytest.fixture(params=[
 
@@ -320,6 +324,7 @@ class TestReals:
 def datetime_init_tuple(request):
     return request.param
 
+
 class TestDatetime:
     """
     Test CIM real data type classes.
@@ -364,4 +369,3 @@ class TestDatetime:
 # TODO: Add testcases for get_local_utcoffset()
 # TODO: Add testcases for now()
 # TODO: Add testcases for fromtimestamp()
-

--- a/testsuite/test_cim_xml.py
+++ b/testsuite/test_cim_xml.py
@@ -20,6 +20,7 @@ from pywbem.cim_obj import _ensure_bytes
 
 DTD_FILE = 'CIM_DTD_V22.dtd'
 
+
 def validate_xml(data, dtd_directory=None):
 
     from subprocess import Popen, PIPE
@@ -49,16 +50,20 @@ def validate_xml(data, dtd_directory=None):
 
 # Test data to save typing
 
+
 def LOCALNAMESPACEPATH():   # pylint: disable=invalid-name
     return cim_xml.LOCALNAMESPACEPATH([cim_xml.NAMESPACE('root'),
                                        cim_xml.NAMESPACE('cimv2')])
+
 
 def NAMESPACEPATH():   # pylint: disable=invalid-name
     return cim_xml.NAMESPACEPATH(
         cim_xml.HOST('leonardo'), LOCALNAMESPACEPATH())
 
+
 def CLASSNAME():  # pylint: disable=invalid-name
     return cim_xml.CLASSNAME('CIM_Foo')
+
 
 def INSTANCENAME():  # pylint: disable=invalid-name
     return cim_xml.INSTANCENAME(
@@ -67,6 +72,7 @@ def INSTANCENAME():  # pylint: disable=invalid-name
          cim_xml.KEYBINDING('age', cim_xml.KEYVALUE('2', 'numeric'))])
 
 # Base classes
+
 
 class CIMXMLTest(unittest.TestCase):
     """Run validate.py script against an xml document fragment."""
@@ -119,6 +125,7 @@ class UnimplementedTest(object):
 
 #     3.2.1.1. CIM
 
+
 class CIM(CIMXMLTest):
     def setUp(self):
         super(CIM, self).setUp()
@@ -131,6 +138,7 @@ class CIM(CIMXMLTest):
                 '1001', '1.0'),
             '2.0', '2.0'))
 
+
 #################################################################
 #     3.2.2. Declaration Elements
 #################################################################
@@ -142,11 +150,13 @@ class CIM(CIMXMLTest):
 #     3.2.2.5. QUALIFIER.DECLARATION
 #     3.2.2.6. SCOPE
 
+
 # pylint: disable=too-few-public-methods
 class Declaration(UnimplementedTest):
     """
     <!ELEMENT DECLARATION  (DECLGROUP|DECLGROUP.WITHNAME|DECLGROUP.WITHPATH)+>
     """
+
 
 # pylint: disable=too-few-public-methods
 class DeclGroup(UnimplementedTest):
@@ -154,8 +164,8 @@ class DeclGroup(UnimplementedTest):
     <!ELEMENT DECLGROUP  ((LOCALNAMESPACEPATH|NAMESPACEPATH)?,
                           QUALIFIER.DECLARATION*,VALUE.OBJECT*)>
     """
-
     pass
+
 
 # pylint: disable=too-few-public-methods
 class DeclGroupWithName(UnimplementedTest):
@@ -164,12 +174,14 @@ class DeclGroupWithName(UnimplementedTest):
                                    QUALIFIER.DECLARATION*,VALUE.NAMEDOBJECT*)>
     """
 
+
 # pylint: disable=too-few-public-methods
 class DeclGroupWithPath(UnimplementedTest):
     """
     <!ELEMENT DECLGROUP.WITHPATH  (VALUE.OBJECTWITHPATH|
                                    VALUE.OBJECTWITHLOCALPATH)*>
     """
+
 
 # pylint: disable=too-few-public-methods
 class QualifierDeclaration(UnimplementedTest):
@@ -182,6 +194,7 @@ class QualifierDeclaration(UnimplementedTest):
         %ArraySize;
         %QualifierFlavor;>
     """
+
 
 class Scope(CIMXMLTest):
     """
@@ -200,6 +213,7 @@ class Scope(CIMXMLTest):
         super(Scope, self).setUp()
         self.xml.append(cim_xml.SCOPE())
 
+
 #################################################################
 #     3.2.3. Value Elements
 #################################################################
@@ -214,6 +228,7 @@ class Scope(CIMXMLTest):
 #     3.2.3.8. VALUE.OBJECTWITHPATH
 #     3.2.3.9. VALUE.OBJECTWITHLOCALPATH
 #     3.2.3.10. VALUE.NULL
+
 
 class Value(CIMXMLTest):
     """
@@ -237,11 +252,11 @@ class Value(CIMXMLTest):
         # Note: This is illegal, Value.Null should be used instead.
 
         self.xml.append(cim_xml.VALUE(''))
-        self.xml_str.append('<VALUE></VALUE>') # Assuming not folded to <VALUE/>
+        self.xml_str.append('<VALUE></VALUE>')  # Assum. not folded to <VALUE/>
 
         # Some control characters
         self.xml.append(cim_xml.VALUE('a\nb\rc\td'))
-        self.xml_str.append('<VALUE>a\nb\rc\td</VALUE>') # Assuming XML 1.1
+        self.xml_str.append('<VALUE>a\nb\rc\td</VALUE>')  # Assuming XML 1.1
 
         # Some XML special characters
         self.xml.append(cim_xml.VALUE('a&b<c>d'))
@@ -256,7 +271,7 @@ class Value(CIMXMLTest):
         self.xml_str.append(
             '<VALUE><![CDATA[<![CDATA[a&b<c>d]]]><![CDATA[]>]]></VALUE>')
 
-        cim_xml._CDATA_ESCAPING = False # Back to its default
+        cim_xml._CDATA_ESCAPING = False  # Back to its default
 
         self.xml.append(cim_xml.VALUE('dog'))
         self.xml_str.append('<VALUE>dog</VALUE>')
@@ -265,11 +280,11 @@ class Value(CIMXMLTest):
         # Note: This is illegal, Value.Null is used instead.
 
         self.xml.append(cim_xml.VALUE(''))
-        self.xml_str.append('<VALUE></VALUE>') # Assuming not folded to <VALUE/>
+        self.xml_str.append('<VALUE></VALUE>')  # Assum. not folded to <VALUE/>
 
         # Some control characters
         self.xml.append(cim_xml.VALUE('a\nb\rc\td'))
-        self.xml_str.append('<VALUE>a\nb\rc\td</VALUE>') # Assuming XML 1.1
+        self.xml_str.append('<VALUE>a\nb\rc\td</VALUE>')  # Assuming XML 1.1
 
         # Some XML special characters
         self.xml.append(cim_xml.VALUE('a&b<c>d'))
@@ -284,6 +299,7 @@ class Value(CIMXMLTest):
         self.xml_str.append(
             '<VALUE>&lt;![CDATA[a&amp;b&lt;c&gt;d]]&gt;</VALUE>')
 
+
 class ValueArray(CIMXMLTest):
     """
     <!ELEMENT VALUE.ARRAY (VALUE*)>
@@ -296,6 +312,7 @@ class ValueArray(CIMXMLTest):
 
         self.xml.append(cim_xml.VALUE_ARRAY([cim_xml.VALUE('cat'),
                                              cim_xml.VALUE('dog')]))
+
 
 class ValueReference(CIMXMLTest):
     """
@@ -336,6 +353,7 @@ class ValueReference(CIMXMLTest):
 
         self.xml.append(cim_xml.VALUE_REFERENCE(INSTANCENAME()))
 
+
 class ValueRefArray(CIMXMLTest):
     """
     <!ELEMENT VALUE.REFARRAY (VALUE.REFERENCE*)>
@@ -355,6 +373,7 @@ class ValueRefArray(CIMXMLTest):
              cim_xml.VALUE_REFERENCE(cim_xml.LOCALCLASSPATH(
                  LOCALNAMESPACEPATH(), CLASSNAME()))]))
 
+
 class ValueObject(CIMXMLTest):
     """
     <!ELEMENT VALUE.OBJECT (CLASS|INSTANCE)>
@@ -371,6 +390,7 @@ class ValueObject(CIMXMLTest):
 
         self.xml.append(cim_xml.VALUE_OBJECT(cim_xml.INSTANCE('CIM_Pet', [])))
 
+
 class ValueNamedInstance(CIMXMLTest):
     """
     <!ELEMENT VALUE.NAMEDINSTANCE (INSTANCENAME,INSTANCE)>
@@ -382,6 +402,7 @@ class ValueNamedInstance(CIMXMLTest):
         self.xml.append(cim_xml.VALUE_NAMEDINSTANCE(
             INSTANCENAME(),
             cim_xml.INSTANCE('CIM_Pet', [])))
+
 
 class ValueNamedObject(CIMXMLTest):
     """
@@ -401,6 +422,7 @@ class ValueNamedObject(CIMXMLTest):
         self.xml.append(cim_xml.VALUE_NAMEDOBJECT(
             (INSTANCENAME(),
              cim_xml.INSTANCE('CIM_Pet', []))))
+
 
 class ValueObjectWithPath(CIMXMLTest):
     """
@@ -424,6 +446,7 @@ class ValueObjectWithPath(CIMXMLTest):
                 NAMESPACEPATH(), INSTANCENAME()),
             cim_xml.INSTANCE('CIM_Pet', [])))
 
+
 class ValueObjectWithLocalPath(CIMXMLTest):
     """
     <!ELEMENT VALUE.OBJECTWITHLOCALPATH ((LOCALCLASSPATH,CLASS)|
@@ -446,6 +469,7 @@ class ValueObjectWithLocalPath(CIMXMLTest):
                 LOCALNAMESPACEPATH(),
                 INSTANCENAME()),
             cim_xml.INSTANCE('CIM_Pet', [])))
+
 
 # pylint: disable=too-few-public-methods
 class ValueNull(UnimplementedTest):
@@ -473,6 +497,7 @@ class ValueNull(UnimplementedTest):
 #     3.2.4.12. KEYBINDING
 #     3.2.4.13. KEYVALUE
 
+
 class NamespacePath(CIMXMLTest):
     """
     <!ELEMENT NAMESPACEPATH (HOST,LOCALNAMESPACEPATH)>
@@ -482,6 +507,7 @@ class NamespacePath(CIMXMLTest):
         super(NamespacePath, self).setUp()
 
         self.xml.append(NAMESPACEPATH())
+
 
 class LocalNamespacePath(CIMXMLTest):
     """
@@ -493,6 +519,7 @@ class LocalNamespacePath(CIMXMLTest):
 
         self.xml.append(LOCALNAMESPACEPATH())
 
+
 class Host(CIMXMLTest):
     """
     <!ELEMENT HOST (#PCDATA)>
@@ -502,6 +529,7 @@ class Host(CIMXMLTest):
         super(Host, self).setUp()
 
         self.xml.append(cim_xml.HOST('leonardo'))
+
 
 class Namespace(CIMXMLTest):
     """
@@ -515,6 +543,7 @@ class Namespace(CIMXMLTest):
 
         self.xml.append(cim_xml.NAMESPACE('root'))
 
+
 class ClassPath(CIMXMLTest):
     """
     <!ELEMENT CLASSPATH (NAMESPACEPATH,CLASSNAME)>
@@ -524,6 +553,7 @@ class ClassPath(CIMXMLTest):
         super(ClassPath, self).setUp()
 
         self.xml.append(cim_xml.CLASSPATH(NAMESPACEPATH(), CLASSNAME()))
+
 
 class LocalClassPath(CIMXMLTest):
     """
@@ -535,6 +565,7 @@ class LocalClassPath(CIMXMLTest):
 
         self.xml.append(cim_xml.LOCALCLASSPATH(
             LOCALNAMESPACEPATH(), CLASSNAME()))
+
 
 class ClassName(CIMXMLTest):
     """
@@ -548,6 +579,7 @@ class ClassName(CIMXMLTest):
 
         self.xml.append(CLASSNAME())
 
+
 class InstancePath(CIMXMLTest):
     """
     <!ELEMENT INSTANCEPATH (NAMESPACEPATH,INSTANCENAME)>
@@ -559,6 +591,7 @@ class InstancePath(CIMXMLTest):
         self.xml.append(cim_xml.INSTANCEPATH(
             NAMESPACEPATH(), INSTANCENAME()))
 
+
 class LocalInstancePath(CIMXMLTest):
     """
     <!ELEMENT LOCALINSTANCEPATH (LOCALNAMESPACEPATH,INSTANCENAME)>
@@ -569,6 +602,7 @@ class LocalInstancePath(CIMXMLTest):
 
         self.xml.append(cim_xml.LOCALINSTANCEPATH(
             LOCALNAMESPACEPATH(), INSTANCENAME()))
+
 
 class InstanceName(CIMXMLTest):
     """
@@ -599,6 +633,7 @@ class InstanceName(CIMXMLTest):
             'CIM_Pet',
             cim_xml.VALUE_REFERENCE(INSTANCENAME())))
 
+
 class ObjectPath(CIMXMLTest):
     """
     <!ELEMENT OBJECTPATH (INSTANCEPATH|CLASSPATH)>
@@ -613,6 +648,7 @@ class ObjectPath(CIMXMLTest):
 
         self.xml.append(cim_xml.OBJECTPATH(
             cim_xml.CLASSPATH(NAMESPACEPATH(), CLASSNAME())))
+
 
 class KeyBinding(CIMXMLTest):
     """
@@ -632,6 +668,7 @@ class KeyBinding(CIMXMLTest):
             cim_xml.VALUE_REFERENCE(
                 cim_xml.CLASSPATH(NAMESPACEPATH(), CLASSNAME()))))
 
+
 class KeyValue(CIMXMLTest):
     """
     <!ELEMENT KEYVALUE (#PCDATA)>
@@ -648,6 +685,7 @@ class KeyValue(CIMXMLTest):
         self.xml.append(cim_xml.KEYVALUE('FALSE', 'boolean'))
         self.xml.append(cim_xml.KEYVALUE('2', 'numeric', 'uint16'))
         self.xml.append(cim_xml.KEYVALUE(None))
+
 
 #################################################################
 #     3.2.5. Object Definition Elements
@@ -669,6 +707,7 @@ class KeyValue(CIMXMLTest):
 #     3.2.5.14. TABLEROW.DECLARATION
 #     3.2.5.15. TABLE
 #     3.2.5.16. TABLEROW
+
 
 class Class(CIMXMLTest):
     """
@@ -719,6 +758,7 @@ class Class(CIMXMLTest):
         self.xml.append(cim_xml.CLASS(
             'CIM_Foo',
             methods=[cim_xml.METHOD('FooMethod')]))
+
 
 class Instance(CIMXMLTest):
     """
@@ -779,6 +819,7 @@ class Instance(CIMXMLTest):
              cim_xml.PROPERTY_REFERENCE(
                  'Cat',
                  cim_xml.VALUE_REFERENCE(cim_xml.CLASSNAME('CIM_Cat')))]))
+
 
 class Qualifier(CIMXMLTest):
     """
@@ -864,6 +905,7 @@ class Property(CIMXMLTest):
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
 
+
 class PropertyArray(CIMXMLTest):
     """
     <!ELEMENT PROPERTY.ARRAY (QUALIFIER*,VALUE.ARRAY?)>
@@ -913,6 +955,7 @@ class PropertyArray(CIMXMLTest):
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
 
+
 class PropertyReference(CIMXMLTest):
     """
     <!ELEMENT PROPERTY.REFERENCE (QUALIFIER*,VALUE.REFERENCE?)>
@@ -951,6 +994,7 @@ class PropertyReference(CIMXMLTest):
             cim_xml.VALUE_REFERENCE(cim_xml.CLASSNAME('CIM_Dog')),
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
+
 
 class Method(CIMXMLTest):
     """
@@ -1035,6 +1079,7 @@ class Parameter(CIMXMLTest):
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
 
+
 class ParameterReference(CIMXMLTest):
     """
     <!ELEMENT PARAMETER.REFERENCE (QUALIFIER*)>
@@ -1057,6 +1102,7 @@ class ParameterReference(CIMXMLTest):
             reference_class='CIM_Foo',
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
+
 
 class ParameterArray(CIMXMLTest):
     """
@@ -1083,6 +1129,7 @@ class ParameterArray(CIMXMLTest):
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
 
+
 class ParameterReferenceArray(CIMXMLTest):
     """
     <!ELEMENT PARAMETER.REFARRAY (QUALIFIER*)>
@@ -1108,6 +1155,7 @@ class ParameterReferenceArray(CIMXMLTest):
             qualifiers=[cim_xml.QUALIFIER('IMPISH', 'string',
                                           cim_xml.VALUE('true'))]))
 
+
 # New in v2.2 of the DTD
 
 # TABLECELL.DECLARATION
@@ -1115,6 +1163,7 @@ class ParameterReferenceArray(CIMXMLTest):
 # TABLEROW.DECLARATION
 # TABLE
 # TABLEROW
+
 
 #################################################################
 #     3.2.6. Message Elements
@@ -1143,6 +1192,7 @@ class ParameterReferenceArray(CIMXMLTest):
 #     3.2.6.21 EXPPARAMVALUE
 #     3.2.6.22 RESPONSEDESTINATION
 #     3.2.6.23 SIMPLEREQACK
+
 
 class Message(CIMXMLTest):
     """
@@ -1198,6 +1248,7 @@ class Message(CIMXMLTest):
         # SIMPLEEXPRSP
         # MULTIEXPRSP
 
+
 class MultiReq(CIMXMLTest):
     """
     <!ELEMENT MULTIREQ (SIMPLEREQ, SIMPLEREQ+)>
@@ -1212,6 +1263,7 @@ class MultiReq(CIMXMLTest):
              cim_xml.SIMPLEREQ(cim_xml.IMETHODCALL('FooMethod',
                                                    LOCALNAMESPACEPATH()))]))
 
+
 class MultiExpReq(CIMXMLTest):
     """
     <!ELEMENT MULTIEXPREQ (SIMPLEEXPREQ, SIMPLEEXPREQ+)>
@@ -1223,6 +1275,7 @@ class MultiExpReq(CIMXMLTest):
         self.xml.append(cim_xml.MULTIEXPREQ(
             [cim_xml.SIMPLEEXPREQ(cim_xml.EXPMETHODCALL('FooMethod')),
              cim_xml.SIMPLEEXPREQ(cim_xml.EXPMETHODCALL('FooMethod'))]))
+
 
 class SimpleReq(CIMXMLTest):
     """
@@ -1244,6 +1297,7 @@ class SimpleReq(CIMXMLTest):
                 'FooMethod',
                 cim_xml.LOCALCLASSPATH(LOCALNAMESPACEPATH(), CLASSNAME()))))
 
+
 class SimpleExpReq(CIMXMLTest):
     """
     <!ELEMENT SIMPLEEXPREQ (EXPMETHODCALL)>
@@ -1254,6 +1308,7 @@ class SimpleExpReq(CIMXMLTest):
 
         self.xml.append(cim_xml.SIMPLEEXPREQ(
             cim_xml.EXPMETHODCALL('FooMethod')))
+
 
 class IMethodCall(CIMXMLTest):
     """
@@ -1274,6 +1329,7 @@ class IMethodCall(CIMXMLTest):
             [cim_xml.IPARAMVALUE('Dog', cim_xml.VALUE('Spottyfoot'))]))
 
         # TODO: RESPONSEDESTINATION
+
 
 class MethodCall(CIMXMLTest):
     """
@@ -1306,6 +1362,7 @@ class MethodCall(CIMXMLTest):
             [cim_xml.PARAMVALUE('Dog', cim_xml.VALUE('Spottyfoot'))]))
 
         # TODO: RESPONSEDESTINATION
+
 
 class ExpMethodCall(CIMXMLTest):
     """
@@ -1483,6 +1540,7 @@ class MultiExpRsp(CIMXMLTest):
                 [cim_xml.SIMPLEEXPRSP(cim_xml.EXPMETHODRESPONSE('FooMethod')),
                  cim_xml.SIMPLEEXPRSP(cim_xml.EXPMETHODRESPONSE('FooMethod'))]))
 
+
 class SimpleRsp(CIMXMLTest):
     """
     <!ELEMENT SIMPLERSP (METHODRESPONSE | IMETHODRESPONSE | SIMPLEREQACK>
@@ -1503,6 +1561,7 @@ class SimpleRsp(CIMXMLTest):
 
         # TODO: SIMPLEREQACK
 
+
 class SimpleExpRsp(CIMXMLTest):
     """
     <!ELEMENT SIMPLEEXPRSP (EXPMETHODRESPONSE)>
@@ -1513,6 +1572,7 @@ class SimpleExpRsp(CIMXMLTest):
 
         self.xml.append(
             cim_xml.SIMPLEEXPRSP(cim_xml.EXPMETHODRESPONSE('FooMethod')))
+
 
 class MethodResponse(CIMXMLTest):
     """
@@ -1557,6 +1617,7 @@ class MethodResponse(CIMXMLTest):
                 (cim_xml.RETURNVALUE(cim_xml.VALUE('Dog')),
                  cim_xml.PARAMVALUE('Dog', cim_xml.VALUE('Spottyfoot')))))
 
+
 class ExpMethodResponse(CIMXMLTest):
     """
     <!ELEMENT EXPMETHODRESPONSE (ERROR | IRETURNVALUE?)>
@@ -1582,6 +1643,7 @@ class ExpMethodResponse(CIMXMLTest):
         self.xml.append(cim_xml.EXPMETHODRESPONSE(
             'FooMethod',
             cim_xml.IRETURNVALUE(cim_xml.VALUE('Dog'))))
+
 
 class IMethodResponse(CIMXMLTest):
     """
@@ -1609,6 +1671,7 @@ class IMethodResponse(CIMXMLTest):
             'FooMethod',
             cim_xml.IRETURNVALUE(cim_xml.VALUE('Dog'))))
 
+
 class Error(CIMXMLTest):
     """
     <!ELEMENT ERROR (INSTANCE*)>
@@ -1623,6 +1686,7 @@ class Error(CIMXMLTest):
         self.xml.append(cim_xml.ERROR('1'))
         self.xml.append(cim_xml.ERROR('1', 'Foo not found'))
         # TODO: INSTANCE*
+
 
 class ReturnValue(CIMXMLTest):
     """
@@ -1644,6 +1708,7 @@ class ReturnValue(CIMXMLTest):
             cim_xml.CLASSPATH(NAMESPACEPATH(), CLASSNAME()))))
 
         # TODO: PARAMTYPE
+
 
 class IReturnValue(CIMXMLTest):
     """
@@ -1732,6 +1797,7 @@ class IReturnValue(CIMXMLTest):
                 INSTANCENAME(),
                 cim_xml.INSTANCE('CIM_Pet', []))))
 
+
 # pylint: disable=too-few-public-methods
 class ResponseDestination(UnimplementedTest):
     """
@@ -1740,6 +1806,8 @@ class ResponseDestination(UnimplementedTest):
 
     <!ELEMENT RESPONSEDESTINATON (INSTANCE)>
     """
+
+
 # pylint: disable=too-few-public-methods
 class SimpleReqAck(UnimplementedTest):
     """

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -35,18 +35,18 @@ import yaml
 import httpretty
 from httpretty.core import HTTPrettyRequestEmpty
 from lxml import etree, doctestcompare
+import pywbem
+from pywbem.cim_obj import _ensure_unicode, NocaseDict
 if six.PY2:
     from M2Crypto.Err import SSLError
 else:
     from ssl import SSLError
 
-import pywbem
-from pywbem.cim_obj import _ensure_unicode, NocaseDict
-
 # Directory with the JSON test case files, relative to this script:
 TESTCASE_DIR = os.path.join(os.path.dirname(__file__), "testclient")
 
 RUN_ONE_TESTCASE = None
+
 
 class ClientTestError(Exception):
     """Exception indicating an issue in the test case definition."""
@@ -147,6 +147,7 @@ def tc_getattr(tc_name, dict_, key, default=-1):
                               "'%s' attribute missing" % (tc_name, key))
     return value
 
+
 def tc_getattr_list(tc_name, dict_, key, default=-1):
     """ Gets the attribute of a name/value pair defined by key in dictionary
         defined by dict_. The entry may be dictionary, ordinary value or
@@ -170,6 +171,7 @@ def tc_getattr_list(tc_name, dict_, key, default=-1):
 def tc_hasattr(dict_, key):
     """Return true if key is in dict_"""
     return key in dict_
+
 
 class Callback(object):
     """A class with static methods that are HTTPretty callback functions for
@@ -196,27 +198,28 @@ class Callback(object):
     """
 
     @staticmethod
-    def socket_ssl(request, uri, headers): # pylint: disable=unused-argument
+    def socket_ssl(request, uri, headers):  # pylint: disable=unused-argument
         """HTTPretty callback function that raises an arbitrary
         SSLError."""
         raise SSLError(1, "Arbitrary SSL error.")
 
     @staticmethod
-    def socket_104(request, uri, headers): # pylint: disable=unused-argument
+    def socket_104(request, uri, headers):  # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.error 104."""
         raise socket.error(104, "Connection reset by peer.")
 
     @staticmethod
-    def socket_32(request, uri, headers): # pylint: disable=unused-argument
+    def socket_32(request, uri, headers):  # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.error 32."""
         raise socket.error(32, "Broken pipe.")
 
     @staticmethod
-    def socket_timeout(request, uri, headers): # pylint: disable=unused-argument
+    def socket_timeout(request, uri, headers):  # pylint: disable=unused-argument # noqa: E501
         """HTTPretty callback function that raises socket.timeout error.
            The socket.timeout is just a string, no status.
         """
         raise socket.timeout("Socket timeout.")
+
 
 def xml_embed(tree_elem):
     """
@@ -237,6 +240,7 @@ def xml_embed(tree_elem):
     """
     return xml_escape(etree.tostring(tree_elem))
 
+
 def xml_escape(s):
     """
     Return the XML-escaped input string.
@@ -254,6 +258,7 @@ def xml_escape(s):
         s = s.replace(b"\"", b"&quot;")
         s = s.replace(b"'", b"&apos;")
     return s
+
 
 def xml_unembed(emb_str):
     """
@@ -276,6 +281,7 @@ def xml_unembed(emb_str):
     """
     parser = etree.XMLParser(remove_blank_text=True)
     return etree.XML(xml_unescape(emb_str), parser=parser)
+
 
 def xml_unescape(s):
     """
@@ -729,7 +735,7 @@ class ClientTest(unittest.TestCase):
                 print("- Actual result len: %s" % len(result))
                 raise AssertionError("PyWBEM CIM result type is not"
                                      " as expected.")
-            #eos is required result
+            # eos is required result
             if result.eos != exp_pull_result_obj.eos:
                 print("Details for the following assertion error:")
                 print("- Expected pull result.eos: %r" %
@@ -744,7 +750,7 @@ class ClientTest(unittest.TestCase):
             if result.context != exp_pull_result_obj.context:
                 print("Details for the following assertion error:")
                 print("- Expected pull result.context: %r" %
-                    exp_pull_result_obj.context)
+                      exp_pull_result_obj.context)
                 print("- Actual pull result.context: %r" % result.context)
                 if conn.debug:
                     print("- HTTP response data: %r" % conn.last_raw_reply)
@@ -775,14 +781,15 @@ class ClientTest(unittest.TestCase):
                                          "result is not as expected.")
             else:
                 raise AssertionError("WBEMConnection operation method result "
-                     "is not as expected. No 'instances' "
-                     "or 'paths' component.")
+                                     "is not as expected. No 'instances' "
+                                     "or 'paths' component.")
 
             # TODO redo as indexed loop to compare all items.
 
         else:
             self.assertEqual(result, None,
                              "PyWBEM CIM result is not None: %s" % repr(result))
+
 
 def result_tuple(value, tc_name):
     """ Process the value (a dictionary) to create a named tuple of
@@ -820,7 +827,7 @@ def result_tuple(value, tc_name):
 
     else:
         raise AssertionError("WBEMConnection operation invalid tuple "
-                                 "definition.")
+                             "definition.")
 
 
 if __name__ == '__main__':
@@ -835,6 +842,5 @@ if __name__ == '__main__':
 
     elif len(sys.argv) > 2:
         sys.exit('ERROR: too many cmd line args')
-
 
     unittest.main()

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -9,8 +9,9 @@ from __future__ import absolute_import, print_function
 import six
 import pytest
 
-from pywbem import Error, ConnectionError, AuthError, HTTPError, \
-                   TimeoutError, ParseError, VersionError, CIMError
+from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError,\
+    ParseError, VersionError, CIMError
+
 
 def _assert_subscription(exc):
 
@@ -36,12 +37,14 @@ def _assert_subscription(exc):
             else:
                 assert False, "Access by index did not fail in Python 3"
 
+
 # The exception classes for which the simple test should be done:
 @pytest.fixture(params=[
     Error, ConnectionError, AuthError, TimeoutError, ParseError, VersionError
 ], scope='module')
 def simple_class(request):
     return request.param
+
 
 # The init arguments for the simple exception classes:
 @pytest.fixture(params=[
@@ -51,6 +54,7 @@ def simple_class(request):
 ], scope='module')
 def simple_args(request):
     return request.param
+
 
 def test_simple(simple_class, simple_args):
 
@@ -66,6 +70,7 @@ def test_simple(simple_class, simple_args):
 
     _assert_subscription(exc)
 
+
 # The init arguments for the HTTPError exception class:
 @pytest.fixture(params=[
     # (status, reason, cimerror=None, cimdetails={})
@@ -75,6 +80,7 @@ def test_simple(simple_class, simple_args):
 ], scope='module')
 def httperror_args(request):
     return request.param
+
 
 def test_httperror(httperror_args):
 
@@ -98,6 +104,7 @@ def test_httperror(httperror_args):
     assert len(exc.args) == 4
 
     _assert_subscription(exc)
+
 
 # The CIM status codes for the CIMError exception class:
 @pytest.fixture(params=[
@@ -139,6 +146,7 @@ def test_httperror(httperror_args):
 def status_tuple(request):
     return request.param
 
+
 def test_cimerror_1(status_tuple):
 
     status_code = status_tuple[0]
@@ -162,6 +170,7 @@ def test_cimerror_1(status_tuple):
     assert len(exc.args) == 2
 
     _assert_subscription(exc)
+
 
 def test_cimerror_2(status_tuple):
 

--- a/testsuite/test_indicationlistener.py
+++ b/testsuite/test_indicationlistener.py
@@ -28,11 +28,13 @@ RCV_FAIL = False
 VERBOSE = False
 LISTENER = None
 
+
 class ElapsedTimer(object):
     """
         Set up elapsed time timer. Calculates time between initiation
         and access.
     """
+
     def __init__(self):
         """ Initiate the object with current time"""
         self.start_time = datetime.datetime.now()
@@ -46,14 +48,15 @@ class ElapsedTimer(object):
             point representation of elapsed time in seconds.
         """
         dt = datetime.datetime.now() - self.start_time
-        return ((dt.days * 24 * 3600) + dt.seconds) * 1000  \
-                + dt.microseconds / 1000.0
+        return ((dt.days * 24 * 3600) + dt.seconds) * 1000 + \
+            dt.microseconds / 1000.0
 
     def elapsed_sec(self):
         """ get the elapsed time in seconds. Returns floating
             point representation of time in seconds
         """
         return self.elapsed_ms() / 1000
+
 
 def create_indication_data(msg_id, sequence_number, delta_time, protocol_ver):
     """Create a test indication from the template and input attributes"""
@@ -85,6 +88,7 @@ def create_indication_data(msg_id, sequence_number, delta_time, protocol_ver):
             'protocol_ver': protocol_ver, 'msg_id': msg_id}
     return data_template % data
 
+
 def send_indication(url, headers, payload, verbose):
     """Send a single indication using Python requests"""
 
@@ -100,6 +104,7 @@ def send_indication(url, headers, payload, verbose):
                                                          response.text))
 
     return True if(response.status_code == 200) else False
+
 
 def _process_indication(indication, host):
     """
@@ -124,11 +129,12 @@ def _process_indication(indication, host):
         RCV_FAIL = True
         print('ERROR in process indication counter=%s, COUNT=%s' % (counter,
                                                                     RCV_COUNT))
-    #print('counter %s COUNT %s' % (counter, RCV_COUNT))
+    # print('counter %s COUNT %s' % (counter, RCV_COUNT))
     RCV_COUNT += 1
     if VERBOSE:
         print("Received indication %s from %s:\n%s" % (RCV_COUNT, host,
                                                        indication.tomof()))
+
 
 class TestIndications(unittest.TestCase):
     """
@@ -158,6 +164,7 @@ class TestIndications(unittest.TestCase):
         LISTENER.add_callback(_process_indication)
         LISTENER.start()
 
+    # pylint: disable=unused-argument
     def send_indications(self, send_count, http_port, https_port):
         """
         Send the number of indications defined by the send_count attribute
@@ -168,7 +175,7 @@ class TestIndications(unittest.TestCase):
         that each carries its own sequence number
         """
 
-        #pylint: disable=global-variable-not-assigned
+        # pylint: disable=global-variable-not-assigned
         global VERBOSE
         global RCV_FAIL
         RCV_FAIL = False
@@ -191,7 +198,7 @@ class TestIndications(unittest.TestCase):
                    'Accept-Encoding': 'Identity',
                    'CIMProtocolVersion': cim_protocol_version}
         # includes accept-encoding because of requests issue.
-        #He supplies it if don't TODO try None
+        # He supplies it if don't TODO try None
 
         delta_time = time() - start_time
         rand_base = randint(1, 10000)
@@ -223,8 +230,8 @@ class TestIndications(unittest.TestCase):
         RCV_FAIL = False
         LISTENER.stop()
 
-#TODO issue 452. Reuse of the indication listener fails at least in python 3
-# Therefore we use different port for each test
+    # TODO issue 452. Reuse of the indication listener fails at least in py3,
+    # therefore we use different port for each test.
     def test_send_10(self):
         """Test with sending 10 indications"""
         self.send_indications(10, 5000, None)
@@ -234,13 +241,14 @@ class TestIndications(unittest.TestCase):
         self.send_indications(100, 5001, None)
 
     # Disabled the following test, because in some environments it takes 30min.
-    #def test_send_1000(self):
-    #    """Test sending 1000 indications"""
-    #    self.send_indications(1000, 5002, None)
+    # def test_send_1000(self):
+    #     """Test sending 1000 indications"""
+    #     self.send_indications(1000, 5002, None)
 
-#    This test takes about 60 seconds and so is disabled for now
-#    def test_send_10000(self):
-#        self.send_indications(10000)
+    # This test takes about 60 seconds and so is disabled for now
+    # def test_send_10000(self):
+    #     self.send_indications(10000)
+
 
 if __name__ == '__main__':
     VERBOSE = False

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -92,12 +92,14 @@ class TestInit(unittest.TestCase):
         else:
             self.fail("TypeError was unexpectedly not thrown.")
 
+
 class BaseTest(unittest.TestCase):
 
     def setUp(self):
         self.dic = NocaseDict()
         self.dic['Dog'] = 'Cat'
         self.dic['Budgie'] = 'Fish'
+
 
 class TestGetitem(BaseTest):
 
@@ -112,10 +114,12 @@ class TestGetitem(BaseTest):
         else:
             self.fail("KeyError was unexpectedly not thrown.")
 
+
 class TestLen(BaseTest):
 
     def test_all(self):
         self.assertTrue(len(self.dic) == 2)
+
 
 class TestSetitem(BaseTest):
 
@@ -135,6 +139,7 @@ class TestSetitem(BaseTest):
         else:
             self.fail('TypeError expected')
 
+
 class TestDelitem(BaseTest):
 
     def test_all(self):
@@ -149,12 +154,14 @@ class TestDelitem(BaseTest):
         else:
             self.fail("KeyError was unexpectedly not thrown.")
 
+
 class TestHasKey(BaseTest):
 
     def test_all(self):
         self.assertTrue('DOG' in self.dic)
         self.assertTrue('budgie' in self.dic)
         self.assertTrue(1234 not in self.dic)
+
 
 class TestKeys(BaseTest):
 
@@ -166,6 +173,7 @@ class TestKeys(BaseTest):
             keys.remove(ani)
         self.assertTrue(keys == [])
 
+
 class TestValues(BaseTest):
 
     def test_all(self):
@@ -175,6 +183,7 @@ class TestValues(BaseTest):
             self.assertTrue(ani in values)
             values.remove(ani)
         self.assertTrue(values == [])
+
 
 class TestItems(BaseTest):
 
@@ -186,11 +195,13 @@ class TestItems(BaseTest):
             items.remove(ani)
         self.assertTrue(items == [])
 
+
 class TestClear(BaseTest):
 
     def test_all(self):
         self.dic.clear()
         self.assertTrue(len(self.dic) == 0)
+
 
 class TestUpdate(BaseTest):
 
@@ -218,6 +229,7 @@ class TestUpdate(BaseTest):
         self.assertTrue(self.dic['COW'] == 'Beef')
         self.assertTrue(self.dic['cow'] == 'Beef')
 
+
 class TestCopy(BaseTest):
 
     def test_all(self):
@@ -228,12 +240,14 @@ class TestCopy(BaseTest):
         self.assertTrue(self.dic['Dog'] == 'Cat')
         self.assertTrue(cp['Dog'] == 'Kitten')
 
+
 class TestGet(BaseTest):
 
     def test_all(self):
         self.assertTrue(self.dic.get('Dog', 'Chicken') == 'Cat')
         self.assertTrue(self.dic.get('Ningaui') is None)
         self.assertTrue(self.dic.get('Ningaui', 'Chicken') == 'Chicken')
+
 
 class TestSetDefault(BaseTest):
 
@@ -243,10 +257,12 @@ class TestSetDefault(BaseTest):
         self.dic.setdefault('Ningaui', 'Chicken')
         self.assertTrue(self.dic['Ningaui'] == 'Chicken')
 
+
 class TestPopItem(BaseTest):
 
     def test_all(self):
         pass
+
 
 # TODO: swapcase2() is also defined in test_cim_obj.py. Consolidate.
 def swapcase2(text):
@@ -261,6 +277,7 @@ def swapcase2(text):
         text_cs += c
         i += 1
     return text_cs
+
 
 class TestEqual(BaseTest):
 
@@ -380,6 +397,7 @@ class TestEqual(BaseTest):
             test_ncdicts.append((test_ncdict, relation, comment))
         self.run_test_dicts(base_ncdict, test_ncdicts)
 
+
 class TestOrdering(BaseTest):
     """Verify that ordering comparisons between NocaseDict instances
     issue a deprecation warning, and for Python 3, in addition the usual
@@ -408,12 +426,14 @@ class TestOrdering(BaseTest):
         self.assertWarning("self.dic > self.dic")
         self.assertWarning("self.dic >= self.dic")
 
+
 class TestContains(BaseTest):
 
     def test_all(self):
         self.assertTrue('dog' in self.dic)
         self.assertTrue('Dog' in self.dic)
         self.assertTrue('Cat' not in self.dic)
+
 
 class TestForLoop(BaseTest):
 
@@ -423,6 +443,7 @@ class TestForLoop(BaseTest):
             keys.add(key)
         self.assertTrue(keys, set(['Budgie', 'Dog']))
 
+
 class TestIterkeys(BaseTest):
 
     def test_all(self):
@@ -431,6 +452,7 @@ class TestIterkeys(BaseTest):
             keys.add(key)
         self.assertTrue(keys, set(['Budgie', 'Dog']))
 
+
 class TestItervalues(BaseTest):
 
     def test_all(self):
@@ -438,6 +460,7 @@ class TestItervalues(BaseTest):
         for val in self.dic.itervalues():
             vals.add(val)
         self.assertTrue(vals, set(['Cat', 'Fish']))
+
 
 class TestIteritems(BaseTest):
 

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -14,9 +14,8 @@ from __future__ import absolute_import
 import unittest
 
 from pywbem import tupletree, tupleparse
-from pywbem import CIMInstance, CIMInstanceName, CIMClass, \
-                   CIMProperty, CIMParameter, CIMQualifier, \
-                   Uint8, Uint16, Uint32
+from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMProperty, \
+    CIMParameter, CIMQualifier, Uint8, Uint16, Uint32
 
 
 class TupleTest(unittest.TestCase):
@@ -38,6 +37,7 @@ class TupleTest(unittest.TestCase):
                          '\nbefore: %s\nafter:  %s' %
                          (xml, result.tocimxml().toxml()))
 
+
 class RawXMLTest(unittest.TestCase):
     """Test parse of any XML to object"""
 
@@ -51,6 +51,7 @@ class RawXMLTest(unittest.TestCase):
 
         self.assertEqual(obj, result,
                          'parsed XML: %s' % result)
+
 
 class ParseCIMInstanceName(TupleTest):
     """Test parsing of CIMInstanceName objects."""
@@ -78,6 +79,7 @@ class ParseCIMInstanceName(TupleTest):
                             host='woot.com',
                             namespace='root/cimv2'))
 
+
 class ParseCIMInstance(TupleTest):
     """Test parsing of CIMInstance objects."""
 
@@ -98,6 +100,7 @@ class ParseCIMInstance(TupleTest):
                         {'InstanceID': '1234'},
                         path=CIMInstanceName('CIM_Foo',
                                              {'InstanceID': '1234'})))
+
 
 # TODO 2/16 KS: Create test for more complete class.
 class ParseCIMClass(TupleTest):
@@ -156,6 +159,7 @@ class ParseCIMClass(TupleTest):
                        }  # noqa: E124
             ))  # noqa: E123
 
+
 # TODO 2/16 KS: Extend to all property data types.
 class ParseCIMProperty(TupleTest):
     """Test parsing of CIMProperty objects."""
@@ -194,6 +198,7 @@ class ParseCIMProperty(TupleTest):
                            {'one': Uint8(1), 'two': Uint8(2)})
         self._run_single(CIMProperty('Foo', inst))
         self._run_single(CIMProperty('Foo', [inst]))
+
 
 # TODO 2/16 KS: Extend for all data types.
 class ParseCIMParameter(TupleTest):

--- a/testsuite/test_valuemapping.py
+++ b/testsuite/test_valuemapping.py
@@ -10,7 +10,7 @@ import unittest
 from mock import Mock
 
 from pywbem import CIMClass, CIMProperty, CIMQualifier, Uint8, WBEMServer, \
-                   WBEMConnection, ValueMapping
+    WBEMConnection, ValueMapping
 
 CLASSNAME = 'C1'
 NAMESPACE = 'ns'

--- a/testsuite/unittest_extensions.py
+++ b/testsuite/unittest_extensions.py
@@ -12,6 +12,7 @@ import os
 
 from pywbem.cim_obj import NocaseDict
 
+
 class RegexpMixin(object):
     """Mixin class for classes derived from unittest.TestCase, providing
     assertion functions for regular expression tests."""
@@ -53,17 +54,19 @@ class RegexpMixin(object):
                 "    text:    %r\n"
                 "    pattern: %r" % (text, pattern))
 
+
 class FileMixin(object):
     """Mixin class for classes derived from unittest.TestCase, providing
     assertion functions for file related tests."""
 
     def assertFileExists(self, filename):
-        assert os.path.exists(filename),\
-               ("File does not exist but should: %s" % filename)
+        assert os.path.exists(filename), \
+            ("File does not exist but should: %s" % filename)
 
     def assertFileNotExists(self, filename):
-        assert not os.path.exists(filename),\
-               ("File exists but should not: %s" % filename)
+        assert not os.path.exists(filename), \
+            ("File exists but should not: %s" % filename)
+
 
 class CIMObjectMixin(object):
     """Mixin class for classes derived from unittest.TestCase, providing

--- a/testsuite/validate.py
+++ b/testsuite/validate.py
@@ -37,6 +37,7 @@ from pywbem.cim_obj import _ensure_bytes
 
 DTD_FILE = 'CIM_DTD_V22.dtd'
 
+
 def validate_xml(data, dtd_directory=None, root_elem=None):
     """
     Validate the provided XML instance data against a CIM-XML DTD, optionally

--- a/wbemcli
+++ b/wbemcli
@@ -1001,7 +1001,8 @@ def OpenAssociatorInstancePaths(op, ac=None, rc=None, r=None, rr=None, iq=None,
                                         MaxObjectCount=moc)
 
 
-def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None):
+def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None,
+                       rc=None):
     """
     Open an enumeration sequence to execute a query `fi` using the query
     language `fl`.  If this operation returns `eos` == False, the
@@ -1035,6 +1036,9 @@ def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None):
 
       moc (integer) Maximum number of objects to return for this operation.
                    This is a required parameter.
+
+      rc (ClassName) ClassName for return class which the server constructs
+                   if this parameter is provided.
 
     Returns:
 
@@ -1580,7 +1584,25 @@ def _get_banner():
 
     return result
 
-def main():
+class wbemcliCustomFormatter(_SmartFormatter,
+                             _argparse.RawDescriptionHelpFormatter):
+    """
+    Define a custom Formatter to allow formatting help and epilog.
+
+    argparse formatter specifically allows multiple inheritance for the
+    formatter customization and actually recommends this in a discussion
+    in one of the issues:
+
+        http://bugs.python.org/issue13023
+
+    Also recommended in a StackOverflow discussion:
+
+    http://stackoverflow.com/questions/18462610/argumentparser-epilog-and-description-formatting-in-conjunction-with-argumentdef
+    """
+    pass
+
+
+def main(prog):
     """
     Parse command line arguments, connect to the WBEM server and open the
     interactive shell.
@@ -1588,10 +1610,15 @@ def main():
 
     global CONN     # pylint: disable=global-statement
 
-    prog = "wbemcli"  # Name of the script file invoking this module
     usage = '%(prog)s [options] server'
-    desc = 'Provide an interactive shell for issuing operations against' \
-           ' a WBEM server.'
+    desc = """
+Provide an interactive shell for issuing operations against a WBEM server.
+
+wbemcli executes the WBEMConnection as part of initialization so the user can
+input requests as soon as the interactive shell is started.
+
+Use h() in thenteractive shell for help for wbemcli methods and variables.
+"""
     epilog = """
 Examples:
   %s https://localhost:15345 -n vendor -u sheldon -p penny
@@ -1603,7 +1630,7 @@ Examples:
 
     argparser = _argparse.ArgumentParser(
         prog=prog, usage=usage, description=desc, epilog=epilog,
-        add_help=False, formatter_class=_SmartFormatter)
+        add_help=False, formatter_class=wbemcliCustomFormatter)
 
     pos_arggroup = argparser.add_argument_group(
         'Positional arguments')
@@ -1732,5 +1759,4 @@ Examples:
     return 0
 
 if __name__ == '__main__':
-    rc = main()
-    _sys.exit(rc)
+    _sys.exit(main(_os.path.basename(_sys.argv[0])))


### PR DESCRIPTION
**I just realized that somehow I messed this one up and it changed 40 files..  Not sure why but Ignore it and will resubmit. Will remove pr once I understand what I did wrong.**

This fixes formatting of the argparse desc and epilog by adding a custom formatter that has multiple  formatters.  I am not sure how far I trust this fix in the future but found the proposal on stackoverflow and it is also recommended solution. in a python issue. That is documented in the code

In addition it:

- expanded the desc slightly.

- changes main and main call to get script name from args.

- fixes an issue with a missing parameter on one of the command definitions. This one popped up during testing with on pylint (this actually showed up after I had run a number of pylints that did not show the error) but it announced that the rc  attribute for ClassName did not exist. Fixed