### PR TITLE
Fixes #493: Added support to the operation recorder for an on/off switch.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -58,6 +58,8 @@ Enhancements
   as a context manager, whose exit method automatically cleans up by calling
   `remove_all_servers()`.
 
+* Added methods to the operation recorder (class `BaseOperationRecorder`) for
+  disabling and enabling it. (issue #493).
 
 Bug fixes
 ^^^^^^^^^


### PR DESCRIPTION
Please review.

Details:
- Added enable() and disable() methods to class BaseOperationRecorder, and changed the invocaiton of the record() method such that it only happens when the recorder is enabled.
- by default, the recorder is enabled.
- for completeness, added a property enabled that indicates whether the recorder is currently enabled.