### PR TITLE
Fixes #648, fixes #601: WIP: Pull Operations yaml uses keyword 'pullresult' rather than 'result'

### DIFF
--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -250,7 +250,7 @@ class BaseOperationRecorder(object):
         """Indicate whether the recorder is enabled."""
         return self._enabled
 
-    def reset(self):
+    def reset(self, pull_op=None):
         """Reset all the attributes in the class"""
         self._pywbem_method = None
         self._pywbem_args = None
@@ -270,6 +270,7 @@ class BaseOperationRecorder(object):
         self._http_response_reason = None
         self._http_response_headers = None
         self._http_response_payload = None
+        self._pull_op = pull_op
 
     def stage_pywbem_args(self, method, **kwargs):
         self._pywbem_method = method
@@ -418,7 +419,9 @@ class TestClientRecorder(BaseOperationRecorder):
 
         tc_pywbem_response = OrderedDict()
         if pywbem_result.ret is not None:
-            tc_pywbem_response['result'] = self.toyaml(pywbem_result.ret)
+                yaml_txt = 'pullresult' if self._pull_op else 'result'
+                tc_pywbem_response[yaml_txt] = self.toyaml(pywbem_result.ret)
+
         if pywbem_result.exc is not None:
             exc = pywbem_result.exc
             if isinstance(exc, CIMError):
@@ -492,6 +495,7 @@ class TestClientRecorder(BaseOperationRecorder):
         """
         if isinstance(obj, (list, tuple)):
             ret = []
+            # This does not handle namedtuple
             for item in obj:
                 ret.append(self.toyaml(item))
             return ret

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -3722,7 +3722,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenEnumerateInstancePaths',
                 ClassName=ClassName,
@@ -3984,7 +3984,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """  # noqa: E501
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenEnumerateInstances',
                 ClassName=ClassName,
@@ -4207,7 +4207,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenReferenceInstancePaths',
                 InstanceName=InstanceName,
@@ -4455,7 +4455,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """  # noqa: E501
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenReferenceInstances',
                 InstanceName=InstanceName,
@@ -4687,7 +4687,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenAssociatorInstancePaths',
                 InstanceName=InstanceName,
@@ -4953,7 +4953,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """  # noqa: E501
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenAssociatorInstances',
                 InstanceName=InstanceName,
@@ -5170,7 +5170,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                            "ReturnQueryResultClass invalid or missing.")
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='OpenQueryInstances',
                 FilterQueryLanguage=FilterQueryLanguage,
@@ -5322,7 +5322,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='PullInstancesWithPath',
                 context=context,
@@ -5456,7 +5456,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='PullInstancePaths',
                 context=context,
@@ -5586,7 +5586,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         if self.operation_recorder:
-            self.operation_recorder.reset()
+            self.operation_recorder.reset(pull_op=True)
             self.operation_recorder.stage_pywbem_args(
                 method='PullInstances',
                 context=context,


### PR DESCRIPTION
Status: WIP. Code complete for change of yaml entry name but we have to add code to prcess named tuples ouput in the recorder.

Adds code to recorder to output yaml section definition of 'pullresult:' for pull operations that return tuples of info  vs. 'result:' for other operations

Also does small code cleanup in test_client.py so reduce code in hope that
we can reduce the result and pullresult to a single type in the future.

Adds options to identify pull operations in cim_operations call to recorder.
