### PR TITLE
fixes #620 and #643 Add testclient tests and add cim_obj tests

### DIFF
--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -7880,7 +7880,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         if self.operation_recorder:
             self.operation_recorder.reset()
             self.operation_recorder.stage_pywbem_args(
-                method='SetQualifier',
+                method='DeleteQualifier',
                 QualifierName=QualifierName,
                 namespace=namespace,
                 **extra)

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -457,6 +457,7 @@ class ClientTest(unittest.TestCase):
             # Sort sibling elements with <first> tag by its <second> attribute
             ("IPARAMVALUE", "NAME"),
             ("PROPERTY", "NAME"),
+            ("PROPERTY.ARRAY", "NAME"),
             ("PARAMETER", "NAME"),
             ("KEYBINDING", "NAME"),
         ]
@@ -769,6 +770,8 @@ class ClientTest(unittest.TestCase):
                 print("- Expected pull_result tuple size: %s" %
                       len(exp_pull_result_obj))
                 print("- Actual result len: %s" % len(result))
+                # print('result %s exp %s' % ((result, ),
+                #      (exp_pull_result_obj, )))
                 raise AssertionError("PyWBEM CIM result type is not"
                                      " as expected.")
             # eos is required result
@@ -885,8 +888,7 @@ def result_tuple(value, tc_name):
 
 
 if __name__ == '__main__':
-    print('args %s len %s type %s' % (sys.argv, len(sys.argv), type(sys.argv)))
-
+    """Main function of test_client. Calls unittest"""
     # NonDocumented option to run a single testcase if that testcase name
     # is listed on the cmd line.
     if len(sys.argv) > 1:

