### PR TITLE
Fixes #700: Fix issue with recorder creating non-text files

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -148,6 +148,12 @@ Bug fixes
 * Correct Error in run_cimoperations with use of namespace in iter... function
   See issue #718. This was a test code issue. No changes to the iter
   operations.
+
+* Correct issue with Recorder creating non-text files.  This issue
+  Documents the requirement for text files and also adds a static
+  method to force creation of the recorder output as a text file.
+  See issue # 700
+
   
 
 Build, test, quality

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -290,6 +290,7 @@ class BaseOperationRecorder(object):
             recorder = TestClientRecorder(open_file('recorder.log')
         """
         if six.PY2:
+            # Open with codecs to define text mode
             return codecs.open(filename, mode=file_mode, encoding='utf-8')
 
         return open(filename, file_mode, encoding='utf8')

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -37,6 +37,9 @@ from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
 from .cim_types import CIMInt, CIMFloat, CIMDateTime
 from .exceptions import CIMError
 
+if six.PY2:
+    import codecs  # pylint: disable=wrong-import-order
+
 __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
            'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse']
 
@@ -267,6 +270,30 @@ class BaseOperationRecorder(object):
         """Indicate whether the recorder is enabled."""
         return self._enabled
 
+    @staticmethod
+    def open_file(filename, file_mode='w'):
+        """
+        A static convience function that performs the open of the recorder file
+        correctly for different versions of python.  This covers the
+        issue where the file should be opened in text mode but that is
+        done differently in pythong 2 and python 3
+
+        Parameters:
+          filename: (:term: `string`):
+            Name of the file where the recorder output will be written
+          file_mode: (:term: `string`):
+            Optional file mode.  The default is 'w' which overwrites any
+            existing file.  if 'a' is used, the data is appended to any
+            existing file.
+
+          Example:
+            recorder = TestClientRecorder(open_file('recorder.log')
+        """
+        if six.PY2:
+            return codecs.open(filename, mode=file_mode, encoding='utf-8')
+
+        return open(filename, file_mode, encoding='utf8')
+
     def reset(self, pull_op=None):
         """Reset all the attributes in the class. This also allows setting
         the pull_op attribute that defines whether the operation is to be
@@ -420,7 +447,15 @@ class TestClientRecorder(BaseOperationRecorder):
         Parameters:
 
         fp (file):
-          An open file that each test case will be written to.
+          An open file that each test case will be written to.  This file
+          should have been opened in text mode.
+
+          Since there are differences between python 2 and 3 in opening
+          files in text mode, the static method
+          open__file(filename) can be used to open the file.
+
+        Example:
+          recorder = TestClientRecorder(open_file('recorder.log')
         """
         super(TestClientRecorder, self).__init__()
         self._fp = fp

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -44,9 +44,6 @@ from pywbem.mof_compiler import MOFCompiler
 from unittest_extensions import RegexpMixin
 
 
-if six.PY2:
-    import codecs
-
 # Test for decorator for unimplemented tests
 # decorator is @unittest.skip(UNIMPLEMENTED)
 UNIMPLEMENTED = "test not implemented"
@@ -140,10 +137,7 @@ class ClientTest(unittest.TestCase):
         self.conn.debug = CLI_ARGS['debug']
 
         if self.yamlfile is not None:
-            if six.PY2:
-                self.yamlfp = codecs.open(self.yamlfile, 'a', encoding='utf8')
-            else:
-                self.yamlfp = open(self.yamlfile, 'a')
+            self.yamlfp = TestClientRecorder.open_file(self.yamlfile, 'a')
             self.conn.operation_recorder = TestClientRecorder(self.yamlfp)
 
         self.log('Connected {}, ns {}'.format(self.system_url,

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -30,6 +30,7 @@ import unittest
 import re
 import traceback
 from collections import namedtuple
+from io import open as _open
 import six
 import yaml
 import httpretty
@@ -505,7 +506,7 @@ class ClientTest(unittest.TestCase):
 
         print("Process YAML file: %s" % os.path.basename(fn))
 
-        with open(fn) as fp:
+        with _open(fn, encoding="utf-8") as fp:
             testcases = yaml.load(fp)
             for testcase in testcases:
                 self.runtestcase(testcase)

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -25,9 +25,6 @@ from pywbem import TestClientRecorder as _TestClientRecorder
 # used to build result tuple for test
 from pywbem.cim_operations import pull_path_result_tuple
 
-if six.PY2:
-    import codecs  # pylint: disable=wrong-import-order
-
 # test outpuf file for the recorder tests.  This is opened for each
 # test to save yaml output and may be reloaded during the same test
 # to confirm the yaml results.
@@ -43,11 +40,7 @@ class BaseRecorderTests(unittest.TestCase):
         if os.path.isfile(self.testyamlfile):
             os.remove(self.testyamlfile)
 
-        # if python 2, open with codec to allow utf-8 writes.
-        if six.PY2:
-            self.yamlfp = codecs.open(self.testyamlfile, 'a', encoding='utf8')
-        else:
-            self.yamlfp = open(self.testyamlfile, 'a')
+        self.yamlfp = TestClientRecorder.open_file(self.testyamlfile, 'a')
 
         self.test_recorder = _TestClientRecorder(self.yamlfp)
         self.test_recorder.reset()

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -14,6 +14,7 @@ from datetime import timedelta, datetime, tzinfo
 import unittest
 import os
 import os.path
+from io import open as _open
 import yaml
 import six
 
@@ -40,7 +41,7 @@ class BaseRecorderTests(unittest.TestCase):
         if os.path.isfile(self.testyamlfile):
             os.remove(self.testyamlfile)
 
-        self.yamlfp = TestClientRecorder.open_file(self.testyamlfile, 'a')
+        self.yamlfp = _TestClientRecorder.open_file(self.testyamlfile, 'a')
 
         self.test_recorder = _TestClientRecorder(self.yamlfp)
         self.test_recorder.reset()
@@ -60,7 +61,7 @@ class BaseRecorderTests(unittest.TestCase):
     def loadYamlFile(self):
         """Load any created yaml file"""
         self.closeYamlFile()
-        with open(self.testyamlfile) as fp:
+        with _open(self.testyamlfile, encoding="utf-8") as fp:
             testyaml = yaml.load(fp)
         return testyaml
 
@@ -71,7 +72,7 @@ class BaseRecorderTests(unittest.TestCase):
         """
         class TZ(tzinfo):
             """'Simplistic tsinfo subclass for this test"""
-            def utcoffset(self, dt):
+            def utcoffset(self, dt):  # pylint: disable=unused-argument
                 return timedelta(minutes=-399)
 
         dt = datetime(year=2016, month=3, day=31, hour=19, minute=30,


### PR DESCRIPTION
1. Documented that if an already open file is supplied to the
TestClientRecorder, it must be a text file.

2. Since creating text files is messy in python 2/3 we added a static
method (open_file) to the recorderthat will open the file and return the
handle.

ex:
```
	fp = TestFileRecorder.open_file('yamloutputfile', 'a')
```
will open a test file for append.

We did NOT add any check to be sure that the file handle provided to the
TestClientRecorder __init__ function is, in fact defined as a text file.