### PR TITLE
Fixes #687: Implement handling of WBEMServerResponseTime

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -80,6 +80,16 @@ Enhancements
 * Extend the documentation to list support for specific non-specification
   features of some WBEM servers. Issue #653.
 
+* Extend cim_http.py, cim_operations.py, _statistics.py to handle optional
+  WBEMServerResponseTime header from WBEMServer.  This HTTP header reports
+  the server time in microseconds from request to response in the operation
+  response.  The extension adds the WBEMConnection property
+  last_server_response_time and places the time from the server into the
+  attribute for this property.
+  It also passes server_response_time to statistics so that max/min/avg are
+  maintained.  See issue # 687.
+
+
 Bug fixes
 ^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -86,6 +86,12 @@ Enhancements
   response.  The extension adds the WBEMConnection property
   last_server_response_time and places the time from the server into the
   attribute for this property.
+
+* Extend pywbem to handle optional WBEMServerResponseTime header from a
+  WBEM server.  This HTTP header reports the server time in microseconds from
+  request to response in the operation response.  The extension adds the
+  WBEMConnection property `last_server_response_time` and places the time from
+  the server into the attribute for this property.
   It also passes server_response_time to statistics so that max/min/avg are
   maintained.  See issue # 687.
 

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -324,7 +324,7 @@ class OperationStatistic(object):
             processing the operation.
 
           server_time (:class:`py:bool`)
-            Time in microseconds that the server optionally returns to the
+            Time in seconds that the server optionally returns to the
             client in the HTTP response defining the time from when the
             server received the request to when it started sending the
             response. If None, there is no time from the server.
@@ -583,11 +583,8 @@ class Statistics(object):
         Return a human readable string with the statistics for this container.
         The operations are sorted by decreasing average time.
 
-        If the server time statistic exists, a report with that statistic
-        is output
-
-        The server times are only included if they have been used, i.e. there
-        is data in these properties.
+        Server time statistic is included only if the wbem server has returned
+        statistics information.
 
         Example w/o server times::
 

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -70,7 +70,7 @@ class OperationStatistic(object):
 
         stats = container.start_timer('EnumerateInstances')
         ...
-        stats.stop_timer(request_len, reply_len, exc)
+        stats.stop_timer(request_len, reply_len, server_time, exc)
 
     **Experimental:** This class is experimental for this release.
     """
@@ -98,6 +98,7 @@ class OperationStatistic(object):
         self._server_time_sum = float(0)
         self._server_time_min = float('inf')
         self._server_time_max = float(0)
+        self._server_time_stored = False
 
         self._start_time = None
 
@@ -276,6 +277,7 @@ class OperationStatistic(object):
         self._server_time_sum = float(0)
         self._server_time_min = float('inf')
         self._server_time_max = float(0)
+        self._server_time_stored = False
 
         self._request_len_sum = float(0)
         self._request_len_min = float('inf')
@@ -355,6 +357,7 @@ class OperationStatistic(object):
                 self._time_min = dt
 
             if server_time:
+                self._server_time_stored = True
                 self._server_time_sum += server_time
                 if dt > self._server_time_max:
                     self._server_time_max = server_time
@@ -602,17 +605,17 @@ class Statistics(object):
                               reverse=True)
 
             # Test to see if any server time is non-zero
-            server_time = 0
+            include_svr = False
             for name, stats in snapshot:  # pylint: disable=unused-variable
-                server_time += stats.avg_server_time
-            inc_svr = True if server_time else False
-            if inc_svr:
+                if stats._server_time_stored:
+                    include_svr = True
+            if include_svr:
                 ret += OperationStatistic.formatted_header_w_svr
             else:
                 ret += OperationStatistic.formatted_header
 
             for name, stats in snapshot:  # pylint: disable=unused-variable
-                ret += stats.formatted(inc_svr)
+                ret += stats.formatted(include_svr)
         else:
             ret += "Disabled"
         return ret.strip()

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -56,6 +56,7 @@ __all__ = ['Statistics', 'OperationStatistic']
 
 
 class OperationStatistic(object):
+    # pylint: disable=too-many-instance-attributes
     """
     A statistics data keeper for the executions of all operations with the
     same operation name.
@@ -93,6 +94,11 @@ class OperationStatistic(object):
         self._time_sum = float(0)
         self._time_min = float('inf')
         self._time_max = float(0)
