### PR TITLE
OBSOLETE. CloseMove fixes for pr656 back to 0.10.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,36 @@ contains the `master` branch up to this commit:
    :revisions: 1
 
 
+pywbem v0.10.1.dev0
+-------------------
+
+Released: Not yet
+
+Incompatible changes
+^^^^^^^^^^^^^^^^^^^^
+
+Enhancements
+^^^^^^^^^^^^
+
+Bug fixes
+^^^^^^^^^
+
+* Fix issue with MaxObjectCount on PullInstances and PullInstancePaths
+  CIM_Operations.py methods.  The MaxObjectCount was defined as a keyword
+  parameter where it should have been be positional.  This should NOT impact
+  clients unless they did not supply the parameter at all so that the result
+  was None which is illegal(Pull... operations MUST include MaxObjectCount).
+  In that case, server should return error.
+  Also extends these requests to test the Pull.. methods for valid
+  MaxObjectCount and context parameters. See issue #656.
+
+Build, test, quality
+^^^^^^^^^^^^^^^^^^^^
+
+Documentation
+^^^^^^^^^^^^^
+
+
 pywbem v0.10.0
 --------------
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -427,6 +427,24 @@ def _validateIterCommonParams(MaxObjectCount, OperationTimeout):
                          OperationTimeout)
 
 
+def _validatePullParams(MaxObjectCount, context):
+    """
+        Validate the input paramaters for the PullInstances,
+        PullInstancesWithPath, and PullInstancePaths requests.
+
+        MaxObjectCount: Must be integer type and ge 0
+
+        context: Must be not None and length ge 2
+    """
+    if (not isinstance(MaxObjectCount, six.integer_types) or
+            MaxObjectCount < 0):
+        raise ValueError('MaxObjectCount parameter must be integer >= 0 but '
+                         ' is %s' % MaxObjectCount)
+    if context is None or len(context) < 2:
+        raise ValueError('Pull... Context parameter must be valid tuple %s'
+                         % context)
+
+
 class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     """
     A client's connection to a WBEM server. This is the main class of the
@@ -1987,7 +2005,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                    MaxObjectCount=DEFAULT_ITER_MAXOBJECTCOUNT,
                                    **extra):
         """
-        A generator function to retrieve instances from a WBEM Server.
+        A generator function to retrieve instance paths from a WBEM Server.
         This method frees the user of choices between the multiple
         EnumerateInstances/OpenEnumerateInstance methods and reduces
         the enumeration to a pythonic iterator idiom.
@@ -2374,11 +2392,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * Zero is not allowed; it would mean that zero instances
-              are to be returned for every request issued to the server.
-            * If `None`, this parameter is not passed to the WBEM server, and
-              causes the server-implemented default behaviour to be used.
-              :term:`DSP0200` defines that the server-implemented default is
-              to return zero instances.
+              are to be returned for open and all pull requests issued to the
+              server.
+            * The default is defined as a system config variable.
+            * `None` is not allowed.
 
         Keyword Arguments:
 
@@ -2641,13 +2658,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
-            * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * If `None`, this parameter is not passed to the WBEM server, and
-              causes the server-implemented default behaviour to be used.
-              :term:`DSP0200` defines that the server-implemented default is
-              to return zero instances.
+            * Zero is not allowed; it would mean that zero instances
+              are to be returned for open and all pull requests issued to the
+              server.
+            * The default is defined as a system config variable.
+            * `None` is not allowed.
 
         Keyword Arguments:
 
