### PR TITLE
WIP Ks/#652 create cmdcli

### DIFF
--- a/design/pywbemclidesign.md
+++ b/design/pywbemclidesign.md
@@ -1,0 +1,216 @@
+#Design Document for a PyWBEM Command Line Browser
+
+
+Status: In Process
+Date: 9 Feb. 2017
+      Update 11 Feb 2017
+
+##Goals
+
+* Python Based
+* Expandable. Users should be able to add functionality with plugins
+* Usable effectively by both occasional and power users
+  * Interactive mode
+  * Script mode (complete command entered from command line)
+* Capable of executing all WBEM CIM/XML operations (with specific exceptions)
+* Include commands for other operations that will be a real advantage to
+developers, users, etc.
+* Good integrated help to minize requirement for external documentation
+
+##Licensing
+
+Since the goal is to have the code in a separate repository, we propose to use
+a more liberal license.  Either MIT or the Apache license is logical.  Since
+the Apache v2 license has one additional feature above MIT (patent right to use)
+that seems like a logical solution.
+
+Conclusion: Use Apache 2 license. However, lets do license/ copyright statements
+once and ref in files instead of keeping whole license statement in each file.
+
+
+## Code Location
+
+We propose that the code be in a separate git repository in the pywbem project
+for a number of reasons including:
+
+* It uses a number of additional packages that are not used elsewhere in the
+pywbem client package and this imposes an extra set of constraints on uses
+of just the infrastructure.
+* It is not certain that the cli can meet the same python versoning constraints
+as the client infrastructure code because of the extra packages used some of
+which are not today compatible with python 2.6.
+
+It would have its own release cycle, etc.  However since pywbem and pywbemcli
+are closely developed we should seriously consider integrating them into a
+single documentation set.
+
+The only negatives to this approach are:
+
+* We now have two repositories to maintain with two issue lists, etc.
+* It will be more difficult to consider using pywbemcli as a testtool for
+pywbem itself, in part because they are on different development and release
+cycles.
+  
+
+## Command Taxonomy
+
+Overall we propose that this be written in the manner of a command <subcommand>
+environment where there is a single cli and multiple subcommands.
+
+Wheras most wbem clis are written to parallel the client api taxonomy
+(separate subcommands to match the individual methods of the client api)
+we propose that the taxonomy of this cli be organized around the following
+levels:
+
+* first subcommand - noun representing the entity type against which the
+command is to be executed (class, instance, qualifierdecl, server,
+subscription manager, log, connection, etc.)
+* the second level subcommand be an action on that entity, for example, get,
+delete, create, enumarate, etc.
+* The options for each subcommand represent
+  * All of the options available for the corresponding client api (i.e.
+    localonly, includeclassorigin, includequalifiers, propertylist, etc.)
+  * Include only the maxObjectCount as an option to represent the existence
+    of pull operations
+  * ability to select namespace be included in all commands except those that
+    do not need a namespace or use all namespaces.
+
+The following is the current overall taxonomy of subcommands and their major
+options.
+
+**pywbemwcli**
+
+* **class**
+  * **get** &lt;classname> --namespace &lt;getclass options> (corresponds to getclass)  
+  * **enumerate**  (corresponds to enumerateclasses) &lt;classname> --namespace --names-only &lt;enumerateclass options>  
+  * **references**  &lt;sourceclass> --namespace --names_only &lt;references options>(corresponds to class references)  
+  * **associators** &lt;sourceclass> --namespace --names_only &lt;associator options>(corresponds to class associators)  
+  * **method** &lt;classname> &lt;methodname> [&lt;param_name=value>]*  
+  * **find** Find a class across namespaces (regex names allowed)
+  
+* **instance**
+  * **get** &lt;inst_name>  --namespace &lt;get inst options> (corresponds to GetInstance)
+  * **enumerate** &lt;instname>-- namespace --names-only &lt;enumerate inst options> (corresponds to EnumerateInstances)
+  * **references** &lt;instname>--namespace --names_only &lt;references options>(corresponds to inst references)
+  * **associators** &lt;instname> --namespace --names_only &lt;associator options>(corresponds to inst associators)
+  * **delete** &lt;instname> | &lt;classname>   (use classname for interactive select mode)
+  * **method** &lt;instname> &lt;methodname> [&lt;param_name=value>]*
+* **qualifier**             # operations on the QualifierDecl type
+  * **get** &lt;qualifier_name>  --namespace &lt;get qualifier options> (corresponds to GetQualifier)
+  * **enumerate**   --namespace &lt;enumerate qualifier options> (corresponds to EnumerateQualifiers)
+* **server**                # operations on the pywbem Server Class       
+  * **namespace**
+    * **list**
+    * **interop**
+  * **jobs**                # Operations on a future Jobs Class 
+    *  list
+    *  TBD
+    *  &lt;possible other server objects, etc. adapters>        
+  * **profiles**            # Further operations on the pywbem server class
+    * **list**
+    * ???
+  * **subscriptions**       # Operations on the PywbemSubscriptionManager Class
+    * **list** --filters --subs --dest
+    * **create** &lt;filter|destination|subscription>
+    * **delete** &lt;filter|destination|subscription> 
+  * **connection**          # changes to the WBEMConnection Class
+    * **info**
+    * **setnamespace**
+    * **setnewconnection**
+  * **profile**             # Lots unknown here. This is where we can expand into profiles
+    * **profilename**
+      * **info**
+      * **classes**
+      * **attached_instances**
+
+## General Options
+
+The general options/arguments will include;
+* arguments to define the connection to a wbem server (uri, defaultnamespace,
+credentials, security, output format, verbosity, etc.)
+
+This can parallel the existing parameter set in wbemcli.
+
+ISSUES: This is a lot of overhead for each command.  There are two logical
+solutions:
+
+1. Click includes the capability to use environment variables as alternate
+   to cmd line input for options.  We should take advantage of that
+
+2. It is probably seriously time to begin to use a config file for at least
+   some characteristics so that the user can set defaults, specific options,
+   etc.  This will require some thought since the use of config files has
+   many variations.
+
+
+## Required Packages
+
+We are going to base this on the python click package and other contributions
+to click so at least click and possibly several of the click contributions will
+be required
+
+## User Define Extensions
+TODO
+
+## Testing
+
+This needs some sort of mock testing environment, either through pywbem or
+direct.
+TODO
+
+## Proposal
+
+single tool with git-like subcommand structure:
+
+    pywbemcli [generat-option]* command usb-command [specific-option]*
+
+Examples:
+
+    pywbemcli http://localhost -o mof class get CIM_ManagedElement
+    # Returns the mof for CIM_ManagedElement
+
+    pywbem http://localhost instance get CIM_Blah -i
+    # Does get instances of CIM_Blah and offers user selection for operation
+
+    pywbem http://localhost class fine TST_
+    # finds all classes in environment that begins with TST_ and returns list
+    # of class and namespace
+
+The overall directory structure is probably:
+
+**root**
+
+   * **pywbemcli** - Add files that define the click infrastructure
+   * **pywbemclient** - interface with the pywbem apis.
+   * **tests**
+   * **doc**
+
+QUESTION: Should we break up the code into a package that implements the
+commands and subcommands and a separate one that implements the action functions
+as shown above. Question: Advantages/disadvantages
+
+## TODO Items
+
+### Timing
+Timing of cmd execution. Should we have an option to time the execution of
+commands
+
+### Command Chaining
+Is there a way to achieve command chaining.
+
+TODO Need real example first.
+
+### Aliases
+There are at least two possibilities for aliases:
+
+  * subcommand alias (en substitutes for enumerate)
+  * general text aliasing where a combination of text elements could be
+    aliased (as git does). Thus, the text 'class get' could be aliased to
+    getclass or gc.
+    
+I believe that the current `alias` contrib handles the first but not the second
+form of aliasing.
+
+### Manual level documentation
+ TODO 
+

--- a/pywbemcli
+++ b/pywbemcli
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+#!/usr/bin/env python
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+from __future__ import absolute_import
+
+import re
+from click_repl import register_repl
+import click
+from pywbemclicmds import pywbemcli
+
+if __name__ == '__main__':
+    register_repl(pywbemcli)
+    pywbemcli()  #pylint: disable=no-value-for-parameter

