### PR TITLE
WIP fixes #563 add wbemcli script capability.

### DIFF
--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -68,6 +68,12 @@ Connection security related options:
                         then be part  of the certfile
 
 General options:
+  -s [scripts [scripts ...]], --scripts [scripts [scripts ...]]
+                        Execute the python code defined by the script before the
+                        user gets control. This argument may be repeated to load
+                        multiple scripts or multiple scripts may be listed for a
+                        single use of the option. Scripts are executed after the
+                        WBEMConnection call
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 

--- a/examples/test_wbemcli_script.sh
+++ b/examples/test_wbemcli_script.sh
@@ -1,0 +1,10 @@
+#
+#  Demo of python scripts with wbemcli
+#
+#  This pair of scripts just starts wbemcli, displays the command line
+#  arguments args and exits wbemcli
+#  It works as a simple demo because it does not actually call the server
+#  with an operation so does not understand if there is actually no
+#  running server.
+#
+wbemcli http://localhost -s wbemcli_display_args.py wbemcli_quit.py

--- a/examples/wbemcli_display_args.py
+++ b/examples/wbemcli_display_args.py
@@ -1,0 +1,5 @@
+"""
+    Display the cli input arguments with their names
+"""
+attrs = vars(ARGS)
+print('\n'.join("%s: %s" % item for item in attrs.items()))

--- a/examples/wbemcli_quit.py
+++ b/examples/wbemcli_quit.py
@@ -1,0 +1,5 @@
+"""
+Pywbem scriptlet to quit wbemcli
+"""
+print('Quit Scriplet. Quiting wbemcli')
+quit()

--- a/examples/wbemcli_server.py
+++ b/examples/wbemcli_server.py
@@ -1,0 +1,36 @@
+"""
+This wbemcli scriptlet creates a WBEMServer for the connection
+This is not a separate script but a scriplet for wbemcli.
+It implements the creation of a WBEMServer based on the CONN, the
+creation of the org_valuemap for profiles and a print function to
+display basic profile information.
+"""
+
+from pywbem import WBEMServer, ValueMapping
+
+
+def print_profile_info(org_vm, profile_instance):
+    """
+    Print information on a profile defined by profile_instance.
+
+    Parameters:
+
+      org_vm: The value mapping for CIMRegisterdProfile and
+          RegisteredOrganization so that the value and not value mapping
+          is displayed.
+
+      profile_instance: instance of a profile to be printed
+    """
+    org = org_vm.tovalues(profile_instance['RegisteredOrganization'])
+    name = profile_instance['RegisteredName']
+    vers = profile_instance['RegisteredVersion']
+    print("  %s %s Profile %s" % (org, name, vers))
+
+# Create the server and save in global SERVER
+SERVER = WBEMServer(CONN)
+
+# create the CIMRegisterd Profile ValueMapping for the
+# defined server. This can be used to
+org_vm = ValueMapping.for_property(SERVER, SERVER.interop_ns,
+                                   'CIM_RegisteredProfile',
+                                   'RegisteredOrganization')

--- a/wbemcli
+++ b/wbemcli
@@ -62,6 +62,9 @@ from pywbem._cliutils import SmartFormatter as _SmartFormatter
 # by all functions that execute operations.
 CONN = None
 
+# global ARGS contains the argparse arguments dictionary
+ARGS = None
+
 
 def _remote_connection(server, opts, argparser_):
     """Initiate a remote connection, via PyWBEM. Arguments for
@@ -1697,6 +1700,13 @@ Examples:
     general_arggroup = argparser.add_argument_group(
         'General options')
     general_arggroup.add_argument(
+        '-s', '--scripts', dest='scripts', metavar='scripts', nargs='*',
+        help='R|Execute the python code defined by the script before the\n'
+             'user gets control. This argument may be repeated to load\n'
+             'multiple scripts or multiple scripts may be listed for a\n'
+             'single use of the option. Scripts are executed after the\n'
+             'WBEMConnection call')
+    general_arggroup.add_argument(
         '-v', '--verbose', dest='verbose',
         action='store_true', default=False,
         help='Print more messages while processing')
@@ -1705,6 +1715,10 @@ Examples:
         help='Show this help message and exit')
 
     args = argparser.parse_args()
+
+    # setup the global args so it is available to scripts
+    global ARGS  # pylint: disable=global-statement
+    ARGS = args
 
     if not args.server:
         argparser.error('No WBEM server specified')
@@ -1728,6 +1742,14 @@ Examples:
         except NotFoundError as exc:
             if exc.errno != _errno.ENOENT:
                 raise
+
+    # Execute any python script defined by the script argument
+    if args.scripts:
+        for script in args.scripts:
+            if args.verbose:
+                print('script %s executed' % script)
+            with open(script) as fp:
+                exec(fp.read(), globals(), None)  # pylint: disable=exec-used
 
     # Interact
     i = _code.InteractiveConsole(globals())


### PR DESCRIPTION
Ready for final review: waiting on pr 576 to fix checks failure.

WIP but the current code works and there is a first example of a script. that does work.  The first script just sets up the wbemserver object including a valuemap so that the user has all that available.

I created some examples and put them into examples.  The script test-wbemcli-script.sh executes a simple example that does not require a running server (just displays the args for wbemcli).  Note that I made args into ARGS global to do this for this demo.

This could be expanded to actually do something useful and we could have any number of example scriptlets if we thought this was useful. Remember at this point this is prototype.

Further, since it will allow executing the script and quitting so that it never actually starts the interactive console is could be used to, for example, create a very simple script to show namespaces simply by having a scriptlet that did what the example does, then executed pp(SERVER.namespaces) and then quit.

If this is logical some of the questions include:

1. If we do scriptlets where should they go since I assume that they should be part of the release. Examples is just a temp holding place.
2. How much documentation does this need to be usable for pywbem users.