@@ -2765,9 +2780,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                     **extra):
         # pylint: disable=invalid-name
         """
-        A generator function to retrieve associators from a WBEM Server.
+        A generator function to retrieve associator paths from a WBEM Server.
         This method frees the user of choices between the multiple
-        AssociatorNames/AssociatorInstancePaths methods and reduces
+        AssociatorNames/OpenAssociatorInstancePaths methods and reduces
         the enumeration to a pythonic iterator idiom.
 
         **Experimental:** This method is experimental in this release.
@@ -2907,11 +2922,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * Zero is not allowed; it would mean that zero instances
-              are to be returned for every request issued to the server.
-            * If `None`, this parameter is not passed to the WBEM server, and
-              causes the server-implemented default behaviour to be used.
-              :term:`DSP0200` defines that the server-implemented default is
-              to return zero instances.
+              are to be returned for open and all pull requests issued to the
+              server.
+            * The default is defined as a system config variable.
+            * `None` is not allowed.
 
         Keyword Arguments:
 
@@ -3193,13 +3207,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
-            * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * If `None`, this parameter is not passed to the WBEM server, and
-              causes the server-implemented default behaviour to be used.
-              :term:`DSP0200` defines that the server-implemented default is
-              to return zero instances.
+            * Zero is not allowed; it would mean that zero instances
+              are to be returned for open and all pull requests issued to the
+              server.
+            * The default is defined as a system config variable.
+            * `None` is not allowed.
 
         Keyword Arguments:
 
@@ -3430,13 +3442,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
-            * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
-            * If `None`, this parameter is not passed to the WBEM server, and
-              causes the server-implemented default behaviour to be used.
-              :term:`DSP0200` defines that the server-implemented default is
-              to return zero instances.
+            * Zero is not allowed; it would mean that zero instances
+              are to be returned for open and all pull requests issued to the
+              server.
+            * The default is defined as a system config variable.
+            * `None` is not allowed.
 
         Keyword Arguments:
 
@@ -5266,8 +5276,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5337,6 +5347,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
+            _validatePullParams(MaxObjectCount, context)
 
             namespace = context[1]
 
@@ -5362,7 +5373,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
+    def PullInstancePaths(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
 
         """
@@ -5401,8 +5412,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5469,6 +5480,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
+            _validatePullParams(MaxObjectCount, context)
 
             namespace = context[1]
 
@@ -5494,7 +5506,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstances(self, context, MaxObjectCount=None, **extra):
+    def PullInstances(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
         """
         Retrieve the next set of instances from an open enumeraton
@@ -5532,8 +5544,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5597,6 +5609,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
+            _validatePullParams(MaxObjectCount, context)
 
             namespace = context[1]
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -905,8 +905,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertInstancesValid(result.instances)
 
@@ -932,8 +931,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             insts_pulled.extend(result.instances)
 
         self.assertInstancesValid(insts_pulled)
@@ -983,8 +981,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1008,8 +1005,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1032,8 +1028,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
 
@@ -1049,7 +1044,7 @@ class PullEnumerateInstances(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancesWithPath(result.context, MaxObjectCount=10)
+            self.conn.PullInstancesWithPath(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1062,8 +1057,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
 
         try:
             self.cimcall(self.conn.CloseEnumeration, result.context)
@@ -1217,8 +1211,7 @@ class PullEnumerateInstancePaths(ClientTest):
         # loop to complete the enumeration session
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1248,8 +1241,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1286,9 +1278,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.assertFalse(result.eos)
 
         # Pull the remainder of the paths
-        result = self.cimcall(self.conn.PullInstancePaths,
-                              result.context,
-                              MaxObjectCount=100)
+        result = self.cimcall(self.conn.PullInstancePaths, result.context, 100)
 
         self.assertTrue(result.eos)
 
@@ -1304,7 +1294,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancePaths(result.context, MaxObjectCount=10)
+            self.conn.PullInstancePaths(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1331,8 +1321,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1373,8 +1362,7 @@ class PullReferences(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1420,8 +1408,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1451,8 +1438,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1499,8 +1485,7 @@ class PullReferencePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1545,8 +1530,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1579,8 +1563,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
 
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
@@ -1615,8 +1598,7 @@ class PullAssociators(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1659,8 +1641,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1691,8 +1672,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1744,8 +1724,7 @@ class PullAssociatorPaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1789,8 +1768,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1826,8 +1804,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
                 paths_pulled.extend(result.paths)
@@ -1861,8 +1838,7 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 
@@ -1896,8 +1872,7 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 


### PR DESCRIPTION
Here is hopefully the changes moved back to 0.10.0.  I am obviously missing something since this was not easy to do.  Suggestions welcome.  Also when I created the pr it pointed to the current head  as the merge target but I manually set it to stable-0.10.   

I think I have to learn more about this part of the process