### PR TITLE
Fixes #734: Fix issue with old version of coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ install:
   - pip list
   - make develop
   - pip install python-coveralls
+# Update coverage because the version defined for python-coveralls breaks
+# some of our tests (they specify a specific version) see pr #734 where at
+# least on python 2.6, the test_wbemcli.py code catches a deprecation warning
+# from coverage 4.03 or earlier.
+  - pip install -U coverage
   - pip list
 
 # commands to run builds & tests

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,18 +44,18 @@ Enhancements
   request/reply size information on server requests and replies. The detailed
   information is available in WBEMConnection for operation execution time
   and request/reply content size at the end of each operation.
-  
+
   When statistics gathering is enabled, the information is placed into the
   Statistics class where min/max/avg information is available for each
   operation type.
   Statistics gathering is enabled if the WBEMConnection attribute
   `enable_stats` is `True`.
-  
+
   Statistics can be externalized through the snapshot method of the Statistics
   class.
 
   The functionality is marked experimental for the current release
-  
+
   See issue #761
 
 * Extended development.rst to define how to update dmtf mof and move the\
@@ -156,7 +156,13 @@ Bug fixes
 
 * Correct issue in wbemcli.bat where it was not returning error level.
   see issue #727
-  
+
+* Correct issue where dependency pip installs end up with old version
+  of coverage package. This old version generates unwanted deprecation
+  messages that are fixed after version 4.03. This requires a change to
+  the travis.yaml file directly to force a reinstall of coverage.
+  See issue #734
+
 
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^

--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -34,7 +34,7 @@ namespace and should be used from there.
 
 # disable flake8 tests for no whitespace before : and line too long
 # for this file because of special formatting in the file.
-# flake8: noqa: E203, E501
+# flake8: noqa: E203,E501
 
 # This module is meant to be safe for 'import *'.
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ from os_setup import shell, shell_check, import_setuptools, YumInstaller
 if sys.version_info[0:2] == (2, 6):
     try:
         # pylint: disable=unused-import
-        import multiprocessing  # noqa: E402, F401
+        import multiprocessing  # noqa: E402,F401
     except ImportError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -362,6 +362,7 @@ def main():
             # Wheel may not be installed in every system Python.
             'wheel',
             # Python prereqs for 'develop' command. Handled by os_setup module.
+            "coverage>=4.3",
             "pytest>=2.4",
             "pytest-cov",
             "Sphinx>=1.3" if sys.version_info[0:2] != (2, 6) else None,


### PR DESCRIPTION
This fixes issue where coveralls forced installation of old version of
coverage that causes problems with other tests because of deprecation
warnings it issues.  The problem was fixed after version 4.03 of
coverage
We had to directly change .travis.yml to reinstall/update coverage after
the installation in the setup and reinstallation as a coveralls
dependency with an old version.

We added the version to setup.py but that is mostly for documentation.

Added comment to changes.rst