### PR TITLE
fixes #558 Correct formating of argparse epilog

### DIFF
--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -2,6 +2,11 @@ usage: wbemcli [options] server
 
 Provide an interactive shell for issuing operations against a WBEM server.
 
+wbemcli executes the WBEMConnection as part of initialization so the user can
+input requests as soon as the interactive shell is started.
+
+Use h() in thenteractive shell for help for wbemcli methods and variables.
+
 Positional arguments:
   server                Host name or url of the WBEM server in this format:
                             [{scheme}://]{host}[:{port}]
@@ -71,6 +76,9 @@ General options:
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Examples: wbemcli https://localhost:15345 -n vendor -u sheldon -p penny -
-(https localhost, port=15345, namespace=vendor user=sheldon password=penny)
-wbemcli http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
+Examples:
+  wbemcli https://localhost:15345 -n vendor -u sheldon -p penny
+          - (https localhost, port=15345, namespace=vendor user=sheldon
+         password=penny)
+
+  wbemcli http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)

--- a/wbemcli
+++ b/wbemcli
@@ -1005,7 +1005,8 @@ def OpenAssociatorInstancePaths(op, ac=None, rc=None, r=None, rr=None, iq=None,
                                         MaxObjectCount=moc)
 
 
-def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None):
+def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None,
+                       rc=None):
     """
     Open an enumeration sequence to execute a query `fi` using the query
     language `fl`.  If this operation returns `eos` == False, the
@@ -1039,6 +1040,9 @@ def OpenQueryInstances(ql, qi, ns=None, ot=None, coe=None, moc=None):
 
       moc (integer) Maximum number of objects to return for this operation.
                    This is a required parameter.
+
+      rc (ClassName) ClassName for return class which the server constructs
+                   if this parameter is provided.
 
     Returns:
 
@@ -1588,7 +1592,25 @@ def _get_banner():
     return result
 
 
-def main():
+class wbemcliCustomFormatter(_SmartFormatter,
+                             _argparse.RawDescriptionHelpFormatter):
+    """
+    Define a custom Formatter to allow formatting help and epilog.
+
+    argparse formatter specifically allows multiple inheritance for the
+    formatter customization and actually recommends this in a discussion
+    in one of the issues:
+
+        http://bugs.python.org/issue13023
+
+    Also recommended in a StackOverflow discussion:
+
+    http://stackoverflow.com/questions/18462610/argumentparser-epilog-and-description-formatting-in-conjunction-with-argumentdef
+    """
+    pass
+
+
+def main(prog):
     """
     Parse command line arguments, connect to the WBEM server and open the
     interactive shell.
@@ -1596,10 +1618,15 @@ def main():
 
     global CONN     # pylint: disable=global-statement
 
-    prog = "wbemcli"  # Name of the script file invoking this module
     usage = '%(prog)s [options] server'
-    desc = 'Provide an interactive shell for issuing operations against' \
-           ' a WBEM server.'
+    desc = """
+Provide an interactive shell for issuing operations against a WBEM server.
+
+wbemcli executes the WBEMConnection as part of initialization so the user can
+input requests as soon as the interactive shell is started.
+
+Use h() in thenteractive shell for help for wbemcli methods and variables.
+"""
     epilog = """
 Examples:
   %s https://localhost:15345 -n vendor -u sheldon -p penny
@@ -1611,7 +1638,7 @@ Examples:
 
     argparser = _argparse.ArgumentParser(
         prog=prog, usage=usage, description=desc, epilog=epilog,
-        add_help=False, formatter_class=_SmartFormatter)
+        add_help=False, formatter_class=wbemcliCustomFormatter)
 
     pos_arggroup = argparser.add_argument_group(
         'Positional arguments')
@@ -1741,5 +1768,4 @@ Examples:
 
 
 if __name__ == '__main__':
-    rc = main()
-    _sys.exit(rc)
+    _sys.exit(main(_os.path.basename(_sys.argv[0])))


### PR DESCRIPTION
Ready for review. Complete and two +1 votes.

This fixes formatting of the argparse desc and epilog by adding a custom
formatter that has multiple  formatters.  I am not sure how far I trust
this fix in the future but found the proposal on stackoverflow and it is
also recommended solution. in a python issue. That is documented in the
code

In addition it:

- expanded the desc slightly.

- changes main and main call to get script name from args.

- fixes an issue with a missing parameter on the openQueryInstances
operation definition in wbemcli. This issue popped up during testing
with on pylint (this actually showed up after I had run a number of
pylints that did not show the error) but it announced that the rc
attribute for ClassName did not exist.

There may be more effective ways to do this than force wbemcli to create a
custom formatter but at least this one works.