--- a/pywbemclicmds/__init__.py
+++ b/pywbemclicmds/__init__.py
@@ -1,0 +1,25 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+from __future__ import absolute_import
+
+# from ._cmd_getclass import *       # noqa: F401
+# from ._cmd_enumerateclasses import *       # noqa: F401
+from ._cmd_class import *       # noqa: F401
+from ._cmd_instance import *       # noqa: F401
+from ._cmd_qualifier import *       # noqa: F401
+from ._cmd_server import *       # noqa: F401  
+from .pywbemclicmd import *       # noqa: F401

--- a/pywbemclicmds/_cmd_class.py
+++ b/pywbemclicmds/_cmd_class.py
@@ -1,0 +1,330 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the class command group which includes
+cmds for get, enumerate, list of classes.
+"""
+from __future__ import absolute_import
+
+import click
+from pywbem import Error
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT
+from ._common import display_result, filter_namelist, fix_propertylist
+from ._common_options import propertylist_option, names_only_option, \
+    sort_option, includeclassorigin_option, namespace_option, add_options
+
+#
+#   Common option definitions for class group
+#
+
+
+# TODO This should default to use qualifiers for class commands.
+includequalifiers_option = [              # pylint: disable=invalid-name
+    click.option('-i', '--includequalifiers', is_flag=True, required=False,
+                 help='Include qualifiers in the result.')]
+
+deepinheritance_option = [              # pylint: disable=invalid-name
+    click.option('-d', '--deepinheritance', is_flag=True, required=False,
+                 help='Return complete subclass hiearchy for this class.')]
+
+# TODO add a case sensitive option and make the sort an option group.
+
+
+@pywbemcli.group('class', options_metavar=CMD_OPTS_TXT)
+def class_group():
+    """
+    Command group for class operations.
+    """
+    pass
+
+
+# Reverse includequalifiers so the default is true
+@class_group.command('get', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=True,)
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the class.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(propertylist_option)
+@add_options(namespace_option)
+@click.pass_obj
+def class_get(context, classname, **options):
+    """
+    get and display a single class from the WBEM Server
+    """
+    context.execute_cmd(lambda: cmd_class_get(context, classname, options))
+
+
+@class_group.command('names', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=False,)
+@click.option('-d', '--deepinheritance', is_flag=True, required=False,
+              help='Return complete subclass hiearchy for this class.')
+@add_options(deepinheritance_option)
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(sort_option)
+@add_options(namespace_option)
+@click.pass_obj
+def class_names(context, classname, **options):
+    """
+    get and display a list of classnames from the WBEM Server.
+    """
+    context.execute_cmd(lambda: cmd_class_names(context, classname, options))
+
+
+@class_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=False)
+@click.option('-d', '--deepinheritance', is_flag=True, required=False,
+              help='Return complete subclass hiearchy for this class.')
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the class.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(names_only_option)
+@add_options(sort_option)
+@add_options(namespace_option)
+@click.pass_obj
+def class_enumerate(context, classname, **options):
+    """
+    Enumerate classes from the WBEMServer starting either at the top or from
+    the classname argument if provided
+    """
+    context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
+                                                    options))
+
+
+@class_group.command('references', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=True)
+@click.option('-r', '--resultclass', type=str, required=False,
+              help='Filter by the classname provided.')
+@click.option('-o', '--role', type=str, required=False,
+              help='Filter by the role name provided.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(propertylist_option)
+@add_options(names_only_option)
+@add_options(sort_option)
+@add_options(namespace_option)
+@click.pass_obj
+def class_references(context, classname, **options):
+    """
+    Get the reference classes for the CLASSNAME argument filtered by the
+    role and result class options.
+    """
+    context.execute_cmd(lambda: cmd_class_references(context, classname,
+                                                     options))
+
+
+@class_group.command('associators', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=True)
+@click.option('-a', '--assocclass', type=str, required=False,
+              help='Filter by the associated class name provided.')
+@click.option('-r', '--resultclass', type=str, required=False,
+              help='Filter by the result class name provided.')
+@click.option('-x', '--role', type=str, required=False,
+              help='Filter by the role name provided.')
+@click.option('-o', '--resultrole', type=str, required=False,
+              help='Filter by the role name provided.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(propertylist_option)
+@add_options(names_only_option)
+@add_options(sort_option)
+@add_options(namespace_option)
+@click.pass_obj
+def class_associators(context, classname, **options):
+    """
+    Get the associated classes for the CLASSNAME argument filtered by the
+    assocclass, resultclass, role and resultrole arguments.
+    """
+    context.execute_cmd(lambda: cmd_class_associators(context, classname,
+                                                      options))
+
+
+# TODO we can make optional namespace option the limit search
+@class_group.command('find', options_metavar=CMD_OPTS_TXT)
+@click.argument('CLASSNAME', type=str, metavar='CLASSNAME', required=True)
+@add_options(sort_option)
+@click.pass_obj
+def class_find(context, classname, **options):
+    """
+    Find all classes that match the CLASSNAME argument in the namespaces of
+    the defined WBEMserver. The CLASSNAME argument may be either a
+    classname or a regular expression that can be matched to one or more
+    classnames.
+    """
+    context.execute_cmd(lambda: cmd_class_find(context, classname,
+                                               options))
+
+#
+#  Command functions for each of the subcommands in the class group
+#
+
+
+def cmd_class_get(context, classname, options):
+    """
+    Execute the command for get class and display the result
+    """
+    print('context.conn %r\n classname %s, options %s' %
+          (context.conn, classname, options))
+    try:
+        result = context.conn.GetClass(
+            classname,
+            namespace=options['namespace'],
+            LocalOnly=options['localonly'],
+            IncludeQualifiers=options['includequalifiers'],
+            IncludeClassOrigin=options['includeclassorigin'],
+            PropertyList=fix_propertylist(options['propertylist']))
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_class_names(context, classname, options):
+    """ Execute the EnumerateClassNames operation."""
+    try:
+        result = context.conn.EnumerateClassNames(
+            ClassName=classname,
+            namespace=options['namespace'],
+            DeepInheritance=options['deepinheritance'])
+        if options['sort']:
+            result.sort()
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_class_enumerate(context, classname, options):
+    """
+        Enumerate the classes returning a list of classes from the WBEM server.
+    """
+    print('options %s' % options)
+    try:
+        if options['names_only']:
+            result = context.conn.EnumerateClassNames(
+                ClassName=classname,
+                namespace=options['namespace'],
+                DeepInheritance=options['deepinheritance'])
+            if options['sort']:
+                result.sort()
+        else:
+            result = context.conn.EnumerateClasses(
+                ClassName=classname,
+                namespace=options['namespace'],
+                LocalOnly=options['localonly'],
+                Deepinheritance=options['deepinheritance'],
+                IncludeQualifiers=options['includequalifiers'],
+                IncludeClassOrigin=options['includeclassorigin'])
+            if options['sort']:
+                result.sort(key=lambda x: x.classname)
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_class_references(context, classname, options):
+    """Execute the references request operation to get references for
+       the classname defined
+    """
+    try:
+        if options['names_only']:
+            result = context.conn.ReferenceNames(
+                classname,
+                namespace=options['namespace'],
+                ResultClass=options['resultclass'],
+                Role=options['role'])
+            if options['sort']:
+                result.sort()
+        else:
+            result = context.conn.References(
+                classname,
+                namespace=options['namespace'],
+                ResultClass=options['resultclass'],
+                Role=options['role'],
+                IncludeQualifiers=options['includequalifiers'],
+                IncludeClassOrigin=options['includeclassorigin'],
+                PropertyList=options['propertylist'])
+            if options['sort']:
+                result.sort(key=lambda x: x.classname)
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_class_associators(context, classname, options):
+    """Execute the references request operation to get references for
+       the classname defined
+    """
+    try:
+        if options['names_only']:
+            result = context.conn.Associators(
+                classname,
+                namespace=options['namespace'],
+                AssocClass=options['assocclass'],
+                Role=options['role'],
+                ResultClass=options['resultclass'],
+                ResultRole=options['resultrole'])
+            if options['sort']:
+                result.sort()
+        else:
+            result = context.conn.Associators(
+                classname,
+                namespace=options['namespace'],
+                AssocClass=options['assocclass'],
+                Role=options['role'],
+                ResultClass=options['resultclass'],
+                ResultRole=options['resultrole'],
+                IncludeQualifiers=options['includequalifiers'],
+                IncludeClassOrigin=options['includeclassorigin'],
+                PropertyList=options['propertylist'])
+            if options['sort']:
+                result.sort(key=lambda x: x.classname)
+        display_result(result)
+
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_class_find(context, classname, options):
+    """
+    Execute the command for get class and display the result. The result is
+    a list of classes/namespaces
+    """
+    ns_names = context.wbem_server.namespaces
+    if options['sort']:
+        ns_names.sort()
+
+    try:
+        print('clasname regex %s' % classname)
+        names_dict = {}
+        for ns in ns_names:
+            classnames = context.conn.EnumerateClassNames(
+                namespace=options['namespace'],)
+            filtered_classnames = filter_namelist(classname, classnames)
+            if options['sort']:
+                filtered_classnames.sort()
+            names_dict[ns] = filtered_classnames
+
+        # special display function to display classnames returned with
+        # their namespaces in the form <namespace>:<classname>
+        # TODO merge into single for-loop
+        for ns_name in names_dict:
+            for classname in names_dict[ns_name]:
+                print('  %s:%s' % (ns_name, classname))
+
+        # ##display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemclicmds/_cmd_enumerateclasses.py.save
+++ b/pywbemclicmds/_cmd_enumerateclasses.py.save
@@ -1,0 +1,64 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the enumerate classes command.
+"""
+
+import click
+from pywbem import Error
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT, display_result
+
+
+@pywbemcli.command('enumerateclasses', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', type=str, metavar='classname', required=False)
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the class.')
+@click.option('-d', '--deepinheritance', is_flag=True, required=False,
+              help='Return complete subclass hiearchy for this class.')
+@click.option('-i', '--includequalifiers', is_flag=True, required=False,
+              help='Include qualifiers in the result.')
+@click.option('-c', '--includeclassorigin', is_flag=True, required=False,
+              help='Include Class Origin in the result.')
+@click.pass_obj
+def enumerateclasses(context, classname, **options):
+    """
+    Get and display a class in the WBEM Server.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    context.execute_cmd(
+        lambda: cmd_enumerateclasses(context, classname, options))
+
+
+def cmd_enumerateclasses(context, classname, options):
+    """
+    Get and display a class.
+    """
+    try:
+        if context._verbose:
+            print('enumerateclasses %s localonly %s includequalfiers%s'
+                  % (classname, options['localonly'],
+                     options['includequalifiers']))
+        result = context._conn.EnumerateClasses(
+            ClassName=classname,
+            LocalOnly=options['localonly'],
+            IncludeQualifiers=options['includequalifiers'],
+            IncludeClassOrigin=options['includeclassorigin'])
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemclicmds/_cmd_getclass.py.save
+++ b/pywbemclicmds/_cmd_getclass.py.save
@@ -1,0 +1,59 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the getclass command.
+"""
+
+import click
+from pywbem import Error
+
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT, display_result
+
+
+@pywbemcli.command('getclass', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', type=str, metavar='classname', required=True)
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the class.')
+@click.option('-i', '--includequalifiers', is_flag=True, required=False,
+              help='Include qualifiers in the result.')
+@click.pass_obj
+def getclass(context, classname, **options):
+    """
+    Get and display a class in the WBEM Server.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    context.execute_cmd(lambda: cmd_getclass(context, classname, options))
+
+
+def cmd_getclass(context, classname, options):
+    """
+    Get and display a class.
+    """
+    try:
+        if context._verbose:
+            print('getClass %s localonly %s includequalfiers%s'
+                  % (classname, options['localonly'],
+                     options['includequalifiers']))
+        result = context._conn.GetClass(
+            classname,
+            LocalOnly=options['localonly'],
+            IncludeQualifiers=options['includequalifiers'])
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemclicmds/_cmd_instance.py
+++ b/pywbemclicmds/_cmd_instance.py
@@ -1,0 +1,421 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the class command group which includes
+cmds for get, enumerate, list of classes.
+"""
+from __future__ import absolute_import, print_function
+
+import click
+from pywbem import Error
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT
+from ._common import display_result, parse_wbem_uri, pick_instance, \
+    objects_sort, fix_propertylist
+from ._common_options import propertylist_option, names_only_option, \
+    sort_option, includeclassorigin_option, namespace_option, add_options
+
+#
+#   Common option definitions for class group
+#
+
+
+# TODO This should default to use qualifiers for class commands.
+includequalifiers_option = [              # pylint: disable=invalid-name
+    click.option('-i', '--includequalifiers', is_flag=True, required=False,
+                 help='Include qualifiers in the result.')]
+
+deepinheritance_option = [              # pylint: disable=invalid-name
+    click.option('-d', '--deepinheritance', is_flag=True, required=False,
+                 help='Return properties in subclasses of defined target. '
+                      ' If not specified only properties in target class are '
+                      'returned')]
+
+
+@pywbemcli.group('instance', options_metavar=CMD_OPTS_TXT)
+def instance_group():
+    """
+    Processing of requests on CIM instances including get, enumerate,
+    create, modify, delete, etc.
+    """
+
+
+@instance_group.command('get', options_metavar=CMD_OPTS_TXT)
+@click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the returned instance.')
+@add_options(includequalifiers_option)
+@click.option('-c', '--includeclassorigin', is_flag=True, required=False,
+              help='Include Class Origin in the returned instance.')
+@add_options(propertylist_option)
+@add_options(namespace_option)
+@click.option('-i', '--interactive', is_flag=True, required=False,
+              help='instancename is classname. Gets list of all instances '
+                   'namesand the user selects the instance to be returned.')
+@click.pass_obj
+def instance_get(context, instancename, **options):
+    """
+    Get a single CIMInstance.
+
+    Gets the instance defined by instancename.
+
+    This may be executed interactively by providing only a classname and the
+    interactive option.
+
+    """
+    context.execute_cmd(lambda: cmd_instance_get(context, instancename,
+                                                 options))
+
+
+@instance_group.command('names', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', required=False,)
+@add_options(namespace_option)
+@click.pass_obj
+def instance_names(context, classname, **options):
+    """
+    Get and display a list of instance names of the classname argument.
+    """
+    context.execute_cmd(lambda: cmd_instance_names(context, classname, options))
+
+
+@instance_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', type=str, metavar='CLASSNAME', required=True)
+@click.option('-l', '--localonly', is_flag=True, required=False,
+              help='Show only local properties of the class.')
+@add_options(deepinheritance_option)
+@add_options(includequalifiers_option)
+@click.option('-c', '--includeclassorigin', is_flag=True, required=False,
+              help='Include ClassOrigin in the result.')
+@add_options(propertylist_option)
+@add_options(namespace_option)
+@add_options(sort_option)
+@click.pass_obj
+def instance_enumerate(context, classname, **options):
+    """
+    Enumerate instances or instance names from the WBEMServer starting either
+    at the top  of the hiearchy (if no classname provided) or from the
+    classname argument.
+    """
+    context.execute_cmd(lambda: cmd_instance_enumerate(context, classname,
+                                                       options))
+
+
+@instance_group.command('delete', options_metavar=CMD_OPTS_TXT)
+@click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
+@click.option('-i', '--interactive', is_flag=True, required=False,
+              help='If set, instancename argument must be a class and '
+                   ' user is provided with a list of instances of the '
+                   ' class from which the instance to delete is selected.')
+@add_options(namespace_option)
+def instance_delete(context, instancename, **options):
+    """
+    Delete a single instance defined by instancename from the WBEM server.
+    This may be executed interactively by providing only a classname and the
+    interactive option.
+
+    """
+    context.execute_cmd(lambda: cmd_instance_delete(context, instancename,
+                                                    options))
+
+
+@instance_group.command('references', options_metavar=CMD_OPTS_TXT)
+@click.argument('INSTANCENAME', type=str, metavar='INSTANCENAME', required=True)
+@click.option('-r', '--resultclass', type=str, required=False,
+              help='Filter by the instancename provided.')
+@click.option('-o', '--role', type=str, required=False,
+              help='Filter by the role name provided.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(propertylist_option)
+@add_options(names_only_option)
+@add_options(namespace_option)
+@add_options(sort_option)
+@click.pass_obj
+def instance_references(context, instancename, **options):
+    """
+    Get the reference instances or instance names.
+
+    For the INSTANCENAME argument provided return instances or instance
+    names (names-only option) filtered by the role and result class options.
+    This may be executed interactively by providing only a classname and the
+    interactive option.
+    """
+    context.execute_cmd(lambda: cmd_instance_references(context, instancename,
+                                                        options))
+
+
+@instance_group.command('associators', options_metavar=CMD_OPTS_TXT)
+@click.argument('INSTANCENAME', type=str, metavar='INSTANCENAME', required=True)
+@click.option('-a', '--assocclass', type=str, required=False,
+              help='Filter by the associated instancename provided.')
+@click.option('-r', '--resultclass', type=str, required=False,
+              help='Filter by the result instancename provided.')
+@click.option('-x', '--role', type=str, required=False,
+              help='Filter by the role name provided.')
+@click.option('-o', '--resultrole', type=str, required=False,
+              help='Filter by the role name provided.')
+@add_options(includequalifiers_option)
+@add_options(includeclassorigin_option)
+@add_options(propertylist_option)
+@add_options(names_only_option)
+@add_options(namespace_option)
+@add_options(sort_option)
+@click.pass_obj
+def instance_associators(context, instancename, **options):
+    """
+    Get the associated instances or instance names.
+
+    Returns the associated instances or names (names-only option) for the
+    INSTANCENAME argument filtered by the assocclass, resultclass, role and
+    resultrole arguments.
+    This may be executed interactively by providing only a classname and the
+    interactive option.
+    """
+    context.execute_cmd(lambda: cmd_instance_associators(context, instancename,
+                                                         options))
+
+
+# TODO option for class regex
+@instance_group.command('number', options_metavar=CMD_OPTS_TXT)
+@add_options(namespace_option)
+@add_options(sort_option)
+@click.pass_obj
+def instance_number(context, **options):
+    """
+    Get number of instances for each class in namespace.
+
+    """
+    context.execute_cmd(lambda: cmd_instance_number(context, options))
+
+
+####################################################################
+#  cmd_instance_<action> processors
+####################################################################
+def cmd_instance_get(context, instancename, options):
+    """
+    get and display an instance defined either by the instancename provided
+    or by the classname provided in instancename if the interactive flag
+    is provided
+    """
+    if options['interactive']:
+        try:
+            instancepath = pick_instance(context, instancename,
+                                         namespace=options['namespace'])
+        except ValueError:
+            print('Function aborted')
+            return
+    else:
+        instancepath = parse_wbem_uri(instancename)
+
+    try:
+        result = context.conn.GetInstance(
+            instancepath,
+            namespace=options['namespace'],
+            LocalOnly=options['localonly'],
+            IncludeQualifiers=options['includequalifiers'],
+            IncludeClassOrigin=options['includeclassorigin'],
+            PropertyList=fix_propertylist(options['propertylist']))
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_instance_names(context, classname, options):
+    """
+    get and display a the instancenames of the instances of the class
+    classname
+    """
+    try:
+        result = context.conn.EnumerateInstanceNames(
+            classname,
+            namespace=options['namespace'],
+            DeepInheritance=options['deepinheritance'])
+
+        if options['sort']:
+            result.sort()
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_instance_enumerate(context, classname, options):
+    """
+    Enumerate classes starting either at the top or from the optional
+    classname argument.
+    """
+    try:
+        result = context.conn.EnumerateInstances(
+            ClassName=classname,
+            namespace=options['namespace'],
+            LocalOnly=options['localonly'],
+            Deepinheritance=options['deepinheritance'],
+            IncludeQualifiers=options['includequalifiers'],
+            IncludeClassOrigin=options['includeClassOrigin'])
+
+        if options['sort']:
+            result = objects_sort(result)
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+# TODO the class and instance references and associators can go to a single
+#       client processing module I believe
+def cmd_instance_references(context, instancename, options):
+    """Execute the references request operation to get references for
+       the classname defined. This may be either interactive or if the
+       interactive option is set or use the instancename directly.
+
+       If the interactive option is selected, the instancename MUST BE
+       a classname.
+    """
+    if options['interactive']:
+        try:
+            instancepath = pick_instance(context, instancename)
+        except ValueError:
+            print('Function aborted')
+            return
+        else:
+            instancepath = parse_wbem_uri(instancename)
+
+    try:
+        if options['names_only']:
+            result = context.conn.ReferenceNames(
+                instancepath,
+                namespace=options['namespace'],
+                ResultClass=options['resultclass'],
+                Role=options['role'])
+            if options['sort']:
+                result.sort()
+        else:
+            result = context.conn.References(
+                instancepath,
+                namespace=options['namespace'],
+                ResultClass=options['resultclass'],
+                Role=options['role'],
+                IncludeQualifiers=options['includequalifiers'],
+                IncludeClassOrigin=options['includeclassorigin'],
+                PropertyList=options['propertylist'])
+            if options['sort']:
+                result.sort(key=lambda x: x.classname)
+        if options['sort']:
+            result = objects_sort(result)
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_instance_associators(context, instancename, options):
+    """Execute the references request operation to get references for
+       the classname defined
+    """
+    if options['interactive']:
+        try:
+            instancepath = pick_instance(context, instancename)
+        except ValueError:
+            print('Function aborted')
+            return
+        else:
+            instancepath = parse_wbem_uri(instancename)
+    try:
+        if options['names_only']:
+            result = context.conn.Associators(
+                instancepath,
+                namespace=options['namespace'],
+                AssocClass=options['assocclass'],
+                Role=options['role'],
+                ResultClass=options['resultclass'],
+                ResultRole=options['resultrole'])
+            if options['sort']:
+                result.sort()
+        else:
+            result = context.conn.Associators(
+                instancepath,
+                namespace=options['namespace'],
+                AssocClass=options['assocclass'],
+                Role=options['role'],
+                ResultClass=options['resultclass'],
+                ResultRole=options['resultrole'],
+                IncludeQualifiers=options['includequalifiers'],
+                IncludeClassOrigin=options['includeclassorigin'],
+                PropertyList=options['propertylist'])
+            if options['sort']:
+                result.sort(key=lambda x: x.classname)
+        if options['sort']:
+            result = objects_sort(result)
+        display_result(result)
+
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_instance_delete(context, instancename, options):
+    """
+        If option interactive is set, get instances of the class defined
+        by instance name and allow the user to select the instance to
+        delete.
+        Otherwise attempt to delete the instance defined by instancename
+    """
+    if options['interactive']:
+        try:
+            instancename = pick_instance(context, instancename)
+        except ValueError:
+            print('Function aborted')
+            return
+
+    try:
+        instancepath = parse_wbem_uri(instancename)
+        context.conn.DeleteInstance(instancepath,
+                                    namespace=options['namespace'])
+
+        print('%s deleted')
+
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_instance_number(context, options):
+    """
+    Get the number of instances of each class in the namespace
+    """
+    def maxlen(str_list):
+        """ get the maximum length of the elements in a list of strings"""
+        maxlen = 0
+        for item in str_list:
+            if len(item) > maxlen:
+                maxlen = len(item)
+        return maxlen
+
+    # Get all classes in Namespace
+    classlist = context.conn.EnumerateClassNames(
+        DeepInheritance=True,
+        namespace=options['namespace'])
+    if options['sort']:
+        classlist.sort()
+
+    maxlen = maxlen(classlist)
+
+    for classname in classlist:
+        insts = context.conn.EnumerateInstanceNames(
+            classname,
+            namespace=options['namespace'])
+        count = 0
+        # get only for the defined classname, not subclasses
+        for inst in insts:
+            if inst.classname == classname:
+                count += 1
+
+        if count != 0:
+            print('{0:<{width}}: {1}'.format(classname, count, width=maxlen))

--- a/pywbemclicmds/_cmd_qualifier.py
+++ b/pywbemclicmds/_cmd_qualifier.py
@@ -1,0 +1,92 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the qualifer command group which includes
+cmds for get and enumerate for CIM qualifier types.
+"""
+
+from __future__ import absolute_import
+
+import click
+from pywbem import Error
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT
+from ._common import display_result
+from ._common_options import sort_option, namespace_option, add_options
+
+
+@pywbemcli.group('qualifier', options_metavar=CMD_OPTS_TXT)
+def qualifier_group():
+    """
+    Command group for qualifier declaration subcommands.
+
+    Includes the capability to get and enumerate qualifier declarations.
+
+    This does not provide the capability to create or delete CIM
+    QualifierDeclarations
+    """
+    pass
+
+
+@qualifier_group.command('get', options_metavar=CMD_OPTS_TXT)
+@click.argument('NAME', type=str, metavar='NAME', required=True,)
+@add_options(namespace_option)
+@click.pass_obj
+def qualifier_get(context, name, **options):
+    """
+    Display a single CIMQualifierDeclaration for the defined namespace.
+    """
+    context.execute_cmd(lambda: cmd_qualifier_get(context, name, options))
+
+
+@qualifier_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
+@add_options(sort_option)
+@add_options(namespace_option)
+@click.pass_obj
+def qualifier_enumerate(context, **options):
+    """
+    Enumerate CIMQualifierDeclaractions for the defined namespace.
+    """
+    context.execute_cmd(lambda: cmd_qualifier_enumerate(context, options))
+
+
+####################################################################
+#   Qualifier declaration command processing functions
+#####################################################################
+def cmd_qualifier_get(context, name, options):
+    """
+    Execute the command for get qualifier and display result
+    """
+    try:
+        if context.verbose:
+            print('get qualifier name: %s ' % (name))
+
+        result = context.conn.GetQualifier(name,
+                                           namespace=options['namespace'])
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+
+
+def cmd_qualifier_enumerate(context, options):
+    """
+    Execute the command for enumerate qualifiers and desplay the result.
+    """
+    try:
+        result = context.conn.EnumerateQualifiers(
+            namespace=options['namespace'])
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemclicmds/_cmd_server.py
+++ b/pywbemclicmds/_cmd_server.py
@@ -1,0 +1,174 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click command definition for the server command group which includes
+cmds for inspection and management of the objects defined by the pywbem
+server class including namespaces, WBEMServer information, and profile
+information.
+"""
+from __future__ import absolute_import
+
+import click
+from pywbem import Error, ValueMapping
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT
+from ._common import display_result
+from ._common_options import sort_option, add_options
+
+
+def print_profile_info(org_vm, inst):
+    """Print the registered org, name, version for the profile defined by
+       inst
+    """
+    org = org_vm.tovalues(inst['RegisteredOrganization'])
+    name = inst['RegisteredName']
+    vers = inst['RegisteredVersion']
+    print("  %s %s Profile %s" % (org, name, vers))
+
+
+@pywbemcli.group('server', options_metavar=CMD_OPTS_TXT)
+def class_group():
+    """
+    Command group for server operations.
+    """
+    pass
+
+
+@class_group.command('namespaces', options_metavar=CMD_OPTS_TXT)
+@add_options(sort_option)
+@click.pass_obj
+def server_namespaces(context, **options):
+    """
+    Display the set of namespaces in the current WBEM server
+    """
+    context.execute_cmd(lambda: cmd_server_namespaces(context, options))
+
+
+@class_group.command('interop', options_metavar=CMD_OPTS_TXT)
+@add_options(sort_option)
+@click.pass_obj
+def server_interop(context, **options):
+    """
+    Display the interop namespace name in the WBEM Server.
+    """
+    context.execute_cmd(lambda: cmd_server_interop(context, options))
+
+
+@class_group.command('brand', options_metavar=CMD_OPTS_TXT)
+@add_options(sort_option)
+@click.pass_obj
+def server_brand(context, **options):
+    """
+    Display the interop namespace name in the WBEM Server.
+    """
+    context.execute_cmd(lambda: cmd_server_brand(context, options))
+
+
+@class_group.command('info', options_metavar=CMD_OPTS_TXT)
+@click.pass_obj
+def server_info(context, **options):
+    """
+    Display the brand information on the current WBEM Server.
+    """
+    context.execute_cmd(lambda: cmd_server_info(context, options))
+
+
+@class_group.command('profiles', options_metavar=CMD_OPTS_TXT)
+@click.option('-o', '--organization', type=str, required=False,
+              help='Filter by the defined organization. (ex. -o DMTF_')
+@click.option('-n', '--profilename', type=str, required=False,
+              help='Filter by the profile name. (ex. -n Array')
+@click.pass_obj
+def server_profiles(context, **options):
+    """
+    Display the brand information on the current WBEM Server.
+    """
+    context.execute_cmd(lambda: cmd_server_profiles(context, options))
+
+@class_group.command('connection', options_metavar=CMD_OPTS_TXT)
+@click.pass_obj
+def server_connection(context, **options):
+    """
+    Display information on the connection used by this server.
+    """
+    context.execute_cmd(lambda: cmd_server_connection(context))
+
+
+###############################################################
+#         Server cmds
+###############################################################
+def cmd_server_namespaces(context, options):
+    """
+    Get the list of namespaces from the current WBEMServer
+    """
+    ns = context.wbem_server.namespaces
+    display_result(ns)
+
+
+def cmd_server_interop(context, options):
+    """
+    Get the list of namespaces from the current WBEMServer
+    """
+    display_result(context.wbem_server.interop_ns)
+
+
+def cmd_server_brand(context, options):
+    """
+    Get the list of namespaces from the current WBEMServer
+    """
+    display_result(context.wbem_server.brand)
+
+
+def cmd_server_info(context, options):
+    """
+    Display general overview of info from current WBEMServer
+    """
+
+    print("Brand:\n  %s" % context.wbem_server.brand)
+    print("Version:\n  %s" % context.wbem_server.version)
+    print("Interop namespace:\n  %s" % context.wbem_server.interop_ns)
+
+    print("All namespaces:")
+    for ns in context.wbem_server.namespaces:
+        print("  %s" % ns)
+
+
+def cmd_server_profiles(context, options):
+    """
+    Display general overview of info from current WBEMServer
+    """
+    found_server_profiles = context.wbem_server.get_selected_profiles(
+        options['organization'],
+        options['profilename'])
+
+    org_vm = ValueMapping.for_property(context.wbem_server,
+                                       context.wbem_server.interop_ns,
+                                       'CIM_RegisteredProfile',
+                                       'RegisteredOrganization')
+
+    print('Profiles for %s:%s' % (options['organization'],
+                                  options['profilename']))
+    for inst in found_server_profiles:
+        print_profile_info(org_vm, inst)
+
+def cmd_server_connection(context):
+    conn = context.conn
+    print('url %s: ' %conn.url)
+    print('creds %s: ' %conn.creds)
+    print('.x509 %s: ' %conn.x509)
+    print('verify_callback: %s' %conn.verify_callback)
+    print('default_namespace: %s' %conn.default_namespace)
+    print('timeout: %s sec.' %conn.timeout)
+    print('ca_certs: %s ' % conn.ca_certs)

--- a/pywbemclicmds/_common.py
+++ b/pywbemclicmds/_common.py
@@ -1,0 +1,295 @@
+"""
+Common Functions applicable across multiple components of pywbemcli
+"""
+
+from __future__ import absolute_import
+
+import re
+import click
+from pywbem import WBEMConnection, CIMInstanceName
+
+
+# TODO This should become a special click option type
+def fix_propertylist(propertylist):
+    """
+    Correct property list received from options.  Click options produces an
+    empty list when there is no property list.  Pywbem requires None
+    when there is no propertylist
+    """
+    if not propertylist:
+        rtn = None
+    else:
+        rtn = propertylist
+    return rtn
+
+
+def pick_instance(context, objectname, namespace=None):
+    """
+    Display list of instances names from provided classname to console and user
+    selects one. Returns the selected instancename.
+
+      Parameters:
+        context:
+            Current click context
+
+        classname:
+            Classname to use to get instance names from server
+
+      Returns:
+        instancename selected
+      Exception:
+        ValueError Exception if user elects to abort the selection
+    """
+    if not is_classname(objectname):
+        raise click.ClickException('%s must be a classname' % objectname)
+    instance_names = context.conn.EnumerateInstanceNames(objectname,
+                                                         namespace)
+
+    try:
+        instancename, _ = pick_from_list(instance_names,
+                                         'Pick Instance name to process')
+        return instancename
+    except Exception:
+        raise ValueError('Invalid pick')
+
+
+def pick_from_list(options, title):
+    """
+    Interactive component that displays a set of options (strings) and asks
+    the user to select one.  Returns the item and index of the selected string.
+
+    Parameters:
+      options:
+        List of strings to select
+
+      title:
+        Title to display before selection
+
+    Retries until either integer within range of options list is input
+    or user enter ctrl-c.
+
+    Returns: Tuple of option selected, index of selected item
+
+    Exception: Returns ValueError if Ctrl-c input from console.
+
+    TODO: This could be replaced by the python pick library that would use
+    curses for the selection process.
+    """
+    print(title)
+    index = -1
+    for str_ in options:
+        index += 1
+        print('%s: %s' % (index, str_))
+    while True:
+        n = raw_input('Index of selection or Ctrl-C to exit> ')
+        try:
+            n = int(n)
+            if n >= 0 and n <= index:
+                return options[index], index
+        except ValueError:
+            pass
+        # TODO make this one our own exception.
+        except KeyboardInterrupt:
+            raise ValueError
+        print('%s Invalid. Must be integer between 0 and %s. Ctrl-C to '
+              ' terminate selection' % (n, index))
+
+
+def is_classname(str_):
+    """
+    Test if the str_ input is a classname or contains instance name
+    components.  The existence of a period at the end of the name component
+
+    Returns:
+        True if classname. Otherwise it returns False
+    """
+    match = re.match(r'[a-zA_Z0-9_].*\.', str_)
+    return False if match else True
+
+
+def filter_namelist(regex, name_list, case_insensitive=True):
+    """
+    Filter out names in name_list that match compiled_regex.
+
+    Note that the regex may define a subset of the name string.  Thus,  regex:
+        - CIM matches any name that starts with CIM
+        - CIM_abc matches any name that starts with CIM_abc
+        - CIM_ABC$ matches only the name CIM_ABC.
+
+    Parameters:
+      Compiled_regex: Compile regex string to match
+
+      name_list: List of strings to be matched.
+
+    Returns the list of names that match.
+
+    """
+    flags = re.IGNORECASE if case_insensitive else None
+
+    compiled_regex = re.compile(regex, flags=flags)
+
+    nl = [n for n in name_list for m in[compiled_regex.match(n)] if m]
+
+    return nl
+
+
+def remote_connection(server, namespace, user=None, password=None):
+    """Initiate a remote connection, via PyWBEM. Arguments for
+       the request are part of the command line arguments and include
+       user name, password, namespace, etc.
+    """
+
+    if server[0] == '/':
+        url = server
+
+    elif re.match(r"^https{0,1}://", server) is not None:
+        url = server
+
+    elif re.match(r"^[a-zA-Z0-9]+://", server) is not None:
+        print('Invalid scheme on server argument.'
+              ' Use "http" or "https"')
+
+    else:
+        url = '%s://%s' % ('https', server)
+
+    creds = None
+
+    # if opts.key_file is not None and opts.cert_file is None:
+    #    argparser_.error('keyfile option requires certfile option')
+
+    if user is not None or password is not None:
+        creds = (user, password)
+    timeout = 30
+
+    if timeout is not None and (timeout < 0 or timeout > 300):
+        print('timeout option(%s) out of range' % timeout)
+        quit(1)
+
+    # if client cert and key provided, create dictionary for wbem connection
+    x509_dict = None
+    # if opts.cert_file is not None:
+    #    x509_dict = {"cert_file": opts.cert_file}
+    #    if opts.key_file is not None:
+    #        x509_dict.update({'key_file': opts.key_file})
+    no_verify_cert = True
+    ca_certs = None
+    conn = WBEMConnection(url, creds, default_namespace=namespace,
+                          no_verification=no_verify_cert,
+                          x509=x509_dict, ca_certs=ca_certs,
+                          timeout=timeout)
+
+    conn.debug = True
+    return conn
+
+
+def objects_sort(objects):
+    """
+    Sort CIMInstances or instance names
+    """
+    # TODO: Not implemented
+    return objects
+
+
+# TODO if namespace element, it should go back to context. I tink.
+def parse_wbem_uri(uri):
+    """
+    Create and return a CIMObjectPath from a string input.
+    For now we do not allow the host element.  The uri is of the form
+    namespace:className.<name=value>*
+
+    This differs from wbemuri in that it does not require quotes around
+    value elements unless they include commas or quotation marks
+    """
+    print('parse uri %s' % uri)
+    host = None
+    # if matches re.match(r"^//(.*)/".uri,re.I):
+    #    # host =  matches.group(1))
+    #    # span = matches.span())
+
+    namespace = None
+    key_bindings = {}
+    classname = None
+    if not uri.startswith('//'):
+        host = None
+    # TODO implement host component of parse.
+    uri_pattern = r'''(?x)
+              ([a-zA-Z0-9_]*).      # classname
+'''
+    match = re.match(uri_pattern, uri, re.VERBOSE)
+    print('uri match %s' % match)
+    if match:
+        # namespace = match.group(1)
+        classname = match.group(1)
+        if host and not namespace:
+            raise ValueError('HostName with no namespace is invalid')
+        next_char = match.end()
+
+        kb_pattern = r'([a-zA-Z0-9_]*=[^",][^,]*)'
+
+        for pmatch in re.finditer(kb_pattern, uri[next_char:]):
+            print('pmatch %s' % pmatch)
+            pair = pmatch.group(1).split('=', 1)
+            print('pair %s' % pair)
+            if len(pair[0]):
+                if pair[1][0] == '"':
+                    # if pair[1][:-1] != '"'
+                    #    ValueError('Mismatched quotes %s' % pmatch.group(1))
+                    key_bindings[pair[0]] = pair[1][1:-1]
+                else:
+                    try:
+                        key_bindings[pair[0]] = int(pair[1])
+                    except ValueError:
+                        key_bindings[pair[0]] = pair[1]
+                    except TypeError:
+                        key_bindings[pair[0]] = pair[1]
+            else:
+                # Value Error when name component empty
+                ValueError('Cannot parse keybinding %s' % pair)
+    else:
+        ValueError('Cannot parse wbemuri %s' % uri)
+
+    inst_name = CIMInstanceName(classname, keybindings=key_bindings, host=host,
+                                namespace=namespace)
+    print('CIMInstanceName %s' % inst_name)
+
+    return inst_name
+
+
+def display_result(objects, output_format='mof'):
+    """
+    Input is either a list of objects or a single object. It may be
+    any of the CIM types.
+
+    output_format defines the proposed format for output of the objects.
+
+    Note: This function may override that choice in the case where the output
+    choice is not avialable for the object type.  Thus, for example,
+    mof output makes no sense for class names. In that case, the output is
+    in the str of the type.
+    """
+    # TODO this is very simplistic and needs refinement.
+    if isinstance(objects, list):
+        for item in objects:
+            display_result(item)
+    elif isinstance(objects, tuple):
+        for item in objects:
+            display_result(item)
+    else:
+        object_ = objects
+        if output_format == 'mof':
+            try:
+                print(object_.tomof())
+            except AttributeError:
+                # no tomof functionality
+                print(object_)
+        elif output_format == 'xml':
+            try:
+                print(object_.toxmlstr())
+            except AttributeError:
+                # no toxmlstr functionality
+                print(object)
+        elif output_format == 'str':
+            try:
+                print(object)
+            except AttributeError:
+                print('%r' % object)

--- a/pywbemclicmds/_common_options.py
+++ b/pywbemclicmds/_common_options.py
@@ -1,0 +1,63 @@
+"""
+Defines click options that are used for multiple subcommands and that have
+the same definition throughout the environment.  This allows the characteristics
+and help to be defined once and used multiple times.
+"""
+from __future__ import absolute_import
+
+import click
+
+#
+# property_list opetion - Defined here because the option is used in
+# multiple places in the command structure.
+#
+propertylist_option = [                      # pylint: disable=invalid-name
+    click.option('-p', '--propertylist', multiple=True, type=str,
+                 default=None,
+                 help='Define a propertylist for the request. If not included '
+                      'a Null property list is defined and the server '
+                      'returns all properties. If defines as empty string '
+                      'the server returns no properties'
+                      ' ex: -p propertyname1 -p propertyname2')]
+
+names_only_option = [                      # pylint: disable=invalid-name
+    click.option('-o', '--names_only', is_flag=True, required=False,
+                 help='Show only local properties of the class.')]
+
+sort_option = [                            # pylint: disable=invalid-name
+    click.option('-s', '--sort', is_flag=True, required=False,
+                 help='Sort into alphabetical order by classname.')]
+
+includeclassorigin_option = [            # pylint: disable=invalid-name
+    click.option('-c', '--includeclassorigin', is_flag=True,
+                 required=False,
+                 help='Include classorigin in the result.')]
+
+namespace_option = [                     # pylint: disable=invalid-name
+    click.option('-n', '--namespace', type=str,
+                 required=False,
+                 help='Namespace to use for this operation. If defined that '
+                      'namespace overrides the general options namespace')]
+
+
+def add_options(options):
+    """
+    Accumulate multiple options into a list. This list can be referenced as
+    a click decorator @att_options(name_of_list)
+
+    The list is reversed because of the way click processes options
+
+    Parameters:
+
+      options: list of click.option definitions
+
+    Returns:
+        Reversed list
+
+    """
+    def _add_options(func):
+        """ Reverse options list"""
+        for option in reversed(options):
+            func = option(func)
+        return func
+    return _add_options

--- a/pywbemclicmds/_enumerateclassnames.py
+++ b/pywbemclicmds/_enumerateclassnames.py
@@ -1,0 +1,54 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click Command definition for the enumerate classes command.
+"""
+
+import click
+from pywbem import Error
+from .pywbemclicmd import pywbemcli, CMD_OPTS_TXT, display_result
+
+
+@pywbemcli.command('enumerateclassnames', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', type=str, metavar='classname')
+@click.option('-d', '--deepinheritance', is_flag=True, required=False,
+              help='Return complete subclass hiearchy for this class.')
+@click.pass_obj
+def enumerateclassenames(context, classname, **options):
+    """
+    Get and display a class in the WBEM Server.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'zhmc --help') can also be specified before the
+    command.
+    """
+    context.execute_cmd(
+        lambda: cmd_enumerateclassnames(context, classname, options))
+
+
+def cmd_enumerateclassnames(context, classname, options):
+    """
+    get and display a list of classnames.
+    """
+    try:
+        if context._verbose:
+            print('enumerateclassnames %s deepinheritance %s' %
+                  (classname, options['deepinheritance']))
+        result = context._conn.EnumerateClasseNames(
+            classname, options['deepinheritance'])
+        display_result(result)
+    except Error as er:
+        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemclicmds/pywbemclicmd.py
+++ b/pywbemclicmds/pywbemclicmd.py
@@ -1,0 +1,243 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Click command definition for the pywbemcli command, the top level command for
+the pywbemcli click tool
+"""
+from __future__ import absolute_import
+
+import re
+from click_repl import repl
+import click
+# import click_spinner
+from pywbem import WBEMConnection, CIMInstanceName, WBEMServer
+from ._common import remote_connection
+
+__all__ = ['pywbemcli']
+
+
+# uses -h  and --help rather than just --help
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+# Display of options in usage line
+GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
+CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
+
+DEFAULT_OUTPUT_FORMAT = 'mof'
+DEFAULT_NAMESPACE = 'root/cimv2'
+
+# TODO how can we express that we want output to be summary or full
+# TODO express system default in the help.
+# TODO fix up all of the system/config default options.
+
+@click.group(invoke_without_command=True,
+             options_metavar=GENERAL_OPTIONS_METAVAR)
+@click.option('-s', '--server', type=str, envvar='WBEM_SERVER',
+              help="Hostname or IP address of the WBEMServer "
+                   "(Default: WBEM_SERVER environment variable).")
+@click.option('-d', '--default_namespace', type=str, envvar='WBEM_NAMESPACE',
+              help="Default Namespace to use in the target WBEMServer if no "
+                   "namespace is defined in the subcommand"
+                   "(Default: WBEM_NAMESPACE environment variable or "
+                   "pywbemcli default TODO).")
+@click.option('-u', '--user', type=str, envvar='WBEM_USER',
+              help="Username for the WBEM Server "
+                   "(Default: WBEM_USER environment variable).")
+@click.option('-p', '--password', type=str, envvar='WBEM_PASSWORD',
+              help="Password for the WBEM Server "
+                   "(Default: WBEM_PASSWORD environment variable).")
+@click.option('-t', '--timeout', type=str, envvar='WBEM_TIMEOUT',
+              help="Operation timeout for the WBEM Server "
+                   "(Default: WBEM_TIMEOUT environment variable).")
+@click.option('-n', '--noverify', type=str, is_flag=True,
+              help='If set, client does not verify server certificate.')
+@click.option('-k', '--certfile', type=str, envvar='WBEM_CERTFILE',
+              help="Server certfile. Not used if noverify set"
+                   "(Default: WBEM_KEYFILE environment variable).")
+@click.option('-k', '--keyfile', type=str, envvar='WBEM_KEYFILE',
+              help="Client private key file"
+                   "(Default: WBEM_KEYFILE environment variable).")
+@click.option('-o', '--output-format',
+              type=click.Choice(['mof', 'xml', 'table', 'csv', 'text']),
+              help='Output format (Default: {of}).'
+              .format(of=DEFAULT_OUTPUT_FORMAT))
+@click.option('-v', '--verbose', type=str, is_flag=True,
+              help='Display extra information about the processing.')
+@click.version_option(help="Show the version of this command and exit.")
+@click.pass_context
+def pywbemcli(ctx, server, default_namespace, user, password, timeout, noverify,
+         certfile, keyfile, output_format, verbose, conn=None,
+         wbem_server=None):
+    """
+    Command line browser for WBEM Servers. This cli tool implements the
+    CIM/XML client APIs as defined in pywbem to make requests to a WBEM
+    server.    
+
+    The options shown above that can also be specified on any of the
+    (sub-)commands.
+    """
+    # TODO add for noverify, etc.
+    if ctx.obj is None:
+        # We are in command mode or are processing the command line options in
+        # interactive mode.
+        # We apply the documented option defaults.
+        if output_format is None:
+            output_format = DEFAULT_OUTPUT_FORMAT
+        if default_namespace is None:
+            default_namespace = DEFAULT_NAMESPACE
+        # TODO force noverify for now.
+        noverify = True
+    else:
+        # Processing an interactive command.
+        # Apply the option defaults from the command line options.
+        if server is None:
+            server = ctx.obj.server            
+        if default_namespace is None:
+            default_namespace = ctx.obj.default_namespace
+        if user is None:
+            user = ctx.obj.user
+        if password is None:
+            password = ctx.obj.password
+        if timeout is None:
+            timeout = ctx.obj.timeout
+        if output_format is None:
+            output_format = ctx.obj.output_format
+        if conn is None:
+            conn = ctx.obj.conn
+        if wbem_server is None:
+            wbem_server = ctx.obj.wbem_server
+
+
+    # Create a command context for each command: An interactive command has
+    # its own command context different from the command context for the
+    # command line.
+    ctx.obj = Context(ctx, server, default_namespace, user, password, timeout,
+                      noverify, certfile, keyfile, output_format, verbose, conn,
+                      wbem_server)
+
+    # Invoke default command
+    if ctx.invoked_subcommand is None:
+        repl(ctx)
+
+
+class Context(object):
+    """
+        Manage the click context object
+    """
+
+    def __init__(self, ctx, server, default_namespace, user, password, timeout,
+                 noverify, certfile, keyfile, output_format, verbose, conn,
+                 wbem_server):
+        self._server = server
+        self._default_namespace = default_namespace
+        self._user = user
+        self._password = password
+        self._timeout = timeout
+        self._noverify = noverify
+        self._certfile = certfile
+        self._keyfile = keyfile
+        self._output_format = output_format
+        self._verbose = verbose
+        self._conn = conn
+        self._wbem_server = wbem_server
+        # self._spinner = click_spinner.Spinner()
+
+    @property
+    def server(self):
+        """
+        :term:`string`: Hostname or IP address of the HMC.
+        """
+        return self._server
+
+    @property
+    def user(self):
+        """
+        :term:`string`: Userid on the HMC.
+        """
+        return self._user
+
+    @property
+    def output_format(self):
+        """
+        :term:`string`: Output format to be used.
+        """
+        return self._output_format
+
+    @property
+    def default_namespace(self):
+        """
+        bool: Namespace to be used as default  or requests.
+        """
+        return self._default_namespace
+
+    @property
+    def timeout(self):
+        """
+        bool: Namespace to be used for requests.
+        """
+        return self._timeout
+
+    @property
+    def conn(self):
+        """
+        bool: WBEMConnection to be used for requests.
+        """
+        return self._conn
+    @property
+    def wbem_server(self):
+        """
+        bool: WBEMServer to be used for requests.
+        """
+        return self._wbem_server
+
+    @property
+    def password(self):
+        """
+        :term:`string`: password to be used instead of logging on, or `None`.
+        """
+        return self._password
+
+    # @property
+    # def spinner(self):
+    #    """
+    #    :class:`~click_spinner.Spinner` object.
+    #    """
+    #    return self._spinner
+
+    def execute_cmd(self, cmd):
+        """
+        Call the cmd executor defined by cmd with the spinner
+        """
+        if self._conn is None:
+            if self._server is None:
+                raise click.ClickException("No WBEM Server defined")
+            # TODO expand this
+            self._conn = remote_connection(self.server, self.default_namespace,
+                                            user=None,
+                                            password=None)
+            self._wbem_server = WBEMServer(self.conn)
+        # self.spinner.start()
+        try:
+            cmd()
+        finally:
+            # self.spinner.stop()
+            pass
+
+    @property
+    def verbose(self):
+        """
+        :class:`~click_spinner.Spinner` object.
+        """
+        return self._verbose

--- a/setup.py
+++ b/setup.py
@@ -342,6 +342,7 @@ def main():
         'scripts': [
             'wbemcli',
             'wbemcli.py',
+            'pywbemcli',
             'mof_compiler',
             'wbemcli.bat',
             'mof_compiler.bat',
@@ -353,6 +354,11 @@ def main():
             # at Python startup time).
             'six',
             'ply',
+            # The following are used by wcli
+            'click',
+            'click-repl',
+            'click-spinner',
+            'click-configfile',
             # The PyYAML package contains the "yaml" Python package. yaml is
             # needed by the pywbem._recorder module.
             'PyYAML',

--- a/wcli.py
+++ b/wcli.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+from __future__ import absolute_import
+
+import re
+from click_repl import register_repl
+import click
+from wclicmds import wcli
+
+if __name__ == '__main__':
+    register_repl(wcli)
+
+    wcli()  #pylint: disable=no-value-for-parameter


### PR DESCRIPTION
This is strictly prototype and experiments now.  I have a prototype (wcli using click) and parts of a second that would integrate with wbemcli using argparse. Effort now is on wcli.

NOTE: I moved the whole discussion to a design document in a design directory of this package.

After discussion and review, I concluded that click and its extra contributions works well for this.

Click brings at least the following advantages:
1. repl integrated through a contributor library so that an interactive mode exists.
2. parser and commands are closely linked so that new subcommands can be easily implemented without impacting the core processor.
3. A number of other contributor libraries including log, spinner, config file
4. Apparently integrated plugin mechanism so new plugins can be added by user and integrate into the cmd structure
5. Options, arguments for subcommands are easily integrated into each command and local.

This commit consists of a prototype (incomplete but working (without documentation)) code set for a tool named pywbemcli

I committed this pr at this stage for discussion.  I revised it after discussions last week.

It mixes two metaphors for the client right now.\:

1. Just emulate the request operations. Thus it implements getclass and enumerateclass.
With this we would start with 28 subcommands, one for each operation.
     ex. pywbemcli getclass CIM_ManagedElement

2. A new metaphor for the client organization that matches the multi-level command concepts integrated into multiple levels of subcommand. What I chose for now is
      <noun representing object being processed> <action on that object(s)>
    ex. pywbemcli class get CIM_ManagedElement

For the moment, the nouns representing the nouns for connection level requests are:
    1. class
    2. instance
    3. qualifier.

However, the goal is to expand this to include:
   1. object subcommands for managing pywbemcli capabilities (log, connection, etc.)
   2. object subcmds for other components including:
       a. namespace
       b. server
       c. subscriptions
       e. profiles

Proposed command taxonomy:
```
**pywbemwcli**
* **class**
  * **get** <classname> --namespace <getclass options> (corresponds to getclass) 
  * **enumerate**  (corresponds to enumerateclasses) <classname> --namespace --names-only <enumerateclass options>
  * **references**  <sourceclass> --namespace --names_only <references options>(corresponds to class references)
  * **associators**<sourceclass> --namespace --names_only <associator options>(corresponds to class associators)
  * **invokemethod** <classname> <methodname> [<param_name=value>]*
  * **find** Find a class across namespaces (regex names allowed)
* **instance**
  * **get** <inst_name>  --namespace <get inst options> (corresponds to GetInstance)
  * **enumerate** <instname>-- namespace --names-only <enumerate inst options> (corresponds to EnumerateInstances)
  * **references** <instname>--namespace --names_only <references options>(corresponds to inst references)
  * **associators** <instname> --namespace --names_only <associator options>(corresponds to inst associators)
  * **delete** <instname> | <classname>   (use classname for interactive select mode)
  * **invokemethod** <instname> <methodname> [<param_name=value>]*
* **qualifier**
  * **get** <qualifier_name>
* **server**
  * **namespace**
    * **list**
    * **interop**
  * **jobs**
    *  list
    *  TBD
    *  <possible other server objects, etc. adapters>        
  * **profiles**
    * **list**
    * ???
  * **subscriptions**
    * **list** --filters --subs --dest
    * **create**
    * **delete**
  * **connection**
    * **info**
    * **setnamespace**
    * **setnewconnection**
  * **profile**
    * **profilename**
      * **info**
      * **classes**
      * **attached_instances**
```
DISCUSSION:

1. is this a logical taxonomy of subcommands.  I think this is much better that the list of all request types. Also if we implement a git-like alias, we get the request semantics also. ex. gi and getinstance are aliases for "instance get".

**CONCLUSION:** the overall taxonomy is logical but we need to be more precise.  We revised the taxonomy somewhat on 27 Jan telecon and Karl will put up new documentation

2. I hate enumerate/list but do not have anything better.  Suggestions welcome.  One idea was to have enumerate with an options that when true returned the names rather than the objects.

**CONCLUSION:** We agreed that  the enumerate/list seperation is not logical and that we should use an option to specify when just names/ paths are to be returns.  The document reflects the option --names-only but not -n as the short form since that should be for namespace.

DISCUSSION: Karl proposed 'enumerate' as the standard word.

We agreed that namespace should be an option on each command

3. I did not begin to implement the delete, modify, set, create operations.  we should decide which ones we want to do.  Suggestion. Delete but not the modify, set, create for class and qualifierdecl and all of them for instances.

DISCUSSION: Do we agree that we will have create/modify on instances but will not support create/modify on classes or create on qualifierdecls????

4. I do not use the config parser at all at this point so there is no config.ini file.  I think that will become a requirement however.

5. Way to many options in the general group (server, namespace, user, password, certs, etc.  However, this can be mitigated by use of the env variables, config parser and a means for the user to set server names with these parameters and save them.

6. Should this be part of pywbem repository or a separate repository since it imposes a number of additional import requirements on pywbem.

**CONCLUSION:** We agreed that this should probably be a separate repository but Karl suggest reviewing this when the code is further along.  For now we will leave in the current repository for development.

Next action is for Karl to produce a better design definition (the discussion was in powerpoint) and also the next set of code.

   

