### PR TITLE
Fixes #761: Create classes for keeping statistics and add statistics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,21 @@ Enhancements
   No other functional changes.
   See issue #680
 
+* Add operation statistics gathering.  This adds the class Statistics which
+  serves as a common place to gather execution time and request/reply size
+  information. The detailed information is available in WBEMConnect for
+  execution time and request/reply content size at the end of each operation.
+  
+  Statistics information is placed into the Statistics class where min/max/avg
+  information is available for each operation time if statistics is enabled.
+  Statistics gathering is enabled if the WBEMConnection attribute
+  `enable_stats` is `True`.
+  
+  Statistics can be externalized through the snapshot method of the Statistics
+  class.
+  
+  See issue #761
+
 Bug fixes
 ^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,18 +39,22 @@ Enhancements
   No other functional changes.
   See issue #680
 
-* Add operation statistics gathering.  This adds the class Statistics which
-  serves as a common place to gather execution time and request/reply size
-  information. The detailed information is available in WBEMConnect for
-  execution time and request/reply content size at the end of each operation.
+* Add operation statistics gathering **experimental**.  Adds the class
+  Statistics which serves as a common place to gather execution time and
+  request/reply size information on server requests and replies. The detailed
+  information is available in WBEMConnection for operation execution time
+   and request/reply content size at the end of each operation.
   
-  Statistics information is placed into the Statistics class where min/max/avg
-  information is available for each operation time if statistics is enabled.
+  When statistics gathering is enabled, the information is placed into the
+  Statistics class where min/max/avg information is available for each
+  operation type.
   Statistics gathering is enabled if the WBEMConnection attribute
   `enable_stats` is `True`.
   
   Statistics can be externalized through the snapshot method of the Statistics
   class.
+
+  The functionality is marked experimental for the current release
   
   See issue #761
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,7 +43,7 @@ Enhancements
   Statistics which serves as a common place to gather execution time and
   request/reply size information on server requests and replies. The detailed
   information is available in WBEMConnection for operation execution time
-   and request/reply content size at the end of each operation.
+  and request/reply content size at the end of each operation.
   
   When statistics gathering is enabled, the information is placed into the
   Statistics class where min/max/avg information is available for each

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -274,6 +274,21 @@ Exceptions
    :members:
    :special-members: __str__
 
+.. _`Statistics`:
+
+Statistics
+----------
+
+.. automodule:: pywbem._statistics
+
+.. autoclass:: pywbem.Statistics
+   :members:
+   :special-members: __str__
+
+.. autoclass:: pywbem.OperationStatistic
+   :members:
+   :special-members: __str__
+
 .. _`Security considerations`:
 
 Security considerations

--- a/makefile
+++ b/makefile
@@ -108,6 +108,7 @@ doc_dependent_files := \
     $(package_name)/_subscription_manager.py \
     $(package_name)/_recorder.py \
     $(package_name)/_server.py \
+    $(package_name)/_statistics.py \
     $(package_name)/config.py \
     wbemcli.py \
 

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -44,6 +44,7 @@ from ._subscription_manager import *  # noqa: F403,F401
 from ._listener import *  # noqa: F403,F401
 from ._recorder import *  # noqa: F403,F401
 from .config import *  # noqa: F403,F401
+from ._statistics import *  # noqa: F403,F401
 
 from ._version import __version__  # noqa: F401
 

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -16,26 +16,35 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 """
-The :class:`~pywbem.Statistics` class allows measuring the elapsed
-time and request/reply length of WBEM Operations and keeping statistics on the
-measured times
+Pywbem supports measuring the elapsed times of the WBEM operations that
+were performed in context of a connection, and maintaining a statistics
+over these times.
 
-It consists of two classes:
+This capability is disabled by default and can be enabled in either
+of these ways:
+
+* When creating a :class:`~pywbem.WBEMConnection` object, via its
+  ``enable_stats`` argument.
+
+* After the :class:`~pywbem.WBEMConnection` object has been created, by
+  modifying its :attr:`~pywbem.WBEMConnection.stats_enabled` instance
+  attribute.
+
+The :class:`~pywbem.Statistics` class maintains statistics over the measured
+elapsed times of the WBEM operations and is the interface for accessing the
+statistics. The statistics of a :class:`~pywbem.WBEMConnection` object are
+accessible via its :attr:`~pywbem.WBEMConnection.statistics` instance
+attribute.
 
 The :class:`~pywbem.OperationStatistic` class is a helper class that contains
-the actual measurement data for all invocations of a particular name. Its
-objects are under control of the :class:`~pywbem.Statistics` class.
-This class should be used independently.  Use the start_timer in the
-Statistics class to both start a timer and if it does not exist, create
-a new named statistic  category.
+the actual measurement data for one operation name.
+There will be one :class:`~pywbem.OperationStatistic` object each operation
+name (see the table of WBEMConnection methods in the :ref:`WBEM operations`
+section for the operation names).
+The :class:`~pywbem.OperationStatistic` objects are under control of the
+:class:`~pywbem.Statistics` class.
 
-The :class:`~pywbem.Statistics` class maintins time statistics over
-multiple separate named statistics gatherers (TimeStatistic class) and provides
-tools for reporting these statistics
-
-**Experimental:** The statistics functions are experimental for this
-release***.
-
+**Experimental:** The statistics support is experimental for this release.
 """
 
 from __future__ import absolute_import
@@ -43,38 +52,35 @@ from __future__ import absolute_import
 import time
 import copy
 
-__all__ = ['Statistics']
+__all__ = ['Statistics', 'OperationStatistic']
 
 
 class OperationStatistic(object):
     """
-    Elapsed time information for all invocations of a particular named
-    operation.
+    A statistics data keeper for the executions of all operations with the
+    same operation name.
 
-    This class maintains max, min, avg and count for a single named
-    statistic for time, request length and reply length.
+    This class maintains max, min, avg and count for elapsed time, request
+    size, and response size over the executed operations of a single
+    operation name.
 
-    Use :meth:`pywbem.Statistics.get_statistic` method  to
-    create objects of this class.
-
-    Ex:
+    Use the :meth:`pywbem.Statistics.start_timer` method to create objects
+    of this class::
 
         stats = container.start_timer('EnumerateInstances')
         ...
-        stats.stop_timer(req_len, reply_len, exception=True)
+        stats.stop_timer(request_len, reply_len, exc)
+
+    **Experimental:** This class is experimental for this release.
     """
-    display_col_hdr = \
-        'Count  Time    Time    Time  Req     Req   Req   Reply     Reply ' \
-        'Reply Exc Name\n' \
-        '       Avg     Min     Max   Avg     Min   Max   Avg       Min ' \
-        'Max   \n'
 
     def __init__(self, container, name):
         """
         Parameters:
 
-          container (Statistics):
-            The statistics container that holds this time statistics.
+          container (:class:`~pywbem.Statistics`):
+            The statistics container that holds this operation statistic
+            object.
 
           name (string):
             Name of the operation.
@@ -89,9 +95,9 @@ class OperationStatistic(object):
         self._time_max = float(0)
         self._start_time = None
 
-        self._req_len_sum = float(0)
-        self._req_len_min = float('inf')
-        self._req_len_max = float(0)
+        self._request_len_sum = float(0)
+        self._request_len_min = float('inf')
+        self._request_len_max = float(0)
 
         self._reply_len_sum = float(0)
         self._reply_len_min = float('inf')
@@ -100,16 +106,17 @@ class OperationStatistic(object):
     @property
     def stat_start_time(self):
         """
-        :py:time: Time the first statistic was taken since this object
-        was either created or reset.
+        :class:`py:float`: Point in time when the first statistic was taken
+        since this object was either created or reset, in seconds since the
+        epoch (for details, see :func:`py:time.time`).
         """
         return self._stat_start_time
 
     @property
     def name(self):
         """
-        :term:`string`: Name for a sequence of time statistics that represents
-        a single entitiy (ex. pywbem operation name)
+        :term:`string`: Name of the operation for which this statistics
+        object maintains data.
 
         This name is used by the :class:`~pywbem.Statistics` object
         holding this time statistics as a key.
@@ -119,22 +126,33 @@ class OperationStatistic(object):
     @property
     def container(self):
         """
-        :class:`~pywbem.Statistics`: This time statistics container.
+        :class:`~pywbem.Statistics`: The statistics container that holds
+        this statistics object.
         """
         return self._container
 
     @property
     def count(self):
         """
-        :term:`integer`: The number of invocations of the start_timer() and
-        stop_timer()).
+        :term:`integer`: The number of measured operations (that is,
+        invocations of the :meth:`~pywbem.OperationStatistic.stop_timer`
+        method).
         """
         return self._count
 
     @property
+    def exception_count(self):
+        """
+        :term:`integer`: The number of exceptions that occurred when invoking
+        the measured operations.
+        """
+        return self._exception_count
+
+    @property
     def avg_time(self):
         """
-        float: The average elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The average elapsed time for invoking the measured
+        operations, in seconds.
         """
         try:
             return self._time_sum / self._count
@@ -144,75 +162,76 @@ class OperationStatistic(object):
     @property
     def min_time(self):
         """
-        float: The minimum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The minimum elapsed time for invoking the measured
+        operations, in seconds.
         """
         return self._time_min
 
     @property
     def max_time(self):
         """
-        float: The maximum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The maximum elapsed time for invoking the measured
+        operations, in seconds.
         """
         return self._time_max
 
     @property
-    def avg_req_len(self):
+    def avg_request_len(self):
         """
-        float: The average elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The average size of the HTTP body in the CIM-XML
+        requests of the invoked operations, in Bytes.
         """
         try:
-            return self._req_len_sum / self._count
+            return self._request_len_sum / self._count
         except ZeroDivisionError:
-            return 0
+            return 0.0
 
     @property
-    def min_req_len(self):
+    def min_request_len(self):
         """
-        float: The minimum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The minimum size of the HTTP body in the CIM-XML
+        requests of the invoked operations, in Bytes.
         """
-        return self._req_len_min
+        return self._request_len_min
 
     @property
-    def max_req_len(self):
+    def max_request_len(self):
         """
-        float: The maximum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The maximum size of the HTTP body in the CIM-XML
+        requests of the invoked operations, in Bytes.
         """
-        return self._req_len_max
+        return self._request_len_max
 
     @property
     def avg_reply_len(self):
         """
-        float: The average elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The average size of the HTTP body in the CIM-XML
+        responses of the invoked operations, in Bytes.
         """
         try:
             return self._reply_len_sum / self._count
         except ZeroDivisionError:
-            return 0
+            return 0.0
 
     @property
     def min_reply_len(self):
         """
-        float: The minimum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The minimum size of the HTTP body in the CIM-XML
+        responses of the invoked operations, in Bytes.
         """
         return self._reply_len_min
 
     @property
     def max_reply_len(self):
         """
-        float: The maximum elapsed time for invoking the operation, in seconds.
+        :class:`py:float`: The maximum size of the HTTP body in the CIM-XML
+        responses of the invoked operations, in Bytes.
         """
         return self._reply_len_max
 
-    @property
-    def exception_count(self):
-        """
-            :py:time: Count of exceptions that occurred for named operation
-        """
-        return self._exception_count
-
     def reset(self):
         """
-        Reset the statistics data.
+        Reset the statistics data for this object.
         """
         self._count = 0
         self._exception_count = 0
@@ -221,9 +240,9 @@ class OperationStatistic(object):
         self._time_min = float('inf')
         self._time_max = float(0)
 