+
+        self._server_time_sum = float(0)
+        self._server_time_min = float('inf')
+        self._server_time_max = float(0)
+
         self._start_time = None
 
         self._request_len_sum = float(0)
@@ -176,6 +182,33 @@ class OperationStatistic(object):
         return self._time_max
 
     @property
+    def avg_server_time(self):
+        """
+        :class:`py:float`: The average elapsed time for invoking the measured
+        operations, in seconds.
+        """
+        try:
+            return self._server_time_sum / self._count
+        except ZeroDivisionError:
+            return 0
+
+    @property
+    def min_server_time(self):
+        """
+        :class:`py:float`: The minimum elapsed time for invoking the measured
+        operations, in seconds.
+        """
+        return self._server_time_min
+
+    @property
+    def max_server_time(self):
+        """
+        :class:`py:float`: The maximum elapsed time for invoking the measured
+        operations, in seconds.
+        """
+        return self._server_time_max
+
+    @property
     def avg_request_len(self):
         """
         :class:`py:float`: The average size of the HTTP body in the CIM-XML
@@ -240,6 +273,10 @@ class OperationStatistic(object):
         self._time_min = float('inf')
         self._time_max = float(0)
 
+        self._server_time_sum = float(0)
+        self._server_time_min = float('inf')
+        self._server_time_max = float(0)
+
         self._request_len_sum = float(0)
         self._request_len_min = float('inf')
         self._request_len_max = float(0)
@@ -265,7 +302,8 @@ class OperationStatistic(object):
             if not self._stat_start_time:
                 self._stat_start_time = self._start_time
 
-    def stop_timer(self, request_len, reply_len, exception=False):
+    def stop_timer(self, request_len, reply_len, server_time=None,
+                   exception=False):
         """
         This method needs to be called at the end of an operation that is
         intended to be measured. It completes the measurement for that
@@ -284,6 +322,12 @@ class OperationStatistic(object):
           exception (:class:`py:bool`)
             Boolean that specifies whether an exception was raised while
             processing the operation.
+
+          server_time (:class:`py:bool`)
+            Time in microseconds that the server optionally returns to the
+            client in the HTTP response defining the time from when the
+            server received the request to when it started sending the
+            response. If None, there is no time from the server.
 
         Returns:
 
@@ -309,6 +353,13 @@ class OperationStatistic(object):
                 self._time_max = dt
             if dt < self._time_min:
                 self._time_min = dt
+
+            if server_time:
+                self._server_time_sum += server_time
+                if dt > self._server_time_max:
+                    self._server_time_max = server_time
+                if dt < self._server_time_min:
+                    self._server_time_min = server_time
 
             if request_len > self._request_len_max:
                 self._request_len_max = request_len
@@ -336,6 +387,9 @@ class OperationStatistic(object):
                'avg_time={s.avg_time!r}, ' \
                'min_time={s.min_time!r}, ' \
                'max_time={s.max_time!r}, ' \
+               'avg_server_time={s.avg_server_time!r}, ' \
+               'min_server_time={s.min_server_time!r}, ' \
+               'max_server_time={s.max_server_time!r}, ' \
                'avg_request_len={s.avg_request_len!r}, ' \
                'min_request_len={s.min_request_len!r}, ' \
                'max_request_len={s.max_request_len!r}, ' \
@@ -348,13 +402,19 @@ class OperationStatistic(object):
     #: returned by the :meth:`~pywbem.OperationStatistic.formatted` method.
     #:
     #: For an example, see :meth:`pywbem.Statistics.formatted`.
-    formatted_header = \
-        'Count Excep    Time    Time    Time ReqLen ReqLen ReqLen ' \
-        'ReplyLen ReplyLen ReplyLen Operation\n' \
-        '        Cnt     Avg     Min     Max    Avg    Min    Max ' \
-        '     Avg      Min      Max\n'
+    formatted_header_w_svr = \
+        'Count Excep            Time               ServerTime       ' \
+        '       RequestLen               ReplyLen         Operation\n' \
+        '        Cnt     Avg     Min     Max     Avg     Min     Max   ' \
+        ' Avg    Min    Max      Avg      Min      Max\n'
 
-    def formatted(self):
+    formatted_header = \
+        'Count Excep            Time          ' \
+        '       RequestLen            ReplyLen        Operation\n' \
+        '        Cnt     Avg     Min     Max   ' \
+        ' Avg    Min    Max    Avg      Min      Max\n'
+
+    def formatted(self, include_server_time):
         """
         Return a formatted one-line string with the statistics values for this
         operation.
@@ -364,14 +424,33 @@ class OperationStatistic(object):
 
         For an example, see :meth:`pywbem.Statistics.formatted`.
         """
