### PR TITLE
Fixes #649: coverage html report

### DIFF
--- a/coveragerc
+++ b/coveragerc
@@ -19,6 +19,7 @@ omit =
 # Controls whether lines without coverage are shown in the report.
 show_missing = True
 
+# defines location for coverage html output
 [html]
-directory = coverage_html_report
+directory = coverage_html
 

--- a/coveragerc
+++ b/coveragerc
@@ -19,3 +19,6 @@ omit =
 # Controls whether lines without coverage are shown in the report.
 show_missing = True
 
+[html]
+directory = coverage_html_report
+

--- a/makefile
+++ b/makefile
@@ -343,7 +343,7 @@ endif
 
 $(test_log_file): makefile $(package_name)/*.py testsuite/*.py coveragerc
 	rm -f $(test_log_file)
-	bash -c "set -o pipefail; PYTHONWARNINGS=default PYTHONPATH=. py.test --cov $(package_name) --cov-config coveragerc --ignore=attic --ignore=releases --ignore=testsuite/testclient -s 2>&1 |tee $(test_tmp_file)"
+	bash -c "set -o pipefail; PYTHONWARNINGS=default PYTHONPATH=. py.test --cov $(package_name) --cov-report=annotate --cov-report=html --cov-config coveragerc --ignore=attic --ignore=releases --ignore=testsuite/testclient -s 2>&1 |tee $(test_tmp_file)"
 	mv -f $(test_tmp_file) $(test_log_file)
 	@echo 'Done: Created test log file: $@'
 


### PR DESCRIPTION
Create optional detailed line by line report output showing code coverage.
    
 Adds an optional environment variable for the make file to control
output of a detailed line by line coverage report in html   If this
variable is set (export PYWBEM_COVERAGE_REPORT = true) html output is
generated in the directory coverage_html that shows the files in the
pywbem directory with coloring for which lines are covered and missed.
This also creates temporary files with the suffix ,cover in
pywbem/pywbem directory.  All these files are destroyed by clobber.
    
We made this an optional variable because it is only needed occasionally
when working on coverage issues. There is no need to generate these
reports for every make test.
    
To generate the reports:
      1) set the env var (export PYWBEM_COVERAGE_REPORT=true
      2) run make test
or
      1) run make test PYWBEM_COVERAGE_REPORT=true

Note that it is not necesary to use true, just some value since we only test for existence of the variable not for equality to true