### PR TITLE
fixes #718 Correct Error in run_cimoperations.py with iter... tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -144,6 +144,10 @@ Bug fixes
   this release, the bug was never public. See issue #709
 
 * Remove extra print in cim_operations. See issue # 704
+
+* Correct Error in run_cimoperations with use of namespace in iter... function
+  See issue #718. This was a test code issue. No changes to the iter
+  operations.
   
 
 Build, test, quality

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -319,9 +319,12 @@ class ClientTest(unittest.TestCase):
                 self.assertTrue(len(instance.path.namespace) > 0)
 
                 if namespace is None:
-                    self.assertTrue(instance.path.namespace == self.namespace)
-                else:
-                    self.assertTrue(instance.path.namespace == namespace)
+                    namespace = self.namespace
+
+                self.assertEqual(instance.path.namespace, namespace,
+                                 'Expected instance.path.namespace %s to '
+                                 'match expected namespace %s' %
+                                 (instance.path.namespace, namespace))
 
             if prop_count is not None:
                 self.assertTrue(len(instance.properties) == prop_count)
@@ -4424,8 +4427,9 @@ class IterEnumerateInstances(PegasusServerTestBase):
 
         # account for possible non unicode namespace.  Test fails in compare
         # of unicode and non-unicode namespaces otherwise.
-        if namespace is not None:
-            namespace = namespace.encode('utf-8')
+        if namespace is not None and six.PY3:
+            if isinstance(namespace, bytes):
+                namespace = namespace.decode()
 
         # execute iterator operation
         generator = self.cimcall(self.conn.IterEnumerateInstances, ClassName,


### PR DESCRIPTION
Code incorrectly mapped str to bytes in run_cimoperations.py for iter test.  This was an error in test code, not a case of incorrect typing in base code as far as I can tell.  Note that the code was checking for namespace and forcing it to unicode so underneath there was a case where the namespace is bytes for some condition in some test.  I still have not caught that.