-        return ('{0:5d} {1:5d} {2:7.3f} {3:7.3f} {4:7.3f} {5:6.0f} {6:6.0f} '
-                '{7:6.0f} {8:8.0f} {9:8.0f} {10:8.0f} {11}\n'.
-                format(self.count, self.exception_count,
-                       self.avg_time, self.min_time, self.max_time,
-                       self.avg_request_len, self.min_request_len,
-                       self.max_request_len, self.avg_reply_len,
-                       self.min_reply_len, self.max_reply_len,
-                       self.name))
+        if include_server_time:
+            return ('{0:5d} {1:5d} '
+                    '{2:7.3f} {3:7.3f} {4:7.3f} '
+                    '{5:7.3f} {6:7.3f} {7:7.3f} '
+                    '{8:6.0f} {9:6.0f} {10:6.0f} '
+                    '{11:8.0f} {12:8.0f} {13:8.0f} {14}\n'.
+                    format(self.count, self.exception_count,
+                           self.avg_time, self.min_time, self.max_time,
+                           self.avg_server_time, self.min_server_time,
+                           self.max_server_time,
+                           self.avg_request_len, self.min_request_len,
+                           self.max_request_len,
+                           self.avg_reply_len, self.min_reply_len,
+                           self.max_reply_len,
+                           self.name))
+        else:
+            return ('{0:5d} {1:5d} '
+                    '{2:7.3f} {3:7.3f} {4:7.3f} '
+                    '{5:6.0f} {6:6.0f} {7:6.0f} '
+                    '{8:6.0f} {9:8.0f} {10:8.0f} {11}\n'.
+                    format(self.count, self.exception_count,
+                           self.avg_time, self.min_time, self.max_time,
+                           self.avg_request_len, self.min_request_len,
+                           self.max_request_len,
+                           self.avg_reply_len, self.min_reply_len,
+                           self.max_reply_len,
+                           self.name))
 
 
 class Statistics(object):
@@ -504,10 +583,16 @@ class Statistics(object):
         Return a human readable string with the statistics for this container.
         The operations are sorted by decreasing average time.
 
-        Example::
+        If the server time statistic exists, a report with that statistic
+        is output
+
+        The server times are only included if they have been used, i.e. there
+        is data in these properties.
+
+        Example w/o server times::
 
             Statistics (times in seconds, lengths in Bytes):
-            Count  Exc    Time    Time    Time ReqLen ReqLen ReqLen ReplyLen ReplyLen ReplyLen Operation
+            Count  Exc            Time                ReqLen                ReplyLen          Operation
                    Cnt    Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
                 3    0   0.234   0.100   0.401   1233   1000   1500    26667    20000    35000 EnumerateInstances
                 1    0   0.100   0.100   0.100   1200   1200   1200    22000    22000    22000 EnumerateInstanceNames
@@ -515,12 +600,22 @@ class Statistics(object):
         # pylint: enable=line-too-long
         ret = "Statistics (times in seconds, lengths in Bytes):\n"
         if self.enabled:
-            ret += OperationStatistic.formatted_header
             snapshot = sorted(self.snapshot(),
                               key=lambda item: item[1].avg_time,
                               reverse=True)
+
+            # Test to see if any server time is non-zero
+            server_time = 0
             for name, stats in snapshot:  # pylint: disable=unused-variable
-                ret += stats.formatted()
+                server_time += stats.avg_server_time
+            inc_svr = True if server_time else False
+            if inc_svr:
+                ret += OperationStatistic.formatted_header_w_svr
+            else:
+                ret += OperationStatistic.formatted_header
+
+            for name, stats in snapshot:  # pylint: disable=unused-variable
+                ret += stats.formatted(inc_svr)
         else:
             ret += "Disabled"
         return ret.strip()

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -57,8 +57,8 @@ from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
 if six.PY2 and not _ON_RTD:  # RTD has no swig to install M2Crypto
-    from M2Crypto import SSL           # pylint: disable=wrong-import-position
-    from M2Crypto.Err import SSLError  # pylint: disable=wrong-import-position
+    from M2Crypto import SSL           # pylint: disable=wrong-import-order
+    from M2Crypto.Err import SSLError  # pylint: disable=wrong-import-order
     _HAVE_M2CRYPTO = True
     # pylint: disable=invalid-name
     SocketErrors = (socket.error, socket.sslerror)