--- a/testsuite/testclient/createclass.yaml
+++ b/testsuite/testclient/createclass.yaml
@@ -1,0 +1,600 @@
+- name: CreateClass1
+  description: CreateClass request. Creates a simple class. Successful
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: CreateClass
+      NewClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations0
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+      namespace: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: CreateClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CreateClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="NewClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations0">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="CreateClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+      
+- name: CreateClass2
+  description: CreateClass requests with valid class and many properties. Successful
+  ignore_test: true
+  # TODO fix this.  It does not always correctly sort the properties.
+  # Works most of the time but about 1 in 4 gets properties mixed up.
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: CreateClass
+      namespace: null
+      NewClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations1
+        superclass: null
+        properties:
+          mydatetime:
+            pywbem_object: CIMProperty
+            name: Mydatetime
+            value: 12345678224455.654321:000
+            type: datetime
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myreal64:
+            pywbem_object: CIMProperty
+            name: MyReal64
+            value: 12345.0
+            type: real64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          uint32array:
+            pywbem_object: CIMProperty
+            name: Uint32Array
+            value: null
+            type: uint32
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint64:
+            pywbem_object: CIMProperty
+            name: MyUint64
+            value: 12345
+            type: uint64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint16:
+            pywbem_object: CIMProperty
+            name: MyUint16
+            value: 999
+            type: uint16
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint32:
+            pywbem_object: CIMProperty
+            name: MyUint32
+            value: 12345
+            type: uint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mystr:
+            pywbem_object: CIMProperty
+            name: MyStr
+            value: This is a test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myreal32:
+            pywbem_object: CIMProperty
+            name: MyReal32
+            value: 12345.0
+            type: real32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          sint32array:
+            pywbem_object: CIMProperty
+            name: Sint32Array
+            value: null
+            type: sint32
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          uint64array:
+            pywbem_object: CIMProperty
+            name: Uint64Array
+            value: null
+            type: uint64
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint32:
+            pywbem_object: CIMProperty
+            name: MySint32
+            value: -12345
+            type: sint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          sint64array:
+            pywbem_object: CIMProperty
+            name: Sint64Array
+            value: null
+            type: sint64
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint8:
+            pywbem_object: CIMProperty
+            name: MySint8
+            value: 99
+            type: sint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint16:
+            pywbem_object: CIMProperty
+            name: MySint16
+            value: -999
+            type: sint16
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint64:
+            pywbem_object: CIMProperty
+            name: MySint64
+            value: -12345
+            type: sint64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMMethod: CreateClass
+      CIMObject: root/cimv2
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CreateClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="NewClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations1">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="Mydatetime" TYPE="datetime">
+      <VALUE>12345678224455.654321:000</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyUint32" TYPE="uint32">
+      <VALUE>12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyStr" TYPE="string">
+      <VALUE>This is a test</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="Sint32Array" TYPE="sint32"/>
+      <PROPERTY.ARRAY NAME="Uint64Array" TYPE="uint64"/>
+      <PROPERTY NAME="MySint32" TYPE="sint32">
+      <VALUE>-12345</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="Sint64Array" TYPE="sint64"/>
+      <PROPERTY NAME="MySint8" TYPE="sint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint16" TYPE="sint16">
+      <VALUE>-999</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyReal64" TYPE="real64">
+      <VALUE>1.2345000000000000E+04</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyUint64" TYPE="uint64">
+      <VALUE>12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyReal32" TYPE="real32">
+      <VALUE>1.23450000E+04</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyUint16" TYPE="uint16">
+      <VALUE>999</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="Uint32Array" TYPE="uint32"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint64" TYPE="sint64">
+      <VALUE>-12345</VALUE>
+      </PROPERTY>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="CreateClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: CreateClassF1
+  description: CreateClass fails. Namespace name causes invalid namespace return
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: CreateClass
+      NewClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations1
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint16:
+            pywbem_object: CIMProperty
+            name: MyUint16
+            value: 999
+            type: uint16
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint32:
+            pywbem_object: CIMProperty
+            name: MySint32
+            value: -12345
+            type: sint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint32:
+            pywbem_object: CIMProperty
+            name: MyUint32
+            value: 12345
+            type: uint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mydatetime:
+            pywbem_object: CIMProperty
+            name: Mydatetime
+            value: 12345678224455.654321:000
+            type: datetime
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mystr:
+            pywbem_object: CIMProperty
+            name: MyStr
+            value: This is a test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods: {}
+        qualifiers: {}
+      namespace: blah
+  pywbem_response:
+    cim_status: 3
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: CreateClass
+      CIMObject: blah
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CreateClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="blah"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="NewClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations1">
+      <PROPERTY NAME="MyUint32" TYPE="uint32">
+      <VALUE>12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Mydatetime" TYPE="datetime">
+      <VALUE>12345678224455.654321:000</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyStr" TYPE="string">
+      <VALUE>This is a test</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyUint16" TYPE="uint16">
+      <VALUE>999</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint32" TYPE="sint32">
+      <VALUE>-12345</VALUE>
+      </PROPERTY>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="CreateClass">
+      <ERROR CODE="3" DESCRIPTION="CIM_ERR_INVALID_NAMESPACE: blah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'

--- a/testsuite/testclient/deleteclass.yaml
+++ b/testsuite/testclient/deleteclass.yaml
@@ -1,0 +1,106 @@
+- name: DeleteClass1
+  description: Delete class successful
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: DeleteClass
+      ClassName: PyWbem_Run_CIM_Operations1
+      namespace: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="PyWbem_Run_CIM_Operations1"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+
+- name: DeleteClassF1
+  description: Delete class request fails with CIM_ERR_NOT_FOUND
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: DeleteClass
+      ClassName: PyWbem_Run_CIM_Operations1
+      namespace: null
+  pywbem_response:
+    cim_status: 6
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="PyWbem_Run_CIM_Operations1"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteClass">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: PyWbem_Run_CIM_Operations1"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'

