### PR TITLE
Fixes #646 Change recorder to fix issue of scope names case lose

### DIFF
--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -25,7 +25,7 @@
 # pylint: disable=non-parent-init-called,super-init-not-called
 
 """
-Functions to create XML documens and elements conforming to the DMTF
+Functions to create XML documents and elements conforming to the DMTF
 standard DSP0201, Representation of CIM in XML, v2.2.
 
   http://www.dmtf.org/standards/wbem/DSP201.html

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -3524,28 +3524,29 @@ class GetQualifier(QualifierDeclClientTest):
 
 
 class SetQualifier(QualifierDeclClientTest):
-    """Test the capability to create a qualifierDecl in the server.
-
+    """Test the capability to create a QualifierDeclaration in the server.
+       Since the goal is to keep the server repository clean, this also tests
+       DeleteQualifier.
     """
 
     def test_create_delete(self):
         """
         Create a qualifier declaration, set it into the server, get
-        it and then delete it.
+        the qualifier declaration created and then delete it.
         """
 
-        scopes = {'CLASS': True}
         qd = CIMQualifierDeclaration('FooQualDecl', 'string', is_array=False,
                                      value='Some string',
-                                     scopes=scopes,
+                                     scopes={'CLASS': True},
                                      overridable=False, tosubclass=False)
+
         # Delete if already exists (previous test incomplete)
         try:
             self.cimcall(self.conn.DeleteQualifier, qd.name)
         except CIMError as ce:
             if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
                 print('NOTE: This server/namespace does not support '
-                      'SetQualifier since it returned NOT SUPPORTED')
+                      'DeleteQualifier since it returned NOT SUPPORTED')
                 return
             if ce.args[0] == CIM_ERR_NOT_FOUND:
                 pass
@@ -3563,13 +3564,15 @@ class SetQualifier(QualifierDeclClientTest):
         # get the qd and compare with original
         rtn_qd = self.cimcall(self.conn.GetQualifier, qd.name)
 
-        self.assertEqual(qd, rtn_qd, 'Returned qual decl should match created')
+        self.assertEqual(qd, rtn_qd, 'Returned qualifier declaration did not '
+                         'match created')
 
         self.cimcall(self.conn.DeleteQualifier, qd.name)
 
         # This should fail.  class already deleted
         try:
             self.cimcall(self.conn.GetQualifier, qd.name)
+            self.fail('This call should have failed')
         except CIMError as arg:
             if arg == CIM_ERR_NOT_FOUND:
                 pass
@@ -3626,6 +3629,10 @@ class SetQualifier(QualifierDeclClientTest):
 
 
 class DeleteQualifier(QualifierDeclClientTest):
+    """
+    See the SetQualifier tests for the test to correctly delete a qualifier
+    declaration.
+    """
 
     def test_delete_fail(self):
         """

--- a/testsuite/testclient/setqualifierdecl.yaml
+++ b/testsuite/testclient/setqualifierdecl.yaml
@@ -19,7 +19,7 @@
         is_array: false
         array_size: null
         scopes:
-          class: true
+          CLASS: true
         tosubclass: false
         toinstance: null
         overridable: false
@@ -44,7 +44,7 @@
       <IPARAMVALUE NAME="QualifierDeclaration">
       <QUALIFIER.DECLARATION ISARRAY="false" NAME="FooQualDecl" OVERRIDABLE="false"
       TOSUBCLASS="false" TYPE="string">
-      <SCOPE class="true"/>
+      <SCOPE CLASS="true"/>
       <VALUE>Some string</VALUE>
       </QUALIFIER.DECLARATION>
       </IPARAMVALUE>


### PR DESCRIPTION
Fixes the toyaml function to pass correct key case when converting from NoCaseDict to OrderedDictionary.

Adds tests to test_cimobj for this

We also cleaned all pylint messages out of _recorder.py. All of the changes were variable name changes or setting disable.

Fixes the data in testclient for setQualifier to correctly reflect what
the request and response should reflect (CLASS, not class).

Extends test in run_cim_operations.py
