### PR TITLE
Fixed SAX parse error with unicode strings on Python 2.6.

### DIFF
--- a/pywbem/tupletree.py
+++ b/pywbem/tupletree.py
@@ -58,6 +58,7 @@ import xml.dom.minidom
 import xml.sax
 import re
 import sys
+import six
 
 __all__ = []
 
@@ -142,10 +143,11 @@ def xml_to_tupletree_sax(xml_string):
     """
     handler = CIMContentHandler()
 
-    # The following is required because python version 3.4 does not accept
-    # str for the sax processor xml input.
-    if sys.version_info[0:2] == (3, 4):
-        if isinstance(xml_string, str):
+    # The following is required because the SAX parser in these Python
+    # versions does not accept unicode strings, raising:
+    # SAXParseException: "<unknown>:1:1: not well-formed (invalid token)"
+    if sys.version_info[0:2] in ((2, 6), (3, 4)):
+        if isinstance(xml_string, six.text_type):
             xml_string = xml_string.encode("utf-8")
 
     xml.sax.parseString(xml_string, handler, None)


### PR DESCRIPTION
This PR fixes the SAX parse error that showed up on Python 2.6 starting on 2016-12-01, by applying the same fix that was already implemented for Python 3.4: Encode the unicode string into a byte string.

So far, this fix is not needed on Python 2.7 and Python 3.5, for unknown reasons.

The symptom is that `test_tupleparse.py` fails in the test run on Python 2.6 with:

```
SAXParseException: "<unknown>:1:1: not well-formed (invalid token)"
```

If you encounter this, use this PR via one of these:
- rebase your PR on the branch of this PR (as long as it is not yet merged)
- rebase your PR on master (once this PR has been merged)
- cherry-pick the commit of this PR into your branch