### PR TITLE
Add example scriptlet.

### DIFF
--- a/examples/wbemcli_count_instances.py
+++ b/examples/wbemcli_count_instances.py
@@ -1,0 +1,136 @@
+'''
+    Pywbem wbemcli scriptlet that counts classes and instances in a WBEMServer.
+
+    This class explored the complete server and retrieve all
+    namespaces, then all classes, then all instances for each class and
+    displays the results.
+
+    It includes an ignore list that ignores selected classes and another that
+    will ignore selected namespaces.
+'''
+from collections import defaultdict
+import six
+
+from pywbem import WBEMServer, CIMError, ConnectionError, \
+    TimeoutError
+
+# Create the server and save in global SERVER
+print('Find total classes and instances for all namespaces:\n')
+
+SERVER = WBEMServer(CONN)
+
+# The following are classes where for some reason the enumerateinstancenanes
+# fails in the test version of Pegasus. Typically they cause significant
+# failures if queried, i.e kills pegasus. The classes in this list are ignored
+# during the scan.
+peg_ignore_list = ['PG_User', 'CWS_DirectoryContainsFile_CXX',
+                   'PG_Authorization',
+                   'TestCMPI_Fail_2', 'TestCMPI_Fail_3', 'TestCMPI_Fail_4',
+                   'TST_FaultyInstance', 'CIM_Error',
+                   'CIM_InstMethodCall', 'PG_InstMethodIndication',
+                   'CIM_Indication', 'CIM_InstIndication', 'PG_EmbeddedError']
+
+# Any namespaces in this list are ignored.
+ignore_namespaces_list = []
+
+# list of ignored classes including namespaces
+ignored_classes = []
+# list of failed classes including namespace
+failed_classes = []
+
+# count of total ignored classes, instances, and failures.
+total_classes = 0
+total_instances = 0
+total_errors = 0
+
+table_print_format = '%9s %11s %-30s %5s'
+
+# prepare and print table header with column names
+max_ns_len = 20
+table_hdr = table_print_format % ('# classes',
+                                  '# instances',
+                                  'namespace/classname',
+                                  '# Errors')
+print(table_hdr)
+print('=' * len(table_hdr))
+
+# filter namespaces to be ignored
+namespaces = [ns
+              for ns in sorted(SERVER.namespaces)
+              if ns not in ignore_namespaces_list]
+
+# set max namespace length for output table
+max_ns_len2 = len(max(namespaces, key=len)) + 5
+
+for ns in namespaces:
+    classnames = ecn(ns=ns, di=True)
+    ns_error_count = 0
+    # this accumulates instance counts across the namespace
+    # key is classname, value is total instance count
+    inst_dict = defaultdict(int)
+    assoc_d = {}
+
+    # build filtered classname list
+    classnames = [classname
+                  for classname in classnames
+                  if classname not in peg_ignore_list]
+
+    for classname in classnames:
+        cl = gc(classname, ns=ns)
+        assoc_d[classname] = True if 'Association' in cl.qualifiers else False
+
+        try:
+            instnames = ein(ns=ns, cn=classname)
+            for instname in instnames:
+                # filter to count only instances in this class, not subclasses
+                if instname.classname == classname:
+                    inst_dict[classname] += 1
+                    total_instances += len(instnames)
+        except CIMError as ce:
+            failed_classes.append((classname, ns, ce))
+            ns_error_count += 1
+        except TimeoutError as te:
+            print('Timeout Error ns: %s class: %s err: %s. Quitting' %
+                  (ns, classname, te))
+            quit(2)
+        except ConnectionError as ce:
+            print('Connection Error ns: %s class: %s err: %s. Quitting' %
+                  (ns, classname, ce))
+            quit(2)
+        except Exception as exc:
+            ns_error_count += 1
+            print('Exception error ns %s class %s, err %s. Quitting' %
+                  (ns, classname, exc))
+            quit(3)
+
+    # display results for this namespace
+    print(table_print_format %
+          (len(classnames), sum(six.itervalues(inst_dict)), ns, ns_error_count))
+
+    # display the counts per instance. Note that this is NOT the same
+    # as ein returns but the instance count for this class alone.
+    for classname, inst_count in six.iteritems(inst_dict):
+        if inst_count != 0:
+            assoc_flag = '(*)' if assoc_d[classname] else "   "
+            classname = '%s %s' % (classname, assoc_flag)
+            print('%9s %11s %-30s %5s' % ("", inst_count, classname, ""))
+
+        total_classes += len(classnames)
+    total_errors += ns_error_count
+
+print('=' * len(table_hdr))
+print(table_print_format %
+      (len(SERVER.namespaces), total_classes, '', total_errors))
+
+if ignored_classes:
+    print('List of classes ignored:')
+    for cn in ignored_classes:
+        print('  %s' % cn)
+
+if failed_classes:
+    print('List of classes That failed with CIMError exception:')
+    for item in failed_classes:
+        print('  %s:%s, err %s' % (item[0], item[1], item[2].status_code_name))
+
+print('Success. Quit Scriplet. Quiting wbemcli')
+quit()


