### PR TITLE
Add test to cim_operations with PropertyList attribute.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -85,6 +85,10 @@ Bug fixes
   `WBEMSubscriptionManager` and dictionary iteration errors in its
   `remove_server()` method. PR #583.
 
+* Modified cim_operations that have a PropertyList attribute to allow the
+  PropertyList attribute to have a single string in addition to the iterable.
+  Previously this caused an XML error (issue #577).
+
 
 pywbem v0.9.0
 -------------

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -187,6 +187,19 @@ def _check_classname(val):
         raise ValueError("string expected for classname, not %r" % val)
 
 
+def _iparam_propertylist(property_list):
+    """Validate property_list and if it is not iterable convert to list.
+
+    This is a test for a particular issue where the user supplies a single
+    string in stead of a list for a PropertyList parameter. It prevents
+    an XML error.
+    """
+    if isinstance(property_list, six.string_types):
+        return [property_list]
+    else:
+        return property_list
+
+
 def check_utf8_xml_chars(utf8_xml, meaning):
     """
     Examine a UTF-8 encoded XML string and raise a `pywbem.ParseError`
@@ -1387,9 +1400,10 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be
-            included in the returned instances (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (case independent).
 
             An empty iterable indicates to include no properties.
 
@@ -1420,7 +1434,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -1441,6 +1455,7 @@ class WBEMConnection(object):
                 namespace = ClassName.namespace
             namespace = self._iparam_namespace_from_namespace(namespace)
             classname = self._iparam_classname(ClassName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'EnumerateInstances',
@@ -1725,6 +1740,7 @@ class WBEMConnection(object):
                                OperationTimeout=None, ContinueOnError=None,
                                MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
+        # pylint: disable=invalid-name,line-too-long
         """
         Open an enumeration session to get instances of a class
         (including instances of its subclasses).
@@ -1811,9 +1827,10 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be
-            included in the returned instances (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (case independent).
 
             An empty iterable indicates to include no properties.
 
@@ -1932,7 +1949,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -1958,6 +1975,7 @@ class WBEMConnection(object):
                 namespace = ClassName.namespace
             namespace = self._iparam_namespace_from_namespace(namespace)
             classname = self._iparam_classname(ClassName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'OpenEnumerateInstances',
@@ -2206,6 +2224,7 @@ class WBEMConnection(object):
                                OperationTimeout=None, ContinueOnError=None,
                                MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
+        # pylint: disable=invalid-name,line-too-long
         """
         Open an enumeration session to retrieve the association instances
         that reference a source instance.
@@ -2272,9 +2291,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be included
-            in the returned instances (or classes) (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -2392,7 +2413,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -2416,6 +2437,7 @@ class WBEMConnection(object):
             # TODO ks 6/16 Limit to instance name. No classname allowed.
             namespace = self._iparam_namespace_from_objectname(InstanceName)
             instancename = self._iparam_instancename(InstanceName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'OpenReferenceInstances',
@@ -2686,6 +2708,7 @@ class WBEMConnection(object):
                                 ContinueOnError=None, MaxObjectCount=None,
                                 **extra):
         # pylint: disable=invalid-name
+        # pylint: disable=invalid-name,line-too-long
         """
         Open an enumeration session to retrieve the instances associated
         to a source instance.
@@ -2767,9 +2790,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be included
-            in the returned instances (or classes) (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -2887,7 +2912,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -2912,6 +2937,7 @@ class WBEMConnection(object):
 
             namespace = self._iparam_namespace_from_objectname(InstanceName)
             instancename = self._iparam_instancename(InstanceName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'OpenAssociatorInstances',
@@ -3672,9 +3698,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be
-            included in the returned instance (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instance (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -3702,7 +3730,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -3720,6 +3748,7 @@ class WBEMConnection(object):
             # Strip off host and namespace to make this a "local" object
             namespace = self._iparam_namespace_from_objectname(InstanceName)
             instancename = self._iparam_instancename(InstanceName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'GetInstance',
@@ -3795,9 +3824,9 @@ class WBEMConnection(object):
             This parameter has been deprecated in :term:`DSP0200`. Clients
             cannot rely on it being implemented by WBEM servers.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be
-            modified (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be modified (case independent).
 
             An empty iterable indicates to modify no properties.
 
@@ -3814,7 +3843,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -3842,6 +3871,7 @@ class WBEMConnection(object):
 
             namespace = self._iparam_namespace_from_objectname(
                 ModifiedInstance.path)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             # Strip off host and namespace to avoid producing an INSTANCEPATH or
             # LOCALINSTANCEPATH element instead of the desired INSTANCENAME
@@ -4275,9 +4305,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be included
-            in the returned instances (or classes) (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (or classes) (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -4330,7 +4362,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -4350,6 +4382,7 @@ class WBEMConnection(object):
 
             namespace = self._iparam_namespace_from_objectname(ObjectName)
             objectname = self._iparam_objectname(ObjectName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'Associators',
@@ -4586,9 +4619,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be included
-            in the returned instances (or classes) (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            instances (or classes) (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -4641,7 +4676,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -4659,6 +4694,7 @@ class WBEMConnection(object):
 
             namespace = self._iparam_namespace_from_objectname(ObjectName)
             objectname = self._iparam_objectname(ObjectName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'References',
@@ -5248,9 +5284,11 @@ class WBEMConnection(object):
               causes the server-implemented default to be used. :term:`DSP0200`
               defines that the server-implemented default is `False`.
 
-          PropertyList (:term:`py:iterable` of :term:`string`):
-            An iterable specifying the names of the properties to be included
-            in the returned class (case independent).
+          PropertyList (:term:`py:iterable` of :term:`string` or :term:`string`):
+            An iterable specifying the names of the properties (or a  string
+            that defines a single property) to be included in the returned
+            class (case independent).
+
             An empty iterable indicates to include no properties.
 
             If `None`, all properties are included.
@@ -5271,7 +5309,7 @@ class WBEMConnection(object):
         Raises:
 
             Exceptions described in :class:`~pywbem.WBEMConnection`.
-        """
+        """  # noqa: E501
 
         if self.operation_recorder:
             self.operation_recorder.reset()
@@ -5291,6 +5329,7 @@ class WBEMConnection(object):
                 namespace = ClassName.namespace
             namespace = self._iparam_namespace_from_namespace(namespace)
             classname = self._iparam_classname(ClassName)
+            PropertyList = _iparam_propertylist(PropertyList)
 
             result = self._imethodcall(
                 'GetClass',

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -525,10 +525,13 @@ class EnumerateInstances(ClientTest):
 
         property_list = [TEST_CLASS_PROPERTY2]
 
+        # confirm property is in the class
         cls = self.cimcall(self.conn.GetClass, TEST_CLASS,
                            PropertyList=property_list, LocalOnly=False)
         cls_property_count = len(cls.properties)
+        self.assertEqual(len(cls.properties), len(property_list))
 
+        # Get instances of class
         instances = self.cimcall(self.conn.EnumerateInstances,
                                  TEST_CLASS,
                                  DeepInheritance=True,
@@ -608,6 +611,24 @@ class EnumerateInstances(ClientTest):
         # TODO Apparently ks 5/16 Pegasus did not implement all properties
         # now in the class
         # self.assertTrue(property_count == inst_property_count)
+
+    def test_instance_simple_propertylist(self):  # pylint: disable=invalid-name
+        """Test property list with one property as a string."""
+
+        property_list = TEST_CLASS_PROPERTY1
+
+        # Get instances of class
+        instances = self.cimcall(self.conn.EnumerateInstances,
+                                 TEST_CLASS,
+                                 DeepInheritance=True,
+                                 LocalOnly=False,
+                                 PropertyList=property_list)
+
+        self.assertInstancesValid(instances)
+
+        # confirm same number of properties on each instance
+        for inst in instances:
+            self.assertTrue(len(inst.properties) == 1)
 
     def test_deepinheritance(self):
         """Test with deep inheritance set true and then false."""
@@ -2941,6 +2962,21 @@ class GetClass(ClientClassTest):
                            PropertyList=property_list, LocalOnly=False)
 
         self.assertTrue(len(cls.properties) == len(property_list))
+
+        if self.verbose:
+            for p in cls.properties.values():
+                print('ClassPropertyName=%s' % p.name)
+
+    def test_class_single_property(self):
+        """ Test with propertyList for getClass to confirm that single
+            string not in list works.
+        """
+        property_list = TEST_CLASS_PROPERTY2
+
+        cls = self.cimcall(self.conn.GetClass, TEST_CLASS,
+                           PropertyList=property_list, LocalOnly=False)
+
+        self.assertEqual(len(cls.properties), 1)
 
         if self.verbose:
             for p in cls.properties.values():

--- a/testsuite/testclient/enumerateinstances.yaml
+++ b/testsuite/testclient/enumerateinstances.yaml
@@ -899,6 +899,101 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
+
+    name: EnumerateInstances11
+    description: EnumerateInstances Succeeds, test pl=string, returning 1 instance
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: false
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Person
+            LocalOnly: false
+            PropertyList: Name
+    pywbem_response:
+        result:
+            -
+                pywbem_object: CIMInstance
+                classname: PyWBEM_Person
+                properties:
+                    Name: Fritz
+                path:
+                    pywbem_object: CIMInstanceName
+                    classname: PyWBEM_Person
+                    namespace: root/cimv2
+                    keybindings:
+                        CreationClassname: PyWBEM_Person
+                        Name: Fritz
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>False</VALUE>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="PropertyList">
+                                <VALUE.ARRAY>
+                                    <VALUE>Name</VALUE>
+                                </VALUE.ARRAY>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                            <IRETURNVALUE>
+                                <VALUE.NAMEDINSTANCE>
+                                    <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                        <KEYBINDING NAME="CreationClassName">
+                                            <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                        </KEYBINDING>
+                                        <KEYBINDING NAME="Name">
+                                            <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                                        </KEYBINDING>
+                                    </INSTANCENAME>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Fritz</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.NAMEDINSTANCE>
+                            </IRETURNVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+
 -
     name: EnumerateInstancesF1
     description: EnumerateInstances, server fails with CIM_ERR_ACCESS_DENIED


### PR DESCRIPTION
Please Review:
This adds a test  to the operations that use PropertyList that allows a single string to be passed as a property list as well as an iterable.  Previously a single string caused an
XML error. Now it is mapped to a list.

Also adds tests to run_cimoperations.py and mock (for enumerateinstances)