### PR TITLE
Fixes #677, fixes #679: Compiler inst alias and cim_obj doc missing alias keybinding definition.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,16 @@ Bug fixes
 
 * Fixed names of Python development packages for SLES/OpenSUSE.
 
+* Fixed issue in mof_compiler where instance aliases were incomplete. They
+  only included the class component so that if they were used in the definition
+  of other instances (ex. to define an association where a reference property
+  was the aliased instance, the reference path was incomplete.) This is now
+  a path with keybindings.  Note: It is the responsibility of the user to
+  make these instances complete (i.e. with all key properties) see issue #679
+
+* Correct documentation issue in cim_obj (Exceptions definition missing).
+  See issue #677
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -4183,6 +4183,10 @@ def tocimobj(type_, value):
 
         A :term:`CIM data type` object, representing the specified value and
         type.
+
+    Exceptions:
+        ValueError - Input cannot be converted to defined CIMValue type or
+            invalid CIMDatatype name.
     """
 
     if value is None or type_ is None:


### PR DESCRIPTION
1. Added keybindings to instance alias in compiler. The compiler not produces keybinding in the path and the alias table for instance definitions that include alias.  Before in only produced the class component of the path. That meant that other instances that used the alias did not get a complete instance alias.


2. Added test for instance alias - Added test for this in test_mof_comp

3. Fixed documentation issue in cim_obj.py