### PR DESCRIPTION
Ready for review. Reduced to one script

I wrote the first one to try to gather information for extending run_cim_operations.py for better assocation tests and ended up generalizing it.

This also establishes a couple of limitations to this -s scripting capability:
1. User cannot add new parameters to the cmdline for the script.

The  script is:
1. wbemcli_count_instances.py Scans a server and generates overall information on the namespaces
and the number of classes, instances throughout the server.  Note that
this is tuned to OpenPegasus right now in that it includes a list of classes
where the enumerate operations actually kill the server.  These are
really internal and test classes within pegasus but it is clear that
pegasus does not protect itself in these cases since accessing from a
client can kill the server.


Useful in openpegasus and could server as examples of writing
these scriptlets but not sure if we want to commit them or not.

Output of the count script looks like this:

```
# classes # instances namespace/classname            # Errors
=============================================================
        0           0 root                               0
      272         644 root/PG_InterOp                    0
                   84 PG_InstalledSoftwareIdentity          
                    8 PG_RegisteredSubProfile             
                    1 CIM_IndicationService               
                   14 PG_CIMXMLCommunicationMechanism          
                  134 PG_ProviderCapabilities             
                   12 PG_RegisteredProfile                
                   18 PG_NameSpace                        
                    4 PG_ConsumerCapabilities             
                    1 PG_HostedIndicationService (*)      
                    5 PG_ReferencedProfile (*)            
                   10 PG_ServiceAffectsElement (*)        
                   84 PG_SoftwareIdentity                 
                    1 CIM_IndicationServiceCapabilities          
                   18 PG_NamespaceInManager (*)           
                    5 CIM_ListenerDestinationCIMXML          
                   14 PG_HostedAccessPoint (*)            
                    1 PG_ObjectManager (*)                
                    7 PG_ElementConformsToProfile_RP_RP (*)      
                   14 PG_CommMechanismForManager (*)      
                    4 PG_ProviderProfileCapabilities          
                   26 PG_ElementSoftwareIdentity (*)      
                   11 PG_ElementConformsToProfile (*)      
                    5 CIM_IndicationSubscription (*)      
                    5 CIM_IndicationFilter                
                    1 PG_ElementCapabilities (*)          
                    1 PG_HostedObjectManager (*)          
                   82 PG_Provider                         
                    1 CIM_QueryCapabilities               
                    1 PG_ComputerSystem                   
                   60 PG_ProviderModule                   
                   12 PG_SubProfileRequiresProfile (*)      
        8          56 root/PG_Internal                   1
                   56 PG_ConfigSetting                    
      461         118 root/SampleProvider                3
                    1 QExpr_TestElement                   
                    3 Sample_AdvisorStudent (*)           
                    3 CWS_Directory_CXX                   
                   34 CWS_PlainFile                       
                    4 Lineage (*)                         
                    2 CQL_TestPropertyTypes               
                    1 QExpr_TestPropertyTypes             
                    4 Person                              
                   34 CWS_PlainFile_CXX                   
                    1 CQL_TestNullValueTypes              
                    1 CQL_TestPropertyTypesMissing          
                    1 CIM_ComputerSystem                  
                    3 Sample_InstanceQueryProviderClass          
                    3 Sample_InstanceProviderClass          
                    4 Sample_Teacher                      
                    3 CWS_Directory                       
                    8 Sample_TeacherStudent (*)           
                    1 CQL_TestElement                     
                    3 Sample_Student                      
                    1 CIM_QueryCapabilities               
                    3 CMPISample_InstanceProviderClass          
      205        1050 root/benchmark                     0
                    1 benchmarkClassP00010S01000I00001          
                    1 benchmarkClassP00010S00010I00001          
                  100 benchmarkClassP00010S00100I00100          
                   10 benchmarkClassP00001S00010I00010          
                    1 benchmarkClassP00001S00100I00001          
                  100 benchmarkClassP00010S00010I00100          
                  100 benchmarkClassP00010S01000I00100          
                   10 benchmarkClassP00050S01000I00010          
                   50 benchmarkClassP00010S00020I00050          
                  100 benchmarkClassP00001S00010I00100          
                   10 benchmarkClassP00001S01000I00010          
                   10 benchmarkClassP00010S00010I00010          
                    1 benchmarkClassP00050S00010I00001          
                  100 benchmarkClassP00001S00100I00100          
                   10 benchmarkClassP00050S00010I00010          
                   10 benchmarkClassP00001S00100I00010          
                  100 benchmarkClassP00050S00010I00100          
                    1 benchmarkClassP00010S00100I00001          
                   10 benchmarkClassP00010S01000I00010          
                  100 benchmarkClassP00050S01000I00100          
                  100 benchmarkClassP00050S00100I00100          
                   10 benchmarkClassP00050S00100I00010          
                    1 benchmarkClassP00050S00100I00001          
                    1 benchmarkClassP00001S01000I00001          
                    1 benchmarkClassP00001S00010I00001          
                    1 benchmarkClassP00050S01000I00001          
                    1 benchmarkClassP00030S00010I00001          
                  100 benchmarkClassP00001S01000I00100          
                   10 benchmarkClassP00010S00100I00010          
     1462         671 root/cimv2                         0
                   35 CIM_CIMOMStatisticalData            
                    1 PG_OperatingSystem                  
                    3 PyWBEM_MemberOfPersonCollection          
                    1 PyWBEM_PersonCollection             
                  314 PG_UnixProcessStatisticalInformation          
                    1 CIM_QueryCapabilities               
                    1 PG_ComputerSystem                   
                  312 PG_UnixProcess                      
                    3 PyWBEM_Person                       
      208           0 test/CimsubTestNS0                 0
      208           0 test/CimsubTestNS1                 0
      208           0 test/CimsubTestNS2                 0
      208           0 test/CimsubTestNS3                 0
      182           0 test/EmbeddedInstance/Dynamic      0
      182           0 test/EmbeddedInstance/Static       0
      222           0 test/TestINdSrcNS2                 0
      222           0 test/TestIndSrcNS1                 0
      524        4115 test/TestProvider                 12
                    4 TST_PersonS                         
                    2 Test_OtherSystem                    
                    1 TEST_Teaches (*)                    
                    3 TST_InstanceA                       
                    2 CMPI_TEST_Vehicle                   
                    1 TEST_TeachesDynamic (*)             
                    1 TST_Operations2                     
                    1 Test_CIM_ErrorResponse              
                    1 TEST_Works (*)                      
                    4 TST_Lineage (*)                     
                    1 TST_PersonDynamicSubClass           
                    5 TST_ResponseStressTestCxx           
                    2 Test_ElementConformsToProfile          
                    2 TST_OperationsAssoc (*)             
                    1 Test_CLITestProviderClass           
                 3003 TST_ChunkingStressInstance          
                    2 CMPI_TEST_Racing (*)                
                    1 Test_LocalizedProviderSubClass          
                    3 TST_InstanceB                       
                    8 TEST_PersonDynamic                  
                    4 TST_Person                          
                    2 TST_Operations1                     
                    1 cmpiPerf_TestClassA                 
                    5 TST_PersonDynamic                   
                    6 PG_ElementConformsToProfile (*)      
                 1001 TST_ChunkingStressInstanceS          
                    6 TST_LineageDynamic (*)              
                    4 TST_Instance1                       
                    1 cmpiPerf_TestAssocClass (*)         
                    2 Test_StorageSystem                  
                    6 TST_LabeledLineageDynamic (*)       
                    1 Test_CLITestEmbeddedClass           
                    1 cmpiPerf_TestClassB                 
                    8 TEST_Person                         
                    3 TST_InstanceZ                       
                    5 TST_ResponseStressTestCxx2          
                    1 CIM_QueryCapabilities               
                    2 CMPI_TEST_Person                    
                    2 Test_LocalizedProviderClass          
                    6 Test_MCSStorageSystem               
      181          21 test/WsmTest                       0
                    1 WsmHuge                             
                    4 WsmBase                             
                    4 WsmDerived                          
                    9 WsmLarge                            
                    3 WsmAssociation (*)                  
      773           0 test/cimv2                         0
      242           2 test/static                        1
                    2 PG_TestPropertyTypes                
=============================================================
       18       59331                                   17
List of classes That failed with CIMError exception:
  PG_ShutdownService:root/PG_Internal, err CIM_ERR_NOT_SUPPORTED
  CWS_DirectoryContainsFile:root/SampleProvider, err CIM_ERR_NOT_SUPPORTED
  CIM_DirectoryContainsFile:root/SampleProvider, err CIM_ERR_FAILED
  CIM_Component:root/SampleProvider, err CIM_ERR_FAILED
  TEST_FamilyDynamic:test/TestProvider, err CIM_ERR_NOT_FOUND
  TEST_MarriageDynamic:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TestCMPI_ExecQuery:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TEST_Family:test/TestProvider, err CIM_ERR_NOT_FOUND
  TestCMPI_Thread:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TestCMPI_BrokerInstance:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TEST_WorksDynamic:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TestCMPI_Fail_1:test/TestProvider, err CIM_ERR_FAILED
  TestCMPI_Fail_5:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TestCMPI_Broker:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  TestCMPI_Parent:test/TestProvider, err CIM_ERR_FAILED
  TestCMPI_KeyReturned:test/TestProvider, err CIM_ERR_NOT_SUPPORTED
  PG_TestElement:test/static, err CIM_ERR_INVALID_CLASS
Success. Quit Scriplet. Quiting wbemcli

```