### PR TITLE
WITHDRAWN Fixes #691 and #569: log of cim operations api and http messages with wbemcli extended to use log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ parser.out
 moflog*.txt
 test_recorder.yaml
 pylint_done
+wbemcli.log
 .coverage
 /build/
 /build_doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ install:
   - pip list
   - make develop
   - pip install python-coveralls
+# Update coverage because the version defined for python-coveralls breaks
+# some of our tests (they specify a specific version) see pr #691 where at
+# least on python 2.6, the test_wbemcli.py code catches a deprecation warning
+# from coverage 4.03 or earlier.
+  - pip install -U coverage
   - pip list
 
 # commands to run builds & tests

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -95,6 +95,14 @@ Enhancements
   It also passes server_response_time to statistics so that max/min/avg are
   maintained.  See issue # 687.
 
+* Implement logging of CIM operations with options so that the user
+  can chose to log None/either/both a)Calls and returns from the
+  WBEMConnection CIM operation calls, b)http request/responses. The logging
+  can be to either stderr or file and the user can chose to log the complete
+  requests or responses or subsets (log_detail level). Implement the
+  command line parameter interface for this logging in wbemcli so that
+  wbemcli can log cim operations and HTTP requests/responses. See issue #691.
+ 
 
 Bug fixes
 ^^^^^^^^^

--- a/makefile
+++ b/makefile
@@ -278,7 +278,7 @@ test: $(test_log_file)
 
 .PHONY: clobber
 clobber: clean
