### PR TITLE
Two more working examples of scriptlets for wbemcli

### DIFF
--- a/examples/wbemcli_clean_subscriptions.py
+++ b/examples/wbemcli_clean_subscriptions.py
@@ -1,0 +1,54 @@
+"""
+Wbemcli scriptlet that removes all subscriptions, filters, and destination
+objects from the defined wbem connection
+"""
+
+from pywbem import WBEMServer
+
+
+def display_path_info(descriptor, class_, namespace):
+    """
+    Display info on the instance names of the class parameter retrieved
+    from the interop namespace of the server defined by CONN.
+
+    The descriptor is text defining the class(ex. Filter)).
+    Returns a list of the paths
+    """
+    paths = CONN.EnumerateInstanceNames(class_, namespace=interop)  # noqa: F821
+    print('%ss: count=%s' % (descriptor, len(paths)))
+    for path in paths:
+        print('%s: %s' % (descriptor, path))
+    return paths
+
+
+def delete_paths(paths):
+    """Delete all the CIMInstanceNames in paths paramter from the server."""
+    for path in paths:
+        CONN.DeleteInstance(path)  # noqa: F821
+
+
+MY_SERVER = WBEMServer(CONN)  # noqa: F821
+interop = MY_SERVER.interop_ns
+print('Interop namespace=%s' % interop)
+
+filter_paths = display_path_info("Filter", 'CIM_IndicationFilter', interop)
+dest_paths = display_path_info("Destination", 'CIM_ListenerDestination',
+                               interop)
+sub_paths = display_path_info("Subscription", 'CIM_IndicationSubscription',
+                              interop)
+
+# If any paths exist, remove them and then redisplay the results
+if filter_paths or dest_paths or sub_paths:
+
+    delete_paths(sub_paths)
+    delete_paths(dest_paths)
+    delete_paths(filter_paths)
+
+    filter_paths = display_path_info("Filter", 'CIM_IndicationFilter', interop)
+    dest_paths = display_path_info("Destination", 'CIM_ListenerDestination',
+                                   interop)
+    sub_paths = display_path_info("Subscription", 'CIM_IndicationSubscription',
+                                  interop)
+
+print('Quit Scriplet. Quiting wbemcli')
+quit()

--- a/examples/wbemcli_view_subscriptions.py
+++ b/examples/wbemcli_view_subscriptions.py
@@ -1,0 +1,31 @@
+"""
+Wbemcli scriptlet displays the number of subscriptions, filters, and
+distination objects on the defined server and the list of instance paths.
+"""
+
+from pywbem import WBEMServer, WBEMSubscriptionManager
+
+
+def display_paths(instances, type_str):
+    """Display the count and paths for the list of instances in instances."""
+    print('%ss: count=%s' % (type_str, len(instances),))
+    for path in [instance.path for instance in instances]:
+        print('%s: %s' % (type_str, path))
+    if len(instances):
+        print('')
+
+
+MY_SERVER = WBEMServer(CONN)  # noqa: F821
+print('Interop namespace=%s' % MY_SERVER.interop_ns)
+
+with WBEMSubscriptionManager('fred') as sub_mgr:
+    server_id = sub_mgr.add_server(MY_SERVER)
+
+    display_paths(sub_mgr.get_all_filters(server_id), 'Filter')
+
+    display_paths(sub_mgr.get_all_destinations(server_id), 'Destination')
+
+    display_paths(sub_mgr.get_all_subscriptions(server_id), 'Subscription')
+
+print('Quit Scriplet. Quiting wbemcli')
+quit()


### PR DESCRIPTION
Ready for review and commit:

I used these extensively in testing of the subscription manager changes.
Allowed me to see what was done and clean up the server easily.
At the same time they demo the weakness of the scriplets.

The scriptlets are:

1. View counts and paths for subscriptions, filters, destinations on a server
2. Remove all subscriptions, filters, destinations on a server.

Note: They do not use subscription manager today because I did them to help test the changes.
Probably should update to use subscription manager before committing.

Second they do not pass flake8 because of the ein, etc. functions from wbemcli.  Not importing anything to get around that.