-        self._req_len_sum = float(0)
-        self._req_len_min = float('inf')
-        self._req_len_max = float(0)
+        self._request_len_sum = float(0)
+        self._request_len_min = float('inf')
+        self._request_len_max = float(0)
 
         self._reply_len_sum = float(0)
         self._reply_len_min = float('inf')
@@ -231,42 +250,46 @@ class OperationStatistic(object):
 
     def start_timer(self):
         """
-        This method starts the timer for this OperationStatistic object if
-        the container is enabled.
-
-        A subsequent :meth:`~pywbem.OperationStatistic.stop_timer` computes the
-        statistics for the time duration between the start and stop for this
-        :meth:`~pywbem.OperationStatistic.
-
-        If the statistics container holding this time statistics is disabled,
+        This method needs to be called at the begin of an operation that
+        is intended to be measured. It starts the measurement for that
+        operation (by capturing the current point in time), if the
+        statistics container holding this object is enabled. Otherwise,
         this method does nothing.
+
+        A subsequent invocation of :meth:`~pywbem.OperationStatistic.stop_timer`
+        will complete the measurement for that operation and will update the
+        statistics data.
         """
         if self.container.enabled:
             self._start_time = time.time()
             if not self._stat_start_time:
                 self._stat_start_time = self._start_time
 
-    def stop_timer(self, req_len, reply_len, exception=False):
+    def stop_timer(self, request_len, reply_len, exception=False):
         """
-        This method is called at the completion of the timed event. It
-        captures current time, computes the event duration since the
-        corresponding :meth:`~pywbem.OperationStatistic.start_timer` and
-        computes average, max, and min for the timedduration, request length,
-        and response length if the container is enabled.
+        This method needs to be called at the end of an operation that is
+        intended to be measured. It completes the measurement for that
+        operation by capturing the needed data, and updates the statistics
+        data, if the statistics container holding this object is enabled.
+        Otherwise, this method does nothing.
 
         Parameters:
-          req_len (:term:`integer`)
-            Integer value of the request length
+
+          request_len (:term:`integer`)
+            Size of the HTTP body of the CIM-XML request message, in Bytes.
 
           reply_len (:term:`integer`)
-            Integer value of the reply length
+            Size of the HTTP body of the CIM-XML response message, in Bytes.
 
           exception (:class:`py:bool`)
-            If True, add one to the exception accumulator
+            Boolean that specifies whether an exception was raised while
+            processing the operation.
 
-        If the statistics container is disabled, this method does nothing.
+        Returns:
 
-        Returns the time for this operation or None if not recorded
+          float: The elapsed time for the operation that just ended, or
+          `None` if the statistics container holding this object is not
+          enabled.
         """
         if self.container.enabled:
             if self._start_time is None:
@@ -276,7 +299,7 @@ class OperationStatistic(object):
             self._start_time = None
             self._count += 1
             self._time_sum += dt
-            self._req_len_sum += req_len
+            self._request_len_sum += request_len
             self._reply_len_sum += reply_len
 
             if exception:
@@ -287,10 +310,10 @@ class OperationStatistic(object):
             if dt < self._time_min:
                 self._time_min = dt
 
-            if req_len > self._req_len_max:
-                self._req_len_max = req_len
-            if req_len < self._req_len_min:
-                self._req_len_min = req_len
+            if request_len > self._request_len_max:
+                self._request_len_max = request_len
+            if request_len < self._request_len_min:
+                self._request_len_min = request_len
 
             if reply_len > self._reply_len_max:
                 self._reply_len_max = reply_len
@@ -301,66 +324,89 @@ class OperationStatistic(object):
         else:
             return None
 
-    def __str__(self):
+    def __repr__(self):
         """
-        Return a human readable string with the time statistics for this
-        name.
+        Return a human readable string with the statistics values, for debug
+        purposes.
         """
-        return 'Operations Statistic: {} count={:d} AvgTime={:.3f}s ' \
-               'MinTime={:.3f}s '\
-               'MaxTime={:.3f}s exceptions={:d} ' \
-               'AvgReq={:.3f}s MinReq={:.3f}s MaxReq={:.3f}s ' \
-               'AvgReq={:.3f}s MinReq={:.3f}s MaxReq={:.3f}s'. \
-               format(self.name,
-                      self.count,
-                      self.avg_time,
-                      self.min_time,
-                      self.max_time,
+        return 'OperationStatistic(' \
+               'name={s.name!r}, ' \
+               'count={s.count!r}, ' \
+               'exception_count={s.exception_count!r}, ' \
+               'avg_time={s.avg_time!r}, ' \
+               'min_time={s.min_time!r}, ' \
+               'max_time={s.max_time!r}, ' \
+               'avg_request_len={s.avg_request_len!r}, ' \
+               'min_request_len={s.min_request_len!r}, ' \
+               'max_request_len={s.max_request_len!r}, ' \
+               'avg_reply_len={s.avg_reply_len!r}, ' \
+               'min_reply_len={s.min_reply_len!r}, ' \
+               'max_reply_len={s.max_reply_len!r})'. \
+               format(s=self)
 
-                      self.avg_req_len,
-                      self.min_req_len,
-                      self.max_req_len,
-
-                      self.avg_reply_len,
-                      self.min_reply_len,
-                      self.max_reply_len,
-                      self.exception_count)
+    #: Formatted header string (two lines), for use with the formatted rows
+    #: returned by the :meth:`~pywbem.OperationStatistic.formatted` method.
+    #:
+    #: For an example, see :meth:`pywbem.Statistics.formatted`.
+    formatted_header = \
+        'Count ExcCt    Time    Time    Time ReqLen ReqLen ReqLen ' \
+        'ReplyLen ReplyLen ReplyLen Operation\n' \
+        '                Avg     Min     Max    Avg    Min    Max ' \
+        '     Avg      Min      Max\n'
 
     def formatted(self):
         """
-        Returns a formatted OperationStatistic consistent with the display
-        header.  The formatting must match the header formatting in
+        Return a formatted one-line string with the statistics values for this
+        operation.
 
+        The returned string can be used with the formatted header string
+        defined in :attr:`~pywbem.OperationStatistic.formatted_header`.
+
+        For an example, see :meth:`pywbem.Statistics.formatted`.
         """
-        return ('{:5d}{:7.3f} {:7.3f} {:7.3f} {:5.1f} {:5d} {:5d} '
-                '{:7.1f} {:7d} {:7d} {:5d} {}\n'.
-                format(self.count, self.avg_time, self.min_time, self.max_time,
-                       self.avg_req_len, self.min_req_len, self.max_req_len,
-                       self.avg_reply_len, self.min_reply_len,
-                       self.max_reply_len, self.exception_count, self.name))
+        return ('{:5d} {:5d} {:7.3f} {:7.3f} {:7.3f} {:6.0f} {:6.0f} {:6.0f} '
+                '{:8.0f} {:8.0f} {:8.0f} {}\n'.
+                format(self.count, self.exception_count,
+                       self.avg_time, self.min_time, self.max_time,
+                       self.avg_request_len, self.min_request_len,
+                       self.max_request_len, self.avg_reply_len,
+                       self.min_reply_len, self.max_reply_len,
+                       self.name))
 
 
 class Statistics(object):
     """
-    Statistics is a container for multiple statistics capture objects each
-    defined by the :class:`~pywbem.OperationStatistic`).
+    A container class for multiple operation statistic objects (of class
+    :class:`~pywbem.OperationStatistic`).
 
-    Each capture object is identified by a name defined in the start_timer
-    method.
+    Each operation statistic object is identified by a name, that is defined
+    in the :meth:`~pywbem.Statistics.start_timer` method.
 
     The statistics container can be in a state of enabled or disabled.
-    If enabled, it accumulates the elapsed times between subsequent calls to the
-    :meth:`~pywbem.OperationStatistic.start_timer` and
-     :meth:`~pywbem.OperationStatistic.stop_timer`
-    methods of class :class:`~pywbem.OperationStatistic`.
+    If enabled, it accumulates the elapsed times between subsequent calls to
+    the :meth:`~pywbem.OperationStatistic.start_timer` and
+    :meth:`~pywbem.OperationStatistic.stop_timer` methods of class
+    :class:`~pywbem.OperationStatistic`.
     If disabled, calls to these methods do not accumulate any time.
+    Initially, the statistics container is disabled. Its enablement state can
+    be controlled via the :meth:`~pywbem.Statistics.enable` and
+    :meth:`~pywbem.Statistics.disable` methods. Its current enablement
+    state can be accessed via the :attr:`~pywbem.Statistics.enabled`
+    property.
 
-    Initially, the statistics container is disabled.
+    **Experimental:** This class is experimental for this release.
     """
 
-    def __init__(self, enabled=False):
-        self._enabled = enabled
-        self._time_stats = {}
+    def __init__(self, enable=False):
+        """
+        Parameters:
+
+          enable (:class:`py:bool`):
+            Initial enablement status for this statistics container.
+        """
+        # We convert any non-boolean values to True/False:
+        self._enabled = bool(enable)
+        self._op_stats = {}
         self._disabled_stats = OperationStatistic(self, "disabled")
 
     @property
@@ -384,45 +430,45 @@ class Statistics(object):
 
     def start_timer(self, name):
         """
-        Start the timer for a defined timer name. If that  timer name does not
-        exist, it is created in Statistics.
+        Start the timer for a given operation name and return the corresponding
+        :class:`~pywbem.OperationStatistic` object, creating one if needed.
 
         Parameters:
 
           name (string):
-            Name of the timer.
+            Name of the operation.
 
         Returns:
 
-          OperationStatistic: The time statistics for the specified name. If
-          the statistics container is disabled, a dummy time statistics object
-          is returned.
+          :class:`~pywbem.OperationStatistic`: The operation statistic for the
+          specified name. If this statistics container is disabled, a dummy
+          operation statistic object is returned.
         """
-        named_statistic = self.get_named_statistic(name)
-        named_statistic.start_timer()
-        return named_statistic
+        op_stat = self.get_op_statistic(name)
+        op_stat.start_timer()
+        return op_stat
 
-    def get_named_statistic(self, name):
+    def get_op_statistic(self, name):
         """
-        Get the OperationStatistic instance for a name or create a new
-        OperationStatistic instance if that name does not exist
+        Get the :class:`~pywbem.OperationStatistic` object for an operation
+        name or create a new object if an object for that name does not exist.
 
         Parameters:
 
           name (string):
-            Name of the timer.
+            Name of the operation.
 
         Returns:
 
-          OperationStatistic: The time statistics for the specified name. If
-          the statistics container is disabled, a dummy time statistics object
-          is returned.
+          :class:`~pywbem.OperationStatistic`: The operation statistic for the
+          specified operation name. If this statistics container is disabled,
+          a dummy operation statistic object is returned.
         """
         if not self.enabled:
             return self._disabled_stats
-        if name not in self._time_stats:
-            self._time_stats[name] = OperationStatistic(self, name)
-        return self._time_stats[name]
+        if name not in self._op_stats:
+            self._op_stats[name] = OperationStatistic(self, name)
+        return self._op_stats[name]
 
     def snapshot(self):
         """
@@ -440,24 +486,36 @@ class Statistics(object):
           - stats (:class:`~pywbem.OperationStatistic`): Time statistics for
             the operation
         """
-        return copy.deepcopy(self._time_stats).items()
+        return copy.deepcopy(self._op_stats).items()
 
