### PR TITLE
Improved diagnostics when PyYAML cannot represent an object.

### DIFF
--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -26,6 +26,7 @@ except ImportError:
     from ordereddict import OrderedDict
 from datetime import datetime, timedelta
 import yaml
+from yaml.representer import RepresenterError
 import six
 
 from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
@@ -81,6 +82,18 @@ yaml.SafeDumper.add_representer(
     OrderedDict,
     lambda dumper, value:
     _represent_ordereddict(dumper, u'tag:yaml.org,2002:map', value))
+
+
+# Some monkey-patching for better diagnostics:
+def _represent_undefined(self, data):
+    raise RepresenterError("cannot represent an object: %s of type: %s; "
+                           "yaml_representers: %r, "
+                           "yaml_multi_representers: %r" %
+                           (data, type(data), self.yaml_representers.keys(),
+                            self.yaml_multi_representers.keys()))
+
+
+yaml.SafeDumper.represent_undefined = _represent_undefined
 
 
 class OpArgs(OpArgs_tuple):


### PR DESCRIPTION
Karl tested. See below: I voted +1 on this based on the test.

This PR improves the diganostics for issue #588, but does not solve it.

Please reproduce the issue and report the results.

KS marked this update needed since I made comments