### PR TITLE
Fixes #556 for 0.9: Added git as an OS-level dependency for development.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,9 @@ Enhancements
 * Added a section "Prerequisite operating system packages" to the documentation
   that describes the prerequisite packages by distribution.
 
+* Added `git` as an OS-level dependency for development (it is used by GitPython
+  when building the documentation).
+
 
 Bug fixes
 ^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -417,6 +417,7 @@ def main():
                     "libyaml-devel",        # for installing Python pyyaml pkg
                     "make",                 # PyWBEM has a makefile
                     "tar",                  # for distribution archive
+                    "git",                  # used by GitPython
                 ],
                 'centos': 'redhat',
                 'fedora': 'redhat',
@@ -427,6 +428,7 @@ def main():
                     "libyaml-dev",
                     "make",
                     "tar",
+                    "git",
                 ],
                 'ubuntu': [
                     "libxml2-dev",
@@ -435,6 +437,7 @@ def main():
                     "libyaml-dev",
                     "make",
                     "tar",
+                    "git",
                 ],
                 'linuxmint': [
                     "libxml2-dev",
@@ -443,6 +446,7 @@ def main():
                     "libyaml-dev",
                     "make",
                     "tar",
+                    "git",
                 ],
                 'suse': [
                     "libxml2-devel",
@@ -451,6 +455,7 @@ def main():
                     "libyaml-devel",
                     "make",
                     "tar",
+                    "git",
                 ],
             },
             # TODO: Add support for Windows. Some notes:


### PR DESCRIPTION
Roll back PR #581 to 0.9.