@@ -785,11 +785,11 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                 # Attempt to get the optional response time header sent from
                 # the server
                 svr_resp_time = response.getheader(
-                    'WBEMServerResponseTime', '')
+                    'WBEMServerResponseTime', None)
                 if svr_resp_time:
                     try:
-                        # convert to integer and map from microsec to sec.
-                        svr_resp_time = int(svr_resp_time) / 1000000
+                        # convert to float and map from microsec to sec.
+                        svr_resp_time = float(svr_resp_time) / 1000000
                     except ValueError:
                         pass
 

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -418,8 +418,9 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
             The CIM-XML formatted response data from the WBEM server, as a
             :term:`unicode string` object.
 
-            The server response time in milliseconds if this data was received
-            from the server.
+            The server response time in seconds as floating point number if
+            this data was received from the server. If no data returned
+            from server `None is returned.
 
     Raises:
         :exc:`~pywbem.AuthError`

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -916,13 +916,12 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         header
 
         This time is available only subsequent to the execution of an operation
-        on this connection, if the statistics are enabled on this
-        connection and if the WBEMServerResponseTime is received from the
+        on this connection  if the WBEMServerResponseTime is received from the
         WBEM server. Otherwise, the value is `None`.
 
         **Experimental:** This property is experimental for this release.
         """
-        return self._last_operation_time
+        return self._last_server_response_time
 
     def __str__(self):
         """

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -192,6 +192,7 @@ class ClientTest(unittest.TestCase):
         # those few exceptions that occur outside of the try block in the
         # Iter... operations.
         if self.enable_stats:
+            # svr_time and operation_time may return None
             svr_time = ('%.4f' % self.conn.last_server_response_time) \
                 if self.conn.last_server_response_time else 'None'
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -192,16 +192,18 @@ class ClientTest(unittest.TestCase):
         # those few exceptions that occur outside of the try block in the
         # Iter... operations.
         if self.enable_stats:
-            if not self.conn.last_operation_time:
-                print('Operation info time %s req_len %s reply_len %s' %
-                      (self.conn.last_operation_time,
-                       self.conn.last_request_len,
-                       self.conn.last_reply_len))
-            else:
-                print('Operation info time %.3f req_len %s reply_len %s' %
-                      (self.conn.last_operation_time,
-                       self.conn.last_request_len,
-                       self.conn.last_reply_len))
+            svr_time = ('%.4f' % self.conn.last_server_response_time) \
+                if self.conn.last_server_response_time else 'None'
+
+            operation_time = ('%.4f' % self.conn.last_operation_time) \
+                if self.conn.last_operation_time else None
+
+            print('Operation info: time %s req_len %d reply_len %d '
+                  'svr_time %s' %
+                  (operation_time,
+                   self.conn.last_request_len,
+                   self.conn.last_reply_len,
+                   svr_time))
 
         return result
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -199,7 +199,7 @@ class ClientTest(unittest.TestCase):
             operation_time = ('%.4f' % self.conn.last_operation_time) \
                 if self.conn.last_operation_time else None
 
-            print('Operation info: time %s req_len %d reply_len %d '
+            print('Operation stats: time %s req_len %d reply_len %d '
                   'svr_time %s' %
                   (operation_time,
                    self.conn.last_request_len,
@@ -4611,7 +4611,7 @@ class IterEnumerateInstances(PegasusServerTestBase):
         self.assertEqual(self.conn._use_query_pull_operations, False)
 
     def test_propertylist2(self):
-        """Test withone item property list."""
+        """Test with one item property list."""
         expected_response_count = 200
         self.set_stress_provider_parameters(expected_response_count, 200)
 


### PR DESCRIPTION
Extend pywbem to get WBEMServerResponseTime from server and include as new attribute/property in WBEMConnection (last_server_response_time) and new statistic in statistics.

1. Extend cim_http.py to capture optional WBEM_ServerResponseTime header
and convert from microseconds to seconds.
2.Extend cim_operations to add new attribute _server_response_time and
new property server_response_time that holds either None or the server
response time in seconds.
3. Extend statistics to include this statistic and display it in reports
if it is provided by the wbem server.
4. Extend run_cimoperations.py to display the last_server_response_time
if it exists.

Adds entry to changes.rst