### PR TITLE
Fixed the Travis issue with installing swig.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
   - python -c "import platform; print('Demonstration of incorrect distro returned by platform.linux_distribution():'); print(repr(platform.linux_distribution()))"
   - python -c "import pip, os; print('Site-packages directory of system Python:'); print(os.path.dirname(os.path.dirname(pip.__file__)))"
   - pip list
+#  - sudo apt-get update
+#  - sudo apt search swig
+  - sudo apt-get install -y swig
   - pip install --upgrade pip
   - python uninstall_pbr_on_py26.py
   - make clobber


### PR DESCRIPTION
This is a quick fix for the issue that Travis fails since its Ubuntu update in early may, when "make develop" tries to install swig. For unknown reasons, installing it directly in the Travis control file works fine, and that's what this change does.

A follow-on change is supposed to provide the "real fix".