-    def __str__(self):
-        """ Return a human readable display of the contents"""
-        for stat in self._time_stats:
-            print(stat)
-
-    def display(self):
+    def __repr__(self):
         """
-        Return a display formatted string with the time statistics for this
-        container. The operations are sorted by decreasing average time.
-
-        Note that this display is simplistic and assumes max size of the
-        statistics for formatting.
+        Return a human readable display of the contents, for debug purposes.
         """
-        ret = "Statistics (time in sec. Length in char. Exc: Exceptions):\n"
+        ret = "Statistics(\n"
+        for name in self._op_stats:
+            ret += "  %r\n" % self._op_stats[name]
+        ret += ")"
+        return ret
+
+    def formatted(self):
+        # pylint: disable=line-too-long
+        """
+        Return a human readable string with the statistics for this container.
+        The operations are sorted by decreasing average time.
+
+        Example::
+
+            Statistics (times in seconds, lengths in Bytes):
+            Count ExcCt    Time    Time    Time ReqLen ReqLen ReqLen ReplyLen ReplyLen ReplyLen Operation
+                            Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
+                3     0   0.234   0.100   0.401   1233   1000   1500    26667    20000    35000 EnumerateInstances
+                1     0   0.100   0.100   0.100   1200   1200   1200    22000    22000    22000 EnumerateInstanceNames
+        """  # noqa: E501
+        # pylint: enable=line-too-long
+        ret = "Statistics (times in seconds, lengths in Bytes):\n"
         if self.enabled:
-            ret += OperationStatistic.display_col_hdr
+            ret += OperationStatistic.formatted_header
             snapshot = sorted(self.snapshot(),
                               key=lambda item: item[1].avg_time,
                               reverse=True)

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -349,9 +349,9 @@ class OperationStatistic(object):
     #:
     #: For an example, see :meth:`pywbem.Statistics.formatted`.
     formatted_header = \
-        'Count ExcCt    Time    Time    Time ReqLen ReqLen ReqLen ' \
+        'Count Excep    Time    Time    Time ReqLen ReqLen ReqLen ' \
         'ReplyLen ReplyLen ReplyLen Operation\n' \
-        '                Avg     Min     Max    Avg    Min    Max ' \
+        '        Cnt     Avg     Min     Max    Avg    Min    Max ' \
         '     Avg      Min      Max\n'
 
     def formatted(self):
@@ -507,10 +507,10 @@ class Statistics(object):
         Example::
 
             Statistics (times in seconds, lengths in Bytes):
