### PR TITLE
fixes #656 Backport pull request #658 from pywbem/issue#656-pullops-maxobjcount

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,37 @@ contains the `master` branch up to this commit:
    :revisions: 1
 
 
+
+pywbem v0.10.1.dev0
+-------------------
+
+Released: Not yet
+
+Incompatible changes
+^^^^^^^^^^^^^^^^^^^^
+
+Enhancements
+^^^^^^^^^^^^
+
+Bug fixes
+^^^^^^^^^
+
+* Fix issue with MaxObjectCount on PullInstances and PullInstancePaths
+  CIM_Operations.py methods.  The MaxObjectCount was defined as a keyword
+  parameter where it should have been be positional.  This should NOT impact
+  clients unless they did not supply the parameter at all so that the result
+  was None which is illegal(Pull... operations MUST include MaxObjectCount).
+  In that case, server should return error.
+  Also extends these requests to test the Pull.. methods for valid
+  MaxObjectCount and context parameters. See issue #656.
+
+Build, test, quality
+^^^^^^^^^^^^^^^^^^^^
+
+Documentation
+^^^^^^^^^^^^^
+
+
 pywbem v0.10.0
 --------------
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -427,6 +427,24 @@ def _validateIterCommonParams(MaxObjectCount, OperationTimeout):
                          OperationTimeout)
 
 
+def _validatePullParams(MaxObjectCount, context):
+    """
+        Validate the input paramaters for the PullInstances,
+        PullInstancesWithPath, and PullInstancePaths requests.
+
+        MaxObjectCount: Must be integer type and ge 0
+
+        context: Must be not None and length ge 2
+    """
+    if (not isinstance(MaxObjectCount, six.integer_types) or
+            MaxObjectCount < 0):
+        raise ValueError('MaxObjectCount parameter must be integer >= 0 but '
+                         ' is %s' % MaxObjectCount)
+    if context is None or len(context) < 2:
+        raise ValueError('Pull... Context parameter must be valid tuple %s'
+                         % context)
+
+
 class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     """
     A client's connection to a WBEM server. This is the main class of the
@@ -5266,8 +5284,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer
+            * None is not allowed for this operation.
+
 
         Keyword Arguments:
 
@@ -5338,6 +5357,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         try:
 
+            _validatePullParams(MaxObjectCount, context)
+
             namespace = context[1]
 
             result = self._imethodcall(
@@ -5362,7 +5383,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstancePaths(self, context, MaxObjectCount=None, **extra):
+    def PullInstancePaths(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
 
         """
@@ -5401,8 +5422,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5470,6 +5491,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         try:
 
