### PR TITLE
Fixes #727: Extend wbemcli.bat to exit with exit level.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -154,6 +154,8 @@ Bug fixes
   method to force creation of the recorder output as a text file.
   See issue # 700
 
+* Correct issue in wbemcli.bat where it was not returning error level.
+  see issue #727
   
 
 Build, test, quality

--- a/wbemcli.bat
+++ b/wbemcli.bat
@@ -1,3 +1,5 @@
 @setlocal enableextensions
+@set errorlevel=
 @python %~d0%~p0%~n0 %*
 @endlocal
+@exit /b %errorlevel%


### PR DESCRIPTION
Adds line to the bat file to return exit code.

This was originally part of pr#691 but that has been withdrawn in favor of a number of smaller prs.

Note that there is no test for this change. That will be part of another pr