### PR TITLE
Fixes #407: Added context manager capability to WBEMSubscriptionManager

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -81,6 +81,10 @@ Bug fixes
   version to <=2.0.8, due to its use of unittest.case which is not available
   on Python 2.6.
 
+* Fixed an `AttributeError` in the `remove_all_servers()` method of
+  `WBEMSubscriptionManager` and dictionary iteration errors in its
+  `remove_server()` method. PR #583.
+
 
 pywbem v0.9.0
 -------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,10 @@ Enhancements
 * Added `git` as an OS-level dependency for development (it is used by GitPython
   when building the documentation).
 
+* Added enter and exit methods to `WBEMSubscriptionManager` to enable using it
+  as a context manager, whose exit method automatically cleans up by calling
+  `remove_all_servers()`.
+
 
 Bug fixes
 ^^^^^^^^^

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -143,7 +143,9 @@ as a context manager, in order to get automatic cleanup::
 
     with WBEMSubscriptionManager('fred') as subscription_manager:
         server1_id = subscription_manager.add_server(server1)
-    # exit method automatically calls remove_all_servers()
+        . . .
+    # The exit method automatically calls remove_all_servers(), which removes
+    # all owned subscriptions, filters and destinations.
 
 Another more practical example is in the script
 ``examples/pegIndicationTest.py`` (when you clone the GitHub pywbem/pywbem
@@ -176,9 +178,8 @@ class WBEMSubscriptionManager(object):
     """
     A class for managing subscriptions for CIM indications in a WBEM server.
 
-    The class may be used as a context manager, whose
-    :meth:`~pywbem.WBEMSubscriptionManager.__exit__` method will automatically
-    clean up.
+    The class may be used as a Python context manager, in order to get
+    automatic clean up (see :meth:`~pywbem.WBEMSubscriptionManager.__exit__`).
     """
 
     def __init__(self, subscription_manager_id=None):

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -138,6 +138,13 @@ callback function for indication delivery::
 
         subscription_manager.add_subscription(server2_id, filter2_path)
 
+The following example code briefly shows how to use a subscription manager
+as a context manager, in order to get automatic cleanup::
+
+    with WBEMSubscriptionManager('fred') as subscription_manager:
+        server1_id = subscription_manager.add_server(server1)
+    # exit method automatically calls remove_all_servers()
+
 Another more practical example is in the script
 ``examples/pegIndicationTest.py`` (when you clone the GitHub pywbem/pywbem
 project).
@@ -169,6 +176,9 @@ class WBEMSubscriptionManager(object):
     """
     A class for managing subscriptions for CIM indications in a WBEM server.
 
+    The class may be used as a context manager, whose
+    :meth:`~pywbem.WBEMSubscriptionManager.__exit__` method will automatically
+    clean up.
     """
 
     def __init__(self, subscription_manager_id=None):
@@ -225,6 +235,22 @@ class WBEMSubscriptionManager(object):
                (self.__class__.__name__, self._subscription_manager_id,
                 self._servers, self._owned_subscription_paths,
                 self._owned_filter_paths, self._owned_destination_paths)
+
+    def __enter__(self):
+        """
+        Enter method when the class is used as a context manager.
+        """
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Exit method when the class is used as a context manager.
+
+        It cleans up by calling
+        :meth:`~pywbem.WBEMSubscriptionManager.remove_all_servers`.
+        """
+        self.remove_all_servers()
+        return False  # re-raise any exceptions
 
     def _get_server(self, server_id):
         """
@@ -546,7 +572,7 @@ class WBEMSubscriptionManager(object):
         This method verifies that there are not currently any subscriptions on
         the specified listener destination, in order to handle server
         implementations that do not ensure that on the server side as required
-        by :ref:`DSP1054`.
+        by :term:`DSP1054`.
 
         Parameters:
 
@@ -763,7 +789,7 @@ class WBEMSubscriptionManager(object):
         This method verifies that there are not currently any subscriptions on
         the specified indication filter, in order to handle server
         implementations that do not ensure that on the server side as required
-        by :ref:`DSP1054`.
+        by :term:`DSP1054`.
 
         Parameters:
 

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -386,19 +386,19 @@ class WBEMSubscriptionManager(object):
 
         # Delete any instances we recorded to be cleaned up
 
-        if server_id in self._owned_subscription_paths:
+        if server_id in list(self._owned_subscription_paths.keys()):
             paths = self._owned_subscription_paths[server_id]
             for path in paths:
                 server.conn.DeleteInstance(path)
             del self._owned_subscription_paths[server_id]
 
-        if server_id in self._owned_filter_paths:
+        if server_id in list(self._owned_filter_paths.keys()):
             paths = self._owned_filter_paths[server_id]
             for path in paths:
                 server.conn.DeleteInstance(path)
             del self._owned_filter_paths[server_id]
 
-        if server_id in self._owned_destination_paths:
+        if server_id in list(self._owned_destination_paths.keys()):
             for path in self._owned_destination_paths[server_id]:
                 server.conn.DeleteInstance(path)
             del self._owned_destination_paths[server_id]
@@ -420,9 +420,8 @@ class WBEMSubscriptionManager(object):
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
         """
 
-        for server in self._servers:
-            # This depends on server.url same as server_id
-            self.remove_server(server.url)
+        for server_id in list(self._servers.keys()):
+            self.remove_server(server_id)
 
     # pylint: disable=line-too-long
     def add_listener_destinations(self, server_id, listener_urls, owned=True):

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -3652,6 +3652,37 @@ class PyWBEMListenerClass(PyWBEMServerClass):
 
             my_listener.stop()
 
+    def test_subscription_context_manager(self):
+        """Test that the WBEMSUbscriptionmanager class can be used as a
+           Python context manager and that its exit method cleans up.
+        """
+
+        if self.is_pegasus_test_build():
+
+            server = WBEMServer(self.conn)
+
+            # First, verify the behavior of remove_all_servers() with a
+            # normal WBEMSubscriptionManager instance.
+
+            sub_mgr = WBEMSubscriptionManager(
+                subscription_manager_id='test_ctxt_mgr_1')
+
+            server_id = sub_mgr.add_server(server)
+            self.assertEqual(set(sub_mgr._servers.keys()), {server_id})
+
+            sub_mgr.remove_all_servers()
+            self.assertEqual(set(sub_mgr._servers.keys()), {})
+
+            # Now, perform the actual test of the context manager.
+
+            with WBEMSubscriptionManager(
+                    subscription_manager_id='test_ctxt_mgr_2') as sub_mgr:
+
+                server_id = sub_mgr.add_server(server)
+                self.assertEqual(set(sub_mgr._servers.keys()), {server_id})
+
+            self.assertEqual(set(sub_mgr._servers.keys()), {})
+
 
 #################################################################
 # Main function


### PR DESCRIPTION
Also, corrected DSP1054 references in the docs of `WBEMSubscriptionManager`.

The only testcase is in `run_cim_operations.py`, and I did not test with it.