-            Count ExcCt    Time    Time    Time ReqLen ReqLen ReqLen ReplyLen ReplyLen ReplyLen Operation
-                            Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
-                3     0   0.234   0.100   0.401   1233   1000   1500    26667    20000    35000 EnumerateInstances
-                1     0   0.100   0.100   0.100   1200   1200   1200    22000    22000    22000 EnumerateInstanceNames
+            Count  Exc    Time    Time    Time ReqLen ReqLen ReqLen ReplyLen ReplyLen ReplyLen Operation
+                   Cnt    Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
+                3    0   0.234   0.100   0.401   1233   1000   1500    26667    20000    35000 EnumerateInstances
+                1    0   0.100   0.100   0.100   1200   1200   1200    22000    22000    22000 EnumerateInstanceNames
         """  # noqa: E501
         # pylint: enable=line-too-long
         ret = "Statistics (times in seconds, lengths in Bytes):\n"

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 #
-# (C) Copyright 2003-2007 Hewlett-Packard Development Company, L.P.
-# (C) Copyright 2006-2007 Novell, Inc.
+# (C) Copyright 2017 InovaDevelopment Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -34,6 +32,9 @@ a new named statistic  category.
 The :class:`~pywbem.Statistics` class maintins time statistics over
 multiple separate named statistics gatherers (TimeStatistic class) and provides
 tools for reporting these statistics
+
+**Experimental:** The statistics functions are experimental for this
+release***.
 
 """
 

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -364,8 +364,8 @@ class OperationStatistic(object):
 
         For an example, see :meth:`pywbem.Statistics.formatted`.
         """
-        return ('{:5d} {:5d} {:7.3f} {:7.3f} {:7.3f} {:6.0f} {:6.0f} {:6.0f} '
-                '{:8.0f} {:8.0f} {:8.0f} {}\n'.
+        return ('{0:5d} {1:5d} {2:7.3f} {3:7.3f} {4:7.3f} {5:6.0f} {6:6.0f} '
+                 '{7:6.0f} {8:8.0f} {9:8.0f} {10:8.0f} {11}\n'.
                 format(self.count, self.exception_count,
                        self.avg_time, self.min_time, self.max_time,
                        self.avg_request_len, self.min_request_len,

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -365,7 +365,7 @@ class OperationStatistic(object):
         For an example, see :meth:`pywbem.Statistics.formatted`.
         """
         return ('{0:5d} {1:5d} {2:7.3f} {3:7.3f} {4:7.3f} {5:6.0f} {6:6.0f} '
-                 '{7:6.0f} {8:8.0f} {9:8.0f} {10:8.0f} {11}\n'.
+                '{7:6.0f} {8:8.0f} {9:8.0f} {10:8.0f} {11}\n'.
                 format(self.count, self.exception_count,
                        self.avg_time, self.min_time, self.max_time,
                        self.avg_request_len, self.min_request_len,

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python
+#
+# (C) Copyright 2003-2007 Hewlett-Packard Development Company, L.P.
+# (C) Copyright 2006-2007 Novell, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+"""
+The :class:`~pywbem.Statistics` class allows measuring the elapsed
+time and request/reply length of WBEM Operations and keeping statistics on the
+measured times
+
+It consists of two classes:
+
+The :class:`~pywbem.OperationStatistic` class is a helper class that contains
+the actual measurement data for all invocations of a particular name. Its
+objects are under control of the :class:`~pywbem.Statistics` class.
+This class should be used independently.  Use the start_timer in the
+Statistics class to both start a timer and if it does not exist, create
+a new named statistic  category.
+
+The :class:`~pywbem.Statistics` class maintins time statistics over
+multiple separate named statistics gatherers (TimeStatistic class) and provides
+tools for reporting these statistics
+
+"""
+
+from __future__ import absolute_import
+
+import time
+import copy
+
+__all__ = ['Statistics']
+
+
+class OperationStatistic(object):
+    """
+    Elapsed time information for all invocations of a particular named
+    operation.
+
+    This class maintains max, min, avg and count for a single named
+    statistic for time, request length and reply length.
+
+    Use :meth:`pywbem.Statistics.get_statistic` method  to
+    create objects of this class.
+
+    Ex:
+
+        stats = container.start_timer('EnumerateInstances')
+        ...
+        stats.stop_timer(req_len, reply_len, exception=True)
+    """
+    display_col_hdr = \
+        'Count  Time    Time    Time  Req     Req   Req   Reply     Reply ' \
+        'Reply Exc Name\n' \
+        '       Avg     Min     Max   Avg     Min   Max   Avg       Min ' \
+        'Max   \n'
+
+    def __init__(self, container, name):
+        """
+        Parameters:
+
+          container (Statistics):
+            The statistics container that holds this time statistics.
+
+          name (string):
+            Name of the operation.
+        """
+        self._container = container
+        self._stat_start_time = None
+        self._name = name
+        self._count = 0
+        self._exception_count = 0
+        self._time_sum = float(0)
+        self._time_min = float('inf')
+        self._time_max = float(0)
+        self._start_time = None
+
+        self._req_len_sum = float(0)
+        self._req_len_min = float('inf')
+        self._req_len_max = float(0)
+
+        self._reply_len_sum = float(0)
+        self._reply_len_min = float('inf')
+        self._reply_len_max = float(0)
+
+    @property
+    def stat_start_time(self):
+        """
+        :py:time: Time the first statistic was taken since this object
+        was either created or reset.
+        """
+        return self._stat_start_time
+
+    @property
+    def name(self):
+        """
+        :term:`string`: Name for a sequence of time statistics that represents
+        a single entitiy (ex. pywbem operation name)
+
+        This name is used by the :class:`~pywbem.Statistics` object
+        holding this time statistics as a key.
+        """
+        return self._name
+
+    @property
+    def container(self):
+        """
+        :class:`~pywbem.Statistics`: This time statistics container.
+        """
+        return self._container
+
+    @property
+    def count(self):
+        """
+        :term:`integer`: The number of invocations of the start_timer() and
+        stop_timer()).
+        """
+        return self._count
+
+    @property
+    def avg_time(self):
+        """
+        float: The average elapsed time for invoking the operation, in seconds.
+        """
+        try:
+            return self._time_sum / self._count
+        except ZeroDivisionError:
+            return 0
+
+    @property
+    def min_time(self):
+        """
+        float: The minimum elapsed time for invoking the operation, in seconds.
+        """
+        return self._time_min
+
+    @property
+    def max_time(self):
+        """
+        float: The maximum elapsed time for invoking the operation, in seconds.
+        """
+        return self._time_max
+
+    @property
+    def avg_req_len(self):
+        """
+        float: The average elapsed time for invoking the operation, in seconds.
+        """
+        try:
+            return self._req_len_sum / self._count
+        except ZeroDivisionError:
+            return 0
+
+    @property
+    def min_req_len(self):
+        """
+        float: The minimum elapsed time for invoking the operation, in seconds.
+        """
+        return self._req_len_min
+
+    @property
+    def max_req_len(self):
+        """
+        float: The maximum elapsed time for invoking the operation, in seconds.
+        """
+        return self._req_len_max
+
+    @property
+    def avg_reply_len(self):
+        """
+        float: The average elapsed time for invoking the operation, in seconds.
+        """
+        try:
+            return self._reply_len_sum / self._count
+        except ZeroDivisionError:
+            return 0
+
+    @property
+    def min_reply_len(self):
+        """
+        float: The minimum elapsed time for invoking the operation, in seconds.
+        """
+        return self._reply_len_min
+
+    @property
+    def max_reply_len(self):
+        """
+        float: The maximum elapsed time for invoking the operation, in seconds.
+        """
+        return self._reply_len_max
+
+    @property
+    def exception_count(self):
+        """
+            :py:time: Count of exceptions that occurred for named operation
+        """
+        return self._exception_count
+
+    def reset(self):
+        """
+        Reset the statistics data.
+        """
+        self._count = 0
+        self._exception_count = 0
+        self._stat_start_time = None
+        self._time_sum = float(0)
+        self._time_min = float('inf')
+        self._time_max = float(0)
+
+        self._req_len_sum = float(0)
+        self._req_len_min = float('inf')
+        self._req_len_max = float(0)
+
+        self._reply_len_sum = float(0)
+        self._reply_len_min = float('inf')
+        self._reply_len_max = float(0)
+
+    def start_timer(self):
+        """
+        This method starts the timer for this OperationStatistic object if
+        the container is enabled.
+
+        A subsequent :meth:`~pywbem.OperationStatistic.stop_timer` computes the
+        statistics for the time duration between the start and stop for this
+        :meth:`~pywbem.OperationStatistic.
+
+        If the statistics container holding this time statistics is disabled,
+        this method does nothing.
+        """
+        if self.container.enabled:
+            self._start_time = time.time()
+            if not self._stat_start_time:
+                self._stat_start_time = self._start_time
+
+    def stop_timer(self, req_len, reply_len, exception=False):
+        """
+        This method is called at the completion of the timed event. It
+        captures current time, computes the event duration since the
+        corresponding :meth:`~pywbem.OperationStatistic.start_timer` and
+        computes average, max, and min for the timedduration, request length,
+        and response length if the container is enabled.
+
+        Parameters:
+          req_len (:term:`integer`)
+            Integer value of the request length
+
+          reply_len (:term:`integer`)
+            Integer value of the reply length
+
+          exception (:class:`py:bool`)
+            If True, add one to the exception accumulator
+
+        If the statistics container is disabled, this method does nothing.
+
+        Returns the time for this operation or None if not recorded
+        """
+        if self.container.enabled:
+            if self._start_time is None:
+                raise RuntimeError('stop_timer() called without preceding '
+                                   ' start_timer()')
+            dt = time.time() - self._start_time
+            self._start_time = None
+            self._count += 1
+            self._time_sum += dt
+            self._req_len_sum += req_len
+            self._reply_len_sum += reply_len
+
+            if exception:
+                self._exception_count += 1
+
+            if dt > self._time_max:
+                self._time_max = dt
+            if dt < self._time_min:
+                self._time_min = dt
+
+            if req_len > self._req_len_max:
+                self._req_len_max = req_len
+            if req_len < self._req_len_min:
+                self._req_len_min = req_len
+
+            if reply_len > self._reply_len_max:
+                self._reply_len_max = reply_len
+            if reply_len < self._reply_len_min:
+                self._reply_len_min = reply_len
+
+            return dt
+        else:
+            return None
+
+    def __str__(self):
+        """
+        Return a human readable string with the time statistics for this
+        name.
+        """
+        return 'Operations Statistic: {} count={:d} AvgTime={:.3f}s ' \
+               'MinTime={:.3f}s '\
+               'MaxTime={:.3f}s exceptions={:d} ' \
+               'AvgReq={:.3f}s MinReq={:.3f}s MaxReq={:.3f}s ' \
+               'AvgReq={:.3f}s MinReq={:.3f}s MaxReq={:.3f}s'. \
+               format(self.name,
+                      self.count,
+                      self.avg_time,
+                      self.min_time,
+                      self.max_time,
+
+                      self.avg_req_len,
+                      self.min_req_len,
+                      self.max_req_len,
+
+                      self.avg_reply_len,
+                      self.min_reply_len,
+                      self.max_reply_len,
+                      self.exception_count)
+
+    def formatted(self):
+        """
+        Returns a formatted OperationStatistic consistent with the display
+        header.  The formatting must match the header formatting in
+
+        """
+        return ('{:5d}{:7.3f} {:7.3f} {:7.3f} {:5.1f} {:5d} {:5d} '
+                '{:7.1f} {:7d} {:7d} {:5d} {}\n'.
+                format(self.count, self.avg_time, self.min_time, self.max_time,
+                       self.avg_req_len, self.min_req_len, self.max_req_len,
+                       self.avg_reply_len, self.min_reply_len,
+                       self.max_reply_len, self.exception_count, self.name))
+
+
+class Statistics(object):
+    """
+    Statistics is a container for multiple statistics capture objects each
+    defined by the :class:`~pywbem.OperationStatistic`).
+
+    Each capture object is identified by a name defined in the start_timer
+    method.
+
+    The statistics container can be in a state of enabled or disabled.
+    If enabled, it accumulates the elapsed times between subsequent calls to the
+    :meth:`~pywbem.OperationStatistic.start_timer` and
+     :meth:`~pywbem.OperationStatistic.stop_timer`
+    methods of class :class:`~pywbem.OperationStatistic`.
+    If disabled, calls to these methods do not accumulate any time.
+
+    Initially, the statistics container is disabled.
+    """
+
+    def __init__(self, enabled=False):
+        self._enabled = enabled
+        self._time_stats = {}
+        self._disabled_stats = OperationStatistic(self, "disabled")
+
+    @property
+    def enabled(self):
+        """
+        Indicates whether the statistics container is enabled.
+        """
+        return self._enabled
+
+    def enable(self):
+        """
+        Enable the statistics container.
+        """
+        self._enabled = True
+
+    def disable(self):
+        """
+        Disable the statistics container.
+        """
+        self._enabled = False
+
+    def start_timer(self, name):
+        """
+        Start the timer for a defined timer name. If that  timer name does not
+        exist, it is created in Statistics.
+
+        Parameters:
+
+          name (string):
+            Name of the timer.
+
+        Returns:
+
+          OperationStatistic: The time statistics for the specified name. If
+          the statistics container is disabled, a dummy time statistics object
+          is returned.
+        """
+        named_statistic = self.get_named_statistic(name)
+        named_statistic.start_timer()
+        return named_statistic
+
+    def get_named_statistic(self, name):
+        """
+        Get the OperationStatistic instance for a name or create a new
+        OperationStatistic instance if that name does not exist
+
+        Parameters:
+
+          name (string):
+            Name of the timer.
+
+        Returns:
+
+          OperationStatistic: The time statistics for the specified name. If
+          the statistics container is disabled, a dummy time statistics object
+          is returned.
+        """
+        if not self.enabled:
+            return self._disabled_stats
+        if name not in self._time_stats:
+            self._time_stats[name] = OperationStatistic(self, name)
+        return self._time_stats[name]
+
+    def snapshot(self):
+        """
+        Return a snapshot of the time statistics of this container.
+
+        The snapshot represents the statistics data at the time this method
+        is called, and remains unchanged even if the statistics of this
+        container continues to be updated.
+
+        Returns:
+
+          : A list of tuples (name, stats) with:
+
+          - name (:term:`string`): Name of the operation
+          - stats (:class:`~pywbem.OperationStatistic`): Time statistics for
+            the operation
+        """
+        return copy.deepcopy(self._time_stats).items()
+
+    def __str__(self):
+        """ Return a human readable display of the contents"""
+        for stat in self._time_stats:
+            print(stat)
+
+    def display(self):
+        """
+        Return a display formatted string with the time statistics for this
+        container. The operations are sorted by decreasing average time.
+
+        Note that this display is simplistic and assumes max size of the
+        statistics for formatting.
+        """
+        ret = "Statistics (time in sec. Length in char. Exc: Exceptions):\n"
+        if self.enabled:
+            ret += OperationStatistic.display_col_hdr
+            snapshot = sorted(self.snapshot(),
+                              key=lambda item: item[1].avg_time,
+                              reverse=True)
+            for name, stats in snapshot:  # pylint: disable=unused-variable
+                ret += stats.formatted()
+        else:
+            ret += "Disabled"
+        return ret.strip()

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -703,8 +703,7 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
 
     header_tuples = []
     header_tuples.append(('Content-type', 'application/xml; charset="utf-8"'))
-    # TODO we are doing length twice.
-    header_tuples.append(('Content-length', len(data)))
+    header_tuples.append(('Content-length', str(len(data))))
     if local_auth_header is not None:
         # The following pylint stmt disables a false positive, see
         # https://github.com/PyCQA/pylint/issues/701

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -703,7 +703,8 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
 
     header_tuples = []
     header_tuples.append(('Content-type', 'application/xml; charset="utf-8"'))
-    header_tuples.append(('Content-length', str(len(data))))
+    # TODO we are doing length twice.
+    header_tuples.append(('Content-length', len(data)))
     if local_auth_header is not None:
         # The following pylint stmt disables a false positive, see
         # https://github.com/PyCQA/pylint/issues/701

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -4877,7 +4877,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             exc = exce
             raise
         finally:
-            print('Before finally req %s, reply %s, exc %s' % (self.last_request_len, self.last_reply_len, exc))
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len, exc)
             print('finally optim %s' % self._last_operation_time)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -4877,8 +4877,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             exc = exce
             raise
         finally:
+            print('Before finally req %s, reply %s, exc %s' % (self.last_request_len, self.last_reply_len, exc))
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len, exc)
+            print('finally optim %s' % self._last_operation_time)
             if self.operation_recorder:
                 self.operation_recorder.stage_pywbem_result(result_tuple, exc)
                 self.operation_recorder.record_staged()

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1002,8 +1002,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self.last_reply = None
 
         # Send request and receive response
+        self.last_request_len = 0
+        self.last_reply_len = 0
         try:
             request_data = req_xml.toxml()
+            self.last_request_len = len(request_data)
             reply_xml = wbem_request(
                 self.url, request_data, self.creds, headers,
                 x509=self.x509,
@@ -1013,16 +1016,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 timeout=self.timeout,
                 debug=self.debug,
                 recorder=self.operation_recorder)
-            self.last_request_len = len(request_data)
             self.last_reply_len = len(reply_xml)
         except (AuthError, ConnectionError, TimeoutError, Error):
-            self.last_reply_len = 0
             raise
         # TODO 3/16 AM: Clean up exception handling. The next two lines are a
         # workaround in order not to ignore TypeError and other exceptions
         # that may be raised.
         except Exception:
-            self.last_reply_len = 0
             raise
 
         # Set the raw response before parsing (which can fail)
@@ -1249,8 +1249,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         # Send request and receive response
 
+        self.last_request_len = 0
+        self.last_reply_len = 0
         try:
             request_data = req_xml.toxml()
+            self.last_request_len = len(request_data)
             reply_xml = wbem_request(
                 self.url, request_data, self.creds, headers,
                 x509=self.x509,
@@ -1260,16 +1263,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 timeout=self.timeout,
                 debug=self.debug,
                 recorder=self.operation_recorder)
-            self.last_request_len = len(request_data)
             self.last_reply_len = len(reply_xml)
         except (AuthError, ConnectionError, TimeoutError, Error):
-            self.last_reply_len = 0
             raise
         # TODO 3/16 AM: Clean up exception handling. The next two lines are a
         # workaround in order not to ignore TypeError and other exceptions
         # that may be raised.
         except Exception:
-            self.last_reply_len = 0
             raise
 
         # Set the raw response before parsing and checking (which can fail)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -816,6 +816,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             WBEM operations executed via this connection. See the
             :ref:`Statistics` section for details.
 
+            Statistics may also be enabled or disabled with the WBEMConnection
+            property `stats_enabled`. This may be used to view the current
+            status or change the status (ex. `conn.stats_enabled(False)`)
+
             **Experimental:** This argument is experimental for this release.
         """
 
@@ -895,7 +899,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def last_operation_time(self):
         """
         :class:`py:float`: Elapsed time of the last operation that was executed
-        via this connection.
+        via this connection in seconds.
 
         This time is available only subsequent to the execution of an operation
         on this connection, and if the statistics are enabled on this

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -182,10 +182,20 @@ class ClientTest(unittest.TestCase):
         last_reply = self.conn.last_reply or self.conn.last_raw_reply
         self.log('Reply:\n\n%s\n' % last_reply)
 
+        # account for issue where last operation exception, in particular
+        # those few exceptions that occur outside of the try block in the
+        # Iter... operations.
         if self.enable_stats:
-            print('Operation info time %.3f req_len %s reply_len %s' %
-                  (self.conn.last_operation_time, self.conn.last_request_len,
-                   self.conn.last_reply_len))
+            if not self.conn.last_operation_time:
+                print('Operation info time %s req_len %s reply_len %s' %
+                      (self.conn.last_operation_time,
+                       self.conn.last_request_len,
+                       self.conn.last_reply_len))
+            else:
+                print('Operation info time %.3f req_len %s reply_len %s' %
+                      (self.conn.last_operation_time,
+                       self.conn.last_request_len,
+                       self.conn.last_reply_len))
 
         return result
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -149,7 +149,7 @@ class ClientTest(unittest.TestCase):
         if self.enable_stats:
             print('%s: Test time %.2f sec.' % (self.id(),
                                                (time.time() - self.start_time)))
-            print('%s\n%s' % (self.id(), self.conn.statistics.display()))
+            print('%s\n%s' % (self.id(), self.conn.statistics.formatted()))
 
         if self.yamlfp is not None:
             self.yamlfp.close()
@@ -184,7 +184,7 @@ class ClientTest(unittest.TestCase):
 
         if self.enable_stats:
             print('Operation info time %.3f req_len %s reply_len %s' %
-                  (self.conn.last_operation_time, self.conn.last_req_len,
+                  (self.conn.last_operation_time, self.conn.last_request_len,
                    self.conn.last_reply_len))
 
         return result
@@ -5079,7 +5079,7 @@ class IterReferenceInstancePaths(PegasusServerTestBase):
 
 
 class IterAssociatorInstances(PegasusServerTestBase):
-    """Test IterAssociatorInstancePaths methods"""
+    """Test IterAssociatorInstances methods"""
 
     def get_source_name(self):
         """

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -110,6 +110,9 @@ class ClientTest(unittest.TestCase):
         self.debug = CLI_ARGS['debug']
         self.yamlfile = CLI_ARGS['yamlfile']
         self.yamlfp = None
+        self.enable_stats = True if CLI_ARGS['stats'] else False
+        if self.enable_stats:
+            self.start_time = time.time()
 
         # set this because python 3 http libs generate many ResourceWarnings
         # and unittest enables these warnings.
@@ -127,7 +130,8 @@ class ClientTest(unittest.TestCase):
             timeout=CLI_ARGS['timeout'],
             no_verification=CLI_ARGS['nvc'],
             ca_certs=CLI_ARGS['cacerts'],
-            use_pull_operations=use_pull_operations)
+            use_pull_operations=use_pull_operations,
+            enable_stats=self.enable_stats)
 
         # enable saving of xml for display
         self.conn.debug = CLI_ARGS['debug']
@@ -141,6 +145,11 @@ class ClientTest(unittest.TestCase):
 
     def tearDown(self):
         """Close the test_client YAML file."""
+
+        if self.enable_stats:
+            print('%s: Test time %.2f sec.' % (self.id(),
+                                               (time.time() - self.start_time)))
+            print('%s\n%s' % (self.id(), self.conn.statistics.display()))
 
         if self.yamlfp is not None:
             self.yamlfp.close()
@@ -172,6 +181,11 @@ class ClientTest(unittest.TestCase):
         self.log('Request:\n\n%s\n' % last_request)
         last_reply = self.conn.last_reply or self.conn.last_raw_reply
         self.log('Reply:\n\n%s\n' % last_reply)
+
+        if self.enable_stats:
+            print('Operation info time %.3f req_len %s reply_len %s' %
+                  (self.conn.last_operation_time, self.conn.last_req_len,
+                   self.conn.last_reply_len))
 
         return result
 
@@ -2550,6 +2564,14 @@ class Associators(ClientTest):
             for inst in ref_insts:
                 self.assertEqual(inst.classname, 'PyWBEM_PersonCollection')
 
+    def test_invalid_classname(self):
+        """Test fail with invalid classname"""
+        try:
+            self.cimcall(self.conn.Associators, 'CIM_BlanBlahBlah')
+        except CIMError as ce:
+            if ce.args[0] != CIM_ERR_INVALID_PARAMETER:
+                raise
+
     @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
     def test_all_class_associators(self):
         """Test getting associator classes for all classes in a namespace."""
@@ -2698,6 +2720,14 @@ class AssociatorNames(ClientTest):
             self.assertTrue(len(ref_inst_names) > 0)
             self.assertInstanceNamesValid(ref_inst_names)
 
+    def test_invalid_classname(self):
+        """Test fail with invalid classname"""
+        try:
+            self.cimcall(self.conn.AssociatorNames, 'CIM_BlanBlahBlah')
+        except CIMError as ce:
+            if ce.args[0] != CIM_ERR_INVALID_PARAMETER:
+                raise
+
     @unittest.skipIf(SKIP_LONGRUNNING_TEST, 'skip long test')
     def test_all_class_associatornames(self):
         """Test getting associator classes for all classes in a namespace."""
@@ -2805,6 +2835,14 @@ class References(ClientTest):
                 self.assertEqual(inst.classname,
                                  PYWBEM_MEMBEROFPERSONCOLLECTION)
 
+    def test_invalid_classname(self):
+        """Test fail with invalid classname"""
+        try:
+            self.cimcall(self.conn.References, 'CIM_BlanBlahBlah')
+        except CIMError as ce:
+            if ce.args[0] != CIM_ERR_INVALID_PARAMETER:
+                raise
+
 
 class ReferenceNames(ClientTest):
 
@@ -2885,6 +2923,14 @@ class ReferenceNames(ClientTest):
             # for inst in ref_insts:
             #    self.assertEqual(inst.classname,
             #        PYWBEM_MEMBEROFPERSONCOLLECTION)
+
+    def test_invalid_classname(self):
+        """Test fail with invalid classname"""
+        try:
+            self.cimcall(self.conn.ReferenceNames, 'CIM_BlanBlahBlah')
+        except CIMError as ce:
+            if ce.args[0] != CIM_ERR_INVALID_PARAMETER:
+                raise
 
 
 #################################################################
@@ -5383,7 +5429,7 @@ class IterAssociatorInstancePaths(PegasusServerTestBase):
 
 class IterQueryInstances(PegasusServerTestBase):
 
-    def test_simple_iter_queryinstances(self):
+    def test_simple_iter_queryinstances(self):  # pylint: disable=invalid-name
         try:
             # Simplest invocation
 
@@ -6383,7 +6429,8 @@ def parse_args(argv_):
         print('    -nvc                Do not verify server certificates.')
         print('    --cacerts           File/dir with ca certificate(s).')
         print('    --yamlfile yamlfile  Test_client YAML file to be recorded.')
-
+        print('    --stats             If set, statistics are generated')
+        print('                        and displayed.')
         print('    UT_OPTS             Unittest options (see below).')
         print('    UT_CLASS            Name of testcase class (e.g.\n'
               '                        EnumerateInstances).')
@@ -6430,6 +6477,7 @@ def parse_args(argv_):
     args_['nvc'] = None
     args_['yamlfile'] = None
     args_['long_running'] = None
+    args_['stats'] = None
 
     # options must proceed arguments
     while True:
@@ -6453,6 +6501,9 @@ def parse_args(argv_):
             del argv[1:2]
         elif argv[1] == '-d':
             args_['debug'] = True
+            del argv[1:2]
+        elif argv[1] == '--stats':
+            args_['stats'] = True
             del argv[1:2]
         elif argv[1] == '-l':
             args_['long_running'] = True
@@ -6499,6 +6550,7 @@ def main():
         print("  cacerts: %s" % CLI_ARGS['cacerts'])
         print("  timeout: %s" % CLI_ARGS['timeout'])
         print("  verbose: %s" % CLI_ARGS['verbose'])
+        print("  stats: %s" % CLI_ARGS['stats'])
         print("  debug: %s" % CLI_ARGS['debug'])
         print("  yamlfile: %s" % CLI_ARGS['yamlfile'])
         print("  long_running: %s" % CLI_ARGS['long_running'])

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -635,15 +635,15 @@ class ClientTest(unittest.TestCase):
         # get the expected result.  This may be either the the definition
         # of a value or cimobject or a list of values or cimobjects or
         # a named tuple of results.
-        exp_req_len = tc_getattr_list(tc_name, exp_pywbem_response, "req_len",
-                                      None)
+        exp_request_len = tc_getattr_list(tc_name, exp_pywbem_response,
+                                          "request_len", None)
         exp_reply_len = tc_getattr_list(tc_name, exp_pywbem_response,
                                         "reply_len", None)
-        exp_result = tc_getattr_list(tc_name, exp_pywbem_response, "result",
-                                     None)
+        exp_result = tc_getattr_list(tc_name, exp_pywbem_response,
+                                     "result", None)
 
-        exp_pull_result = tc_getattr(tc_name, exp_pywbem_response, "pullresult",
-                                     None)
+        exp_pull_result = tc_getattr(tc_name, exp_pywbem_response,
+                                     "pullresult", None)
 
         if exp_pull_result and exp_result:
             raise ClientTestError("Error in definition of testcase %s: "
@@ -711,10 +711,11 @@ class ClientTest(unittest.TestCase):
             exp_data = tc_getattr(tc_name, exp_http_request, "data", None)
             self.assertXMLEqual(http_request.body, exp_data,
                                 "Unexpected CIM-XML payload in HTTP request")
-        if exp_req_len is not None:
-            self.assertEqual(exp_req_len, conn.last_req_len, 'request lengths '
+        if exp_request_len is not None:
+            self.assertEqual(exp_request_len, conn.last_request_len,
+                             'request lengths '
                              'do not match. exp %s rcvd %s' %
-                             (exp_req_len, conn.last_req_len))
+                             (exp_request_len, conn.last_request_len))
 
         if exp_reply_len is not None:
             self.assertEqual(exp_reply_len, conn.last_reply_len, 'ply '

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -716,8 +716,7 @@ class ClientTest(unittest.TestCase):
                                 "Unexpected CIM-XML payload in HTTP request")
         if exp_request_len is not None:
             self.assertEqual(exp_request_len, conn.last_request_len,
-                             'request lengths '
-                             'do not match. exp %s rcvd %s' %
+                             'request lengths do not match. exp %s rcvd %s' %
                              (exp_request_len, conn.last_request_len))
 
             if conn.stats_enabled:
@@ -732,8 +731,8 @@ class ClientTest(unittest.TestCase):
                 self.assertEqual(stat.min_request_len, exp_request_len)
 
         if exp_reply_len is not None:
-            self.assertEqual(exp_reply_len, conn.last_reply_len, 'ply '
-                             'lengths do not match. exp %s rcvd %s' %
+            self.assertEqual(exp_reply_len, conn.last_reply_len,
+                             'Reply lengths do not match. exp %s rcvd %s' %
                              (exp_reply_len, conn.last_reply_len))
 
             if conn.stats_enabled:

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -576,7 +576,9 @@ class ClientTest(unittest.TestCase):
             url=tc_getattr(tc_name, pywbem_request, "url"),
             creds=tc_getattr(tc_name, pywbem_request, "creds"),
             default_namespace=tc_getattr(tc_name, pywbem_request, "namespace"),
-            timeout=tc_getattr(tc_name, pywbem_request, "timeout"))
+            timeout=tc_getattr(tc_name, pywbem_request, "timeout"),
+            enable_stats=tc_getattr(tc_name, pywbem_request, "enable-stats",
+                                    False))
 
         conn.debug = tc_getattr(tc_name, pywbem_request, "debug", False)
 
@@ -633,6 +635,10 @@ class ClientTest(unittest.TestCase):
         # get the expected result.  This may be either the the definition
         # of a value or cimobject or a list of values or cimobjects or
         # a named tuple of results.
+        exp_req_len = tc_getattr_list(tc_name, exp_pywbem_response, "req_len",
+                                      None)
+        exp_reply_len = tc_getattr_list(tc_name, exp_pywbem_response,
+                                        "reply_len", None)
         exp_result = tc_getattr_list(tc_name, exp_pywbem_response, "result",
                                      None)
 
@@ -705,6 +711,15 @@ class ClientTest(unittest.TestCase):
             exp_data = tc_getattr(tc_name, exp_http_request, "data", None)
             self.assertXMLEqual(http_request.body, exp_data,
                                 "Unexpected CIM-XML payload in HTTP request")
+        if exp_req_len is not None:
+            self.assertEqual(exp_req_len, conn.last_req_len, 'request lengths '
+                             'do not match. exp %s rcvd %s' %
+                             (exp_req_len, conn.last_req_len))
+
+        if exp_reply_len is not None:
+            self.assertEqual(exp_reply_len, conn.last_reply_len, 'ply '
+                             'lengths do not match. exp %s rcvd %s' %
+                             (exp_reply_len, conn.last_reply_len))
 
         # Continue with validating the result
 

--- a/testsuite/test_statistics.py
+++ b/testsuite/test_statistics.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+"""
+Tests for statistics (`_statistics` in pywbem module).
+"""
+
+from __future__ import absolute_import, print_function
+
+import time
+import unittest
+
+from pywbem import Statistics
+
+
+def time_abs_delta(t1, t2):
+    """
+    Return the positive difference between two float values.
+    """
+    return abs(t1 - t2)
+
+
+class StatisticsTests(unittest.TestCase):
+    """All tests for Statistics and TimeCapture."""
+
+    def test_enabling(self):
+        """Test enabling and disabling."""
+
+        statistics = Statistics()
+
+        self.assertFalse(statistics.enabled,
+                         "Error: initial state is not disabled")
+
+        statistics.disable()
+        self.assertFalse(statistics.enabled,
+                         "Error: disabling a disabled statistics works")
+
+        statistics.enable()
+        self.assertTrue(statistics.enabled,
+                        "Error: enabling a disabled statistics works")
+
+        statistics.enable()
+        self.assertTrue(statistics.enabled,
+                        "Error: enabling an enabled statistics works")
+
+        statistics.disable()
+        self.assertFalse(statistics.enabled,
+                         "Errror: disabling an enabled statistics works")
+
+    def test_get(self):
+        """Test getting statistics."""
+
+        statistics = Statistics()
+        snapshot_length = len(statistics.snapshot())
+        self.assertEqual(snapshot_length, 0,
+                         "Error:  initial state has no time statistics. "
+                         "Actual number = %d" % snapshot_length)
+
+        stats = statistics.get_named_statistic('EnumerateInstances')
+        snapshot_length = len(statistics.snapshot())
+        self.assertEqual(snapshot_length, 0,
+                         "Error: getting a new stats with a disabled "
+                         "statistics results in no time statistics. "
+                         "Actual number = %d" % snapshot_length)
+        self.assertEqual(stats.container, statistics)
+        self.assertEqual(stats.name, "disabled")
+        self.assertEqual(stats.count, 0)
+        self.assertEqual(stats.avg_time, 0)
+        self.assertEqual(stats.min_time, float('inf'))
+        self.assertEqual(stats.max_time, 0)
+
+        self.assertEqual(stats.avg_req_len, 0)
+        self.assertEqual(stats.min_req_len, float('inf'))
+        self.assertEqual(stats.max_req_len, 0)
+
+        statistics.enable()
+
+        method_name = 'OpenEnumerateInstances'
+
+        stats = statistics.get_named_statistic(method_name)
+        snapshot_length = len(statistics.snapshot())
+        self.assertEqual(snapshot_length, 1,
+                         "Error: getting a new stats with an enabled "
+                         "statistics results in one time statistics. "
+                         "Actual number = %d" % snapshot_length)
+
+        self.assertEqual(stats.container, statistics)
+        self.assertEqual(stats.name, method_name)
+        self.assertEqual(stats.count, 0)
+        self.assertEqual(stats.avg_time, 0)
+        self.assertEqual(stats.min_time, float('inf'))
+        self.assertEqual(stats.max_time, 0)
+
+        statistics.get_named_statistic(method_name)
+        snapshot_length = len(statistics.snapshot())
+        self.assertEqual(snapshot_length, 1,
+                         "Error: getting an existing stats with an "
+                         "enabled statistics results in the same number of "
+                         "statistics. "
+                         "Actual number = %d" % snapshot_length)
+
+    def test_measure_enabled(self):
+        """Test measuring time with enabled statistics."""
+
+        statistics = Statistics()
+        statistics.enable()
+
+        duration = 0.4
+        # On Windows has only a precision of 1/60 sec:
+        delta = 0.04
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        for _, stats in statistics.snapshot():
+            self.assertEqual(stats.count, 1)
+            self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
+            self.assertEqual(stats.max_req_len, 100)
+            self.assertEqual(stats.min_req_len, 100)
+            self.assertEqual(stats.avg_req_len, 100)
+            self.assertEqual(stats.max_reply_len, 200)
+            self.assertEqual(stats.min_reply_len, 200)
+            self.assertEqual(stats.avg_reply_len, 200)
+
+        stats.reset()
+        self.assertEqual(stats.count, 0)
+        self.assertEqual(stats.avg_time, 0)
+        self.assertEqual(stats.min_time, float('inf'))
+        self.assertEqual(stats.max_time, 0)
+
+    def test_measure_disabled(self):
+        """Test measuring time with disabled statistics."""
+
+        statistics = Statistics()
+
+        duration = 0.2
+
+        stats = statistics.get_named_statistic('GetClass')
+        self.assertEqual(stats.name, 'disabled')
+
+        stats.start_timer()
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        for _, stats in statistics.snapshot():
+            self.assertEqual(stats.count, 0)
+            self.assertEqual(stats.avg_time, 0)
+            self.assertEqual(stats.min_time, float('inf'))
+            self.assertEqual(stats.max_time, 0)
+
+    def test_measure_avg(self):
+        """Test measuring time with enabled statistics."""
+
+        statistics = Statistics()
+        statistics.enable()
+
+        duration = 0.4
+        # On Windows has only a precision of 1/60 sec:
+        delta = 0.04
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(duration)
+        stats.stop_timer(200, 400)
+
+        for _, stats in statistics.snapshot():
+            self.assertEqual(stats.count, 2)
+            self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
+            self.assertEqual(stats.max_req_len, 200)
+            self.assertEqual(stats.min_req_len, 100)
+            self.assertEqual(stats.avg_req_len, 150)
+            self.assertEqual(stats.max_reply_len, 400)
+            self.assertEqual(stats.min_reply_len, 200)
+            self.assertEqual(stats.avg_reply_len, 300)
+
+    def test_measure_exception(self):
+        """Test measuring time with enabled statistics."""
+
+        statistics = Statistics()
+        statistics.enable()
+
+        duration = 0.4
+        # On Windows has only a precision of 1/60 sec:
+        delta = 0.04
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(duration)
+        stats.stop_timer(200, 400)
+
+        for _, stats in statistics.snapshot():
+            self.assertEqual(stats.count, 2)
+            self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
+            self.assertEqual(stats.max_req_len, 200)
+            self.assertEqual(stats.min_req_len, 100)
+            self.assertEqual(stats.avg_req_len, 150)
+            self.assertEqual(stats.max_reply_len, 400)
+            self.assertEqual(stats.min_reply_len, 200)
+            self.assertEqual(stats.avg_reply_len, 300)
+
+    def test_snapshot(self):
+        """Test that snapshot() takes a stable snapshot."""
+
+        statistics = Statistics()
+        statistics.enable()
+
+        duration = 0.4
+        # On Windows has only a precision of 1/60 sec:
+        delta = 0.04
+
+        stats = statistics.start_timer('GetInstance')
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        # take the snapshot
+        snapshot = statistics.snapshot()
+
+        # keep producing statistics data
+        stats.start_timer()
+        time.sleep(duration)
+        stats.stop_timer(100, 200)
+
+        # verify that only the first set of data is in the snapshot
+        for _, stats in snapshot:
+            self.assertEqual(stats.count, 1)
+            self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
+            self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testsuite/test_statistics.py
+++ b/testsuite/test_statistics.py
@@ -55,7 +55,7 @@ class StatisticsTests(unittest.TestCase):
                          "Error:  initial state has no time statistics. "
                          "Actual number = %d" % snapshot_length)
 
-        stats = statistics.get_named_statistic('EnumerateInstances')
+        stats = statistics.get_op_statistic('EnumerateInstances')
         snapshot_length = len(statistics.snapshot())
         self.assertEqual(snapshot_length, 0,
                          "Error: getting a new stats with a disabled "
@@ -68,15 +68,15 @@ class StatisticsTests(unittest.TestCase):
         self.assertEqual(stats.min_time, float('inf'))
         self.assertEqual(stats.max_time, 0)
 
-        self.assertEqual(stats.avg_req_len, 0)
-        self.assertEqual(stats.min_req_len, float('inf'))
-        self.assertEqual(stats.max_req_len, 0)
+        self.assertEqual(stats.avg_request_len, 0)
+        self.assertEqual(stats.min_request_len, float('inf'))
+        self.assertEqual(stats.max_request_len, 0)
 
         statistics.enable()
 
         method_name = 'OpenEnumerateInstances'
 
-        stats = statistics.get_named_statistic(method_name)
+        stats = statistics.get_op_statistic(method_name)
         snapshot_length = len(statistics.snapshot())
         self.assertEqual(snapshot_length, 1,
                          "Error: getting a new stats with an enabled "
@@ -90,7 +90,7 @@ class StatisticsTests(unittest.TestCase):
         self.assertEqual(stats.min_time, float('inf'))
         self.assertEqual(stats.max_time, 0)
 
-        statistics.get_named_statistic(method_name)
+        statistics.get_op_statistic(method_name)
         snapshot_length = len(statistics.snapshot())
         self.assertEqual(snapshot_length, 1,
                          "Error: getting an existing stats with an "
@@ -117,9 +117,9 @@ class StatisticsTests(unittest.TestCase):
             self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
-            self.assertEqual(stats.max_req_len, 100)
-            self.assertEqual(stats.min_req_len, 100)
-            self.assertEqual(stats.avg_req_len, 100)
+            self.assertEqual(stats.max_request_len, 100)
+            self.assertEqual(stats.min_request_len, 100)
+            self.assertEqual(stats.avg_request_len, 100)
             self.assertEqual(stats.max_reply_len, 200)
             self.assertEqual(stats.min_reply_len, 200)
             self.assertEqual(stats.avg_reply_len, 200)
@@ -137,7 +137,7 @@ class StatisticsTests(unittest.TestCase):
 
         duration = 0.2
 
-        stats = statistics.get_named_statistic('GetClass')
+        stats = statistics.get_op_statistic('GetClass')
         self.assertEqual(stats.name, 'disabled')
 
         stats.start_timer()
@@ -173,9 +173,9 @@ class StatisticsTests(unittest.TestCase):
             self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
-            self.assertEqual(stats.max_req_len, 200)
-            self.assertEqual(stats.min_req_len, 100)
-            self.assertEqual(stats.avg_req_len, 150)
+            self.assertEqual(stats.max_request_len, 200)
+            self.assertEqual(stats.min_request_len, 100)
+            self.assertEqual(stats.avg_request_len, 150)
             self.assertEqual(stats.max_reply_len, 400)
             self.assertEqual(stats.min_reply_len, 200)
             self.assertEqual(stats.avg_reply_len, 300)
@@ -203,9 +203,9 @@ class StatisticsTests(unittest.TestCase):
             self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
-            self.assertEqual(stats.max_req_len, 200)
-            self.assertEqual(stats.min_req_len, 100)
-            self.assertEqual(stats.avg_req_len, 150)
+            self.assertEqual(stats.max_request_len, 200)
+            self.assertEqual(stats.min_request_len, 100)
+            self.assertEqual(stats.avg_request_len, 150)
             self.assertEqual(stats.max_reply_len, 400)
             self.assertEqual(stats.min_reply_len, 200)
             self.assertEqual(stats.avg_reply_len, 300)
@@ -238,6 +238,37 @@ class StatisticsTests(unittest.TestCase):
             self.assertTrue(time_abs_delta(stats.avg_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.min_time, duration) < delta)
             self.assertTrue(time_abs_delta(stats.max_time, duration) < delta)
+
+    def test_print_statistics(self):
+        """Simply print repr() and formatted() for a small statistics."""
+
+        statistics = Statistics()
+        statistics.enable()
+
+        stats = statistics.start_timer('EnumerateInstanceNames')
+        time.sleep(0.1)
+        stats.stop_timer(1200, 22000)
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(0.1)
+        stats.stop_timer(1000, 20000)
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(0.2)
+        stats.stop_timer(1500, 25000)
+
+        stats = statistics.start_timer('EnumerateInstances')
+        time.sleep(0.4)
+        stats.stop_timer(1200, 35000)
+
+        print("\n\nTest print of repr() for a small statistics:")
+        print("================")
+        print(repr(statistics))
+        print("================")
+        print("\nTest print of formatted() for the same statistics:")
+        print("================")
+        print(statistics.formatted())
+        print("================")
 
 
 if __name__ == '__main__':

--- a/testsuite/testclient/README.md
+++ b/testsuite/testclient/README.md
@@ -25,6 +25,7 @@ The following YAML is an example for one testcase in such a file:
             namespace: root/cimv2
             timeout: 10
             debug: false
+            enable_stats: false
             operation:
                 pywbem_method: GetInstance
                 InstanceName:
@@ -34,6 +35,8 @@ The following YAML is an example for one testcase in such a file:
                         Name: Fritz
                 LocalOnly: false
         pywbem_response:
+            req_len: 100
+            reply_len: 100
             result:
                 pywbem_object: CIMInstance
                 classname: PyWBEM_Person
@@ -156,6 +159,10 @@ Elements in `pywbem_request` element
 * `debug`:
   Boolean indicating whether the PyWBEM client enables debug mode.
 
+* `enable_stats`:
+  Boolean indicating whether the PyWBEM client enables gathering statistical
+  information on operations.
+
 * `operation`:
   A specification of the WBEMConnection method (= CIM operation) to be
   invoked. Its child elements are:
@@ -191,6 +198,16 @@ Elements in `pywbem_response` element
   The name of the Python exception that is expectd to be raised.
   This is optional; if not specified, it defaults to None (=no exception is
   raised).
+
+* `req_len`:
+  Defines expected length of the request. If this element exists, the
+  value is tested against the last_req_len field of the connection. If not
+  specified the test is bypassed.
+
+* `reply_len`:
+  Defines expected length of the response. If this element exists, the
+  value is tested against the last_reply_len field of the connection. If not
+  specified the test is bypassed.
 
 * `result`:
   A specification of the expected result (= return value) of the operation,

--- a/testsuite/testclient/README.md
+++ b/testsuite/testclient/README.md
@@ -25,7 +25,7 @@ The following YAML is an example for one testcase in such a file:
             namespace: root/cimv2
             timeout: 10
             debug: false
-            enable_stats: false
+            enable_stats: true
             operation:
                 pywbem_method: GetInstance
                 InstanceName:
@@ -35,7 +35,7 @@ The following YAML is an example for one testcase in such a file:
                         Name: Fritz
                 LocalOnly: false
         pywbem_response:
-            req_len: 100
+            request_len: 100
             reply_len: 100
             result:
                 pywbem_object: CIMInstance
@@ -199,7 +199,7 @@ Elements in `pywbem_response` element
   This is optional; if not specified, it defaults to None (=no exception is
   raised).
 
-* `req_len`:
+* `request_len`:
   Defines expected length of the request. If this element exists, the
   value is tested against the last_req_len field of the connection. If not
   specified the test is bypassed.

--- a/testsuite/testclient/associatorinstances.yaml
+++ b/testsuite/testclient/associatorinstances.yaml
@@ -484,7 +484,100 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
-
+- name: AssociatorInsts6
+  description: Associator instances Request with most parameters, zero responses, succeeds. Statistics enabled
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    enable-stats: true
+    operation:
+      pywbem_method: Associators
+      IncludeQualifiers: true
+      ObjectName:
+        pywbem_object: CIMInstanceName
+        classname: PG_ComputerSystem
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PG_ComputerSystem
+          Name: sheldon
+      ResultClass: myResultClass
+      ResultRole: myResultRole
+      IncludeClassOrigin: true
+      Role: myRole
+      AssocClass: myAssocClass
+  pywbem_response:
+    request_len: 981
+    reply_len: 251
+    result: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: Associators
+      CIMObject: root/cimv2
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <IMETHODCALL NAME="Associators">
+              <LOCALNAMESPACEPATH>
+                <NAMESPACE NAME="root"/>
+                <NAMESPACE NAME="cimv2"/>
+              </LOCALNAMESPACEPATH>
+              <IPARAMVALUE NAME="IncludeQualifiers">
+                <VALUE>True</VALUE>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="ObjectName">
+                <INSTANCENAME CLASSNAME="PG_ComputerSystem">
+                  <KEYBINDING NAME="CreationClassName">
+                    <KEYVALUE VALUETYPE="string">PG_ComputerSystem</KEYVALUE>
+                  </KEYBINDING>
+                  <KEYBINDING NAME="Name">
+                    <KEYVALUE VALUETYPE="string">sheldon</KEYVALUE>
+                  </KEYBINDING>
+                </INSTANCENAME>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="ResultClass">
+                <CLASSNAME NAME="myResultClass"></CLASSNAME>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="ResultRole">
+                <VALUE>myResultRole</VALUE>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="IncludeClassOrigin">
+                <VALUE>True</VALUE>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="Role">
+                <VALUE>myRole</VALUE>
+              </IPARAMVALUE>
+              <IPARAMVALUE NAME="AssocClass">
+                <CLASSNAME NAME="myAssocClass"></CLASSNAME>
+              </IPARAMVALUE>
+            </IMETHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="Associators">
+      <IRETURNVALUE>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
 - name: AssociatorInstsF1
   description: associator Instance Fails with invalid Namespace
   pywbem_request:

--- a/testsuite/testclient/createinstance.yaml
+++ b/testsuite/testclient/createinstance.yaml
@@ -107,5 +107,118 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
+
+- name: CreateInstance2
+  description: Create instance of PyWBEM_Person successful test sizes
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    enable-stats: true
+    operation:
+      pywbem_method: CreateInstance
+      NewInstance:
+        pywbem_object: CIMInstance
+        classname: PyWBEM_Person
+        properties:
+          creationclassname:
+            pywbem_object: CIMProperty
+            name: CreationClassName
+            value: PyWBEM_Person
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          name:
+            pywbem_object: CIMProperty
+            name: Name
+            value: run_cimoperations_test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        path:
+          pywbem_object: CIMInstanceName
+          classname: PyWBEM_Person
+          namespace: null
+          keybindings:
+            creationclassname: PyWBEM_Person
+            name: run_cimoperations_test
+      namespace: null
+  pywbem_response:
+    request_len: 523
+    reply_len: 519
+    result:
+      pywbem_object: CIMInstanceName
+      classname: PyWBEM_Person
+      namespace: root/cimv2
+      keybindings:
+        creationclassname: PyWBEM_Person
+        name: run_cimoperations_test
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: CreateInstance
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CreateInstance">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="NewInstance">
+      <INSTANCE CLASSNAME="PyWBEM_Person">
+      <PROPERTY NAME="CreationClassName" TYPE="string">
+      <VALUE>PyWBEM_Person</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name" TYPE="string">
+      <VALUE>run_cimoperations_test</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="CreateInstance">
+      <IRETURNVALUE>
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string">run_cimoperations_test</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
 # TODO needs much more complete instance to create
 # TODO needs failure test.

--- a/testsuite/testclient/enumerateclasses.yaml
+++ b/testsuite/testclient/enumerateclasses.yaml
@@ -74,7 +74,7 @@
       ClassName: PyWBEM_Person
       DeepInheritance: null
   pywbem_response:
-    req_len: 337
+    request_len: 337
     reply_len: 225
     result: []
   http_request:

--- a/testsuite/testclient/enumerateclasses.yaml
+++ b/testsuite/testclient/enumerateclasses.yaml
@@ -55,6 +55,66 @@
       </MESSAGE>
       </CIM>'
 - name: EnumerateClasses2
+  description: EnumerateClasses starting at PyWBEM_Person and test stats
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    enable-stats: true
+    operation:
+      pywbem_method: EnumerateClasses
+      IncludeClassOrigin: null
+      IncludeQualifiers: null
+      namespace: null
+      LocalOnly: null
+      ClassName: PyWBEM_Person
+      DeepInheritance: null
+  pywbem_response:
+    req_len: 337
+    reply_len: 225
+    result: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateClasses
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateClasses">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="EnumerateClasses">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: EnumerateClasses3
   description: EnumerateClasses starting at PyWBEM_Person with all optional parameters. Successful but returns no classes
   pywbem_request:
     url: http://acme.com:80

--- a/testsuite/testclient/enumerateinstancenames.yaml
+++ b/testsuite/testclient/enumerateinstancenames.yaml
@@ -614,6 +614,67 @@
                 </MESSAGE>
             </CIM>
 -
+    name: EnumerateInstanceNames10
+    description: EnumerateInstanceNames, extra arg causes no server failure, test sizes
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: false
+        enable-stats: true
+        operation:
+            pywbem_method: EnumerateInstanceNames
+            ClassName: PyWBEM_Person
+            ExtraParam: false
+    pywbem_response:
+        request_len: 408
+        reply_len: 280
+        result: []
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstanceNames
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="EnumerateInstanceNames">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="ClassName">
+                        <CLASSNAME NAME="PyWBEM_Person"/>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="ExtraParam">
+                      <VALUE>False</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstanceNames">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+-
     name: EnumerateInstanceNamesF1
     description: EnumerateInstanceNames, server fails with CIM_ERR_ACCESS_DENIED
     pywbem_request:

--- a/testsuite/testclient/enumerateinstances.yaml
+++ b/testsuite/testclient/enumerateinstances.yaml
@@ -1014,7 +1014,7 @@
             # parameters occur correctly in the request message, and any others
             # don't.
     pywbem_response:
-        req_len: 403
+        request_len: 403
         reply_len: 3816
         result:
             -

--- a/testsuite/testclient/enumerateinstances.yaml
+++ b/testsuite/testclient/enumerateinstances.yaml
@@ -1501,3 +1501,63 @@
                 </SIMPLERSP>
               </MESSAGE>
             </CIM>
+-
+    name: EnumerateInstancesF7
+    description: EnumerateInstances, server fails with CIM_ERR_FAILED. statistics gathering set
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: false
+        enable-stats: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Person
+    pywbem_response:
+        request_len: 339
+        reply_len: 331
+        cim_status: 1
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="EnumerateInstances">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="ClassName">
+                        <CLASSNAME NAME="PyWBEM_Person"/>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="EnumerateInstances">
+                    <ERROR CODE="1" DESCRIPTION="CIM_ERR_FAILED: Internal server error."/>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+
+

--- a/testsuite/testclient/enumerateinstances.yaml
+++ b/testsuite/testclient/enumerateinstances.yaml
@@ -993,6 +993,179 @@
                 </MESSAGE>
             </CIM>
 
+-
+    name: EnumerateInstances12
+    description: EnumerateInstances with lo=f succeeds returning 3 instances; test that returned instances get namespace in set in their path. Tests request and response size
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: false
+        enable-stats: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Person
+            LocalOnly: false
+            # These input parameters do not need to be varied, because they
+            # are just passed through and the test is that the specified
+            # parameters occur correctly in the request message, and any others
+            # don't.
+    pywbem_response:
+        req_len: 403
+        reply_len: 3816
+        result:
+            -
+                pywbem_object: CIMInstance
+                classname: PyWBEM_Person
+                properties:
+                    CreationClassName: PyWBEM_Person
+                    Name: Fritz
+                    Address: Fritz Town
+                path:
+                    pywbem_object: CIMInstanceName
+                    classname: PyWBEM_Person
+                    namespace: root/cimv2
+                    keybindings:
+                        CreationClassname: PyWBEM_Person
+                        Name: Fritz
+            -
+                pywbem_object: CIMInstance
+                classname: PyWBEM_Person
+                properties:
+                    CreationClassName: PyWBEM_Person
+                    Name: Alice
+                    Address: Alice Town
+                path:
+                    pywbem_object: CIMInstanceName
+                    classname: PyWBEM_Person
+                    namespace: root/cimv2
+                    keybindings:
+                        CreationClassname: PyWBEM_Person
+                        Name: Alice
+            -
+                pywbem_object: CIMInstance
+                classname: PyWBEM_Person
+                properties:
+                    CreationClassName: PyWBEM_Person
+                    Name: Charlie
+                    Address: Charlie Town
+                path:
+                    pywbem_object: CIMInstanceName
+                    classname: PyWBEM_Person
+                    namespace: root/cimv2
+                    keybindings:
+                        CreationClassname: PyWBEM_Person
+                        Name: Charlie
+
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>False</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                            <IRETURNVALUE>
+                                <VALUE.NAMEDINSTANCE>
+                                    <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                        <KEYBINDING NAME="CreationClassName">
+                                            <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                        </KEYBINDING>
+                                        <KEYBINDING NAME="Name">
+                                            <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                                        </KEYBINDING>
+                                    </INSTANCENAME>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Fritz</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Fritz Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.NAMEDINSTANCE>
+                                <VALUE.NAMEDINSTANCE>
+                                    <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                        <KEYBINDING NAME="CreationClassName">
+                                            <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                        </KEYBINDING>
+                                        <KEYBINDING NAME="Name">
+                                            <KEYVALUE VALUETYPE="string">Alice</KEYVALUE>
+                                        </KEYBINDING>
+                                    </INSTANCENAME>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Alice</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Alice Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.NAMEDINSTANCE>
+                                <VALUE.NAMEDINSTANCE>
+                                    <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                        <KEYBINDING NAME="CreationClassName">
+                                            <KEYVALUE VALUETYPE="string">PyWBEM_Person</KEYVALUE>
+                                        </KEYBINDING>
+                                        <KEYBINDING NAME="Name">
+                                            <KEYVALUE VALUETYPE="string">Charlie</KEYVALUE>
+                                        </KEYBINDING>
+                                    </INSTANCENAME>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Charlie</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Charlie Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.NAMEDINSTANCE>
+                            </IRETURNVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
 
 -
     name: EnumerateInstancesF1

--- a/testsuite/testclient/getinstance.yaml
+++ b/testsuite/testclient/getinstance.yaml
@@ -9,6 +9,7 @@
         namespace: root/cimv2
         timeout: 10
         debug: false
+        enable-stats: false
         operation:
             pywbem_method: GetInstance
             InstanceName:
@@ -87,6 +88,96 @@
             </CIM>
 -
     name: GetInstance2
+    description: GetInstance succeeds stats gathered and request/reply lengths tested
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: false
+        enable-stats: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        req_len: 503
+        reply_len: 585
+        result:
+            pywbem_object: CIMInstance
+            classname: PyWBEM_Person
+            properties:
+                Name: Fritz
+                Address: Fritz Town
+            path:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                namespace: root/cimv2
+                keybindings:
+                    Name: Fritz
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>False</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="GetInstance">
+                    <IRETURNVALUE>
+                      <INSTANCE CLASSNAME="PyWBEM_Person">
+                        <PROPERTY NAME="Name" TYPE="string">
+                          <VALUE>Fritz</VALUE>
+                        </PROPERTY>
+                        <PROPERTY NAME="Address" TYPE="string">
+                          <VALUE>Fritz Town</VALUE>
+                        </PROPERTY>
+                      </INSTANCE>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+-
+    name: GetInstanceE1
     description: GetInstance fails with CIM_ERR_ACCESS_DENIED
     pywbem_request:
         url: http://acme.com:80
@@ -153,7 +244,7 @@
               </MESSAGE>
             </CIM>
 -
-    name: GetInstance3
+    name: GetInstanceE2
     description: GetInstance fails with CIM_ERR_INVALID_NAMESPACE (and input params swapped)
     pywbem_request:
         url: http://acme.com:80
@@ -220,7 +311,7 @@
               </MESSAGE>
             </CIM>
 -
-    name: GetInstance4
+    name: GetInstanceE3
     description: GetInstance fails with CIM_ERR_INVALID_PARAMETER
     pywbem_request:
         url: http://acme.com:80
@@ -291,7 +382,7 @@
               </MESSAGE>
             </CIM>
 -
-    name: GetInstance5
+    name: GetInstanceE4
     description: GetInstance fails with CIM_ERR_INVALID_CLASS
     pywbem_request:
         url: http://acme.com:80
@@ -358,7 +449,7 @@
               </MESSAGE>
             </CIM>
 -
-    name: GetInstance6
+    name: GetInstanceE5
     description: GetInstance fails with CIM_ERR_NOT_FOUND
     pywbem_request:
         url: http://acme.com:80
@@ -425,7 +516,7 @@
               </MESSAGE>
             </CIM>
 -
-    name: GetInstance7
+    name: GetInstanceE6
     description: GetInstance fails with CIM_ERR_FAILED
     pywbem_request:
         url: http://acme.com:80

--- a/testsuite/testclient/getinstance.yaml
+++ b/testsuite/testclient/getinstance.yaml
@@ -107,7 +107,7 @@
                     Name: Fritz
             LocalOnly: false
     pywbem_response:
-        req_len: 503
+        request_len: 503
         reply_len: 585
         result:
             pywbem_object: CIMInstance

--- a/testsuite/testclient/openenumerateinstanceswithpath.yaml
+++ b/testsuite/testclient/openenumerateinstanceswithpath.yaml
@@ -831,6 +831,88 @@
                 </MESSAGE>
             </CIM>
 -
+    name: OpenEnumerateInstances9
+    description: OpenEnumerateInstances with all parameters to default and extra parameter. succeeds. Test statistics
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        enable-stats: true
+        operation:
+            pywbem_method: OpenEnumerateInstances
+            ClassName: PyWBEM_Person
+            IncludeClassOrigin:
+            ContinueOnError:
+            MaxObjectCount:
+            namespace: root/cimv2
+            DeepInheritance:
+            FilterQuery:
+            FilterQueryLanguage:
+            OperationTimeout:
+            LocalOnly:
+            IncludeQualifiers:
+            ExtraParam: false
+    pywbem_response:
+        request_len: 408
+        reply_len: 530
+        pullresult:
+            context:
+                - blahblah
+                - root/cimv2
+            eos: false
+            instances: []
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: OpenEnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+             <?xml version="1.0" encoding="utf-8" ?>
+             <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                 <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                     <SIMPLEREQ>
+                         <IMETHODCALL NAME="OpenEnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                 <NAMESPACE NAME="root"/>
+                                 <NAMESPACE NAME="cimv2"/>
+                             </LOCALNAMESPACEPATH>
+                             <IPARAMVALUE NAME="ClassName">
+                                 <CLASSNAME NAME="PyWBEM_Person"/>
+                             </IPARAMVALUE>
+                            <IPARAMVALUE NAME="ExtraParam">
+                               <VALUE>False</VALUE>
+                            </IPARAMVALUE>
+                         </IMETHODCALL>
+                     </SIMPLEREQ>
+                 </MESSAGE>
+             </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="OpenEnumerateInstances">
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>FALSE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE>blahblah</VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+-
     name: OpenEnumerateInstancesF1
     description: OpenEnumerateInstances fails with CIM_ERR_ACCESS_DENIED
     pywbem_request:

--- a/testsuite/testclient/pullinstanceswithpath.yaml
+++ b/testsuite/testclient/pullinstanceswithpath.yaml
@@ -462,7 +462,80 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-
+- name: PullInstancesWithPath4
+  description: Pull request and returns zero instances with eos=false and valid context. Test statistics
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    enable-stats: true
+    operation:
+      pywbem_method: PullInstancesWithPath
+      MaxObjectCount: 1
+      context:
+      - '500001'
+      - root/cimv2
+  pywbem_response:
+        request_len: 404
+        reply_len: 590
+        pullresult:
+            context:
+              - '500001'
+              - root/cimv2            
+            eos: false
+            instances: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancesWithPath
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancesWithPath">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500001</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>1</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstancesWithPath">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>FALSE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE>500001</VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
 - name: PullInstancesWithPathF1
   description: PullInstancesWithPath request fails. Invalid Context
   pywbem_request:

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -115,7 +115,7 @@ def _remote_connection(server, opts, argparser_):
     CONN = WBEMConnection(url, creds, default_namespace=opts.namespace,
                           no_verification=opts.no_verify_cert,
                           x509=x509_dict, ca_certs=opts.ca_certs,
-                          timeout=opts.timeout)
+                          timeout=opts.timeout, enable_stats=opts.enable_stats)
 
     CONN.debug = True
 
@@ -2953,6 +2953,10 @@ Examples:
         '-v', '--verbose', dest='verbose',
         action='store_true', default=False,
         help='Print more messages while processing')
+    general_arggroup.add_argument(
+        '-e', '--enable_stats', dest='verbose',
+        action='store_true', default=False,
+        help='Enable gathering of statistics on operations.')
     general_arggroup.add_argument(
         '-h', '--help', action='help',
         help='Show this help message and exit')


### PR DESCRIPTION
Keeps time statistics on cim_operations.  This keeps statistics on time to
execute and request/response sizes for the cim operations.

Implements a Statistics class and connects cim_operations to that class to record execution time, request size, and reply size in that class for each operation type.  It saves count, avg time, request size, response size in and exception count in that class for each WBEM operation type by name.

The Statistics class provides for snapshotting and resetting the statistics in addition to the functions to record each new statistics with start_time() and stop_time()

NOTE: At this point the statistics are not really general.  The class OperationStatistics specializes the statistics for the operations and their is no provision for another class with its specialization at this point.

Finally, includes ability to disable statistics but I am not really using that capability. You enable statistics for each WBEMConnection.

In addition, the change adds three attributes to WBEMConnection.

last_req_len - Always
last_reply_len - Always
last_operation_time - Only when the enable-stats is set  

ANDY: I goofed and force updated over your changes before I realized you had made them.


NOTE: This does NOT capture info from the server statistics.