+            _validatePullParams(MaxObjectCount, context)
+
             namespace = context[1]
 
             result = self._imethodcall(
@@ -5494,7 +5517,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.operation_recorder.record_staged()
             return result_tuple
 
-    def PullInstances(self, context, MaxObjectCount=None, **extra):
+    def PullInstances(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
         """
         Retrieve the next set of instances from an open enumeraton
@@ -5532,8 +5555,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             * If positive, the WBEM server is to return no more than the
               specified number of instances.
             * If zero, the WBEM server is to return no instances. This may
-              be used by a client to leave the handling of any returned
-              instances to a loop of Pull operations.
+              be used by a client to reset the interoperation timer.
+            * None is not allowed for this operation.
 
         Keyword Arguments:
 
@@ -5597,6 +5620,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
         try:
+
+            _validatePullParams(MaxObjectCount, context)
 
             namespace = context[1]
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -243,7 +243,7 @@ class ClientTest(unittest.TestCase):
         # if list, recurse this function
         if isinstance(instances, list):
             for inst in instances:
-                self.assertInstancesValid(inst, includes_path=True,
+                self.assertInstancesValid(inst, includes_path=includes_path,
                                           prop_count=prop_count,
                                           property_list=property_list,
                                           namespace=namespace)
@@ -905,8 +905,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertInstancesValid(result.instances)
 
@@ -932,8 +931,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             insts_pulled.extend(result.instances)
 
         self.assertInstancesValid(insts_pulled)
@@ -983,8 +981,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1008,8 +1005,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1032,8 +1028,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
 
@@ -1049,7 +1044,7 @@ class PullEnumerateInstances(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancesWithPath(result.context, MaxObjectCount=10)
+            self.conn.PullInstancesWithPath(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1062,8 +1057,7 @@ class PullEnumerateInstances(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=100)
+                self.conn.PullInstancesWithPath, result.context, 100)
 
         try:
             self.cimcall(self.conn.CloseEnumeration, result.context)
@@ -1217,8 +1211,7 @@ class PullEnumerateInstancePaths(ClientTest):
         # loop to complete the enumeration session
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1248,8 +1241,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1286,9 +1278,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.assertFalse(result.eos)
 
         # Pull the remainder of the paths
-        result = self.cimcall(self.conn.PullInstancePaths,
-                              result.context,
-                              MaxObjectCount=100)
+        result = self.cimcall(self.conn.PullInstancePaths, result.context, 100)
 
         self.assertTrue(result.eos)
 
@@ -1304,7 +1294,7 @@ class PullEnumerateInstancePaths(ClientTest):
         self.cimcall(self.conn.CloseEnumeration, result.context)
 
         try:
-            self.conn.PullInstancePaths(result.context, MaxObjectCount=10)
+            self.conn.PullInstancePaths(result.context, 10)
             self.fail('Expected CIMError')
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_ENUMERATION_CONTEXT:
@@ -1331,8 +1321,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
-                                  result.context,
-                                  MaxObjectCount=1)
+                                  result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1373,8 +1362,7 @@ class PullReferences(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1420,8 +1408,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1451,8 +1438,7 @@ class PullReferences(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1499,8 +1485,7 @@ class PullReferencePaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1545,8 +1530,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1579,8 +1563,7 @@ class PullReferencePaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
 
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
@@ -1615,8 +1598,7 @@ class PullAssociators(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancesWithPath, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancesWithPath, result.context, 1)
 
             self.assertTrue(len(result.instances) <= 1)
             insts_pulled.extend(result.instances)
@@ -1659,8 +1641,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
 
@@ -1691,8 +1672,7 @@ class PullAssociators(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancesWithPath, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancesWithPath, result.context, 1)
 
                 self.assertTrue(len(result.instances) <= 1)
                 insts_pulled.extend(result.instances)
@@ -1744,8 +1724,7 @@ class PullAssociatorPaths(ClientTest):
 
         while not result.eos:
             result = self.cimcall(
-                self.conn.PullInstancePaths, result.context,
-                MaxObjectCount=1)
+                self.conn.PullInstancePaths, result.context, 1)
 
             self.assertTrue(len(result.paths) <= 1)
             paths_pulled.extend(result.paths)
@@ -1789,8 +1768,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(
-                    self.conn.PullInstancePaths, result.context,
-                    MaxObjectCount=1)
+                    self.conn.PullInstancePaths, result.context, 1)
                 self.assertTrue(len(result.paths) <= 1)
                 paths_pulled.extend(result.paths)
 
@@ -1826,8 +1804,7 @@ class PullAssociatorPaths(ClientTest):
 
             while not result.eos:
                 result = self.cimcall(self.conn.PullInstancePaths,
-                                      result.context,
-                                      MaxObjectCount=1)
+                                      result.context, 1)
                 for path in result.path:
                     self.assertInstanceNamesValid(path)
                 paths_pulled.extend(result.paths)
@@ -1861,12 +1838,11 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 
-            # TODO ks extend this test
+            self.assertInstancesValid(insts_pulled, includes_path=False)
 
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
@@ -1896,8 +1872,7 @@ class PullQueryInstances(ClientTest):
 
             while eos is False:
                 op_result = self.cimcall(self.conn.PullInstances,
-                                         result.context,
-                                         MaxObjectCount=100)
+                                         result.context, 100)
                 insts_pulled.extend(result.instances)
                 eos = op_result.eos
 

--- a/testsuite/testclient/pullinstancepaths.yaml
+++ b/testsuite/testclient/pullinstancepaths.yaml
@@ -504,4 +504,57 @@
             </CIM>
 
 
+- name: PullInstancePathsF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancePathsF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancePathsF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+
 

--- a/testsuite/testclient/pullinstances.yaml
+++ b/testsuite/testclient/pullinstances.yaml
@@ -1,0 +1,669 @@
+- name: PullInstances1
+  description: PullInstances request part of OpenQueryInstances sequence. Successful with eol and null context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+    pullresult:
+        context: null
+        eos: True
+        instances:
+          - pywbem_object: CIMInstance
+            classname: PG_ComputerSystem
+            properties:
+              status:
+                pywbem_object: CIMProperty
+                name: Status
+                value: OK
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              elementname:
+                pywbem_object: CIMProperty
+                name: ElementName
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powerstate:
+                pywbem_object: CIMProperty
+                name: PowerState
+                value: 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementsupported:
+                pywbem_object: CIMProperty
+                name: PowerManagementSupported
+                value: false
+                type: boolean
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              nameformat:
+                pywbem_object: CIMProperty
+                name: NameFormat
+                value: Other
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              caption:
+                pywbem_object: CIMProperty
+                name: Caption
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              operationalstatus:
+                pywbem_object: CIMProperty
+                name: OperationalStatus
+                value:
+                - 2
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementcapabilities:
+                pywbem_object: CIMProperty
+                name: PowerManagementCapabilities
+                value:
+                - 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              creationclassname:
+                pywbem_object: CIMProperty
+                name: CreationClassName
+                value: PG_ComputerSystem
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              name:
+                pywbem_object: CIMProperty
+                name: Name
+                value: sheldon
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+            path: null
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="PullInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>
+      </VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: PullInstances2
+  description: PullInstances request part of OpenQueryInstances sequence. Successful with valid context and eol=False
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+    pullresult:
+        context:
+        - '500182'
+        - root/cimv2
+        eos: False
+        instances:
+          - pywbem_object: CIMInstance
+            classname: PG_ComputerSystem
+            properties:
+              status:
+                pywbem_object: CIMProperty
+                name: Status
+                value: OK
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              elementname:
+                pywbem_object: CIMProperty
+                name: ElementName
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powerstate:
+                pywbem_object: CIMProperty
+                name: PowerState
+                value: 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementsupported:
+                pywbem_object: CIMProperty
+                name: PowerManagementSupported
+                value: false
+                type: boolean
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              nameformat:
+                pywbem_object: CIMProperty
+                name: NameFormat
+                value: Other
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              caption:
+                pywbem_object: CIMProperty
+                name: Caption
+                value: Computer System
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              operationalstatus:
+                pywbem_object: CIMProperty
+                name: OperationalStatus
+                value:
+                - 2
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              powermanagementcapabilities:
+                pywbem_object: CIMProperty
+                name: PowerManagementCapabilities
+                value:
+                - 1
+                type: uint16
+                reference_class: null
+                embedded_object: null
+                is_array: true
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              creationclassname:
+                pywbem_object: CIMProperty
+                name: CreationClassName
+                value: PG_ComputerSystem
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+              name:
+                pywbem_object: CIMProperty
+                name: Name
+                value: sheldon
+                type: string
+                reference_class: null
+                embedded_object: null
+                is_array: false
+                array_size: null
+                class_origin: null
+                propagated: null
+                qualifiers: {}
+            path: null
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="PullInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>FALSE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: PullInstances3
+  description: Pull request and returns zero instances with eos=true and no context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        pullresult:
+            context: null
+            eos: true
+            instances: []
+
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500001</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>1</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstances">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>TRUE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE></VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+- name: PullInstancesF1
+  description: PullInstances request fails. Invalid Context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+     cim_status: 21
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="PullInstances">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIM>
+
+- name: PullInstancesF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+-
+  name: PullInstancesF5
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: None
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+

--- a/testsuite/testclient/pullinstanceswithpath.yaml
+++ b/testsuite/testclient/pullinstanceswithpath.yaml
@@ -392,3 +392,207 @@
                 </MESSAGE>
             </CIM>
 
+- name: PullInstancesWithPath4
+  description: Pull request and returns zero instances with eos=false and valid context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        pullresult:
+            context:
+              - '500001'
+              - root/cimv2            
+            eos: false
+            instances: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancesWithPath
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancesWithPath">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500001</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>1</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstancesWithPath">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>FALSE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE>500001</VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+- name: PullInstancesWithPathF1
+  description: PullInstancesWithPath request fails. Invalid Context
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+     cim_status: 21
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancesWithPath
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancesWithPath">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="PullInstancesWithPath">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIM>
+-
+  name: PullInstancesWithPathF2
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: -1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesWithPathF3
+  description: Pull request with context None raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+      context: null
+  pywbem_response:
+        exception: ValueError
+-
+  name: PullInstancesWithPathF4
+  description: Pull request with Invalid Input Parameter (no MaxObjectCount)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+  pywbem_response:
+        exception: TypeError
+
+-
+  name: PullInstancesWithPathF5
+  description: Pull request with MaxObjectCount invalid raises ValueError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: None
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        exception: ValueError


### PR DESCRIPTION
Fixes 656: MaxObjectCount parameter of Pull operations inconsistent
backported to 0.10.0 release. Backported with git cherry-pick

Failed two tests becuase of communication issues, not the code