### PR TITLE
Add __init__.py to subdirs testsuite and examples to tell pylint to search for config file

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,2 @@
+# used to activate pylint config directory algorithm. It
+# searches up directory from any module directory (i.e. with __init__.py)

--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -1,0 +1,2 @@
+# used to activate pylint config directory algorithm. It
+# searches up directory from any module directory (i.e. with __init__.py)


### PR DESCRIPTION
That did not work out so well.  Adding the empty __init__.py causes the local imports in testsuite to fail when test run from the package root.  I am thinking about this for the moment.  It was just a minor thing in any case (get rid of the extra pylintrc files that I use in testsuite and examples directories when doing pylint within editior on single files. Not worth a major effort but If you have any ideas Andy they would be welcome.


pylint searches up the hiearchy for the config file for any directory
that it considers a module (with __init__.py).  Add this to examples and
testsuite to force that search if pylint is used within an editor or if
it is run against a particular file or directory.

This appears to be the rules from pylint 1.8 documentation:

1. pylintrc in the current working directory
2. .pylintrc in the current working directory
3. If the current working directory is in a Python module, Pylint searches
up the hierarchy of Python modules until it finds a pylintrc file. This
allows you to specify coding standards on a module-by-module basis. Of
course, a directory is judged to be a Python module if it contains an
__init__.py file.
4. The file named by environment variable PYLINTRC

Sadly, flake8 does not have this complete a config file ruleset.  It is this directory
or home.