### PR TITLE
Fixes #575 A number of new flake8 issues

### DIFF
--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -84,5 +84,5 @@ General options:
   -v, --verbose         Print more messages while processing
   -h, --help            Show this help message and exit
 
-Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost:15989 -n
-root/cimv2 -u sheldon -p penny42
+Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost -n root/cimv2
+-u sheldon -p p42

--- a/os_setup.py
+++ b/os_setup.py
@@ -165,16 +165,18 @@ import pip
 
 
 # Some types to avoid dependency on "six" package during installation.
+# pylint: disable=invalid-name
 if sys.version_info[0] == 2:
-    string_types = basestring,      # pylint: disable=invalid-name # noqa: F821
-    text_type = unicode             # pylint: disable=invalid-name # noqa: F821
-    binary_type = str               # pylint: disable=invalid-name # noqa: F821
+    string_types = basestring,      # noqa: F821
+    text_type = unicode             # noqa: F821
+    binary_type = str               # noqa: F821
     from xmlrpclib import ServerProxy as xmlrpc_ServerProxy
 else:
-    string_types = str,             # pylint: disable=invalid-name # noqa: F821
-    text_type = str                 # pylint: disable=invalid-name # noqa: F821
-    binary_type = bytes             # pylint: disable=invalid-name # noqa: F821
+    string_types = str,             # noqa: F821
+    text_type = str                 # noqa: F821
+    binary_type = bytes             # noqa: F821
     from xmlrpc.client import ServerProxy as xmlrpc_ServerProxy
+# pylint: enable=invalid-name
 
 
 class OsDistribution(Distribution):


### PR DESCRIPTION
1. Issues with 2 lines after function or class. This is new to
flake8 version 3.2.0

2. Issue with both # pylint and $ noqa on same line.
Found another pylint syntax # pylint: enable=...
that helps with this issue. This probably new to
flake8 3.2.0.