### PR TITLE
Fixes #645: Extension to test for valid qualifier declaration constructor parameters

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,9 @@ Bug fixes
   Also extends these requests to test the Pull.. methods for valid
   MaxObjectCount and context parameters. See issue #656.
 
+* Add constructor parameter checking to QualifierDeclaration. See issue #645.
+
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3880,6 +3880,17 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         self.tosubclass = tosubclass
         self.toinstance = toinstance
         self.translatable = translatable
+        if is_array is None:
+            raise ValueError('None not allowed for is_array')
+        if array_size and not is_array:
+            raise ValueError('QualifierDeclaration array_size allowed only '
+                             'when is_array is True.')
+        if isinstance(value, list) and not is_array:
+            raise ValueError('QualifierDeclaration is_array is False and '
+                             'value is a list.')
+        elif is_array and value is not None and not isinstance(value, list):
+            raise ValueError('QualifierDeclaration is_array is True but '
+                             'value is scalar')
 
     def _cmp(self, other):
         """

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -3245,6 +3245,51 @@ class InitCIMQualifierDeclaration(unittest.TestCase):
                                 array_size=4, scopes=scopes,
                                 overridable=True, tosubclass=True,
                                 toinstance=True, translatable=False)
+        CIMQualifierDeclaration('FooQualDecl', 'uint32', is_array=True,
+                                value=[Uint32(x) for x in [1, 2, 3]],
+                                overridable=True, tosubclass=True,
+                                toinstance=True, translatable=False)
+        CIMQualifierDeclaration('FooQualDecl', 'uint32', is_array=False,
+                                value=Uint32(3),
+                                overridable=True, tosubclass=True,
+                                toinstance=True, translatable=False)
+
+    def test_errors(self):
+        """Test constructors that should generate errors"""
+        try:
+            CIMQualifierDeclaration('FooIs_ArrayNone', 'uint32', is_array=None)
+            self.fail('Exception expected')
+        except ValueError:
+            pass
+        try:
+            CIMQualifierDeclaration('is_arraySizeMismatch', 'string',
+                                    is_array=False,
+                                    array_size=4,
+                                    overridable=True, tosubclass=True,
+                                    toinstance=True, translatable=False)
+            self.fail('Exception expected')
+        except ValueError:
+            pass
+
+        try:
+            CIMQualifierDeclaration('is_arrayValueMismatch', 'uint32',
+                                    is_array=False,
+                                    value=[Uint32(x) for x in [1, 2, 3]],
+                                    overridable=True, tosubclass=True,
+                                    toinstance=True, translatable=False)
+            self.fail('Exception expected')
+        except ValueError:
+            pass
+
+        try:
+            CIMQualifierDeclaration('is_arrayValueMismatch', 'uint32',
+                                    is_array=True,
+                                    value=Uint32(3),
+                                    overridable=True, tosubclass=True,
+                                    toinstance=True, translatable=False)
+            self.fail('Exception expected')
+        except ValueError:
+            pass
 
 
 class CopyCIMQualifierDeclaration(unittest.TestCase):


### PR DESCRIPTION
Adds consistency tests for the multiple constructor paramters (is_array vs array_size and is_array vs. value is a list).

Add comment to changes.rst