### PR TITLE
Fixed AttributeError and dict iteration errors in remove_all_servers and remove_server

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,10 @@ Enhancements
 Bug fixes
 ^^^^^^^^^
 
+* Fixed an `AttributeError` in the `remove_all_servers()` method of
+  `WBEMSubscriptionManager` and dictionary iteration errors in its
+  `remove_server()` method. PR #583.
+
 
 pywbem v0.9.1
 -------------

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -310,19 +310,19 @@ class WBEMSubscriptionManager(object):
 
         # Delete any instances we recorded to be cleaned up
 
-        if server_id in self._owned_subscription_paths:
+        if server_id in list(self._owned_subscription_paths.keys()):
             paths = self._owned_subscription_paths[server_id]
             for path in paths:
                 server.conn.DeleteInstance(path)
             del self._owned_subscription_paths[server_id]
 
-        if server_id in self._owned_filter_paths:
+        if server_id in list(self._owned_filter_paths.keys()):
             paths = self._owned_filter_paths[server_id]
             for path in paths:
                 server.conn.DeleteInstance(path)
             del self._owned_filter_paths[server_id]
 
-        if server_id in self._owned_destination_paths:
+        if server_id in list(self._owned_destination_paths.keys()):
             for path in self._owned_destination_paths[server_id]:
                 server.conn.DeleteInstance(path)
             del self._owned_destination_paths[server_id]
@@ -344,9 +344,8 @@ class WBEMSubscriptionManager(object):
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
         """
 
-        for server in self._servers:
-            # This depends on server.url same as server_id
-            self.remove_server(server.url)
+        for server_id in list(self._servers.keys()):
+            self.remove_server(server_id)
 
     #pylint: disable=line-too-long
     def add_listener_destinations(self, server_id, listener_urls, owned=True):


### PR DESCRIPTION
This rolls back a fix from PR #583 into v0.9.

Details:
- In remove_all_servers(), fixed an AttributeError (str has no 'url' attribute).
- In remove_server() and in remove_all_servers(), fixed dictionary iteration errors where dictionary items were deleted but the iteration was based upon an iterator over the dictionary. Fixed that by making the loop based upon a copied list of the dictionary keys.