-	rm -f pylint.log  flake8.log epydoc.log test_*.log $(moftab_files) $(dist_files) pywbem/*,cover
+	rm -f pylint.log  flake8.log epydoc.log test_*.log $(moftab_files) $(dist_files) pywbem/*,cover wbemcli.log
 	rm -Rf $(doc_build_dir) .tox $(coverage_html_dir)
 	@echo 'Done: Removed everything to get to a fresh state.'
 	@echo '$@ done.'

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -45,6 +45,7 @@ from ._listener import *  # noqa: F403,F401
 from ._recorder import *  # noqa: F403,F401
 from .config import *  # noqa: F403,F401
 from ._statistics import *  # noqa: F403,F401
+from ._logging import *  # noqa: F403,F401
 
 from ._version import __version__  # noqa: F401
 

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -280,9 +280,9 @@ class PywbemLoggers(object):
             # create named logger
             if handler:
                 handler.setFormatter(logging.Formatter(format_string))
-                logger_ops = logging.getLogger(logger_name)
-                logger_ops.addHandler(handler)
-                logger_ops.setLevel(level)
+                logger = logging.getLogger(logger_name)
+                logger.addHandler(handler)
+                logger.setLevel(level)
 
             # save the detail level in the dict that is part of this class.
             # All members of this tuple are just viewing except detail

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -72,7 +72,6 @@ Examples:
 """
 from __future__ import absolute_import
 
-import sys
 import logging
 import six
 

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -1,0 +1,343 @@
+# Copyright 2016 IBM Corp. All Rights Reserved.
+#
+# (C) Copyright 2004,2006 Hewlett-Packard Development Company, L.P.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+"""
+This package supports logging using the standard Python :mod:`py:logging`
+module. The logging support provides two :class:`~py:logging.Logger` objects:
+
+* 'pywbem.api' for user-issued calls to pywbem CIM OperationsAPI functions, at
+  the info level. Internal calls to API functions are not logged.
+
+* 'pywbem.http' for http level information, at the info level.
+
+In addition, there may be loggers for pywbem modules with the module name, for
+situations like errors or warnings.
+
+All these loggers have a null-handler (see :class:`~py:logging.NullHandler`)
+and have no log formatter (see :class:`~py:logging.Formatter`).
+
+As a result, the loggers are silent by default. To turn on logging,
+add a log handler (see :meth:`~py:logging.Logger.addHandler`, and
+:mod:`py:logging.handlers` for the handlers included with Python) and set the
+log level (see :meth:`~py:logging.Logger.setLevel`, and :ref:`py:levels` for
+the defined levels).
+
+If you want to change the default log message format, use
+:meth:`~py:logging.Handler.setFormatter`. Its ``form`` parameter is a format
+string with %-style placeholders for the log record attributes (see Python
+section :ref:`py:logrecord-attributes`).
+
+Examples:
+
+* To output the log records for all cim operations to ``stdout`` in a
+  particular format, do this:
+
+  ::
+
+      import logging
+
+      handler = logging.StreamHandler()
+      format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+      handler.setFormatter(logging.Formatter(format_string))
+      logger = getLogger('pywbem.api')
+      logger.addHandler(handler)
+      logger.setLevel(logging.INFO)
+
+* This example uses the :func:`~py:logging.basicConfig` convenience function
+  that sets the same format and level as in the previous example, but for the
+  root logger. Therefore, it will output all log records, not just from this
+  package:
+
+  ::
+
+      import logging
+
+      format_string = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+      logging.basicConfig(format=format_string, level=logging.DEBUG)
+"""
+from __future__ import print_function, absolute_import
+
+import sys
+import logging
+import six
+from .config import DEFAULT_LOG_FILENAME
+
+# from ._constants import API_LOGGER_NAME
+API_LOGGER_NAME = 'pywbem.api'
+
+#: Name of logger for operantion call methods and their responses.
+#:
+LOG_OPS_CALLS_NAME = 'pywbem.ops'
+
+#: Name of logger for http information
+#:
+LOG_HTTP_NAME = 'pywbem.http'
+
+#: pywbem logger names. The following are the logger names that pywbem
+# recognizes.
+
+PYWBEM_LOG_COMPONENTS = ['ops', 'http', 'all']
+
+# possible log output destinations
+LOG_DESTINATIONS = ['file', 'stderr', 'none']
+
+LOG_DETAIL_LEVELS = ['all', 'min']
+
+LOG_LEVELS = ['error', 'warning', 'info', 'debug']
+
+__all__ = ['PywbemLoggers', 'LOG_DESTINATIONS', 'LOG_LEVELS',
+           'PYWBEM_LOG_COMPONENTS', 'LOG_OPS_CALLS_NAME',
+           'LOG_DETAIL_LEVELS']
+
+
+class PywbemLoggers(object):
+    """
+    Container for pywbem logger information when loggers are created.
+
+    There are two constructors for loggers:
+      PywbemLoggers.create_loggers - Creates one or more logger entries in
+      this class and also in the python logging class from an input string
+      with the format defined in the create_loggers method.
+      PywbemLoggers.create_logger - Creates a single logger from a the
+      separate attributes.
+
+    """
+    loggers = {}
+
+    @classmethod
+    def __repr__(cls):
+        return 'PywbemLoggers(loggers={s.loggers!r})'.format(s=cls)
+
+    @classmethod
+    def create_loggers(cls, input_str):
+        """
+        Create the pywbem loggers defined by the input string in the following
+        format and place in a class level dictionary in this class:
+
+        Parameters:
+            log_spec[,log_spec]
+
+            log_spec := log_comp['=' [dest][":"[detail_level][":"[log_level]]]]
+
+            where:
+                comp (str) must be one of PYWBEM_LOG_COMPONENTS
+                log_level (str) must be one of LOG_LEVELS above
+                detail_level (str) must be one of LOG_DETAIL_LEVELS
+                dest (str) must be one of LOG_DESTINATIONS
+
+        Exceptions:
+          ValueError if any of the parameters are invalid
+        """
+        results = cls._parse_log_specs(input_str)
+        for name, value in six.iteritems(results):
+            cls.create_logger(name, log_dest=value[0],
+                              log_detail_level=value[1],
+                              log_level=value[2])
+
+    @classmethod
+    def create_logger(cls, log_component, log_dest='file',
+                      log_filename=DEFAULT_LOG_FILENAME,
+                      log_detail_level='all', log_level=None):
+        """
+        Setup a single named logger with the characteristics defined on input.
+
+        This function can be used to set up all of the named loggers used by
+        pywbem.
+
+        Parameters:
+          log_compnent (:term:`string`):
+           The name of the logger. It must be one of the
+           names defined in PYWBEM_LOG_COMPONENTS. Subsequent logging users
+           will use this name to reference the parameters of this logger
+
+          log_dest (:term:`string`):
+            String defining the destination for this log. It must be one of the
+            destinations defined in LOG_DESTINATIONS
+
+          log_filename (:term:`string`):
+            Filename to use as logging file if the log destination is `file`.
+            Ignored if log destination is not `file`. The default is
+            DEFAULT_LOG_FILENAME defined in config.py
+
+          log_detail_level (:term:`string`):
+            String defining the level of detail for log output. This is
+            optional.
+            Not all of the loggers use this attribute.  Thus, the ops and http
+            loggers used a defined detail level and always set logging to that
+            level.
+
+          log_level (:term:`string`):
+            String defining the log level. This is optional.  Not all of the
+            loggers use this attribute.  Thus, the ops and http loggers used a
+            defined level and always set logging to that level.
+
+        Return:
+            None
+
+        Exceptions:
+            ValueError - Input cannot be mapped to a defined logger or
+            component.
+            No named logger is created.
+        """
+        if log_dest not in LOG_DESTINATIONS:
+            ValueError('Invalid log destination %s. Not in list %s' %
+                       (log_dest, LOG_DESTINATIONS))
+        if log_component not in PYWBEM_LOG_COMPONENTS:
+            ValueError('Invalid log component %s. Not in list %s' %
+                       (log_component, PYWBEM_LOG_COMPONENTS))
+        if log_level not in LOG_LEVELS:
+            ValueError('Invalid log level %s. Not in list %s' %
+                       (log_level, LOG_LEVELS))
+
+        if log_detail_level not in LOG_DETAIL_LEVELS:
+            ValueError('Invalid log detail %s. Not in list %s' %
+                       (log_detail_level, LOG_DETAIL_LEVELS))
+
+        # If destinations or components is all, recurse for all destinations
+        if log_dest == 'all':
+            for dest in LOG_DESTINATIONS:
+                cls.create_logger(log_component, dest, log_filename, log_level)
+        elif log_component == 'all':
+            for comp in PYWBEM_LOG_COMPONENTS:
+                cls.create_logger(comp, log_dest, log_filename, log_level)
+
+        # Otherwise process results of any recursive calls above
+        else:
+            if log_dest == 'stderr':
+                handler = logging.StreamHandler(stream=sys.stderr)
+                format_string = '%(asctime)s-%(name)s-%(message)s'
+            elif log_dest == 'file':
+                if not log_filename:
+                    assert ValueError('Filename required if log destination '
+                                      'is "file"')
+                handler = logging.FileHandler(log_filename)
+                format_string = '%(asctime)s-%(name)s-%(message)s'
+            else:
+                assert(log_dest == 'none')
+                handler = None
+                format_string = None
+
+            # set the logger name based on the log_component.
+            if log_component == 'http':
+                logger_name = LOG_HTTP_NAME
+                log_level = 'DEBUG'
+            elif log_component == 'ops':
+                logger_name = LOG_OPS_CALLS_NAME
+                log_level = 'DEBUG'
+            else:
+                ValueError('Invalid log_component %s' % log_component)
+
+            # Set the log level based on the log_level input
+            level = getattr(logging, log_level.upper(), None)
+            # check the logging log_level_choices have not changed from expected
+            assert isinstance(level, int)
+            if level is None:
+                ValueError('Invalid log level %s specified. Must be one of %s.'
+                           % (log_level, LOG_LEVELS))
+
+            # create named logger
+            if handler:
+                handler.setFormatter(logging.Formatter(format_string))
+                logger_ops = logging.getLogger(logger_name)
+                logger_ops.addHandler(handler)
+                logger_ops.setLevel(log_level)
+
+            # save the detail level in the dict that is part of this class.
+            # All members of this tuple are just viewing except detail
+            # that is used by individual loggers
+            cls.loggers[logger_name] = (log_detail_level, log_level,
+                                        log_dest, log_filename)
+
+    @classmethod
+    def get_logger_detail(cls, logger_name):
+        """
+            Get the name of a logger that has been defined.
+        """
+        if logger_name in cls.loggers:
+            return cls.loggers[logger_name][0]
+        return None
+
+    @classmethod
+    def get_logger_info(cls, logger_name):
+        """Get information about a logger by name"""
+        if logger_name in cls.loggers:
+            t = cls.loggers[logger_name]
+            return 'comp=%s dest %s detail %s log_level %s file %s' % (logger_name,
+                                                               t[3],
+                                                               t[0],
+                                                               t[2],
+                                                               t[3])
+        return('%s not defined' % logger_name)
+
+    @classmethod
+    def _parse_log_specs(cls, log_spec_str):
+        """
+        Parse a complete cmd line log specification that is in the
+        format defined in PywbemLoggers.create_logger
+
+          Parameters:
+            log_spec_str (:term:`string`) containing the log spec string
+
+          Return:
+            Dictionary containing the parsed information where each entry is
+            log_comp (detail_level, log_level,  dest)
+
+          Exception:
+            ValueError if parse fails
+        """
+        log_specs_dict = dict()
+        log_specs = log_spec_str.split(',')
+        for log_spec in log_specs:
+            try:
+                log_component, log_data = log_spec.split("=", 1)
+            except ValueError:
+                log_component = log_spec
+                log_data = ''
+
+            log_values = log_data.split(":")
+
+            if not log_component:
+                raise ValueError("Log component name required in %s" % log_spec)
+
+            # cvt empty strings to None
+            log_values = [None if x == '' else x for x in log_values]
+            # expand to full size if not all values supplied
+            while len(log_values) < 3:
+                log_values.append(None)
+
+            if len(log_values) > 3:
+                raise ValueError("Invalid log detail. %s too many "
+                                 "components."
+                                 % log_spec)
+            log_specs_dict[log_component] = tuple(log_values)
+        return log_specs_dict
+
+
+def get_logger(name):
+    """
+    Return a :class:`~py:logging.Logger` object with the specified name.
+
+    A :class:`~py:logging.NullHandler` handler is added to the logger if it
+    does not have any handlers yet. This prevents the propagation of log
+    requests up the Python logger hierarchy, and therefore causes this package
+    to be silent by default.
+    """
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        logger.addHandler(logging.NullHandler())
+    return logger

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -245,7 +245,7 @@ class PywbemLoggers(object):
         # Otherwise process results of any recursive calls above
         else:
             if log_dest == 'stderr':
-                handler = logging.StreamHandler(stream=sys.stderr)
+                handler = logging.StreamHandler()
                 format_string = '%(asctime)s-%(name)s-%(message)s'
             elif log_dest == 'file':
                 if not log_filename:

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -37,13 +37,12 @@ from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMQualifierDeclaration, NocaseDict
 from .cim_types import CIMInt, CIMFloat, CIMDateTime
 from .exceptions import CIMError
+from .config import DEFAULT_MAX_LOG_ENTRY_SIZE
+from ._logging import PywbemLoggers, LOG_OPS_CALLS_NAME, LOG_HTTP_NAME
 
 if six.PY2:
     import codecs  # pylint: disable=wrong-import-order
 
-from .config import DEFAULT_MAX_LOG_ENTRY_SIZE
-
-from ._logging import PywbemLoggers, LOG_OPS_CALLS_NAME, LOG_HTTP_NAME
 
 __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
            'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse',

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -27,6 +27,7 @@ except ImportError:
     from ordereddict import OrderedDict  # pylint: disable=import-error
 
 from datetime import datetime, timedelta
+import logging
 import yaml
 from yaml.representer import RepresenterError
 import six
@@ -40,8 +41,13 @@ from .exceptions import CIMError
 if six.PY2:
     import codecs  # pylint: disable=wrong-import-order
 
+from .config import DEFAULT_MAX_LOG_ENTRY_SIZE
+
+from ._logging import PywbemLoggers, LOG_OPS_CALLS_NAME, LOG_HTTP_NAME
+
 __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
-           'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse']
+           'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse',
+           'LogOperationRecorder']
 
 if six.PY2:
     _Longint = long  # noqa: F821
@@ -320,6 +326,13 @@ class BaseOperationRecorder(object):
         self._http_response_payload = None
         self._pull_op = pull_op
 
+    def stage_wbem_connection(self, url, **kwargs):
+        """
+        Stage information about the connection. Used only by
+        LogOperationRecorder.
+        """
+        pass
+
     def stage_pywbem_args(self, method, **kwargs):
         """
         Set requst method and all args.
@@ -417,6 +430,151 @@ class BaseOperationRecorder(object):
             exception was raised before getting there).
         """
         raise NotImplementedError
+
+
+class LogOperationRecorder(BaseOperationRecorder):
+    """
+    An Operation Recorder that logs the information to a set of named logs.
+    This recorder uses two named logs:
+
+    LOG_OPS_CALLS_NAME - Logger for cim_operations method calls and responses
+
+    LOG_HTTP_NAME - Logger for http_requests and responses
+
+    This also implements a method to log information on each connection.
+
+    All logging calls are at the debug level.
+    """
+    def __init__(self):
+        """
+        Create the the loggers for the following logging names
+
+        1. LOG_OPS_CALLS - logs operations calls and responses
+        2. LOG_HTTP - Logs http/xml requests and responses
+
+        Parameters: (:term:`integer`)
+
+        max_log_entry_size (:term:`integer`)
+        The maximum size of each log entry. This is primarily to limit
+        reqsponse sizes since they could be enormous.
+        If `None`, no size limit and the full request or response is logged.
+
+
+        """
+        super(LogOperationRecorder, self).__init__()
+
+        max_sz = DEFAULT_MAX_LOG_ENTRY_SIZE
+
+        self.opslogger = logging.getLogger(LOG_OPS_CALLS_NAME)
+        opsdetaillevel = PywbemLoggers.get_logger_detail(LOG_OPS_CALLS_NAME)
+        self.ops_max_log_entry_size = max_sz if opsdetaillevel == 'min' \
+            else None
+
+        self.httplogger = logging.getLogger(LOG_HTTP_NAME)
+        httpdetaillevel = PywbemLoggers.get_logger_detail(LOG_HTTP_NAME)
+        self.http_max_log_entry_size = max_sz if httpdetaillevel == 'min' \
+            else None
+
+    def stage_pywbem_connection(self, url, **kwargs):
+        """Log connection information"""
+        if self.enabled:
+            kwstr = \
+                ', '.join('{0}={1!r}'.format(k, v) for k, v in kwargs.items())
+
+            self.opslogger.debug('Connection: url=%s, %s', url, kwstr)
+
+    def stage_pywbem_args(self, method, **kwargs):
+        """
+        Log request method and all args.
+        Normally called before the cmd is executed to record request
+        parameters.
+        This method does not limit size of log record.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self._pywbem_method = method
+        if self.enabled:
+            kwstr = \
+                ', '.join('{0}={1!r}'.format(k, v) for k, v in kwargs.items())
+
+            self.opslogger.debug('Request: %s(%s)', method, kwstr)
+
+    def stage_pywbem_result(self, ret, exc):
+        """
+        Log result return or exception parameter. This function allows
+        setting maximum size on the result parameter logged because response
+        information can be very large
+        .
+        """
+        if self.enabled:
+            return_name = 'Return' if ret else 'Exception'
+            result = ret if ret else exc
+
+            if self.ops_max_log_entry_size:
+                result = '{:.{sz}s}...' \
+                    .format(repr(result),
+                            sz=self.ops_max_log_entry_size)
+            else:
+                result = '%r' % result
+
+            self.opslogger.debug('%s: %s: %s', return_name,
+                                 self._pywbem_method,
+                                 result)
+
+    def stage_http_request(self, version, url, target, method, headers,
+                           payload):
+        """Log request HTTP information including url, headers, etc."""
+        if self.enabled:
+            # pylint: disable=attribute-defined-outside-init
+            header_str = ' '.join('{0}:{1!r}'.format(k, v)
+                                  for k, v in headers.items())
+            self.httplogger.debug('Request: %s %s %s %s\n%s\n%s',
+                                  method, url, target, version, header_str,
+                                  payload)
+
+    def stage_http_response1(self, version, status, reason, headers):
+        """Set response http info including headers, status, etc. """
+        # pylint: disable=attribute-defined-outside-init
+        self._http_response_version = version
+        self._http_response_status = status
+        self._http_response_reason = reason
+        self._http_response_headers = headers
+
+    def stage_http_response2(self, payload):
+        """Log complete http response, including response1 and payload"""
+
+        # required because http code uses sending all None to reset
+        # parameters. We ignore that
+        if not self._http_response_version and not payload:
+            return
+        if self.enabled:
+            if self._http_response_headers:
+                header_str = \
+                    ' '.join('{0}:{1!r}'.format(k, v)
+                             for k, v in self._http_response_headers.items())
+            else:
+                header_str = ''
+
+            # format the payload possibly with max size limit
+            if self.http_max_log_entry_size:
+                payload = '{:.{sz}}...'.format(payload.decode('utf-8'),
+                                               sz=self.http_max_log_entry_size)
+            else:
+                payload = '%r' % payload.decode('utf-8')
+
+            self.httplogger.debug('Response: %s %s %s\n%s\n%s',
+                                  self._http_response_status,
+                                  self._http_response_reason,
+                                  self._http_response_version,
+                                  header_str,
+                                  payload)
+
+    def record_staged(self):
+        """Not used for logging"""
+        pass
+
+    def record(self, pywbem_args, pywbem_result, http_request, http_response):
+        """Not used for logging"""
+        pass
 
 
 class TestClientRecorder(BaseOperationRecorder):
@@ -566,6 +724,7 @@ class TestClientRecorder(BaseOperationRecorder):
 
         # namedtuple is subclass of tuple so it is instance of tuple but
         # not type tuple. Cvt to dictionary and cvt dict to yaml.
+        # pylint: disable=unidiomatic-typecheck
         if isinstance(obj, tuple) and type(obj) is not tuple:
             ret_dict = obj._asdict()
             return self.toyaml(ret_dict)
@@ -589,6 +748,7 @@ class TestClientRecorder(BaseOperationRecorder):
         elif isinstance(obj, CIMInt):
             return _Longint(obj)
         elif isinstance(obj, (bool, int)):
+            # TODO ks jun 17 should the above be six.integertypes???
             # The check for int must be after CIMInt, because CIMInt is int.
             return obj
         elif isinstance(obj, CIMFloat):

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -826,10 +826,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Defines whether logging of operations and http requests should
             be executed.   If this is a bool True, logging of the complete
             operations calls and responses and the complete http requests are
-            logged. If False, Nothing is logged.  If it is a positive non-zero
-            integer, request/response methods and http requests/responses are
-            logged but only the length defined by the integer of the payload
-            is actually included.
+            logged. If False, Nothing is logged.
 
             Logging destinations and further information about the loggers
             is defined through the _logger module
@@ -925,8 +922,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         **Experimental:** This property is experimental for this release.
         """  # noqa: E501
-        # TODO completely redo this to clean up whole operation recorder
-        # controller.
+
         if self.operation_recorder:
             return self.operation_recorder.enabled
         else:
@@ -934,7 +930,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @operation_recorder_enabled.setter
     def operation_recorder_enabled(self, value):
-        # TODO: No. Need to call recorder.
+        """
+        Set the operation_recorder to the value defined by the
+        input attribute value.
+
+        **Experimental:** This property setter is experimental for this
+                          release.
+        """
         if self.operation_recorder:
             if value:
                 self.operation_recorder.enable()

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -39,8 +39,7 @@ they should be used from the ``pywbem`` namespace.
 # This module is meant to be safe for 'import *'.
 
 __all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT',
-           'DEFAULT_MAX_LOG_ENTRY_SIZE', 'DEFAULT_LOG_FILENAME',
-           'DEFAULT_LOG_DESTINATION']
+           'DEFAULT_MAX_LOG_ENTRY_SIZE', 'DEFAULT_LOG_DESTINATION']
 
 #: Enforce the allowable value range for CIM integer types (e.g.
 #: :class:`~pywbem.Uint8`). For details, see the :class:`~pywbem.CIMInt` base
@@ -69,8 +68,4 @@ DEFAULT_ITER_MAXOBJECTCOUNT = 1000
 DEFAULT_MAX_LOG_ENTRY_SIZE = 1000
 
 #: Set default log destination.  None means that there will be no logging
-DEFAULT_LOG_DESTINATION = 'none'
-
-#: Default log filename for pywbem if no name is specificd when logging is
-#: defined with a destination of 'file'
-DEFAULT_LOG_FILENAME = 'pywbem.log'
+DEFAULT_LOG_DESTINATION = 'file'

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -38,7 +38,9 @@ they should be used from the ``pywbem`` namespace.
 
 # This module is meant to be safe for 'import *'.
 
-__all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT']
+__all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT',
+           'DEFAULT_MAX_LOG_ENTRY_SIZE', 'DEFAULT_LOG_FILENAME',
+           'DEFAULT_LOG_DESTINATION']
 
 #: Enforce the allowable value range for CIM integer types (e.g.
 #: :class:`~pywbem.Uint8`). For details, see the :class:`~pywbem.CIMInt` base
@@ -60,3 +62,15 @@ ENFORCE_INTEGER_RANGE = True
 #: operations.
 
 DEFAULT_ITER_MAXOBJECTCOUNT = 1000
+
+#: Maximum log entry size. An integer that sets the maximum size of each log
+#: entry if the log_detail_level flag is set.
+
+DEFAULT_MAX_LOG_ENTRY_SIZE = 1000
+
+#: Set default log destination.  None means that there will be no logging
+DEFAULT_LOG_DESTINATION = 'none'
+
+#: Default log filename for pywbem if no name is specificd when logging is
+#: defined with a destination of 'file'
+DEFAULT_LOG_FILENAME = 'pywbem.log'

--- a/setup.py
+++ b/setup.py
@@ -362,9 +362,9 @@ def main():
             # Wheel may not be installed in every system Python.
             'wheel',
             # Python prereqs for 'develop' command. Handled by os_setup module.
+            "coverage>=4.3",
             "pytest>=2.4",
             "pytest-cov",
-            "coverage>=4.3",
             "Sphinx>=1.3" if sys.version_info[0:2] != (2, 6) else None,
             # Pinning GitPython to 2.0.8 max, due to its use of unittest.case
             # which is not available on Python 2.6.

--- a/setup.py
+++ b/setup.py
@@ -364,6 +364,7 @@ def main():
             # Python prereqs for 'develop' command. Handled by os_setup module.
             "pytest>=2.4",
             "pytest-cov",
+            "coverage>=4.3",
             "Sphinx>=1.3" if sys.version_info[0:2] != (2, 6) else None,
             # Pinning GitPython to 2.0.8 max, due to its use of unittest.case
             # which is not available on Python 2.6.

--- a/setup.py
+++ b/setup.py
@@ -365,6 +365,7 @@ def main():
             "coverage>=4.3",
             "pytest>=2.4",
             "pytest-cov",
+            'testfixtures>=4.13.3',
             "Sphinx>=1.3" if sys.version_info[0:2] != (2, 6) else None,
             # Pinning GitPython to 2.0.8 max, due to its use of unittest.case
             # which is not available on Python 2.6.

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -41,6 +41,9 @@ from pywbem import WBEMConnection, WBEMServer, CIMError, Error, WBEMListener, \
 
 from pywbem.mof_compiler import MOFCompiler
 
+from pywbem import ClientLogger
+from pywbem._logging import define_operationlogger
+
 from unittest_extensions import RegexpMixin
 
 
@@ -109,6 +112,7 @@ class ClientTest(unittest.TestCase):
         self.verbose = CLI_ARGS['verbose']
         self.debug = CLI_ARGS['debug']
         self.yamlfile = CLI_ARGS['yamlfile']
+        self.log = CLI_ARGS['log']
         self.yamlfp = None
         self.enable_stats = True if CLI_ARGS['stats'] else False
         if self.enable_stats:
@@ -132,6 +136,13 @@ class ClientTest(unittest.TestCase):
             ca_certs=CLI_ARGS['cacerts'],
             use_pull_operations=use_pull_operations,
             enable_stats=self.enable_stats)
+
+        # if log set, enable the logger.
+        if self.log:
+            define_operationlogger(log_destination='file',
+                                   filename='run_cimoperations.log',
+                                   log_level='debug')
+            self.conn.operation_recorder = ClientLogger()
 
         # enable saving of xml for display
         self.conn.debug = CLI_ARGS['debug']
@@ -6577,6 +6588,7 @@ def parse_args(argv_):
         print('    -l                  Do long running tests. If not set,\n'
               '                        skips a number of tests that take a\n'
               '                        long time to run')
+        print('    -log                Log all operations and http to file.')
         print('    -hl                 List of individual tests')
 
         print('')
@@ -6606,6 +6618,7 @@ def parse_args(argv_):
     args_['yamlfile'] = None
     args_['long_running'] = None
     args_['stats'] = None
+    args_['log'] = None
 
     # options must proceed arguments
     while True:
@@ -6644,6 +6657,8 @@ def parse_args(argv_):
         elif argv[1] == '--yamlfile':
             args_['yamlfile'] = argv[2]
             del argv[1:3]
+        elif argv[1] == '-log':
+            del argv[1:2]
         else:
             print("Error: Unknown option: %s" % argv[1])
             sys.exit(1)
@@ -6681,6 +6696,7 @@ def main():
         print("  stats: %s" % CLI_ARGS['stats'])
         print("  debug: %s" % CLI_ARGS['debug'])
         print("  yamlfile: %s" % CLI_ARGS['yamlfile'])
+        print("  log: %s" % CLI_ARGS['log'])
         print("  long_running: %s" % CLI_ARGS['long_running'])
 
         if CLI_ARGS['long_running'] is True:

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -29,17 +29,19 @@ import unittest
 
 from pywbem import PywbemLoggers
 
+VERBOSE = False
+
 
 class BaseLoggingTests(unittest.TestCase):
     """Base class for logging unit tests"""
     def setUp(self):
-        pass
+        PywbemLoggers.reset()
 
     def tearDown(self):
         pass
 
 
-class LogParseTests(BaseLoggingTests):
+class TestLogParse(BaseLoggingTests):
     """
     Test parse_log_specs
     """
@@ -97,7 +99,7 @@ class LogParseTests(BaseLoggingTests):
                                  'http': (None, None, None)})
 
 
-class LogParseTestErrors(BaseLoggingTests):
+class TestLogParseErrors(BaseLoggingTests):
     """ Test errors on the parse"""
     def parser_error_test(self, param):
         """Test for exception"""
@@ -118,41 +120,197 @@ class LogParseTestErrors(BaseLoggingTests):
         self.parser_error_test(param)
 
 
-class LoggerCreateTests(BaseLoggingTests):
+class TestLoggerCreate(BaseLoggingTests):
     """ Test the PywbemLoggers.create_logger method."""
-    def test_create_single_logger(self):
+    def test_create_single_logger1(self):
         """
         Create a simple logger
         """
         PywbemLoggers.create_logger('ops', 'file',
                                     log_filename='loggingtest.log',
-                                    log_level='debug')
+                                    log_level='debug',
+                                    log_detail_level='min')
 
-        print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        if VERBOSE:
+            print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        expected_result = \
+            {'pywbem.ops': ('min', 'debug', 'file', 'loggingtest.log')}
 
-        # TODO add test    
+        self.assertEqual(PywbemLoggers.loggers, expected_result)
+
+    def test_create_single_logger2(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        PywbemLoggers.create_logger('http', 'file',
+                                    log_filename='loggingtest.log',
+                                    log_level='debug',
+                                    log_detail_level='min')
+
+        if VERBOSE:
+            print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        expected_result = \
+            {'pywbem.http': ('min', 'debug', 'file', 'loggingtest.log')}
+
+        self.assertEqual(PywbemLoggers.loggers, expected_result)
+
+    def test_create_single_logger3(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        PywbemLoggers.create_logger('http', 'stderr',
+                                    log_level='debug',
+                                    log_filename=None,
+                                    log_detail_level='min')
+
+        if VERBOSE:
+            print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        expected_result = \
+            {'pywbem.http': ('min', 'debug', 'stderr', None)}
+
+        self.assertEqual(PywbemLoggers.loggers, expected_result)
+
+    def test_create_single_logger4(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        PywbemLoggers.create_logger('all', 'stderr',
+                                    log_level='debug',
+                                    log_filename=None,
+                                    log_detail_level='min')
+
+        if VERBOSE:
+            print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        expected_result = \
+            {'pywbem.http': ('min', 'debug', 'stderr', None),
+             'pywbem.ops': ('min', 'debug', 'stderr', None)}
+
+        self.assertEqual(PywbemLoggers.loggers, expected_result)
 
 
-class LoggersCreateTests(BaseLoggingTests):
+class TestLoggerCreateErrors(BaseLoggingTests):
+    """Test errors in the LoggerCreate Function"""
+
+    def test_create_single_logger1(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        try:
+            PywbemLoggers.create_logger('httpx', 'stderr',
+                                        log_level='debug',
+                                        log_filename=None,
+                                        log_detail_level='min')
+            self.fail('Exception expected')
+        except ValueError as ve:
+            if VERBOSE:
+                print('ve %s' % ve)
+
+    def test_create_single_logger2(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        try:
+            PywbemLoggers.create_logger('http', 'stderrblah',
+                                        log_level='debug',
+                                        log_filename=None,
+                                        log_detail_level='min')
+            self.fail('Exception expected')
+        except ValueError as ve:
+            if VERBOSE:
+                print('ve %s' % ve)
+
+    def test_create_single_logger3(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        try:
+            PywbemLoggers.create_logger('http', 'stderr',
+                                        log_level='debugblah',
+                                        log_filename=None,
+                                        log_detail_level='min')
+            self.fail('Exception expected')
+        except ValueError as ve:
+            if VERBOSE:
+                print('ve %s' % ve)
+
+    def test_create_single_logger4(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        try:
+            PywbemLoggers.create_logger('http', 'stderr',
+                                        log_level='debug',
+                                        log_filename=None,
+                                        log_detail_level='mi')
+            self.fail('Exception expected')
+        except ValueError as ve:
+            if VERBOSE:
+                print('ve %s' % ve)
+
+    def test_create_single_logger5(self):
+        """
+        Create a simple logger from detailed parameter input
+        """
+        try:
+            PywbemLoggers.create_logger('http', 'file',
+                                        log_level='debug',
+                                        log_filename=None,
+                                        log_detail_level='mi')
+            self.fail('Exception expected')
+        except ValueError as ve:
+            if VERBOSE:
+                print('ve %s' % ve)
+
+
+class TestLoggersCreate(BaseLoggingTests):
     """
-    Tests to create loggers using the PywbemLogger class
+    Tests to create loggers using the PywbemLogger class and the
+    method create_loggers that creates logger definitions from
+    an input string
     """
-    def valid_loggers_create(self, input_str, expected_result):
+    def valid_loggers_create(self, input_str, expected_result,
+                             log_filename=None):
         """Common test to do the create loggers and test result."""
-        PywbemLoggers.create_loggers(input_str)
-        print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        PywbemLoggers.create_loggers(input_str, log_filename)
+        self.assertEqual(PywbemLoggers.loggers, expected_result)
         # TODO add test
-        for name in PywbemLoggers.loggers:
-            print(PywbemLoggers.get_logger_info(name))
+        # for name in PywbemLoggers.loggers:
+        #    print(PywbemLoggers.get_logger_info(name))
 
-
-    def test_create_loggers(self):
+    def test_create_logger(self):
         """
         Create a simple logger
         """
         test_input = 'ops=file:min:debug,http=file:min:debug'
 
-        self.valid_loggers_create(test_input, None)
+        expected_result = \
+            {'pywbem.http': ('min', 'debug', 'file', 'pywbem.log'),
+             'pywbem.ops': ('min', 'debug', 'file', 'pywbem.log')}
+        self.valid_loggers_create(test_input, expected_result,
+                                  log_filename='pywbem.log')
+
+    def test_create_loggers1(self):
+        """
+        Create a simple logger
+        """
+        test_input = 'all=file:min:debug'
+        expected_result = \
+            {'pywbem.http': ('min', 'debug', 'file', 'logfile.log'),
+             'pywbem.ops': ('min', 'debug', 'file', 'logfile.log')}
+
+        self.valid_loggers_create(test_input, expected_result,
+                                  log_filename='logfile.log')
+
+    def test_create_loggers2(self):
+        """
+        Create a simple logger
+        """
+        test_input = 'all=stderr:all:info'
+        expected_result = \
+            {'pywbem.http': ('all', 'info', 'stderr', None),
+             'pywbem.ops': ('all', 'info', 'stderr', None)}
+
+        self.valid_loggers_create(test_input, expected_result)
 
 
 if __name__ == '__main__':

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Karl Schopmeyer
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+"""
+Unit test logging functionality in _logging.py
+
+"""
+
+from __future__ import absolute_import, print_function
+
+# Allows use of lots of single character variable names.
+# pylint: disable=invalid-name,missing-docstring,too-many-statements
+# pylint: disable=too-many-lines,no-self-use
+import unittest
+
+from pywbem import PywbemLoggers
+
+
+class BaseLoggingTests(unittest.TestCase):
+    """Base class for logging unit tests"""
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+
+class LogParseTests(BaseLoggingTests):
+    """
+    Test parse_log_specs
+    """
+    def parser_test(self, param, expected_result):
+        """ Common test for successful parsing"""
+        # pylint: disable=protected-access
+        result = PywbemLoggers._parse_log_specs(param)
+        self.assertEqual(result, expected_result)
+
+    def test_comp_only(self):
+        """Test all string"""
+        param = 'all'
+        self.parser_test(param, {'all': (None, None, None)})
+
+    def test_comp_only2(self):
+        """Test all= string"""
+        param = 'all='
+        self.parser_test(param, {'all': (None, None, None)})
+
+    def test_complete1(self):
+        """Test all=file:min:debug string"""
+        param = 'all=file:min:debug'
+        self.parser_test(param, {'all': ('file', 'min', 'debug')})
+
+    def test_complete2(self):
+        """Test all=file:min: string"""
+        param = 'all=file:min:'
+        self.parser_test(param, {'all': ('file', 'min', None)})
+
+    def test_complete3(self):
+        """Test all=file:min string"""
+        param = 'all=file:min'
+        self.parser_test(param, {'all': ('file', 'min', None)})
+
+    def test_complete4(self):
+        """Test all=::debug string"""
+        param = 'all=::debug'
+        self.parser_test(param, {'all': (None, None, 'debug')})
+
+    def test_complete5(self):
+        """Test all=::debug string"""
+        param = 'all=:min:'
+        self.parser_test(param, {'all': (None, 'min', None)})
+
+    def test_multiple1(self):
+        """Test ops=file:min,http=file:min:debug string"""
+        param = 'ops=file:min,http=file:min:debug'
+        self.parser_test(param, {'ops': ('file', 'min', None),
+                                 'http': ('file', 'min', 'debug')})
+
+    def test_multiple2(self):
+        """Test ops=file:min,http=file:min:debug string"""
+        param = 'ops=file:min,http='
+        self.parser_test(param, {'ops': ('file', 'min', None),
+                                 'http': (None, None, None)})
+
+
+class LogParseTestErrors(BaseLoggingTests):
+    """ Test errors on the parse"""
+    def parser_error_test(self, param):
+        """Test for exception"""
+        try:
+            # pylint: disable=protected-access
+            PywbemLoggers._parse_log_specs(param)
+            self.fail('param should generate exception %s' % param)
+        except ValueError:
+            pass
+
+    def test_to_many_params(self):
+        """ test all=file:min:debug:junk string """
+        param = "all=file:min:debug:junk"
+        self.parser_error_test(param)
+
+    def test_empty(self):
+        param = ""
+        self.parser_error_test(param)
+
+
+class LoggerCreateTests(BaseLoggingTests):
+    """ Test the PywbemLoggers.create_logger method."""
+    def test_create_single_logger(self):
+        """
+        Create a simple logger
+        """
+        PywbemLoggers.create_logger('ops', 'file',
+                                    log_filename='loggingtest.log',
+                                    log_level='debug')
+
+        print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+
+        # TODO add test    
+
+
+class LoggersCreateTests(BaseLoggingTests):
+    """
+    Tests to create loggers using the PywbemLogger class
+    """
+    def valid_loggers_create(self, input_str, expected_result):
+        """Common test to do the create loggers and test result."""
+        PywbemLoggers.create_loggers(input_str)
+        print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
+        # TODO add test
+        for name in PywbemLoggers.loggers:
+            print(PywbemLoggers.get_logger_info(name))
+
+
+    def test_create_loggers(self):
+        """
+        Create a simple logger
+        """
+        test_input = 'ops=file:min:debug,http=file:min:debug'
+
+        self.valid_loggers_create(test_input, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testsuite/test_wbemcli.py
+++ b/testsuite/test_wbemcli.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+"""
+    test wbemcli script.  This test generates a cmdline that calls
+    wbemcli with a specific set of options and tests the returns.
+    Because wbemcli always goes to interactive mode, the test call
+    includes a wbemcli script that forces wbemcli to quit.
+
+    It dynamically generates the set of tests from the TEST_MAP table.
+"""
+
+from __future__ import print_function, absolute_import
+import os
+import unittest
+from re import findall
+from subprocess import Popen, PIPE
+import six
+
+# Location of any test scripts for testing wbemcli.py
+SCRIPT_DIR = os.path.dirname(__file__)
+
+
+# Output fragments to test against for each test defined
+# Each item is a list of fragmants that are tested against the cmd execution
+# result
+HELP_OUTPUT = ['-n namespace,',
+               '-t timeout', ]
+LOG_DEST_STDERR_OUTPUT = ['log=on',
+                          'Connection: http://localhost,',
+                          ' no creds']
+LOG_DEST_FILE_OUTPUT = ['log=on',
+                        'Connection: http://localhost,',
+                        ' no creds']
+
+TIMEOUT_OUTPUT = ['Connection: http://localhost,',
+                  ' no creds',
+                  'timeout=10']
+NAMESPACE_OUTPUT = ['log=on',
+                    'Connection: http://localhost,',
+                    ' no creds',
+                    'default-namespace=rex/fred']
+
+# TODO ks: change this to use named tuple for clarity
+# Each test is dictionary with list containing test definition.
+#    For each test the dictionary entry includes:
+#    0 string defining 
+# expected stderr
+
+TESTS_MAP = {  # pylint: disable=invalid-name
+    'help': ["--help", HELP_OUTPUT, 0, None],
+    'namespace': ["-n rex/fred", NAMESPACE_OUTPUT, 0, None],
+    'timeout': ["-t 10", TIMEOUT_OUTPUT, 0, None], }
+
+# more tests
+#    'log_dest_stderr': ['-l stderr', LOG_DEST_STDERR_OUTPUT]}
+#    'log_dest_file': ['-l file', LOG_DEST_STDERR_OUTPUT]}
+
+
+class ContainerMeta(type):
+    """Class to define the function to generate unittest methods."""
+
+    def __new__(mcs, name, bases, dict):  # pylint: disable=redefined-builtin
+        def generate_test(test_name, cmd_str, expected_stdout, expected_stderr):
+            """
+            Defines the test method (test) that we generate for each test
+            and returns the method.
+
+            The cmd_str defines ONLY the arguments and options part of the
+            command.  This function prepends wbemcli to the cmd_str.
+
+            Since wbemcli is interactive, it also includes a quit script
+
+            Each test builds the pywbemcli command executes it and tests the
+            results
+            """
+            def test(self):  # pylint: disable=missing-docstring
+                """ The test method that is generated."""
+                term_script_file = os.path.join(SCRIPT_DIR,
+                                                'wbemcli_quit_script.py')
+                term_script_param = '-s %s' % term_script_file
+
+                command = ('wbemcli http://blah %s %s' %
+                           (cmd_str, term_script_param))
+                # Disable python warnings for wbemcli call
+                # because some imports generate deprecated warnings
+                # that appear in std_err when nothing expected
+                command = 'export PYTHONWARNINGS="" && %s' % command
+                proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+                std_out, std_err = proc.communicate()
+                exitcode = proc.returncode
+                if six.PY3:
+                    std_out = std_out.decode()
+                    std_err = std_err.decode()
+
+                self.assertEqual(exitcode, 0, ('%s: Unexpected ExitCode Err, '
+                                               'cmd="%s" '
+                                               'exitcode %s stderr=%s' %
+                                               (test_name, command,
+                                               exitcode, std_err)))
+
+                if not expected_stderr:
+                    self.assertEqual(std_err, "",
+                                     '%s stderr not empty. returned %s'
+                                     % (test_name, std_err))
+                else:
+                    for item in expected_stderr:
+                        match_result = findall(item, std_err)
+                        self.assertIsNotNone(match_result, 'test %s, '
+                                             'stderr did not match test '
+                                             'definition. Expected %s in %s' %
+                                             (test_name, item, expected_stderr))
+
+                for item in expected_stdout:
+                    match_result = findall(item, std_out)
+                    self.assertIsNotNone(match_result,
+                                         'Test %s, stdout did not match test '
+                                         'definition. Expected %s in %s' %
+                                         (test_name, item, expected_stdout))
+            return test
+
+        for test_name, params in six.iteritems(TESTS_MAP):
+            test_name = "test_%s" % test_name
+            dict[test_name] = generate_test(test_name, params[0], params[1],
+                                            params[2])
+        return type.__new__(mcs, name, bases, dict)
+
+
+@six.add_metaclass(ContainerMeta)
+class TestsContainer(unittest.TestCase):
+    """Container class for all tests"""
+    __metaclass__ = ContainerMeta
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testsuite/wbemcli_quit_script.py
+++ b/testsuite/wbemcli_quit_script.py
@@ -1,0 +1,6 @@
+"""
+Pywbem scriptlet to quit wbemcli It is used
+by test_wbemcli.py to force wbemcli to terminate after each test.
+"""
+print('Quit Scriplet. Quiting wbemcli')
+quit()

--- a/testsuite/wbemcli_quit_script.py
+++ b/testsuite/wbemcli_quit_script.py
@@ -2,5 +2,9 @@
 Pywbem scriptlet to quit wbemcli It is used
 by test_wbemcli.py to force wbemcli to terminate after each test.
 """
-print('Quit Scriplet. Quiting wbemcli')
+
+# this displays the connection info.  Required because what you see in
+# wbemcli startup is through the python interactive module and not to
+# stdout
+print(_get_connection_info())  # noqa: F821
 quit()

--- a/wbemcli.bat
+++ b/wbemcli.bat
@@ -1,3 +1,5 @@
 @setlocal enableextensions
+@set errorlevel=
 @python %~d0%~p0%~n0 %*
 @endlocal
+@exit /b %errorlevel%

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -57,7 +57,10 @@ except ImportError as arg:
 from pywbem import WBEMConnection
 from pywbem.cim_http import get_default_ca_cert_paths
 from pywbem._cliutils import SmartFormatter as _SmartFormatter
-from pywbem.config import DEFAULT_ITER_MAXOBJECTCOUNT
+from pywbem.config import DEFAULT_ITER_MAXOBJECTCOUNT, DEFAULT_LOG_DESTINATION
+
+from pywbem import PywbemLoggers, LOG_DESTINATIONS, LOG_DETAIL_LEVELS, \
+    PYWBEM_LOG_COMPONENTS, LOG_LEVELS
 from pywbem import __version__
 
 # Connection global variable. Set by remote_connection and use
@@ -66,6 +69,8 @@ CONN = None
 
 # global ARGS contains the argparse arguments dictionary
 ARGS = None
+
+WBEMCLI_LOG_FILE_NAME = 'wbemcli.log'
 
 
 def _remote_connection(server, opts, argparser_):
@@ -113,10 +118,13 @@ def _remote_connection(server, opts, argparser_):
         if opts.key_file is not None:
             x509_dict.update({'key_file': opts.key_file})
 
+    log_info = True if opts.log else False
+
     CONN = WBEMConnection(url, creds, default_namespace=opts.namespace,
                           no_verification=opts.no_verify_cert,
                           x509=x509_dict, ca_certs=opts.ca_certs,
-                          timeout=opts.timeout, enable_stats=opts.enable_stats)
+                          timeout=opts.timeout, enable_stats=opts.enable_stats,
+                          enable_log=log_info)
 
     CONN.debug = True
 
@@ -128,6 +136,7 @@ def _remote_connection(server, opts, argparser_):
 #
 
 # pylint: disable=too-many-arguments
+# pylint: disable=redefined-outer-name
 def iei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
         fq=None, ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT,):
     """
@@ -350,6 +359,8 @@ def ieip(cn, ns=None, fl=None, fq=None, ot=None, coe=None,
 
 
 # pylint: disable=too-many-arguments
+# pylint: disable=redefined-outer-name
+# pylint: disable=invalid-name
 def iri(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
         ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT):
     """
@@ -459,6 +470,7 @@ def iri(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
 
 
 # pylint: disable=too-many-arguments
+# pylint: disable=redefined-outer-name
 def irip(op, rc=None, r=None, fl=None, fq=None, ot=None, coe=None,
          moc=DEFAULT_ITER_MAXOBJECTCOUNT):
     """
@@ -2791,7 +2803,10 @@ def _get_connection_info():
     if CONN.timeout is not None:
         info += ', timeout=%s' % CONN.timeout
 
-    info += ' stats=%s,' % ('on' if CONN._statistics else 'off')
+    info += ' stats=%s, ' % ('on' if CONN._statistics else 'off')
+
+    # TODO find logical way to record that we are logging
+    info += 'log=%s, ' % ('on' if CONN.operation_recorder else 'off')
 
     return fill(info, 78, subsequent_indent='    ')
 
@@ -2964,6 +2979,29 @@ Examples:
         action='store_true', default=False,
         help='Enable gathering of statistics on operations.')
     general_arggroup.add_argument(
+        '-l', '--log', dest='log', metavar='log_spec[,logspec]',
+        action='store', default=None,
+        help='R|Log_spec defines characteristics of the various named\n'
+             'loggers. It is the form:\n COMP=[DEST[:DETAIL[:LEVEL]]] where:\n'
+             '   COMP: Logger component name:[{c}].\n'
+             '         (Default={cd})\n'
+             '   DEST: Destination for component:[{d}].\n'
+             '         (Default={dd})\n'
+             '   DETAIL: Detail Level to log: [{dl}].\n'
+             '           (Default={dll})\n'
+             '   LEVEL: Log level:[{ll}].\n'
+             '          (Default={lld}\n'
+             .format(c='|'.join(PYWBEM_LOG_COMPONENTS),
+                     cd='all',
+                     d='|'.join(LOG_DESTINATIONS),
+                     dd=DEFAULT_LOG_DESTINATION,
+                     dl='|'.join(LOG_DETAIL_LEVELS),
+                     dll='all',
+                     ll='|'.join(LOG_LEVELS),
+                     lld='debug'))
+    # TODO ks July 17generalize where we get the defaults
+
+    general_arggroup.add_argument(
         '-h', '--help', action='help',
         help='Show this help message and exit')
 
@@ -2976,7 +3014,13 @@ Examples:
     if not args.server:
         argparser.error('No WBEM server specified')
 
+    # log information is in the form
+    # -l dest=level:detail:log_level
+    if args.log:
+        PywbemLoggers.create_loggers(args.log)
+
     # Set up a client connection
+    # TODO separate our the detail level parameter
     CONN = _remote_connection(args.server, args, argparser)
 
     # Determine file path of history file

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -60,7 +60,8 @@ from pywbem._cliutils import SmartFormatter as _SmartFormatter
 from pywbem.config import DEFAULT_ITER_MAXOBJECTCOUNT, DEFAULT_LOG_DESTINATION
 
 from pywbem import PywbemLoggers, LOG_DESTINATIONS, LOG_DETAIL_LEVELS, \
-    PYWBEM_LOG_COMPONENTS, LOG_LEVELS
+    PYWBEM_LOG_COMPONENTS, LOG_LEVELS, DEFAULT_LOG_DETAIL_LEVEL, \
+    DEFAULT_LOG_LEVEL
 from pywbem import __version__
 
 # Connection global variable. Set by remote_connection and use
@@ -71,6 +72,8 @@ CONN = None
 ARGS = None
 
 WBEMCLI_LOG_FILE_NAME = 'wbemcli.log'
+
+DEFAULT_LOG_FILENAME = 'pywbem.log'
 
 
 def _remote_connection(server, opts, argparser_):
@@ -2803,9 +2806,10 @@ def _get_connection_info():
     if CONN.timeout is not None:
         info += ', timeout=%s' % CONN.timeout
 
+    # pylint: disable=protected-access
     info += ' stats=%s, ' % ('on' if CONN._statistics else 'off')
 
-    # TODO find logical way to record that we are logging
+    # TODO: ks find more complete way to record that we are logging
     info += 'log=%s, ' % ('on' if CONN.operation_recorder else 'off')
 
     return fill(info, 78, subsequent_indent='    ')
@@ -2990,16 +2994,16 @@ Examples:
              '   DETAIL: Detail Level to log: [{dl}].\n'
              '           (Default={dll})\n'
              '   LEVEL: Log level:[{ll}].\n'
-             '          (Default={lld}\n'
+             '          (Default={lld})\n'
+             # pylint: disable=bad-continuation
              .format(c='|'.join(PYWBEM_LOG_COMPONENTS),
                      cd='all',
                      d='|'.join(LOG_DESTINATIONS),
                      dd=DEFAULT_LOG_DESTINATION,
                      dl='|'.join(LOG_DETAIL_LEVELS),
-                     dll='all',
+                     dll=DEFAULT_LOG_DETAIL_LEVEL,
                      ll='|'.join(LOG_LEVELS),
-                     lld='debug'))
-    # TODO ks July 17generalize where we get the defaults
+                     lld=DEFAULT_LOG_LEVEL))
 
     general_arggroup.add_argument(
         '-h', '--help', action='help',
@@ -3017,10 +3021,9 @@ Examples:
     # log information is in the form
     # -l dest=level:detail:log_level
     if args.log:
-        PywbemLoggers.create_loggers(args.log)
+        PywbemLoggers.create_loggers(args.log, DEFAULT_LOG_FILENAME)
 
     # Set up a client connection
-    # TODO separate our the detail level parameter
     CONN = _remote_connection(args.server, args, argparser)
 
     # Determine file path of history file


### PR DESCRIPTION
**Based on Andy's comment, I am withdrawing this PR and submitting pieces of work as separate prs.**  I will document that list of new PRs as it is submitted.

Logger function added to recorder.  This is no longer a prototype.  However, it functionally complete now but has some issues (see Not Done).

I am keeping this WIP for another day or so while I work out the not done list below.

Includes:
1. New LogOperationRecorder class in recorder logs operations request/responses and http request/responses.  Note that logging for each can be defined separately so that each can have a destination (file, stderr), log_level(debug, etc) and detail level (how much information is output)
2. Addition of PywbemLoggers class in _logging that manages loggers creating new named loggers and keeping the information that logging cannot handle (detail level). Includes parsing of the command line parameter for logging so wbemcli and pywbemtools do not have to do this separately.
3. Add new script test for wbemcli (test_wbemcli.py).  Only includes a few tests today but new tests can be easily added.
4. Extend wbemconnection to add new constructor (enable_logging) that is a boolean.  When this is created, the LogOperationRecorder gets the detail level info from PywbemLoggers by logger name.


Not done:
1. The tests in test_logging and test_wbemcli are incomplete. COMMENT: Move any new tests forward to new issue
2. Some of the new code in _logging.py is a hack and just needs refactoring. In fact, I have only lightly tested the final result. Cleaned up. **Done**
3. There is no documentation on the logging (or for that matter the statistics) in the documentation. COMMENT: Create new issue
4. I left the input parameters in their original order for the moment (destination:detail:log_level rather than Andy's proposal for different order. We should discuss the levels of detail (min, all) right now and exactly what they mean.  The structure is in place so we can manage this detail level as we want to.  Right now detail output 1000 char and all outputs everything.  Maybe a hdrs_only or something but not sure exactly what that means.   COMMENT: Create new issue
5. Not displaying enough in wbemcli when logger enabled. Just says logging=true no info about components, etc. Minor. COMMENT: Create new issue 
6. Only outputs logger or test recorder, not both.  I know how to extend to do both but wanted to get this much running first.   COMMENT: Create new issue
7. I need to review logging of the wbemconnection itself since it is NOT linked to the other log outputs. The logical way to do this might to be to set a counter that increments for each new connection and this counter also is set into the ops and http logs.   COMMENT: Create new issue

DISCUSSION:
1. Do we really need to be able to do both log and test recorder at the same time.
2. Do we need to link the ops/http logs to the connection.



