### PR TITLE
Fixes 656: MaxObjectCount parameter of Pull operations inconsistent

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,15 @@ Enhancements
 Bug fixes
 ^^^^^^^^^
 
+* Fix issue with MaxObjectCount on PullInstances and PullInstancePaths
+  CIM_Operations.py methods.  The MaxObjectCount was defined as a keyword
+  parameter where it should have been be positional.  This should NOT impact
+  clients unless they did not supply the parameter at all so that the result
+  was None which is illegal(Pull... operations MUST include MaxObjectCount).
+  In that case, server should return error.
+  Also extends these requests to test the Pull.. methods for valid
+  MaxObjectCount and context parameters. See issue #656.
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -427,6 +427,24 @@ def _validateIterCommonParams(MaxObjectCount, OperationTimeout):
                          OperationTimeout)
 
 
+def _validatePullParams(MaxObjectCount, context):
+    """
+        Validate the input paramaters for the PullInstances,
+        PullInstancesWithPath, and PullInstancePaths requests.
+
+        MaxObjectCount: Must be integer type and ge 0
+
+        context: Must be not None and length ge 2
+    """
+    if (not isinstance(MaxObjectCount, six.integer_types) or
+            MaxObjectCount < 0):
+        raise ValueError('MaxObjectCount parameter must be integer >= 0 but '
+                         ' is %s' % MaxObjectCount)
+    if context is None or len(context) < 2:
+        raise ValueError('Pull... Context parameter must be valid tuple %s'
+                         % context)
+
+
 class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     """
     A client's connection to a WBEM server. This is the main class of the
@@ -5258,9 +5276,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * `None' is not allowed for this operation.
+              be used by a client to reset the interoperation timer
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5330,8 +5347,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
-            # TODO: ks jan 17. This should check for None on MaxObjectCount
-            # and reject. issue# 656
+            _validatePullParams(MaxObjectCount, context)
+
             namespace = context[1]
 
             result = self._imethodcall(
@@ -5356,7 +5373,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
+    def PullInstancePaths(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
 
         """
@@ -5395,9 +5412,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * `None' is not allowed for this operation.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5464,8 +5480,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
-            # TODO: ks jan 17. This should check for None on MaxObjectCount
-            # and reject. issue # 656
+            _validatePullParams(MaxObjectCount, context)
+
             namespace = context[1]
 
             result = self._imethodcall(
@@ -5490,7 +5506,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstances(self, context, MaxObjectCount=None, **extra):
+    def PullInstances(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
         """
         Retrieve the next set of instances from an open enumeraton
@@ -5528,9 +5544,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * `None' is not allowed for this operation.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5594,7 +5609,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
-            # TODO: ks jan 17 Reject if MaxObjectCount = None. issue # 656
+            _validatePullParams(MaxObjectCount, context)
+
             namespace = context[1]
 
             result = self._imethodcall(

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -273,7 +273,7 @@ class ClientTest(unittest.TestCase):
         # if list, recurse this function
         if isinstance(instances, list):
             for inst in instances:
-                self.assertInstancesValid(inst, includes_path=True,
+                self.assertInstancesValid(inst, includes_path=includes_path,
                                           prop_count=prop_count,
                                           property_list=property_list,
                                           namespace=namespace)
@@ -935,8 +935,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertInstancesValid(result.instances)
 
@@ -962,8 +961,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             insts_pulled.extend(result.instances)
 
         self.assertInstancesValid(insts_pulled)
@@ -1013,8 +1011,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1038,8 +1035,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1062,8 +1058,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
 
@@ -1079,7 +1074,7 @@ class PullEnumerateInstances(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancesWithPath(result.context, MaxObjectCount=10)
+            self.conn.PullInstancesWithPath(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1092,8 +1087,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
 
         try:
             self.cimcall(self.conn.CloseEnumeration, result.context)
@@ -1248,8 +1242,7 @@ class PullEnumerateInstancePaths(ClientTest):
         # loop to complete the enumeration session
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1278,8 +1271,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1315,9 +1307,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.assertFalse(result.eos)
 
         # Pull the remainder of the paths
-        result = self.cimcall(self.conn.PullInstancePaths,
-                              result.context,
-                              MaxObjectCount=100)
+        result = self.cimcall(self.conn.PullInstancePaths, result.context, 100)
 
         self.assertTrue(result.eos)
 
@@ -1333,7 +1323,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancePaths(result.context, MaxObjectCount=10)
+            self.conn.PullInstancePaths(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1360,8 +1350,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1402,8 +1391,7 @@ class PullReferences(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1449,8 +1437,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1481,8 +1468,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1529,8 +1515,7 @@ class PullReferencePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1575,8 +1560,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1609,8 +1593,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
 
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
@@ -1645,8 +1628,7 @@ class PullAssociators(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1689,8 +1671,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1721,8 +1702,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1774,8 +1754,7 @@ class PullAssociatorPaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1819,8 +1798,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1856,8 +1834,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
                 paths_pulled.extend(result.paths)
@@ -1891,12 +1868,11 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 
-            self.assertInstancesValid(insts_pulled)
+            self.assertInstancesValid(insts_pulled, includes_path=False)
 
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
@@ -1926,8 +1902,7 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 

--- a/testsuite/testclient/pullinstancepaths.yaml
+++ b/testsuite/testclient/pullinstancepaths.yaml
@@ -563,4 +563,57 @@
         </CIM>
 
 
+- name: PullInstancePathsF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancePathsF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancePathsF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+
 

--- a/testsuite/testclient/pullinstances.yaml
+++ b/testsuite/testclient/pullinstances.yaml
@@ -462,7 +462,78 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
-# TODO add other options of context, instances, eos on return. see pull paths
+
+- name: PullInstances3
+  description: Pull request and returns zero instances with eos=true and no context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        pullresult:
+            context: null
+            eos: true
+            instances: []
+
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500001</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>1</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstances">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>TRUE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE></VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
 - name: PullInstancesF1
   description: PullInstances request fails. Invalid Context
   pywbem_request:
@@ -523,3 +594,76 @@
             </SIMPLERSP>
           </MESSAGE>
         </CIM>
+
+- name: PullInstancesF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+-
+  name: PullInstancesF5
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: None
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+

--- a/testsuite/testclient/pullinstanceswithpath.yaml
+++ b/testsuite/testclient/pullinstanceswithpath.yaml
@@ -523,3 +523,75 @@
             </SIMPLERSP>
           </MESSAGE>
         </CIM>
+-
+  name: PullInstancesWithPathF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesWithPathF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesWithPathF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+-
+  name: PullInstancesWithPathF5
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: None
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError


### PR DESCRIPTION
This parameter was inconsistent between the different cim_operations.py pull...
operations methods (was keyword in 2 of the methods). The PR made it positional for all 3 operations.  Also added validation for the parameters for these operations (Context and MaxObjectCount).

Added tests to mock tests for the new method validation and modified
run_cim_operations.py to match the changes in cim_operations.py. Note
that these changes should not impact clients since the keyword parameter
is still accepted and the tests we added should be caught by the server
or pywbem code in any case.