--- a/testsuite/testclient/deletequalifier.yaml
+++ b/testsuite/testclient/deletequalifier.yaml
@@ -1,0 +1,106 @@
+- name: DeleteQualifier1
+  description: DeleteQualifier request succeeds
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: DeleteQualifier
+      QualifierName: FooQualDecl
+      namespace: null
+  pywbem_response:
+    cim_status: 6
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>FooQualDecl</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteQualifier">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: FooQualDecl"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+- name: DeleteQualifierF1
+  description: DeleteQualifier operation fails. Returns NOT_FOUND
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: DeleteQualifier
+      QualifierName: BlahBlah
+      namespace: null
+  pywbem_response:
+    cim_status: 6
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>BlahBlah</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteQualifier">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: BlahBlah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'

--- a/testsuite/testclient/execquery.yaml
+++ b/testsuite/testclient/execquery.yaml
@@ -1,0 +1,437 @@
+- name: ExecQuery1
+  description: ExecQuery request returns data. Successful
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: WQL
+      Query: Select * from CIM_ComputerSystem
+      namespace: null
+  pywbem_response:
+    result:
+    - pywbem_object: CIMInstance
+      classname: PG_ComputerSystem
+      properties:
+        name:
+          pywbem_object: CIMProperty
+          name: Name
+          value: sheldon
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        powermanagementcapabilities:
+          pywbem_object: CIMProperty
+          name: PowerManagementCapabilities
+          value:
+          - 1
+          type: uint16
+          reference_class: null
+          embedded_object: null
+          is_array: true
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        powerstate:
+          pywbem_object: CIMProperty
+          name: PowerState
+          value: 1
+          type: uint16
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        operationalstatus:
+          pywbem_object: CIMProperty
+          name: OperationalStatus
+          value:
+          - 2
+          type: uint16
+          reference_class: null
+          embedded_object: null
+          is_array: true
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        powermanagementsupported:
+          pywbem_object: CIMProperty
+          name: PowerManagementSupported
+          value: false
+          type: boolean
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        elementname:
+          pywbem_object: CIMProperty
+          name: ElementName
+          value: Computer System
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        description:
+          pywbem_object: CIMProperty
+          name: Description
+          value: 'Linux version 3.13.0-106-generic (buildd@lcy01-30) (gcc version
+            4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #153-Ubuntu SMP Tue Dec 6 15:44:32
+            UTC 2016'
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        nameformat:
+          pywbem_object: CIMProperty
+          name: NameFormat
+          value: Other
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        status:
+          pywbem_object: CIMProperty
+          name: Status
+          value: OK
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        caption:
+          pywbem_object: CIMProperty
+          name: Caption
+          value: Computer System
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+        creationclassname:
+          pywbem_object: CIMProperty
+          name: CreationClassName
+          value: PG_ComputerSystem
+          type: string
+          reference_class: null
+          embedded_object: null
+          is_array: false
+          array_size: null
+          class_origin: null
+          propagated: null
+          qualifiers: {}
+      path:
+        pywbem_object: CIMInstanceName
+        classname: PG_ComputerSystem
+        namespace: root/cimv2
+        host: sheldon
+        keybindings:
+          name: sheldon
+          creationclassname: PG_ComputerSystem
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <IRETURNVALUE>
+      <VALUE.OBJECTWITHPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PG_ComputerSystem">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string">PG_ComputerSystem</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string">sheldon</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Description"  TYPE="string">
+      <VALUE>Linux version 3.13.0-106-generic (buildd@lcy01-30) (gcc version 4.8.4
+      (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #153-Ubuntu SMP Tue Dec 6 15:44:32 UTC 2016</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </VALUE.OBJECTWITHPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: ExecQueryF1
+  description: ExecQuery request fails, invalid query
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: WQL
+      Query: SelectSLOP * from CIM_ComputerSystem
+      namespace: root/cimv2
+  pywbem_response:
+    cim_status: 15
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>SelectSLOP * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <ERROR CODE="15" DESCRIPTION="CIM_ERR_INVALID_QUERY: SelectSLOP * from CIM_ComputerSystem"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+- name: ExecQueryF2
+  description: ExecQuery request fails, Invalid query language
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: wql
+      Query: Select * from CIM_ComputerSystem
+      namespace: root/cimv2
+  pywbem_response:
+    cim_status: 14
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>wql</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <ERROR CODE="14" DESCRIPTION="CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED: wql"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+- name: ExecQueryF3
+  description: ExecQueryRequest fails, Invalid namespace
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: WQL
+      Query: Select * from CIM_ComputerSystem
+      namespace: root/blah
+  pywbem_response:
+    cim_status: 3
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/blah
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="blah"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <ERROR CODE="3" DESCRIPTION="CIM_ERR_INVALID_NAMESPACE: root/blah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+

--- a/testsuite/testclient/modifyclass.yaml
+++ b/testsuite/testclient/modifyclass.yaml
@@ -1,0 +1,640 @@
+- name: ModifyClass1
+  description: ModifyClass requests, successful. Modifies a simple class
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ModifyClass
+      namespace: null
+      ModifiedClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations0
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          str2:
+            pywbem_object: CIMProperty
+            name: Str2
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations0">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Str2" TYPE="string"/>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+
+- name: ModifyClass2
+  description: Modify a class request successful. Adds one property to existing class
+  ignore_test: True      Sort of the properties fails in test_client
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ModifyClass
+      namespace: null
+      ModifiedClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations1
+        superclass: null
+        properties:
+          mysint8:
+            pywbem_object: CIMProperty
+            name: MySint8
+            value: 99
+            type: sint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint16:
+            pywbem_object: CIMProperty
+            name: MySint16
+            value: -999
+            type: sint16
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myreal64:
+            pywbem_object: CIMProperty
+            name: MyReal64
+            value: 12345.0
+            type: real64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint16:
+            pywbem_object: CIMProperty
+            name: MyUint16
+            value: 999
+            type: uint16
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          strarray:
+            pywbem_object: CIMProperty
+            name: StrArray
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          uint64array:
+            pywbem_object: CIMProperty
+            name: Uint64Array
+            value: null
+            type: uint64
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint32:
+            pywbem_object: CIMProperty
+            name: MySint32
+            value: -12345
+            type: sint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myreal32:
+            pywbem_object: CIMProperty
+            name: MyReal32
+            value: 12345.0
+            type: real32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          sint64array:
+            pywbem_object: CIMProperty
+            name: Sint64Array
+            value: null
+            type: sint64
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint32:
+            pywbem_object: CIMProperty
+            name: MyUint32
+            value: 12345
+            type: uint32
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mydatetime:
+            pywbem_object: CIMProperty
+            name: Mydatetime
+            value: 12345678224455.654321:000
+            type: datetime
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mystr:
+            pywbem_object: CIMProperty
+            name: MyStr
+            value: This is a test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          sint32array:
+            pywbem_object: CIMProperty
+            name: Sint32Array
+            value: null
+            type: sint32
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint64:
+            pywbem_object: CIMProperty
+            name: MyUint64
+            value: 12345
+            type: uint64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mysint64:
+            pywbem_object: CIMProperty
+            name: MySint64
+            value: -12345
+            type: sint64
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          uint32array:
+            pywbem_object: CIMProperty
+            name: Uint32Array
+            value: null
+            type: uint32
+            reference_class: null
+            embedded_object: null
+            is_array: true
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations1">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="MyUint16" TYPE="uint16">
+      <VALUE>999</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="Uint32Array" TYPE="uint32"/>
+      <PROPERTY NAME="MyReal64" TYPE="real64">
+      <VALUE>1.2345000000000000E+04</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint32" TYPE="sint32">
+      <VALUE>-12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint16" TYPE="sint16">
+      <VALUE>-999</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MySint64" TYPE="sint64">
+      <VALUE>-12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyStr" TYPE="string">
+      <VALUE>This is a test</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="MyReal32" TYPE="real32">
+      <VALUE>1.23450000E+04</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MySint8" TYPE="sint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="StrArray" TYPE="string"/>
+      <PROPERTY.ARRAY NAME="Sint64Array" TYPE="sint64"/>
+      <PROPERTY NAME="MyUint32" TYPE="uint32">
+      <VALUE>12345</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Mydatetime" TYPE="datetime">
+      <VALUE>12345678224455.654321:000</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="Uint64Array" TYPE="uint64"/>
+      <PROPERTY.ARRAY NAME="Sint32Array" TYPE="sint32"/>
+      <PROPERTY NAME="MyUint64" TYPE="uint64">
+      <VALUE>12345</VALUE>
+      </PROPERTY>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: ModifyClassF1
+  description: Modify Class requests fails. No class in server to modify
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ModifyClass
+      namespace: null
+      ModifiedClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations2
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mystr:
+            pywbem_object: CIMProperty
+            name: MyStr
+            value: This is a test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods: {}
+        qualifiers: {}
+  pywbem_response:
+    cim_status: 6
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations2">
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyStr" TYPE="string">
+      <VALUE>This is a test</VALUE>
+      </PROPERTY>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyClass">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: PyWbem_Run_CIM_Operations2"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+- name: ModifyClassF2
+  description: ModifyClass request fails. Invalid Namespace
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: ModifyClass
+      namespace: blah
+      ModifiedClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations2
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          mystr:
+            pywbem_object: CIMProperty
+            name: MyStr
+            value: This is a test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods: {}
+        qualifiers: {}
+  pywbem_response:
+    cim_status: 3
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyClass
+      CIMObject: blah
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="blah"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations2">
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyStr" TYPE="string">
+      <VALUE>This is a test</VALUE>
+      </PROPERTY>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyClass">
+      <ERROR CODE="3" DESCRIPTION="CIM_ERR_INVALID_NAMESPACE: blah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+    
+

--- a/testsuite/testclient/pullinstancepaths.yaml
+++ b/testsuite/testclient/pullinstancepaths.yaml
@@ -1,5 +1,4 @@
--
-  name: PullInstancePaths1
+- name: PullInstancePaths1
   description: Pull request and returns 2 paths with eos=false and a context
   pywbem_request:
     url: http://acme.com:80
@@ -139,13 +138,14 @@
                                     <VALUE>FALSE</VALUE>
                                 </PARAMVALUE>
                                 <PARAMVALUE NAME="EnumerationContext">
-                                    <VALUE>abc12345def</VALUE>
+                                    <VALUE>50001</VALUE>
                                 </PARAMVALUE>
                         </IMETHODRESPONSE>
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-  name: PullInstancePaths2
+            
+- name: PullInstancePaths2
   description: Pull request and returns two paths with eos=true and no context
   pywbem_request:
     url: http://acme.com:80
@@ -289,9 +289,9 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
--
-  name: PullInstancePaths3
-  description: Pull request and returns zero instances witheos=true and no context
+
+- name: PullInstancePaths3
+  description: Pull request and returns zero instances with eos=true and no context
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -310,8 +310,7 @@
         pullresult:
             context: null
             eos: true
-            instances: []
-
+            paths: []
   http_request:
     verb: POST
     url: http://acme.com:80/cimom
@@ -360,7 +359,7 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-  name: PullInstancePaths3
+- name: PullInstancePaths4
   description: Pull request and returns zero instances with eos=false and a context
   pywbem_request:
     url: http://acme.com:80
@@ -383,7 +382,6 @@
                 -  root/cimv2
             eos: False
             paths: []
-
   http_request:
     verb: POST
     url: http://acme.com:80/cimom
@@ -432,7 +430,8 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-  name: PullInstancePaths4
+            
+- name: PullInstancePaths5
   description: Pull request and returns zero instances with eos=True and no context
   pywbem_request:
     url: http://acme.com:80
@@ -453,7 +452,6 @@
             context: null
             eos: true
             paths: []
-
   http_request:
     verb: POST
     url: http://acme.com:80/cimom
@@ -502,6 +500,67 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
+
+- name: PullInstancePathsF1
+  description: PullInstancePaths request fails. Invalid Context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+     cim_status: 21
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancePaths
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancePaths">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="PullInstancePaths">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIM>
 
 
 

--- a/testsuite/testclient/pullinstances.yaml
+++ b/testsuite/testclient/pullinstances.yaml
@@ -1,0 +1,525 @@
+- name: PullInstances1
+  description: PullInstances request part of OpenQueryInstances sequence. Successful with eol and null context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+    pullresult:
+        context: null
+        eos: True
+        instances:
+          - pywbem_object: CIMInstance
+            classname: PG_ComputerSystem
+            properties:
+              status:
+                pywbem_object: CIMProperty
+                name: Status
+                value: OK
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              elementname:
+                pywbem_object: CIMProperty
+                name: ElementName
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powerstate:
+                pywbem_object: CIMProperty
+                name: PowerState
+                value: 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementsupported:
+                pywbem_object: CIMProperty
+                name: PowerManagementSupported
+                value: false
+                type: boolean
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              nameformat:
+                pywbem_object: CIMProperty
+                name: NameFormat
+                value: Other
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              caption:
+                pywbem_object: CIMProperty
+                name: Caption
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              operationalstatus:
+                pywbem_object: CIMProperty
+                name: OperationalStatus
+                value:
+                - 2
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementcapabilities:
+                pywbem_object: CIMProperty
+                name: PowerManagementCapabilities
+                value:
+                - 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              creationclassname:
+                pywbem_object: CIMProperty
+                name: CreationClassName
+                value: PG_ComputerSystem
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              name:
+                pywbem_object: CIMProperty
+                name: Name
+                value: sheldon
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+            path: null
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="PullInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>
+      </VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: PullInstances2
+  description: PullInstances request part of OpenQueryInstances sequence. Successful with valid context and eol=False
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+    pullresult:
+        context:
+        - '500182'
+        - root/cimv2
+        eos: False
+        instances:
+          - pywbem_object: CIMInstance
+            classname: PG_ComputerSystem
+            properties:
+              status:
+                pywbem_object: CIMProperty
+                name: Status
+                value: OK
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              elementname:
+                pywbem_object: CIMProperty
+                name: ElementName
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powerstate:
+                pywbem_object: CIMProperty
+                name: PowerState
+                value: 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementsupported:
+                pywbem_object: CIMProperty
+                name: PowerManagementSupported
+                value: false
+                type: boolean
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              nameformat:
+                pywbem_object: CIMProperty
+                name: NameFormat
+                value: Other
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              caption:
+                pywbem_object: CIMProperty
+                name: Caption
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              operationalstatus:
+                pywbem_object: CIMProperty
+                name: OperationalStatus
+                value:
+                - 2
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementcapabilities:
+                pywbem_object: CIMProperty
+                name: PowerManagementCapabilities
+                value:
+                - 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              creationclassname:
+                pywbem_object: CIMProperty
+                name: CreationClassName
+                value: PG_ComputerSystem
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              name:
+                pywbem_object: CIMProperty
+                name: Name
+                value: sheldon
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+            path: null
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="PullInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>FALSE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+# TODO add other options of context, instances, eos on return. see pull paths
+- name: PullInstancesF1
+  description: PullInstances request fails. Invalid Context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+     cim_status: 21
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="PullInstances">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIM>

--- a/testsuite/testclient/pullinstanceswithpath.yaml
+++ b/testsuite/testclient/pullinstanceswithpath.yaml
@@ -320,9 +320,9 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
--
-  name: PullInstancesWithPath3
-  description: Pull request and returns zero instances witheos=true and no context
+            
+- name: PullInstancesWithPath3
+  description: Pull request and returns zero instances with eos=true and no context
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -342,7 +342,6 @@
             context: null
             eos: true
             instances: []
-
   http_request:
     verb: POST
     url: http://acme.com:80/cimom
@@ -392,3 +391,135 @@
                 </MESSAGE>
             </CIM>
 
+- name: PullInstancesWithPath4
+  description: Pull request and returns zero instances with eos=false and valid context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        pullresult:
+            context:
+              - '500001'
+              - root/cimv2            
+            eos: false
+            instances: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancesWithPath
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancesWithPath">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500001</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>1</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstancesWithPath">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>FALSE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE>500001</VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+- name: PullInstancesWithPathF1
+  description: PullInstancesWithPath request fails. Invalid Context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+     cim_status: 21
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancesWithPath
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancesWithPath">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="PullInstancesWithPath">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIM>

--- a/testsuite/testclient/setqualifierdecl.yaml
+++ b/testsuite/testclient/setqualifierdecl.yaml
@@ -1,0 +1,144 @@
+- name: SetQualifier1
+  description: SetQualifier request succeeds. Sets qualifierDecaration
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: SetQualifier
+      namespace: null
+      QualifierDeclaration:
+        pywbem_object: CIMQualifierDeclaration
+        name: FooQualDecl
+        type: string
+        value: Some string
+        is_array: false
+        array_size: null
+        scopes:
+          class: true
+        tosubclass: false
+        toinstance: null
+        overridable: false
+        translatable: null
+  pywbem_response: {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="SetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierDeclaration">
+      <QUALIFIER.DECLARATION ISARRAY="false" NAME="FooQualDecl" OVERRIDABLE="false"
+      TOSUBCLASS="false" TYPE="string">
+      <SCOPE class="true"/>
+      <VALUE>Some string</VALUE>
+      </QUALIFIER.DECLARATION>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="SetQualifier">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: SetQualifierF1
+  description: SetQualifier request fails. Returns NOT_SUPPORTED
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: SetQualifier
+      namespace: null
+      QualifierDeclaration:
+        pywbem_object: CIMQualifierDeclaration
+        name: Abstract
+        type: boolean
+        value: null
+        is_array: false
+        array_size: null
+        scopes:
+          reference: false
+          any: false
+          class: true
+          indication: false
+          property: false
+          parameter: false
+          method: false
+          association: false
+        tosubclass: true
+        toinstance: true
+        overridable: false
+        translatable: false
+  pywbem_response:
+    cim_status: 7
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="SetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierDeclaration">
+      <QUALIFIER.DECLARATION ISARRAY="false" NAME="Abstract" OVERRIDABLE="false" TOINSTANCE="true"
+      TOSUBCLASS="true" TRANSLATABLE="false" TYPE="boolean">
+      <SCOPE ANY="false" ASSOCIATION="false" CLASS="true" INDICATION="false" METHOD="false"
+      PARAMETER="false" PROPERTY="false" REFERENCE="false"/>
+      </QUALIFIER.DECLARATION>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="SetQualifier">
+      <ERROR CODE="7" DESCRIPTION="CIM_ERR_NOT_SUPPORTED: Abstract"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'


### PR DESCRIPTION
**Status:** Ready for Review. 
This gets us up to 66% coverage so all this was about 1.4 % gain

Adds mock tests for CreateClass, DeleteClass, ModifyClass, SetQualifier,
DeleteQualifier, and ExecQuery.

Adds unittests to test_cim_obj.py for CIMQualifierDeclaration. This was part of getting
the mock tests running for setqualifier, etc.

Adds tests  to run_cim_operation.py for CreateClass, DeleteClass, ModifyClass, SetQualifier,
DeleteQualifier.

Corrects an error in CIM_operations where recorder was being called with
incorrect type.

At this point we have at least minimal mock tests for every operation  and most of them have both
success and fail tests.

There are several mock tests marked ignore_test for the following reasons(5 tests are marked ignore out of over 200 separate tests):
1. The reference_class issue (see issue #598) - two tests
2. The create_class, modify_class test for a class with both property and property.array elements has problems sorting the objects correctly so sometimes fails. No issue filed to date.

In addition the parameter component of invoke method is not exercised because of issues in test_client (issue not yet filed)


