### PR TITLE
Ks/#691 part2 operation logging

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -99,14 +99,15 @@ Enhancements
   results. issue #569
 
 * **Experimental:** Add logging to record information passing between the pywbem
-  client and WBEM servers both the WBEMConnection methods that drive information
-  interchange and the http requests and responses.  In includes a new module
+  client and WBEM servers both for the WBEMConnection methods that drive information
+  interchange and the http requests and responses.  Logging includes a new module
   (_logging.py) that provides configuration of logging.
-  Extend WBEMConnection with options so that the user
-  can chose to log None/either/both a)Calls and returns from the
-  WBEMConnection CIM operation calls, b)http request/responses. The logging
-  can be to either stderr or file and the user can chose to log the complete
-  requests or responses or subsets (log_detail level). See issue #691.
+  The logging extends WBEMConnection with methods so that the user
+  can chose to log a)Calls and returns from the WBEMConnection methods that
+  interact with the WBEMServer (ex. getClass), b)http request/responses, c)both.
+  The logging uses the python logging package and the output can be directed
+  to either stderr or a file. The user can chose to log the complete
+  requests and responses or size limited subsets (log_detail level). See issue #691.
 
 * Clarify documentation on wbem operation recorder in client.rst. see
   issue #741

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -101,7 +101,12 @@ Enhancements
 * **Experimental:** Add logging to record information passing between the pywbem
   client and WBEM servers both the WBEMConnection methods that drive information
   interchange and the http requests and responses.  In includes a new module
-  (_logging.py) that provides configuration of logging.  See issue #691
+  (_logging.py) that provides configuration of logging.
+  Extend WBEMConnection with options so that the user
+  can chose to log None/either/both a)Calls and returns from the
+  WBEMConnection CIM operation calls, b)http request/responses. The logging
+  can be to either stderr or file and the user can chose to log the complete
+  requests or responses or subsets (log_detail level). See issue #691.
 
 * Clarify documentation on wbem operation recorder in client.rst. see
   issue #741

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -125,7 +125,7 @@ Enhancements
 
 * Made sure that ``repr()`` on CIM objects produces a reliable order of
   items such as properties, qualifiers, methods, parameters, scopes, by
-  ordering them by their names. This makes debugging using ``repr()`´ easier
+  ordering them by their names. This makes debugging using ``repr()`` easier
   for pywbem users, and it also helps in some unit test cases of pywbem itself.
 
 * Made sure that ``str()`` on ``CIMInstanceName`` produces reliable order of

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -14,7 +14,7 @@ This chapter has the following sections:
   class of the WBEM client library API and is used to issue WBEM operations to
   a WBEM server.
 
-  * :ref:`WBEM Operation recording` -  Class :class:`~pywbem.WBEMConnection`
+  * :ref:`WBEM operation recording` -  Class :class:`~pywbem.WBEMConnection`
     includes the capability to optionally record the WBEMConnection method
     calls that communicate with a WBEM server including creating yaml
     files for test generation and logging using the Python logging facility.
@@ -30,7 +30,7 @@ This chapter has the following sections:
 * :ref:`Exceptions` - Exceptions specific to pywbem that may be raised.
 * :ref:`Statistics` - Statistics classes to gather information on wbem
   operation performance.
-* :ref:`WBEM Operation recorder` - Python classes that implement the operation
+* :ref:`WBEM operation recorder` - Python classes that implement the operation
   recorder functions that are used by :class:`~pywbem.WBEMConnection`.
 * :ref:`Security considerations` - Information about authentication types and
   certificates.

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -98,7 +98,7 @@ A single recorder can be  be disabled with
 :meth:`~pywbem.BaseOperationRecorder.enable` method.
 
 The logger names for the operations and http loggers must be
-defined using  the :class:`~pywbem:`PywbemLoggers` class to
+defined using  the :class:~pywbem.`PywbemLoggers` class to
 define usable loggers because the pywbem loggers include logging attributes in
 addition to the standard python logger attributes.  This is done with the
 method :meth:`~pywbem.PywbemLoggers.create_logger` which defines one or more
@@ -124,10 +124,8 @@ adding activating the LogOperationRecorder in WBEMConnection.
 
     # Create the connection and enable the logger
     conn = WBEMConnection(...)
-    logging = LogOperationRecorder()
-    add_operations_recorder(LogOperationRecorder())
+    conn.add_operation_recorder(LogOperationRecorder())
     # The LogOperationRecorder is now active and writing logs to stderr.
-    # To enable writing logs
 
 The following example activates and enables both recorders:
 
@@ -137,16 +135,16 @@ The following example activates and enables both recorders:
     logger.setLevel(logging.DEBUG)
     PywbemLoggers.create_logger('log')   # define only the log logger
     conn = WBEMConnection(...)
-    add_operations_recorder(LogOperationRecorder())
+    log_recorder = LogOperationRecorder()
+    conn.add_operation_recorder(log_recorder)
     yamlfp = TestClientRecorder.open_file(self.yamlfile, 'a')
-    add_operations_recorder(TestClientRecorder(yamlfp))
+    conn.add_operation_recorder(TestClientRecorder(yamlfp))
 
     # Both TestClientRecorder and LogOperationRecorder are be
     # active, enabled and recording
-    # To change the enabled state of either, use the enabled/disabled
+    # To change the enabled state of either recorder, use the enabled/disabled
     # methods of the Recorder
-
-    logging.disable()   # disables recording to the log
+    log_recorder.disable()   # disables recording to the log
 
 Activated loggers can be computing-wise expensive so it is best not to activate
 either logger unless they are to be used for that specific WBEMConnection.

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -15,16 +15,16 @@
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 """
-The pywbem package implements selected logging based on standard Python
-:mod:`py:logging` module.
+The pywbem package implements selected logging based on the Python
+:mod:`py:logging` facility.
 
 Pywbem logging is used as a tool to record information passing between
-the pywbem client and WBEM servers but Nnot as a general recorder for errors,
+the pywbem client and WBEM servers but not as a general recorder for errors,
 state, etc. within pywbem. Pywbem errors are generally passed to the pywbem API
 user as python exceptions rather than being recorded in a log by a pywbem
 logger.
 
-The logging supports multiple :class:`~py:logging.Logger` objects
+Pywbem logging supports multiple :class:`~py:logging.Logger` objects
 (named loggers). Two named loggers are defined in this code and used
 by pywbem:
 
@@ -40,8 +40,8 @@ by pywbem:
 
 To output log records for one of the defined named loggers, either
 :meth:`~pywbem.PywbemLoggers.create_loggers` or the
-:meth:`~pywbem.PywbemLoggers.create_logger` should be used to create the
-configure logger definitions.
+:meth:`~pywbem.PywbemLoggers.create_logger` should be used to define the
+characteristics of the named logger.
 
 * :meth:`~pywbem.PywbemLoggers.create_loggers` creates one or more loggers from
   a string input that defines the component name and characteristics of each
@@ -52,21 +52,21 @@ configure logger definitions.
   parameter inputs that define the component name and characteristics of each
   logger.
 
-These functions create a dictionary in PywbemLoggers class that is used by
-the logging functions in the recorder so trying to create the named loggers
-independently of this code may cause issues.
+These functions save the logger definitions in the PywbemLoggers class that
+is used by the logging functions in the recorder so trying to create the named
+loggers independently of this code may cause issues.
 
-The pywbem loggers are based on 3 parameters (log destination, log detail level,
-and log level) that determine if the logs for the logger name are created,
-how much information is inserted, and where the logs entries are sent.  This
-extends the python logging to include the log_detail parameter which defines
-whether all the information defined or only a limited size is output.  This
-is used with pywbem because the logs on operation and http responses can be
+The pywbem loggers are based on two parameters (log destination, log detail)
+that determine if the logs for the logger name are created,
+how much information is inserted, and the log destination.  This
+extends the python logging facility to include the log_detail parameter which
+defines whether all the information defined or only a limited size is output.
+This is used with pywbem because the logs on operation and http responses can be
 very large.
 
-The code that executes the loggers call the funciton get_logger(..) to get a
+The code that executes the loggers call the function get_logger(..) to get a
 logger from a defined logger name.  If that logger has not yet been defined
-in PywbemLoggers, an entry will be added
+in PywbemLoggers, an entry will be added with the default parameters.
 """
 from __future__ import absolute_import
 
@@ -184,7 +184,7 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
 
             ``http=file:``        # set http logger to send to file
 
-            ``all=file:all``      # Set all named loggers to
+            ``all=file:all``      # Set all loggers to default log destination
         """  # noqa: E501
         # pylint: enable=line-too-long
 
@@ -219,7 +219,7 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
           log_filename (:term:`string`):
             Filename to use as logging file if the log destination is `file`.
             Ignored if log destination is not `file`. If value is None and
-            this is a ``file`` log, a ValueError is raised.
+            this is a ``file`` log, ValueError is raised.
 
           log_detail_level (:term:`string`):
             String defining the level of detail for log output. This is
@@ -382,5 +382,4 @@ def get_logger(logger_name):
         log_prefix, log_comp = logger_name.split('.')
         # create PywbemLogger with default values
         PywbemLoggers.create_logger(log_comp)
-    print('get_logger dict %s' % PywbemLoggers)
     return logging.getLogger(logger_name)

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -419,4 +419,5 @@ def get_logger(logger_name):
         log_prefix, log_comp = logger_name.split('.')
         # create PywbemLogger with default values
         PywbemLoggers.create_logger(log_comp)
+    print('get_logger dict %s' % PywbemLoggers)
     return logging.getLogger(logger_name)

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -364,7 +364,7 @@ def get_logger(logger_name):
     hierarchy, and therefore causes this package to be silent by default.
 
     Parameters
-        logger_name(:term:`string)
+        logger_name(:term:`string`)
             Name of the logger which must be one of the named defined in
             pywbem for loggers used by pywbem.  These names are structured
             as prefix . <log_component>

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -73,10 +73,9 @@ from __future__ import absolute_import
 import logging
 import six
 
-__all__ = ['PywbemLoggers', 'LOG_DESTINATIONS', 'LOG_LEVELS',
-           'LOG_COMPONENTS', 'LOG_OPS_CALLS_NAME',
-           'LOG_DETAIL_LEVELS', 'DEFAULT_LOG_DETAIL_LEVEL', 'DEFAULT_LOG_LEVEL',
-           'DEFAULT_LOG_DESTINATION', 'MAX_LOG_ENTRY_SIZE']
+__all__ = ['PywbemLoggers', 'LOG_DESTINATIONS', 'LOG_COMPONENTS',
+           'LOG_OPS_CALLS_NAME', 'LOG_DETAIL_LEVELS', 'DEFAULT_LOG_DESTINATION',
+           'MAX_LOG_ENTRY_SIZE']
 
 #: Name of logger for logging user-issued calls to pywbem WBEMConnection
 #: methods functions that drive WBEM operations.
@@ -100,11 +99,6 @@ LOG_DETAIL_LEVELS = ['all', 'min']
 #: :class:`pywbem.PywbemLoggers` methods that configure pywbem named loggers
 DEFAULT_LOG_DETAIL_LEVEL = 'min'
 
-#: Default log level string if none is supplied with a call to the
-#: methods that configure pywbem named loggers. This must be one of the allowed
-#: python log level strings.
-DEFAULT_LOG_LEVEL = 'debug'
-
 #: Maximum log entry size. An integer that sets the maximum size of each log
 #: entry if the log_detail_level attribute is set to 'min' is set.
 MAX_LOG_ENTRY_SIZE = 1000
@@ -112,11 +106,6 @@ MAX_LOG_ENTRY_SIZE = 1000
 #: DEFAULT log destination is none is defined when named loggers are
 #: configured. 'none' means that there is no logging.
 DEFAULT_LOG_DESTINATION = 'none'
-
-#: List of allowed log level strings that are allowed for the
-#: DEFAULT_LOG_LEVEL variable and for the log_level input to the
-#: :meth:`~pywbem.PywbemLoggers.create_logger`.
-LOG_LEVELS = ['critical', 'error', 'warning', 'info', 'debug']
 
 
 class MetaPywbemLoggers(type):
@@ -173,12 +162,10 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
 
             ``log_specs`` := ``log_spec`` [, ``log_spec`` ]
 
-            ``log_spec`` := ``log_comp`` ['=' [ ``dest`` ][":"[ ``detail_level`` ][":"[ ``log_level`` ]]]]
+            ``log_spec`` := ``log_comp`` ['=' [ ``dest`` ][":"[ ``detail_level`` ]]]]
 
             where:
                 ``log_comp``: Must be one of strings in the :data:`~pywbem._logging.LOG_COMPONENTS` list.
-
-                ``log_level``: Must be one of strings in the :data:`~pywbem._logging.LOG_LEVELS` list`.
 
                 ``detail_level``: Must be one of strings in the :data:`~pywbem._logging.LOG_DETAIL_LEVELS` list.
 
@@ -193,11 +180,11 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
           or any of the components is not one of allowed strings.
 
         Examples:
-            ``ops=stderr:min:debug``    # set cim operations logger
+            ``ops=stderr:min``    # set cim operations logger
 
-            ``http=file::debug``        # set http logger to send to file
+            ``http=file:``        # set http logger to send to file
 
-            ``all=file:all:debug``      # Set all named loggers to
+            ``all=file:all``      # Set all named loggers to
         """  # noqa: E501
         # pylint: enable=line-too-long
 
@@ -205,14 +192,12 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
         for name, value in six.iteritems(results):
             cls.create_logger(name, log_dest=value[0],
                               log_detail_level=value[1],
-                              log_level=value[2],
                               log_filename=log_filename)
 
     @classmethod
     def create_logger(cls, log_component, log_dest=DEFAULT_LOG_DESTINATION,
                       log_filename=DEFAULT_LOG_DESTINATION,
-                      log_detail_level=DEFAULT_LOG_DETAIL_LEVEL,
-                      log_level=DEFAULT_LOG_LEVEL):
+                      log_detail_level=DEFAULT_LOG_DETAIL_LEVEL):
         """
         Create the logger defined by the input parameters and place the result
         in a class level dictionary in this class.
@@ -240,10 +225,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
             String defining the level of detail for log output. This is
             optional. The default is defined in DEFAULT_LOG_DETAIL_LEVEL.
 
-          log_level (:term:`string`):
-            String defining the log level for this logger. This is optional.
-            The default is defined in DEFAULT_LOG_LEVEL.
-
         Exceptions:
             ValueError - Input contains an invalid log destination, log level,
             or log detail level. No named logger is configured.
@@ -253,8 +234,7 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
                 if comp != 'all':
                     cls.create_logger(comp, log_dest=log_dest,
                                       log_filename=log_filename,
-                                      log_detail_level=log_detail_level,
-                                      log_level=log_level)
+                                      log_detail_level=log_detail_level)
 
         # Otherwise process results of any recursive calls above
         else:
@@ -266,13 +246,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
                 raise ValueError('Invalid log component %s. Valid log '
                                  'components are: %s' %
                                  (log_component, LOG_COMPONENTS))
-            if not log_level:
-                log_level = DEFAULT_LOG_LEVEL
-            if log_level not in LOG_LEVELS:
-                raise ValueError('Invalid log level %s. Valid log levels are:'
-                                 ' %s' %
-                                 (log_level, LOG_LEVELS))
-
             if not log_detail_level:
                 log_detail_level = DEFAULT_LOG_DETAIL_LEVEL
             if log_detail_level not in LOG_DETAIL_LEVELS:
@@ -287,7 +260,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
                 if not log_filename:
                     raise ValueError('Filename required if log destination '
                                      'is "file"')
-                # pylint: disable=redefined-variable-type
                 handler = logging.FileHandler(log_filename)
                 format_string = '%(asctime)s-%(name)s-%(message)s'
             else:
@@ -303,14 +275,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
             else:
                 raise ValueError('Invalid log_component %s' % log_component)
 
-            # Set the log level based on the log_level input
-            level = getattr(logging, log_level.upper(), None)
-            # check logging log_level_choices have not changed from expected
-            assert isinstance(level, int)
-            if level is None:
-                raise ValueError('Invalid log level %s specified. Must be one '
-                                 'of %s.' % (log_level, LOG_LEVELS))
-
             # create named logger. We allow only a single handler for
             # any logger so must remove any existing handler before adding
             #
@@ -320,12 +284,13 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
                 for hdlr in logger.handlers:
                     logger.removeHandler(hdlr)
                 logger.addHandler(handler)
-                logger.setLevel(level)
+                logger.setLevel(logging.DEBUG)
 
             # save the detail level in the dict that is part of this class.
             # All members of this tuple are just for information.
-            cls.loggers[logger_name] = (log_detail_level, log_level,
-                                        log_dest, log_filename)
+            cls.loggers[logger_name] = (log_detail_level,
+                                        log_dest,
+                                        log_filename)
 
     @classmethod
     def get_logger_info(cls, logger_name):
@@ -354,7 +319,7 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
 
           Return:
             Dictionary containing the parsed information where each entry is
-            log_comp (detail_level, log_level,  dest)
+            log_comp (detail_level, dest)
 
           Exception:
             ValueError The parsing of the input string failed.
@@ -376,10 +341,10 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
             # cvt empty strings to None
             log_values = [None if x == '' else x for x in log_values]
             # expand to full size if not all values supplied
-            while len(log_values) < 3:
+            while len(log_values) < 2:
                 log_values.append(None)
 
-            if len(log_values) > 3:
+            if len(log_values) > 2:
                 raise ValueError("Invalid log detail. %s too many "
                                  "components."
                                  % log_spec)

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -323,8 +323,7 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
                 logger.setLevel(level)
 
             # save the detail level in the dict that is part of this class.
-            # All members of this tuple are just viewing except detail
-            # that is used by individual loggers
+            # All members of this tuple are just for information.
             cls.loggers[logger_name] = (log_detail_level, log_level,
                                         log_dest, log_filename)
 
@@ -340,7 +339,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
         Returns:
            Tuple with the following information in the tuple:
            (log_detail_level, log_level, log_dest, log_filename)
-
            or 'None' if the logger has not been defined to PywbemLoggers
         """
         return cls.loggers.get(logger_name, None)

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -294,9 +294,9 @@ class BaseOperationRecorder(object):
             existing file.  if 'a' is used, the data is appended to any
             existing file.
 
-          Example:
+        Example::
 
-            recorder = TestClientRecorder(open_file('recorder.log')
+            recorder = TestClientRecorder(open_file('recorder.log'))
         """
         if six.PY2:
             # Open with codecs to define text mode
@@ -452,17 +452,15 @@ class LogOperationRecorder(BaseOperationRecorder):
     """
     def __init__(self, max_log_entry_size=None):
         """
-        Create the the loggers for the following logging names
-
-        1. LOG_OPS_CALLS - logs operations calls and responses
-        2. LOG_HTTP - Logs http/xml requests and responses
+        Creates the the loggers and sets the max_log_size for each if
+        the input parameter max_log_entry_size is not `None`.
 
         Parameters: (:term:`integer`)
 
-        max_log_entry_size (:term:`integer`)
-        The maximum size of each log entry. This is primarily to limit
-        reqsponse sizes since they could be enormous.
-        If `None`, no size limit and the full request or response is logged.
+          max_log_entry_size(:term:`integer`)
+            The maximum size of each log entry. This is primarily to limit
+            response sizes since they could be enormous.
+            If `None`, no size limit and the full request or response is logged.
 
 
         """
@@ -523,6 +521,8 @@ class LogOperationRecorder(BaseOperationRecorder):
             return_name = 'Return' if ret else 'Exception'
             if ret:
                 # test if type is namedtuple
+                # (subclass of tuple but not type tuple)
+                # pylint: disable=unidiomatic-typecheck
                 if isinstance(ret, tuple) and type(ret) is not tuple:
                     result = '%r' % (ret,)
                 else:
@@ -622,16 +622,17 @@ class TestClientRecorder(BaseOperationRecorder):
         """
         Parameters:
 
-        fp (file):
-          An open file that each test case will be written to.  This file
-          should have been opened in text mode.
+          fp (file):
+            An open file that each test case will be written to.  This file
+            should have been opened in text mode.
 
-          Since there are differences between python 2 and 3 in opening
-          files in text mode, the static method
-          open__file(filename) can be used to open the file.
+            Since there are differences between python 2 and 3 in opening
+            files in text mode, the static method
+            open_file(filename) can be used to open the file.
 
-        Example:
-          recorder = TestClientRecorder(open_file('recorder.log')
+        Example::
+
+          recorder = TestClientRecorder(open_file('recorder.log'))
         """
         super(TestClientRecorder, self).__init__()
         self._fp = fp

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -469,13 +469,16 @@ class LogOperationRecorder(BaseOperationRecorder):
             else DEFAULT_MAX_LOG_ENTRY_SIZE
 
         self.opslogger = logging.getLogger(LOG_OPS_CALLS_NAME)
-        opsinfo = PywbemLoggers.get_logger_info(LOG_OPS_CALLS_NAME)
-        self.ops_max_log_entry_size = max_sz if opsinfo[0] == 'min'  \
+        ops_logger_info = PywbemLoggers.get_logger_info(LOG_OPS_CALLS_NAME)
+        opsdetaillevel = ops_logger_info[0] if ops_logger_info else None
+
+        self.ops_max_log_entry_size = max_sz if opsdetaillevel == 'min'  \
             else None
 
         self.httplogger = logging.getLogger(LOG_HTTP_NAME)
-        httpinfo = PywbemLoggers.get_logger_info(LOG_HTTP_NAME)
-        self.http_max_log_entry_size = max_sz if httpinfo[0] == 'min' \
+        http_logger_info = PywbemLoggers.get_logger_info(LOG_HTTP_NAME)
+        httpdetaillevel = http_logger_info[0] if http_logger_info else None
+        self.http_max_log_entry_size = max_sz if httpdetaillevel == 'min' \
             else None
 
     def stage_wbem_connection(self, url, conn_id, **kwargs):

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -525,8 +525,6 @@ class LogOperationRecorder(BaseOperationRecorder):
             else:
                 result = '%s(%s)' % (exc.__class__.__name__, exc)
 
-            print('result type %s data %r' % (type(result), result))
-
             if self.ops_max_log_size and (len(result) > self.ops_max_log_size):
                 result = (result[:self.ops_max_log_size] + '...')
 

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -285,14 +285,17 @@ class BaseOperationRecorder(object):
         done differently in pythong 2 and python 3
 
         Parameters:
-          filename: (:term: `string`):
+
+          filename(:term:`string`):
             Name of the file where the recorder output will be written
-          file_mode: (:term: `string`):
+
+          file_mode(:term:`string`):
             Optional file mode.  The default is 'w' which overwrites any
             existing file.  if 'a' is used, the data is appended to any
             existing file.
 
           Example:
+
             recorder = TestClientRecorder(open_file('recorder.log')
         """
         if six.PY2:

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -519,7 +519,11 @@ class LogOperationRecorder(BaseOperationRecorder):
         if self.enabled:
             return_name = 'Return' if ret else 'Exception'
             if ret:
-                result = '%r' % ret
+                # test if type is namedtuple
+                if isinstance(ret, tuple) and type(ret) is not tuple:
+                    result = '%r' % (ret,)
+                else:
+                    result = '%r' % ret
             else:
                 result = '%s(%s)' % (exc.__class__.__name__, exc)
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -531,11 +531,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
       ... : There are some additional properties documented for this class,
         further down.
 
-      debug (:class:`py:bool`): A boolean indicating whether logging of
-        the last request and last reply is enabled.
+      debug (:class:`py:bool`): A boolean indicating whether saving of
+        the last request and last reply to the WBEMConnection object is enabled.
 
         The initial value of this attribute is `False`.
-        Debug logging can be enabled for future operations by setting this
+        Debug saving can be enabled for future operations by setting this
         attribute to `True`.
 
       last_request (:term:`unicode string`):

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -510,7 +510,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     The method to activate has therefore change. To activate a recorder you must
     use the WBEM connection method:
 
-        `:class:`~pywbem.add_operation_recorder`
+        :class:`~pywbem.add_operation_recorder`
 
     The methods of this class may raise the following exceptions:
 
@@ -951,7 +951,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def operation_recorder_enabled(self):
         """
-        :class:`py:bool`: Operation recorder enablement status for connection.
+        Operation recorder enablement status for connection.
 
         This is a writeable property; setting this property will change the
         operation recorder enablement status accordingly for all active
@@ -963,7 +963,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         `True`. Otherwise it returns `False`.
 
         Parameters:
-          value (:term:`boolean`)
+          value (:class:`py:bool`)
             Enablement state to which all active recorders are set.
 
         **Experimental:** This property is experimental for this release.
@@ -1949,7 +1949,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def _get_rslt_params(result, namespace):
         """Common processing for pull results to separate
-           end-of-sequence, enum-context, and endities in IRETURNVALUE.
+           end-of-sequence, enum-context, and entities in IRETURNVALUE.
            Returns tuple of entities in IRETURNVALUE, end_of_sequence,
            and enumeration_context)
         """

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1085,15 +1085,15 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         else:
             x509_repr = "None"
 
-        return "%s(url=%r, creds=%s, " \
+        return "%s(url=%r, creds=%s, conn_id=%s, " \
                "default_namespace=%r, x509=%s, verify_callback=%r, " \
                "ca_certs=%r, no_verification=%r, timeout=%r, " \
-               "use_pull_operations=%r, stats=%r, recorder=%r)" % \
-               (self.__class__.__name__, self.url, creds_repr,
+               "use_pull_operations=%r, stats=%r, recorders=%r)" % \
+               (self.__class__.__name__, self.url, creds_repr, self.conn_id,
                 self.default_namespace, x509_repr, self.verify_callback,
                 self.ca_certs, self.no_verification, self.timeout,
                 self.use_pull_operations, self.statistics,
-                self.operation_recorder)
+                self._operation_recorders)
 
     def add_operation_recorder(self, operation_recorder_object):
         # pylint: disable=line-too-long
@@ -1225,7 +1225,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 no_verification=self.no_verification,
                 timeout=self.timeout,
                 debug=self.debug,
-                recorder=self.operation_recorder)
+                recorders=self._operation_recorders,
+                conn_id=self.conn_id)
             self.last_reply_len = len(reply_xml)
         except (AuthError, ConnectionError, TimeoutError, Error):
             raise
@@ -1473,7 +1474,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 no_verification=self.no_verification,
                 timeout=self.timeout,
                 debug=self.debug,
-                recorder=self.operation_recorder)
+                recorders=self._operation_recorders,
+                conn_id=self.conn_id)
             self.last_reply_len = len(reply_xml)
         except (AuthError, ConnectionError, TimeoutError, Error):
             raise
@@ -4100,8 +4102,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
             if self._operation_recorders:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenEnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                                DeepInheritance=None, IncludeQualifiers=None,
@@ -4383,8 +4384,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
             if self._operation_recorders:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenReferenceInstancePaths(self, InstanceName, ResultClass=None,
                                    Role=None,

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -142,6 +142,7 @@ in pywbem
 
 from __future__ import absolute_import
 
+import os
 import re
 from datetime import datetime, timedelta
 from xml.dom import minidom
@@ -165,6 +166,8 @@ from .cim_http import parse_url
 from .exceptions import Error, ParseError, AuthError, ConnectionError, \
     TimeoutError, CIMError
 from ._statistics import Statistics
+
+from ._recorder import LogOperationRecorder
 
 __all__ = ['WBEMConnection', 'PegasusUDSConnection', 'SFCBUDSConnection',
            'OpenWBEMUDSConnection']
@@ -596,10 +599,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         subsequent `Iter...()` methods.
     """
 
+    # Class level counter. Incremented at each WBEMConnection creation
+    # and used as part of WBEMConnection instance ID.
+    _conn_counter = 0
+
     def __init__(self, url, creds=None, default_namespace=DEFAULT_NAMESPACE,
                  x509=None, verify_callback=None, ca_certs=None,
                  no_verification=False, timeout=None, use_pull_operations=None,
-                 enable_stats=False):
+                 enable_stats=False, enable_log=False):
         """
         Parameters:
 
@@ -819,6 +826,16 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             status or change the status (ex. `conn.stats_enabled(False)`)
 
             **Experimental:** This argument is experimental for this release.
+
+          enable_log (:class:`py_bool`):
+            Defines whether logging of operations and http requests should
+            be executed.   If this is a bool True, logging of the complete
+            operations calls and responses and the complete http requests are
+            logged. If False, Nothing is logged.
+
+            Logging destinations and further information about the loggers
+            is defined through the _logger module
+
         """
 
         # Connection attributes
@@ -840,8 +857,17 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         self.last_request_len = 0
         self.last_reply_len = 0
 
-        # control of recorder
-        self.operation_recorder = None
+        # control of operation recorders
+        self._operation_recorder = None
+        self._operation_recorders = []
+        if enable_log:
+            self. add_operation_recorder(LogOperationRecorder())
+
+        # Create the connection ID for this WWBEMConnection
+        self.__class__._conn_counter += 1
+        self.conn_id = ('%s-%s' % (
+            self.__class__._conn_counter,  # pylint: disable=protected-access
+            os.getpid()))
 
         # pull operations control for iter... operations
         self.use_pull_operations = use_pull_operations
@@ -859,6 +885,50 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         self._statistics = Statistics(enable_stats)
         self._last_operation_time = None
         self._last_server_response_time = None
+
+        # If there is a recorder, record the connection to all of the
+        # recorders in the list
+        if self._operation_recorders:
+            creds = '%s:%s' % (self.creds[0], '****') if creds else None
+            for recorder in self._operation_recorders:
+                recorder.reset()
+                recorder.stage_pywbem_connection(
+                    url=self.url, conn_id=self.conn_id,
+                    creds=creds,
+                    default_namespace=self.default_namespace,
+                    no_verification=self.no_verification,
+                    timeout=self.timeout,
+                    use_pull_operations=self.use_pull_operations,
+                    stats_enabled=self.stats_enabled)
+
+    @property
+    def operation_recorder(self):
+        """
+        TODO
+        This is a writeable property; setting this property will cause the
+        defined recorder to be activated.
+
+        **Experimental:** This property is experimental for this release.
+        This property has been marked deprecated.  The method
+        add_operation_recorder should be used to activate an operation
+        recorder.
+        """
+        warnings.warn(
+            "Directly setting operation recorder has been deprecated",
+            DeprecationWarning)
+        return self._operation_recorder
+
+    @operation_recorder.setter
+    def operation_recorder(self, value):
+        """
+            Set a the value representing the operation recorder instance
+            into the list of active operation recorders
+        """
+        self._operation_recorder = value
+        self. add_operation_recorder(value)
+        warnings.warn(
+            "Directly setting operation recorder has been deprecated",
+            DeprecationWarning)
 
     @property
     def host(self):
@@ -887,6 +957,39 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self.statistics.enable()
         else:
             self.statistics.disable()
+
+    @property
+    def operation_recorder_enabled(self):
+        """
+        :class:`py:bool`: operation_recorder enablement status for connection.
+
+        This is a writeable property; setting this property will change the
+        statistics enablement status accordingly.
+
+        This property returns None if no operation recorder has been set.
+
+        **Experimental:** This property is experimental for this release.
+        """  # noqa: E501
+
+        if self.operation_recorder:
+            return self.operation_recorder.enabled
+
+        return None
+
+    @operation_recorder_enabled.setter
+    def operation_recorder_enabled(self, value):
+        """
+        Set the operation_recorder to the value defined by the
+        input attribute value.
+
+        **Experimental:** This property setter is experimental for this
+                          release.
+        """
+        if self.operation_recorder:
+            if value:
+                self.operation_recorder.enable()
+            else:
+                self.operation_recorder.disable()
 
     @property
     def statistics(self):
@@ -963,11 +1066,55 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         return "%s(url=%r, creds=%s, " \
                "default_namespace=%r, x509=%r, verify_callback=%r, " \
                "ca_certs=%r, no_verification=%r, timeout=%r, " \
-               "use_pull_operations=%r)" % \
+               "use_pull_operations=%r, stats=%r, recorder=%r)" % \
                (self.__class__.__name__, self.url, creds_repr,
                 self.default_namespace, self.x509, self.verify_callback,
                 self.ca_certs, self.no_verification, self.timeout,
-                self.use_pull_operations)
+                self.use_pull_operations, self.statistics,
+                self.operation_recorder)
+
+    def add_operation_recorder(self, operation_recorder):
+        """
+        Adds an operation recorder instance to the list of operation recorders
+        for this WBEMConnection.  This allows multiple recorders to be
+        uses simultaneously.  It ignores multiple additions of the
+        same recorder.
+        """
+        for recorder in self._operation_recorders:
+            # pylint: disable=unidiomatic-typecheck
+            if type(recorder) == type(operation_recorder):
+                return
+        self._operation_recorders.append(operation_recorder)
+
+    def operation_recorder_reset(self, pull_op=False):
+        """
+        Call the recorder reset function for all active recorders
+        """
+        for recorder in self._operation_recorders:
+            recorder.reset(pull_op)
+
+    def operation_recorder_stage_pywbem_args(self, method, **kwargs):
+        """
+        Forward the operation method name and arguments to all defined
+        operation recorders.
+        Recorders are defined by adding them to the list with
+        add_operation_recorder(...) or through instance parameters (i.e.
+        enable_log)
+        """
+        for recorder in self._operation_recorders:
+            recorder.stage_pywbem_args(method, **kwargs)
+
+    def operation_recorder_stage_result(self, ret, exc):
+        """
+        Forward the operation result parameters to all defined operation
+        recorders.
+        Recorders are defined by adding them to the list with
+        add_operation_recorder(...) or through instance parameters (i.e.
+        enable_log)
+        """
+        for recorder in self._operation_recorders:
+            recorder.stage_pywbem_result(ret, exc)
+            recorder.record_staged()
 
     def imethodcall(self, methodname, namespace, response_params_rqd=None,
                     **params):
@@ -1537,9 +1684,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         instancenames = None
         method_name = 'EnumerateInstanceNames'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -1573,9 +1720,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(instancenames, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(instancenames, exc)
 
     def EnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                            DeepInheritance=None, IncludeQualifiers=None,
@@ -1700,9 +1846,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         instances = None
         method_name = 'EnumerateInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -1751,9 +1897,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(instances, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(instances, exc)
 
     @staticmethod
     def _get_rslt_params(result, namespace):
@@ -3875,9 +4020,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenEnumerateInstancePaths'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -3918,7 +4063,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
+            if self._operation_recorders:
                 self.operation_recorder.stage_pywbem_result(result_tuple, exc)
                 self.operation_recorder.record_staged()
 
@@ -4142,9 +4287,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenEnumerateInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -4201,7 +4346,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
+            if self._operation_recorders:
                 self.operation_recorder.stage_pywbem_result(result_tuple, exc)
                 self.operation_recorder.record_staged()
 
@@ -4370,9 +4515,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenReferenceInstancePaths'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 ResultClass=ResultClass,
@@ -4418,9 +4563,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenReferenceInstances(self, InstanceName, ResultClass=None,
                                Role=None, IncludeQualifiers=None,
@@ -4624,9 +4768,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenReferenceInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 ResultClass=ResultClass,
@@ -4676,9 +4820,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenAssociatorInstancePaths(self, InstanceName, AssocClass=None,
                                     ResultClass=None, Role=None,
@@ -4862,9 +5005,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenAssociatorInstancePaths'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 AssocClass=AssocClass,
@@ -4911,9 +5054,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenAssociatorInstances(self, InstanceName, AssocClass=None,
                                 ResultClass=None, Role=None, ResultRole=None,
@@ -5133,9 +5275,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenAssociatorInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 AssocClass=AssocClass,
@@ -5189,9 +5331,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def OpenQueryInstances(self, FilterQueryLanguage, FilterQuery,
                            namespace=None, ReturnQueryResultClass=None,
@@ -5356,9 +5497,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'OpenQueryInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 FilterQueryLanguage=FilterQueryLanguage,
                 FilterQuery=FilterQuery,
@@ -5402,9 +5543,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def PullInstancesWithPath(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
@@ -5512,9 +5652,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'PullInstancesWithPath'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 context=context,
                 MaxObjectCount=MaxObjectCount,
@@ -5546,9 +5686,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def PullInstancePaths(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
@@ -5652,9 +5791,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'PullInstancePaths'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 context=context,
                 MaxObjectCount=MaxObjectCount,
@@ -5686,9 +5825,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def PullInstances(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
@@ -5787,9 +5925,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         result_tuple = None
         method_name = 'PullInstances'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset(pull_op=True)
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset(pull_op=True)
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 context=context,
                 MaxObjectCount=MaxObjectCount,
@@ -5821,9 +5959,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     def CloseEnumeration(self, context, **extra):
         # pylint: disable=invalid-name
@@ -5865,9 +6002,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'CloseEnumeration'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 context=context,
                 **extra)
@@ -5891,9 +6028,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     def GetInstance(self, InstanceName, LocalOnly=None, IncludeQualifiers=None,
                     IncludeClassOrigin=None, PropertyList=None, **extra):
@@ -5992,9 +6128,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         instance = None
         method_name = 'GetInstance'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 LocalOnly=LocalOnly,
@@ -6033,9 +6169,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(instance, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(instance, exc)
 
     def ModifyInstance(self, ModifiedInstance, IncludeQualifiers=None,
                        PropertyList=None, **extra):
@@ -6110,9 +6245,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'ModifyInstance'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ModifiedInstance=ModifiedInstance,
                 IncludeQualifiers=IncludeQualifiers,
@@ -6162,9 +6297,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     def CreateInstance(self, NewInstance, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -6231,9 +6365,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         instancename = None
         method_name = 'CreateInstance'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 NewInstance=NewInstance,
                 namespace=namespace,
@@ -6270,9 +6404,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(instancename, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(instancename, exc)
 
     def DeleteInstance(self, InstanceName, **extra):
         # pylint: disable=invalid-name
@@ -6310,9 +6443,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'DeleteInstance'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 InstanceName=InstanceName,
                 **extra)
@@ -6337,9 +6470,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     #
     # Association operations
@@ -6453,9 +6585,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         objects = None
         method_name = 'AssociatorNames'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ObjectName=ObjectName,
                 AssocClass=AssocClass,
@@ -6493,9 +6625,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(objects, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(objects, exc)
 
     def Associators(self, ObjectName, AssocClass=None, ResultClass=None,
                     Role=None, ResultRole=None, IncludeQualifiers=None,
@@ -6652,9 +6783,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         objects = None
         method_name = 'Associators'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ObjectName=ObjectName,
                 AssocClass=AssocClass,
@@ -6702,9 +6833,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(objects, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(objects, exc)
 
     def ReferenceNames(self, ObjectName, ResultClass=None, Role=None, **extra):
         # pylint: disable=invalid-name, line-too-long
@@ -6801,9 +6931,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         objects = None
         method_name = 'ReferenceNames'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ObjectName=ObjectName,
                 ResultClass=ResultClass,
@@ -6837,9 +6967,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(objects, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(objects, exc)
 
     def References(self, ObjectName, ResultClass=None, Role=None,
                    IncludeQualifiers=None, IncludeClassOrigin=None,
@@ -6982,9 +7111,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         objects = None
         method_name = 'References'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ObjectName=ObjectName,
                 ResultClass=ResultClass,
@@ -7028,9 +7157,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(objects, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(objects, exc)
 
     #
     # Method invocation operation
@@ -7130,9 +7258,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         result_tuple = None
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method='InvokeMethod',
                 MethodName=MethodName,
                 ObjectName=ObjectName,
@@ -7185,9 +7313,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(result_tuple, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(result_tuple, exc)
 
     #
     # Query operations
@@ -7248,9 +7375,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         instances = None
         method_name = 'ExecQuery'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 QueryLanguage=QueryLanguage,
                 Query=Query,
@@ -7285,9 +7412,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(instances, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(instances, exc)
 
     #
     # Class operations
@@ -7365,9 +7491,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         classnames = None
         method_name = 'EnumerateClassNames'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 namespace=namespace,
                 ClassName=ClassName,
@@ -7402,9 +7528,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(classnames, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(classnames, exc)
 
     def EnumerateClasses(self, namespace=None, ClassName=None,
                          DeepInheritance=None, LocalOnly=None,
@@ -7511,9 +7636,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         classes = None
         method_name = 'EnumerateClasses'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 namespace=namespace,
                 ClassName=ClassName,
@@ -7558,9 +7683,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(classes, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(classes, exc)
 
     def GetClass(self, ClassName, namespace=None, LocalOnly=None,
                  IncludeQualifiers=None, IncludeClassOrigin=None,
@@ -7652,9 +7776,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'GetClass'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -7694,9 +7818,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(klass, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(klass, exc)
 
     def ModifyClass(self, ModifiedClass, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -7744,9 +7867,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'ModifyClass'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ModifiedClass=ModifiedClass,
                 namespace=namespace,
@@ -7773,9 +7896,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     def CreateClass(self, NewClass, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -7821,9 +7943,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         exc = None
         method_name = 'CreateClass'
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 NewClass=NewClass,
                 namespace=namespace,
@@ -7851,9 +7973,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     def DeleteClass(self, ClassName, namespace=None, **extra):
         # pylint: disable=invalid-name,line-too-long
@@ -7898,9 +8019,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'DeleteClass'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 ClassName=ClassName,
                 namespace=namespace,
@@ -7928,9 +8049,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     #
     # Qualifier operations
@@ -7979,9 +8099,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         qualifiers = None
         method_name = 'EnumerateQualifiers'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 namespace=namespace,
                 **extra)
@@ -8009,9 +8129,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(qualifiers, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(qualifiers, exc)
 
     def GetQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -8060,9 +8179,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         qualifiername = None
         method_name = 'GetQualifier'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 QualifierName=QualifierName,
                 namespace=namespace,
@@ -8090,10 +8209,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(qualifiername,
-                                                            exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(qualifiername, exc)
 
     def SetQualifier(self, QualifierDeclaration, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -8136,9 +8253,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'SetQualifier'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 QualifierDeclaration=QualifierDeclaration,
                 namespace=namespace,
@@ -8163,9 +8280,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
     def DeleteQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
@@ -8207,9 +8323,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         exc = None
         method_name = 'DeleteQualifier'
 
-        if self.operation_recorder:
-            self.operation_recorder.reset()
-            self.operation_recorder.stage_pywbem_args(
+        if self._operation_recorders:
+            self.operation_recorder_reset()
+            self.operation_recorder_stage_pywbem_args(
                 method=method_name,
                 QualifierName=QualifierName,
                 namespace=namespace,
@@ -8234,9 +8350,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_operation_time = stats.stop_timer(
                 self.last_request_len, self.last_reply_len,
                 self.last_server_response_time, exc)
-            if self.operation_recorder:
-                self.operation_recorder.stage_pywbem_result(None, exc)
-                self.operation_recorder.record_staged()
+            if self._operation_recorders:
+                self.operation_recorder_stage_result(None, exc)
 
 
 def is_subclass(ch, ns, super_class, sub):

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -834,8 +834,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             logged. If False, Nothing is logged.
 
             Logging destinations and further information about the loggers
-            is defined through the _logger module
-
+            is defined through the _logger module.
+            **Experimental:** - The enable_log parameter is experimental
+            for this release.
         """
 
         # Connection attributes
@@ -904,7 +905,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def operation_recorder(self):
         """
-        TODO
         This is a writeable property; setting this property will cause the
         defined recorder to be activated.
 
@@ -912,6 +912,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         This property has been marked deprecated.  The method
         add_operation_recorder should be used to activate an operation
         recorder.
+        **Experimental:** - This method is experimental for this release.
         """
         warnings.warn(
             "Directly setting operation recorder has been deprecated",
@@ -921,8 +922,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @operation_recorder.setter
     def operation_recorder(self, value):
         """
-            Set a the value representing the operation recorder instance
-            into the list of active operation recorders
+        Set a the value representing the operation recorder instance
+        into the list of active operation recorders
+        **Experimental:** This property is experimental for this release.
+
+
         """
         self._operation_recorder = value
         self. add_operation_recorder(value)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1085,15 +1085,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         else:
             x509_repr = "None"
 
+        recorder_list = [recorder.__class__.__name__
+                         for recorder in self._operation_recorders]
+
         return "%s(url=%r, creds=%s, conn_id=%s, " \
                "default_namespace=%r, x509=%s, verify_callback=%r, " \
                "ca_certs=%r, no_verification=%r, timeout=%r, " \
-               "use_pull_operations=%r, stats=%r, recorders=%r)" % \
+               "use_pull_operations=%r, stats=%r, recorders=%s)" % \
                (self.__class__.__name__, self.url, creds_repr, self.conn_id,
                 self.default_namespace, x509_repr, self.verify_callback,
                 self.ca_certs, self.no_verification, self.timeout,
-                self.use_pull_operations, self.statistics,
-                self._operation_recorders)
+                self.use_pull_operations, self.stats_enabled,
+                recorder_list)
 
     def add_operation_recorder(self, operation_recorder_object):
         # pylint: disable=line-too-long

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -6026,7 +6026,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         Parameters:
 
-          context (:term: `string`)
+          context (:term:`string`)
             The `enumeration_context` paramater must contain the
             `Context` value returned by the WBEM server with the
             response to the previous open or pull operation for this

--- a/pywbem/config.py
+++ b/pywbem/config.py
@@ -38,7 +38,8 @@ they should be used from the ``pywbem`` namespace.
 
 # This module is meant to be safe for 'import *'.
 
-__all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT']
+__all__ = ['ENFORCE_INTEGER_RANGE', 'DEFAULT_ITER_MAXOBJECTCOUNT',
+           'DEFAULT_MAX_LOG_ENTRY_SIZE', 'DEFAULT_LOG_DESTINATION']
 
 #: Enforce the allowable value range for CIM integer types (e.g.
 #: :class:`~pywbem.Uint8`). For details, see the :class:`~pywbem.CIMInt` base
@@ -59,3 +60,10 @@ ENFORCE_INTEGER_RANGE = True
 #: Note that this does not necessarily optimize the performance of these
 #: operations.
 DEFAULT_ITER_MAXOBJECTCOUNT = 1000
+
+#: Maximum log entry size. An integer that sets the maximum size of each log
+#: entry if the log_detail_level flag is set.
+DEFAULT_MAX_LOG_ENTRY_SIZE = 1000
+
+#: Set default log destination.  'none' means that there will be no logging.
+DEFAULT_LOG_DESTINATION = 'none'

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -37,7 +37,8 @@ from pywbem import WBEMConnection, WBEMServer, CIMError, Error, WBEMListener, \
     WBEMSubscriptionManager, CIMInstance, CIMInstanceName, CIMClass, \
     CIMClassName, CIMProperty, CIMQualifier, CIMQualifierDeclaration, \
     CIMMethod, ValueMapping, Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, \
-    Sint32, Sint64, Real32, Real64, CIMDateTime, TestClientRecorder
+    Sint32, Sint64, Real32, Real64, CIMDateTime, TestClientRecorder, \
+    LogOperationRecorder
 
 from pywbem.mof_compiler import MOFCompiler
 
@@ -134,25 +135,25 @@ class ClientTest(unittest.TestCase):
             no_verification=CLI_ARGS['nvc'],
             ca_certs=CLI_ARGS['cacerts'],
             use_pull_operations=use_pull_operations,
-            enable_stats=self.enable_stats,
-            enable_log=self.log)
+            enable_stats=self.enable_stats)
 
         # if log set, enable the logger.
         if self.log:
             PywbemLoggers.create_loggers('all=file,all,debug')
+            self.conn.add_operation_recorder(LogOperationRecorder())
 
         # enable saving of xml for display
         self.conn.debug = CLI_ARGS['debug']
 
         if self.yamlfile is not None:
             self.yamlfp = TestClientRecorder.open_file(self.yamlfile, 'a')
-            self.conn.operation_recorder = TestClientRecorder(self.yamlfp)
+            self.conn.add_operation_recorder(TestClientRecorder(self.yamlfp))
 
         self.log('Connected {}, ns {}'.format(self.system_url,
                                               CLI_ARGS['namespace']))
 
     def tearDown(self):
-        """Close the test_client YAML file."""
+        """Close the test_client YAML file and display stats."""
 
         if self.enable_stats:
             print('%s: Test time %.2f sec.' % (self.id(),

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -121,6 +121,8 @@ class ClientTest(unittest.TestCase):
         self.enable_stats = True if CLI_ARGS['stats'] else False
         if self.enable_stats:
             self.start_time = time.time()
+        self.log_output_size = 1000
+        self.log_definition = 'all=file:all'
 
         # Set this because python 3 http libs generate many ResourceWarnings
         # and unittest enables these warnings.
@@ -144,10 +146,11 @@ class ClientTest(unittest.TestCase):
         # if log set, enable the logger.
         if self.output_log:
             PywbemLoggers.create_loggers(
-                'all=file:all',
+                self.log_definition,
                 log_filename=RUN_CIM_OPERATIONS_OUTPUT_LOG)
 
-            self.conn.add_operation_recorder(LogOperationRecorder())
+            self.conn.add_operation_recorder(
+                LogOperationRecorder(max_log_entry_size=self.log_output_size))
 
         # enable saving of xml for display
         self.conn.debug = CLI_ARGS['debug']
@@ -6604,14 +6607,17 @@ def parse_args(argv_):
         print('    -l                  Do long running tests. If not set,\n'
               '                        skips a number of tests that take a\n'
               '                        long time to run')
-        print('    --log               Log all operations and http to file.')
+        print('    --log               Log all operations and http to file.\n'
+              '                        run_cim_operations.log.\n'
+              '                        Any existing log is renamed with .bak\n'
+              '                        suffix.')
         print('    -hl                 List of individual tests')
 
         print('')
         print('Examples:')
         print('    %s https://9.10.11.12 username%%password' % argv[0])
-        print('    %s https://myhost -v username%%password' % argv[0])
-        print('    %s http://localhost -v username%%password'
+        print('    %s --log https://myhostusername%%password' % argv[0])
+        print('    %s -v http://localhost username%%password'
               ' GetQualifier' % argv[0])
 
         print('------------------------')

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -41,6 +41,9 @@ from pywbem import WBEMConnection, WBEMServer, CIMError, Error, WBEMListener, \
 
 from pywbem.mof_compiler import MOFCompiler
 
+from pywbem import ClientLogger
+from pywbem._logging import define_operationlogger
+
 from unittest_extensions import RegexpMixin
 
 
@@ -109,6 +112,7 @@ class ClientTest(unittest.TestCase):
         self.verbose = CLI_ARGS['verbose']
         self.debug = CLI_ARGS['debug']
         self.yamlfile = CLI_ARGS['yamlfile']
+        self.log = CLI_ARGS['log']
         self.yamlfp = None
         self.enable_stats = True if CLI_ARGS['stats'] else False
         if self.enable_stats:
@@ -132,6 +136,13 @@ class ClientTest(unittest.TestCase):
             ca_certs=CLI_ARGS['cacerts'],
             use_pull_operations=use_pull_operations,
             enable_stats=self.enable_stats)
+
+        # if log set, enable the logger.
+        if self.log:
+            define_operationlogger(log_destination='file',
+                                   filename='run_cimoperations.log',
+                                   log_level='debug')
+            self.conn.operation_recorder = ClientLogger()
 
         # enable saving of xml for display
         self.conn.debug = CLI_ARGS['debug']
@@ -6577,6 +6588,7 @@ def parse_args(argv_):
         print('    -l                  Do long running tests. If not set,\n'
               '                        skips a number of tests that take a\n'
               '                        long time to run')
+        print('    -log                Log all operations and http to file.')
         print('    -hl                 List of individual tests')
 
         print('')
@@ -6606,6 +6618,7 @@ def parse_args(argv_):
     args_['yamlfile'] = None
     args_['long_running'] = None
     args_['stats'] = None
+    args_['log'] = None
 
     # options must proceed arguments
     while True:
@@ -6644,6 +6657,8 @@ def parse_args(argv_):
         elif argv[1] == '--yamlfile':
             args_['yamlfile'] = argv[2]
             del argv[1:3]
+        elif argv[1] == '-log':
+            del argv[1:2]
         else:
             print("Error: Unknown option: %s" % argv[1])
             sys.exit(1)
@@ -6681,6 +6696,7 @@ def main():
         print("  stats: %s" % CLI_ARGS['stats'])
         print("  debug: %s" % CLI_ARGS['debug'])
         print("  yamlfile: %s" % CLI_ARGS['yamlfile'])
+        print("  log: %s" % CLI_ARGS['log'])
         print("  long_running: %s" % CLI_ARGS['long_running'])
 
         if CLI_ARGS['long_running'] is True:

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -53,6 +53,8 @@ class BaseLoggingTests(unittest.TestCase):
 
     def tearDown(self):
         LogCapture.uninstall_all()
+        if os.path.isfile(TEST_OUTPUT_LOG):
+            os.remove(TEST_OUTPUT_LOG)
 
 
 class TestLogParse(BaseLoggingTests):

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -23,6 +23,7 @@ Unit test logging functionality in _logging.py
 from __future__ import absolute_import, print_function
 
 import os
+import logging
 
 # Allows use of lots of single character variable names.
 # pylint: disable=invalid-name,missing-docstring,too-many-statements
@@ -53,6 +54,7 @@ class BaseLoggingTests(unittest.TestCase):
 
     def tearDown(self):
         LogCapture.uninstall_all()
+        logging.shutdown()
         if os.path.isfile(TEST_OUTPUT_LOG):
             os.remove(TEST_OUTPUT_LOG)
 

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -68,49 +68,39 @@ class TestLogParse(BaseLoggingTests):
     def test_comp_only(self):
         """Test all string"""
         param = 'all'
-        self.parser_test(param, {'all': (None, None, None)})
+        self.parser_test(param, {'all': (None, None)})
 
     def test_comp_only2(self):
         """Test all= string"""
         param = 'all='
-        self.parser_test(param, {'all': (None, None, None)})
+        self.parser_test(param, {'all': (None, None)})
 
     def test_complete1(self):
-        """Test all=file:min:debug string"""
-        param = 'all=file:min:debug'
-        self.parser_test(param, {'all': ('file', 'min', 'debug')})
+        """Test all=file:min string"""
+        param = 'all=file:min'
+        self.parser_test(param, {'all': ('file', 'min')})
 
     def test_complete2(self):
         """Test all=file:min: string"""
-        param = 'all=file:min:'
-        self.parser_test(param, {'all': ('file', 'min', None)})
+        param = 'all=file:min'
+        self.parser_test(param, {'all': ('file', 'min')})
 
     def test_complete3(self):
         """Test all=file:min string"""
         param = 'all=file:min'
-        self.parser_test(param, {'all': ('file', 'min', None)})
-
-    def test_complete4(self):
-        """Test all=::debug string"""
-        param = 'all=::debug'
-        self.parser_test(param, {'all': (None, None, 'debug')})
-
-    def test_complete5(self):
-        """Test all=::debug string"""
-        param = 'all=:min:'
-        self.parser_test(param, {'all': (None, 'min', None)})
+        self.parser_test(param, {'all': ('file', 'min')})
 
     def test_multiple1(self):
-        """Test ops=file:min,http=file:min:debug string"""
-        param = 'ops=file:min,http=file:min:debug'
-        self.parser_test(param, {'ops': ('file', 'min', None),
-                                 'http': ('file', 'min', 'debug')})
+        """Test ops=file:min,http=file:min string"""
+        param = 'ops=file:min,http=file:min'
+        self.parser_test(param, {'ops': ('file', 'min'),
+                                 'http': ('file', 'min')})
 
     def test_multiple2(self):
-        """Test ops=file:min,http=file:min:debug string"""
+        """Test ops=file:min,http=file:min string"""
         param = 'ops=file:min,http='
-        self.parser_test(param, {'ops': ('file', 'min', None),
-                                 'http': (None, None, None)})
+        self.parser_test(param, {'ops': ('file', 'min'),
+                                 'http': (None, None)})
 
 
 class TestLogParseErrors(BaseLoggingTests):
@@ -125,8 +115,8 @@ class TestLogParseErrors(BaseLoggingTests):
             pass
 
     def test_to_many_params(self):
-        """ test all=file:min:debug:junk string """
-        param = "all=file:min:debug:junk"
+        """ test all=file:min:junk string """
+        param = "all=file:min:junk"
         self.parser_error_test(param)
 
     def test_empty(self):
@@ -142,13 +132,12 @@ class TestLoggerCreate(BaseLoggingTests):
         """
         PywbemLoggers.create_logger('ops', 'file',
                                     log_filename=TEST_OUTPUT_LOG,
-                                    log_level='debug',
                                     log_detail_level='min')
 
         if VERBOSE:
             print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
         expected_result = \
-            {'pywbem.ops': ('min', 'debug', 'file', TEST_OUTPUT_LOG)}
+            {'pywbem.ops': ('min', 'file', TEST_OUTPUT_LOG)}
 
         # test getting from logger variable
         self.assertEqual(PywbemLoggers.loggers, expected_result)
@@ -163,13 +152,12 @@ class TestLoggerCreate(BaseLoggingTests):
         """
         PywbemLoggers.create_logger('http', 'file',
                                     log_filename=TEST_OUTPUT_LOG,
-                                    log_level='debug',
                                     log_detail_level='min')
 
         if VERBOSE:
             print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
         expected_result = \
-            {'pywbem.http': ('min', 'debug', 'file', TEST_OUTPUT_LOG)}
+            {'pywbem.http': ('min', 'file', TEST_OUTPUT_LOG)}
 
         self.assertEqual(PywbemLoggers.loggers, expected_result,
                          'Actual %s, Expected %s' % (PywbemLoggers.loggers,
@@ -180,14 +168,13 @@ class TestLoggerCreate(BaseLoggingTests):
         Create a simple logger from detailed parameter input
         """
         PywbemLoggers.create_logger('http', 'stderr',
-                                    log_level='debug',
                                     log_filename=None,
                                     log_detail_level='min')
 
         if VERBOSE:
             print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
         expected_result = \
-            {'pywbem.http': ('min', 'debug', 'stderr', None)}
+            {'pywbem.http': ('min', 'stderr', None)}
 
         self.assertEqual(PywbemLoggers.loggers, expected_result,
                          'Actual %s, Expected %s' % (PywbemLoggers.loggers,
@@ -198,15 +185,14 @@ class TestLoggerCreate(BaseLoggingTests):
         Create a simple logger from detailed parameter input
         """
         PywbemLoggers.create_logger('all', 'stderr',
-                                    log_level='debug',
                                     log_filename=None,
                                     log_detail_level='min')
 
         if VERBOSE:
             print('pywbem_loggers dict %s' % PywbemLoggers.loggers)
         expected_result = \
-            {'pywbem.http': ('min', 'debug', 'stderr', None),
-             'pywbem.ops': ('min', 'debug', 'stderr', None)}
+            {'pywbem.http': ('min', 'stderr', None),
+             'pywbem.ops': ('min', 'stderr', None)}
 
         self.assertEqual(PywbemLoggers.loggers, expected_result)
 
@@ -220,7 +206,6 @@ class TestLoggerCreateErrors(BaseLoggingTests):
         """
         try:
             PywbemLoggers.create_logger('httpx', 'stderr',
-                                        log_level='debug',
                                         log_filename=None,
                                         log_detail_level='min')
             self.fail('Exception expected')
@@ -234,21 +219,6 @@ class TestLoggerCreateErrors(BaseLoggingTests):
         """
         try:
             PywbemLoggers.create_logger('http', 'stderrblah',
-                                        log_level='debug',
-                                        log_filename=None,
-                                        log_detail_level='min')
-            self.fail('Exception expected')
-        except ValueError as ve:
-            if VERBOSE:
-                print('ve %s' % ve)
-
-    def test_create_single_logger3(self):
-        """
-        Create a simple logger from detailed parameter input
-        """
-        try:
-            PywbemLoggers.create_logger('http', 'stderr',
-                                        log_level='debugblah',
                                         log_filename=None,
                                         log_detail_level='min')
             self.fail('Exception expected')
@@ -262,7 +232,6 @@ class TestLoggerCreateErrors(BaseLoggingTests):
         """
         try:
             PywbemLoggers.create_logger('http', 'stderr',
-                                        log_level='debug',
                                         log_filename=None,
                                         log_detail_level='mi')
             self.fail('Exception expected')
@@ -276,7 +245,6 @@ class TestLoggerCreateErrors(BaseLoggingTests):
         """
         try:
             PywbemLoggers.create_logger('http', 'file',
-                                        log_level='debug',
                                         log_filename=None,
                                         log_detail_level='mi')
             self.fail('Exception expected')
@@ -304,11 +272,11 @@ class TestLoggersCreate(BaseLoggingTests):
         """
         Create a simple logger
         """
-        test_input = 'ops=file:min:debug,http=file:min:debug'
+        test_input = 'ops=file:min,http=file:min'
 
         expected_result = \
-            {'pywbem.http': ('min', 'debug', 'file', TEST_OUTPUT_LOG),
-             'pywbem.ops': ('min', 'debug', 'file', TEST_OUTPUT_LOG)}
+            {'pywbem.http': ('min', 'file', TEST_OUTPUT_LOG),
+             'pywbem.ops': ('min', 'file', TEST_OUTPUT_LOG)}
         self.valid_loggers_create(test_input, expected_result,
                                   log_filename=TEST_OUTPUT_LOG)
 
@@ -316,10 +284,10 @@ class TestLoggersCreate(BaseLoggingTests):
         """
         Create a simple logger
         """
-        test_input = 'all=file:min:debug'
+        test_input = 'all=file:min'
         expected_result = \
-            {'pywbem.http': ('min', 'debug', 'file', TEST_OUTPUT_LOG),
-             'pywbem.ops': ('min', 'debug', 'file', TEST_OUTPUT_LOG)}
+            {'pywbem.http': ('min', 'file', TEST_OUTPUT_LOG),
+             'pywbem.ops': ('min', 'file', TEST_OUTPUT_LOG)}
 
         self.valid_loggers_create(test_input, expected_result,
                                   log_filename=TEST_OUTPUT_LOG)
@@ -328,10 +296,10 @@ class TestLoggersCreate(BaseLoggingTests):
         """
         Create a simple logger
         """
-        test_input = 'all=stderr:all:info'
+        test_input = 'all=stderr:all'
         expected_result = \
-            {'pywbem.http': ('all', 'info', 'stderr', None),
-             'pywbem.ops': ('all', 'info', 'stderr', None)}
+            {'pywbem.http': ('all', 'stderr', None),
+             'pywbem.ops': ('all', 'stderr', None)}
 
         self.valid_loggers_create(test_input, expected_result)
 
@@ -357,7 +325,7 @@ class TestLoggerOutput(BaseLoggingTests):
 
     @log_capture()
     def test_log_output(self, l):  # pylint: disable=blacklisted-name
-        test_input = 'all=file:all:debug'
+        test_input = 'all=file:all'
 
         print('log filename %s' % TEST_OUTPUT_LOG)
         PywbemLoggers.create_loggers(test_input, TEST_OUTPUT_LOG)

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -39,7 +39,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 VERBOSE = False
 
 
-class StringSearch(object):  # pylint; disable=too-few-public-methods
+class StringSearch(object):  # pylint: disable=too-few-public-methods
     """
     This class was modified from the StringComparison class in
     testfixtures.Comparison.py to provide for using the regex search mechanism
@@ -58,7 +58,7 @@ class StringSearch(object):  # pylint; disable=too-few-public-methods
         self.re = compile(regex_source, flags)
 
     def __eq__(self, other):
-        if not isinstance(other, basestring):
+        if not isinstance(other, six.string_types):
             return
         if self.re.search(other):
             return True

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -36,6 +36,9 @@ from pywbem.cim_operations import pull_path_result_tuple, pull_inst_result_tuple
 TEST_YAML_FILE = 'test_recorder.yaml'
 SCRIPT_DIR = os.path.dirname(__file__)
 
+LOG_FILE_NAME = 'test_recorder.log'
+TEST_OUTPUT_LOG = '%s/%s' % (SCRIPT_DIR, LOG_FILE_NAME)
+
 VERBOSE = False
 
 
@@ -488,7 +491,11 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
         """ Setup recorder instance including defining output file"""
 
         PywbemLoggers.create_logger('ops', 'file',
-                                    log_filename='TEST_OUTPUT_LOG',
+                                    log_filename=TEST_OUTPUT_LOG,
+                                    log_detail_level='min')
+
+        PywbemLoggers.create_logger('http', 'file',
+                                    log_filename=TEST_OUTPUT_LOG,
                                     log_detail_level='min')
 
     def recorder_setup(self, max_log_entry_size=None):
@@ -520,7 +527,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         self.test_recorder.reset()
         self.test_recorder.enable()
-        # we must fake the connection to create a fixed data environment
+        # Fake the connection to create a fixed data environment
         conn = WBEMConnection('http://blah')
         conn.conn_id = '%s-%s' % (22, "1234:34")
         self.test_recorder.stage_wbem_connection(conn)

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -550,12 +550,19 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         if VERBOSE:
             print(l)
-        l.check(("pywbem.ops", "DEBUG",
-                 "Connection: url=http://blah, id=test_conn_id elable_log=True,"
-                 " default_namespace='root/blah', no_verification=True, "
-                 "x509={'cert_file': 'Certfile.x', 'key_file': 'keyfile.x'}, "
-                 "use_pull_operaitons=True, timeout=10, enable_stats=True, "
-                 "creds=('username', '******')"))
+        # TODO we have issues in that strings in unicode for namespace and
+        # instance name are inconsistent. Further the order of keybindings
+        # is different in python 3 and python2. We are therefore running
+        # this test in python2 for the moment
+        # TODO sort out how to make this work in python 2 and 3
+        if six.PY2:
+            l.check((
+                "pywbem.ops", "DEBUG",
+                "Connection: url=http://blah, id=test_conn_id elable_log=True,"
+                " default_namespace='root/blah', no_verification=True, "
+                "x509={'cert_file': 'Certfile.x', 'key_file': 'keyfile.x'},"
+                " use_pull_operaitons=True, timeout=10, enable_stats=True,"
+                " creds=('username', '******')"))
 
     @log_capture()
     def test_getinstance_args(self, l):
@@ -577,14 +584,14 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         if VERBOSE:
             print(l)
-
-        l.check(("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
-                 "IncludeQualifiers=True, PropertyList=['propertyblah'], "
-                 "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
-                 " namespace=u'root/cimv2', host=u'woot.com'), "
-                 "LocalOnly=True)"))
+        if six.PY2:
+            l.check(("pywbem.ops", "DEBUG",
+                     "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                     "IncludeQualifiers=True, PropertyList=['propertyblah'], "
+                     "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
+                     "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
+                     " namespace=u'root/cimv2', host=u'woot.com'), "
+                     "LocalOnly=True)"))
 
     @log_capture()
     def test_getinstance_result(self, l):
@@ -607,16 +614,16 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         if VERBOSE:
             print(l)
-
-        l.check(("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
-                 "IncludeQualifiers=True, PropertyList=['propertyblah'], "
-                 "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
-                 " namespace=u'root/cimv2', host=u'woot.com'), "
-                 "LocalOnly=True)"),
-                ("pywbem.ops", "DEBUG",
-                 "Return: GetInstance:test_id(CIMInstanc...)"))
+        if six.PY2:
+            l.check((
+                "pywbem.ops", "DEBUG",
+                "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                "IncludeQualifiers=True, PropertyList=['propertyblah'], "
+                "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
+                "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}), "
+                "namespace=u'root/cimv2', host=u'woot.com'), LocalOnly=True)"),
+                ('pywbem.ops', 'DEBUG',
+                 'Return: GetInstance:test_id(CIMInstanc...)'))
 
     @log_capture()
     def test_getinstance_exception(self, l):
@@ -640,18 +647,19 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if VERBOSE:
             print(l)
 
-        l.check(("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
-                 "IncludeQualifiers=True, PropertyList=['propertyblah'], "
-                 "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
-                 " namespace=u'root/cimv2', host=u'woot.com'), "
-                 "LocalOnly=True)"),
-                ("pywbem.ops", "DEBUG",
-                 "Exception: GetInstance:test_id(CIMError(6...)"))
+        if six.PY2:
+            l.check(("pywbem.ops", "DEBUG",
+                     "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                     "IncludeQualifiers=True, PropertyList=['propertyblah'], "
+                     "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
+                     "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
+                     " namespace=u'root/cimv2', host=u'woot.com'), "
+                     "LocalOnly=True)"),
+                    ("pywbem.ops", "DEBUG",
+                     "Exception: GetInstance:test_id(CIMError(6...)"))
 
     @log_capture()
-    def test_getinstance_exception2(self, l):
+    def test_getinstance_exception2(self, log_test):
         """Test the ops result log for get instance"""
 
         InstanceName = self.create_ciminstancename()
@@ -666,16 +674,20 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         self.test_recorder.stage_pywbem_result(instance, exc)
 
         if VERBOSE:
-            print(l)
-
-        l.check(("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(InstanceName=CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "'Ham', 'Beans': 42}), namespace=u'root/cimv2', "
-                 "host=u'woot.com'))"),
+            print(log_test)
+        # TODO we have issues in that strings in unicode for namespace and
+        # instance name are inconsistent. Further the order of keybindings
+        # is different in python 3 and python2.
+        if six.PY2:
+            log_test.check((
+                "pywbem.ops", "DEBUG",
+                "Request: GetInstance:test_id(InstanceName=CIMInstanceName("
+                "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
+                "'Ham', 'Beans': 42}), namespace=u'root/cimv2', "
+                "host=u'woot.com'))"),
                 ("pywbem.ops", "DEBUG",
                  "Exception: GetInstance:test_id("
-                 "CIMError(6, 'This is a fake CIMError'))"))
+                 "CIMError(6, 'This is a fake CIMError')...)"))
 
     @log_capture()
     def test_getinstance_result_all(self, l):
@@ -698,17 +710,16 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         if VERBOSE:
             print(l)
-
-        l.check(("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
-                 "IncludeQualifiers=True, PropertyList=['propertyblah'], "
-                 "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
-                 " namespace=u'root/cimv2', host=u'woot.com'), "
-                 "LocalOnly=True)"),
-                ("pywbem.ops", "DEBUG",
-                 StringComparison(r"Return: GetInstance:test_id\("
-                                  "CIMInstance\(classname=u'CIM_Foo'")))
+        if six.PY2:
+            l.check(("pywbem.ops", "DEBUG",
+                     "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                     "IncludeQualifiers=True, PropertyList=['propertyblah'], "
+                     "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
+                     "keybindings=NocaseDict({'Chicken': 'Ham', 'Beans': 42}),"
+                     " namespace=u'root/cimv2', host=u'woot.com'), "
+                     "LocalOnly=True)"),
+                    ("pywbem.ops", "DEBUG",
+                     StringComparison("Return: GetInstance:test_id.*")))
 
 
 if __name__ == '__main__':

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -512,6 +512,8 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
     def tearDown(self):
         """Remove LogCapture."""
         LogCapture.uninstall_all()
+        if os.path.isfile(TEST_OUTPUT_LOG):
+            os.remove(TEST_OUTPUT_LOG)
 
 
 class LogOperationRecorderTests(BaseLogOperationRecorderTests):
@@ -536,10 +538,11 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         lc.check(
             ("pywbem.ops", "DEBUG",
              "Connection: WBEMConnection(url='http://blah', creds=None, "
+             "conn_id=22-1234:34, "
              "default_namespace='root/cimv2', x509=None, verify_callback=None, "
              'ca_certs=None, no_verification=False, timeout=None, '
              'use_pull_operations=False, stats=Statistics(\n'
-             '), recorder=None)'),)
+             '), recorders=[])'),)
 
     @log_capture()
     def test_create_connection2(self, lc):
@@ -565,11 +568,12 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         lc.check((
             "pywbem.ops", "DEBUG",
             "Connection: WBEMConnection(url='http://blah', "
-            "creds=('username', ...), default_namespace='root/blah', "
+            "creds=('username', ...), conn_id=23-1234:34, "
+            "default_namespace='root/blah', "
             "x509='cert_file': 'Certfile.x', 'key_file': 'keyfile.x', "
             "verify_callback=None, ca_certs=None, no_verification=True, "
             "timeout=10, use_pull_operations=True, stats=Statistics(\n), "
-            "recorder=None)"),)
+            "recorders=[])"),)
 
     @log_capture()
     def test_getinstance_args(self, lc):
@@ -597,7 +601,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                 "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict("
                  "{'Chicken': 'Ham'}), namespace=u'root/cimv2', "
@@ -607,7 +611,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 'Request: GetInstance:test_id(IncludeClassOrigin=True, '
+                 'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
                  "keybindings=NocaseDict({'Chicken': 'Ham'}), "
@@ -641,17 +645,17 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                 "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: GetInstance:test_id(CIMInstanc...)'))
+                 'Return:test_id GetInstance(CIMInstanc...)'))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 'Request: GetInstance:test_id(IncludeClassOrigin=True, '
+                 'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
                  "keybindings=NocaseDict({'Chicken': 'Ham'}), "
@@ -659,7 +663,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: GetInstance:test_id(CIMInstanc...)'))
+                 'Return:test_id GetInstance(CIMInstanc...)'))
 
     @log_capture()
     def test_getinstance_exception(self, lc):
@@ -686,23 +690,23 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                 "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception: GetInstance:test_id(CIMError(6...)"))
+                 "Exception:test_id GetInstance(CIMError(6...)"))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                 "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname='CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace='root/cimv2', host='woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception: GetInstance:test_id(CIMError(6...)"))
+                 "Exception:test_id GetInstance(CIMError(6...)"))
 
     @log_capture()
     def test_getinstance_exception2(self, lc):
@@ -725,20 +729,20 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(InstanceName=CIMInstanceName("
+                 "Request:test_id GetInstance(InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'))"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception: GetInstance:test_id("
+                 "Exception:test_id GetInstance("
                  "CIMError(6: Fake CIMError))"))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(InstanceName=CIMInstanceName("
+                 "Request:test_id GetInstance(InstanceName=CIMInstanceName("
                  "classname='CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace='root/cimv2', host='woot.com'))"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception: GetInstance:test_id("
+                 "Exception:test_id GetInstance("
                  "CIMError(6: Fake CIMError))"))
 
     @log_capture()
@@ -765,14 +769,14 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: GetInstance:test_id(IncludeClassOrigin=True, "
+                 "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops',
                  'DEBUG',
-                 "Return: GetInstance:test_id(CIMInstance(classname=u'CIM_Foo'"
+                 "Return:test_id GetInstance(CIMInstance(classname=u'CIM_Foo'"
                  ", path=None, properties=NocaseDict({'Bool': CIMProperty("
                  "name=u'Bool', value=True, type='boolean', reference_class="
                  "None, embedded_object=None, is_array=False, array_size=None,"
@@ -795,7 +799,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 'Request: GetInstance:test_id(IncludeClassOrigin=True, '
+                 'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
                  "keybindings=NocaseDict({'Chicken': 'Ham'}), "
@@ -803,7 +807,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
-                 "Return: GetInstance:test_id(CIMInstance(classname='CIM_Foo',"
+                 "Return:test_id GetInstance(CIMInstance(classname='CIM_Foo',"
                  " path=None, "
                  "properties=NocaseDict({'Bool': CIMProperty(name='Bool', "
                  "value=True, "
@@ -855,20 +859,20 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: EnumerateInstances:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id EnumerateInstances(ClassName='CIM_Foo', "
                  "IncludeClassOrigin=True, IncludeQualifiers=True, "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: EnumerateInstances:test_id([CIMInstan...)'))
+                 'Return:test_id EnumerateInstances([CIMInstan...)'))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: EnumerateInstances:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id EnumerateInstances(ClassName='CIM_Foo', "
                  'IncludeClassOrigin=True, IncludeQualifiers=True, '
                  'LocalOnly=True, '
                  "PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: EnumerateInstances:test_id([CIMInstan...)'))
+                 'Return:test_id EnumerateInstances([CIMInstan...)'))
 
     @log_capture()
     def test_enuminstancenames_result(self, lc):
@@ -896,20 +900,20 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: EnumerateInstanceNames:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id EnumerateInstanceNames(ClassName='CIM_Foo', "
                  "IncludeClassOrigin=True, IncludeQualifiers=True, "
                  "LocalOnly=True, PropertyList=['propertyblah', 'blah2'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: EnumerateInstanceNames:test_id([CIMInstan...)'))
+                 'Return:test_id EnumerateInstanceNames([CIMInstan...)'))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: EnumerateInstanceNames:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id EnumerateInstanceNames(ClassName='CIM_Foo', "
                  'IncludeClassOrigin=True, IncludeQualifiers=True, '
                  'LocalOnly=True, '
                  "PropertyList=['propertyblah', 'blah2'])"),
                 ('pywbem.ops', 'DEBUG',
-                 'Return: EnumerateInstanceNames:test_id([CIMInstan...)'))
+                 'Return:test_id EnumerateInstanceNames([CIMInstan...)'))
 
     @log_capture()
     def test_openenuminstances_result_all(self, lc):
@@ -941,23 +945,23 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: OpenEnumerateInstances:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id OpenEnumerateInstances(ClassName='CIM_Foo', "
                  "IncludeClassOrigin=True, IncludeQualifiers=True, "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
-                 "Return: OpenEnumerateInstances:test_id("
+                 "Return:test_id OpenEnumerateInstances("
                  "pull_inst_result_tuple(instances=[], eos=False, "
                  "context=('test_rtn_context', 'root/blah')))"))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request: OpenEnumerateInstances:test_id(ClassName='CIM_Foo', "
+                 "Request:test_id OpenEnumerateInstances(ClassName='CIM_Foo', "
                  'IncludeClassOrigin=True, IncludeQualifiers=True, '
                  'LocalOnly=True, '
                  "PropertyList=['propertyblah'])"),
 
                 ('pywbem.ops', 'DEBUG',
-                 "Return: OpenEnumerateInstances:test_id("
+                 "Return:test_id OpenEnumerateInstances("
                  "pull_inst_result_tuple(instances=[], eos=False, "
                  "context=('test_rtn_context', 'root/blah')))"))
 

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -544,9 +544,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                                                  x509=x509_dict,
                                                  no_verification=True,
                                                  timeout=10,
-                                                 use_pull_operaitons=True,
-                                                 enable_stats=True,
-                                                 elable_log=True)
+                                                 use_pull_operations=True,
+                                                 enable_stats=True)
 
         if VERBOSE:
             print(l)
@@ -558,11 +557,11 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         if six.PY2:
             l.check((
                 "pywbem.ops", "DEBUG",
-                "Connection: url=http://blah, id=test_conn_id elable_log=True,"
-                " default_namespace='root/blah', no_verification=True, "
+                "Connection: url=http://blah, id=test_conn_id "
+                "default_namespace='root/blah', no_verification=True, "
                 "x509={'cert_file': 'Certfile.x', 'key_file': 'keyfile.x'},"
-                " use_pull_operaitons=True, timeout=10, enable_stats=True,"
-                " creds=('username', '******')"))
+                " timeout=10, enable_stats=True, creds=('username', "
+                "'password'), use_pull_operations=True"),)
 
     @log_capture()
     def test_getinstance_args(self, l):
@@ -641,7 +640,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
             IncludeClassOrigin=True,
             PropertyList=['propertyblah'])
         instance = None
-        exc = CIMError(6, "This is a fake CIMError")
+        exc = CIMError(6, "Fake CIMError")
         self.test_recorder.stage_pywbem_result(instance, exc)
 
         if VERBOSE:
@@ -670,7 +669,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
             method='GetInstance',
             InstanceName=InstanceName)
         instance = None
-        exc = CIMError(6, "This is a fake CIMError")
+        exc = CIMError(6, "Fake CIMError")
         self.test_recorder.stage_pywbem_result(instance, exc)
 
         if VERBOSE:
@@ -687,7 +686,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                 "host=u'woot.com'))"),
                 ("pywbem.ops", "DEBUG",
                  "Exception: GetInstance:test_id("
-                 "CIMError(6, 'This is a fake CIMError')...)"))
+                 "CIMError(6: Fake CIMError))"))
 
     @log_capture()
     def test_getinstance_result_all(self, l):

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -14,6 +14,7 @@ from datetime import timedelta, datetime, tzinfo
 import unittest
 import os
 import os.path
+import logging
 from io import open as _open
 import yaml
 import six
@@ -21,7 +22,8 @@ from testfixtures import LogCapture, log_capture
 
 from pywbem import CIMInstanceName, CIMInstance, MinutesFromUTC, \
     Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, \
-    Sint32, Sint64, Real32, Real64, CIMProperty, CIMDateTime, CIMError
+    Sint32, Sint64, Real32, Real64, CIMProperty, CIMDateTime, CIMError, \
+    HTTPError
 # Renamed the following import to not have py.test pick it up as a test class:
 from pywbem import TestClientRecorder as _TestClientRecorder
 from pywbem import LogOperationRecorder as _LogOperationRecorder
@@ -268,7 +270,7 @@ class ToYaml(ClientRecorderTests):
         self.assertEqual(test_yaml['context'], list(context))
 
 
-class StageTests(ClientRecorderTests):
+class LogOperationStageTests(ClientRecorderTests):
     """
     Test staging for different cim_operations.  This defines fixed
     parameters for the before and after staging, stages (which creates
@@ -427,11 +429,6 @@ class StageTests(ClientRecorderTests):
                                qualifiers=pv['qualifiers'],
                                embedded_object=pv['embedded_object'])
 
-            # temp display while sorting out datetime issues.
-            # if pv['type'] == 'datetime':
-            #    print('datetime prop name:%s orig:%s new:%s' %
-            #          (pn, NewInstance.properties[pn], prop))
-
             self.assertEqual(NewInstance.properties[pn], prop,
                              'Property compare failed orig %s, recreated %s' %
                              (NewInstance.properties[pn], prop))
@@ -486,20 +483,16 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
     Test the LogOperationRecorder functions. Creates log entries and
     uses testfixture to validate results
     """
-
-    def setUp(self):
-        """ Setup recorder instance including defining output file"""
-
+    def recorder_setup(self, log_detail_level='min', max_log_entry_size=None):
+        """Setup the recorder for a defined max output size"""
         PywbemLoggers.create_logger('ops', 'file',
                                     log_filename=TEST_OUTPUT_LOG,
-                                    log_detail_level='min')
+                                    log_detail_level=log_detail_level)
 
         PywbemLoggers.create_logger('http', 'file',
                                     log_filename=TEST_OUTPUT_LOG,
-                                    log_detail_level='min')
+                                    log_detail_level=log_detail_level)
 
-    def recorder_setup(self, max_log_entry_size=None):
-        """Setup the recorder for a defined max output size"""
         self.test_recorder = _LogOperationRecorder(max_log_entry_size)
 
         # Set a conn id into the connection. Saves testing the connection
@@ -512,11 +505,142 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
     def tearDown(self):
         """Remove LogCapture."""
         LogCapture.uninstall_all()
+        logging.shutdown()
+        # remove any existing log file
         if os.path.isfile(TEST_OUTPUT_LOG):
             os.remove(TEST_OUTPUT_LOG)
 
 
-class LogOperationRecorderTests(BaseLogOperationRecorderTests):
+# Long log entry for getInstance return all log
+get_inst_return_all_log = (
+    u"Return:test_id GetInstance(CIMInstance(classname='CIM_Foo', path=None, "
+    u"properties=NocaseDict({'Bool': CIMProperty(name='Bool', value=True, "
+    u"type='boolean', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'DTF': CIMProperty(name='DTF', "
+    u"value=CIMDateTime(cimtype='datetime', '20160331193040.654321+120'), "
+    u"type='datetime', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'DTI': CIMProperty(name='DTI', "
+    u"value=CIMDateTime(cimtype='datetime', '00000010000049.000020:000'), "
+    u"type='datetime', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'DTP': CIMProperty(name='DTP', "
+    u"value=CIMDateTime(cimtype='datetime', '20140922104920.524789-399'), "
+    u"type='datetime', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'R32': CIMProperty(name='R32', "
+    u"value=Real32(cimtype='real32', 42.0), type='real32', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'R64': CIMProperty(name='R64', "
+    u"value=Real64(cimtype='real64', 42.64), type='real64', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'S1': CIMProperty(name='S1', value='Ham', "
+    u"type='string', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'S2': CIMProperty(name='S2', value='H\u00E4m'"
+    u", type='string', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'SI16': CIMProperty(name='SI16', "
+    u"value=Sint16(cimtype='sint16', minvalue=-32768, maxvalue=32767, -4216), "
+    u"type='sint16', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'SI32': CIMProperty(name='SI32', "
+    u"value=Sint32(cimtype='sint32', minvalue=-2147483648, "
+    u"maxvalue=2147483647, -4232), type='sint32', reference_class=None, "
+    u"embedded_object=None, is_array=False, array_size=None, "
+    u"class_origin=None, propagated=None, qualifiers=NocaseDict({})), 'SI64': "
+    u"CIMProperty(name='SI64', value=Sint64(cimtype='sint64', "
+    u"minvalue=-9223372036854775808, maxvalue=9223372036854775807, -4264), "
+    u"type='sint64', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'SI8': CIMProperty(name='SI8', "
+    u"value=Sint8(cimtype='sint8', minvalue=-128, maxvalue=127, -42), "
+    u"type='sint8', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'UI16': CIMProperty(name='UI16', "
+    u"value=Uint16(cimtype='uint16', minvalue=0, maxvalue=65535, 4216), "
+    u"type='uint16', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'UI32': CIMProperty(name='UI32', "
+    u"value=Uint32(cimtype='uint32', minvalue=0, maxvalue=4294967295, 4232), "
+    u"type='uint32', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'UI64': CIMProperty(name='UI64', "
+    u"value=Uint64(cimtype='uint64', minvalue=0, "
+    u"maxvalue=18446744073709551615, 4264), type='uint64', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({})), 'UI8': CIMProperty(name='UI8', "
+    u"value=Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 42), "
+    u"type='uint8', reference_class=None, embedded_object=None, "
+    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict({}))}), property_list=None, "
+    u"qualifiers=NocaseDict({})))")
+
+
+get_inst_return_all_log_PY2 = (
+    "Return:test_id GetInstance(CIMInstance(classname=u'CIM_Foo', path=None, "
+    "properties=NocaseDict({'Bool': CIMProperty(name=u'Bool', value=True, "
+    "type='boolean', reference_class=None, embedded_object=None, is_array="
+    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
+    "NocaseDict({})), 'DTF': CIMProperty(name=u'DTF', value=CIMDateTime("
+    "cimtype='datetime', '20160331193040.654321+120'), type='datetime', "
+    "reference_class=None, embedded_object=None, is_array=False, array_size="
+    "None, class_origin=None, propagated=None, qualifiers=NocaseDict({})), "
+    "'DTI': CIMProperty(name=u'DTI', value=CIMDateTime(cimtype='datetime', "
+    "'00000010000049.000020:000'), type='datetime', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, class_origin=None,"
+    " propagated=None, qualifiers=NocaseDict({})), 'DTP': CIMProperty(name="
+    "u'DTP', value=CIMDateTime(cimtype='datetime', '20140922104920.524789-399')"
+    ", type='datetime', reference_class=None, embedded_object=None, is_array="
+    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
+    "NocaseDict({})), 'R32': CIMProperty(name=u'R32', value=Real32(cimtype="
+    "'real32', 42.0), type='real32', reference_class=None, embedded_object="
+    "None, is_array=False, array_size=None, class_origin=None, propagated="
+    "None, qualifiers=NocaseDict({})), 'R64': CIMProperty(name=u'R64', "
+    "value=Real64(cimtype='real64', 42.64), type='real64', reference_class="
+    "None, embedded_object=None, is_array=False, array_size=None, "
+    "class_origin=None, propagated=None, qualifiers=NocaseDict({})), 'S1': "
+    "CIMProperty(name=u'S1', value=u'Ham', type='string', reference_class=None"
+    ", embedded_object=None, is_array=False, array_size=None, class_origin="
+    "None, propagated=None, qualifiers=NocaseDict({})), 'SI16': CIMProperty("
+    "name=u'SI16', value=Sint16(cimtype='sint16', minvalue=-32768, maxvalue="
+    "32767, -4216), type='sint16', reference_class=None, embedded_object=None"
+    ", is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict({})), 'SI32': CIMProperty(name=u'SI32', value="
+    "Sint32(cimtype='sint32', minvalue=-2147483648, maxvalue=2147483647, -4232"
+    "), type='sint32', reference_class=None, embedded_object=None, is_array="
+    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
+    "NocaseDict({})), 'SI64': CIMProperty(name=u'SI64', value=Sint64(cimtype="
+    "'sint64', minvalue=-9223372036854775808, maxvalue=9223372036854775807, "
+    "-4264), type='sint64', reference_class=None, embedded_object=None, "
+    "is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict({})), 'SI8': CIMProperty(name=u'SI8', value=Sint8("
+    "cimtype='sint8', minvalue=-128, maxvalue=127, -42), type='sint8', "
+    "reference_class=None, embedded_object=None, is_array=False, array_size="
+    "None, class_origin=None, propagated=None, qualifiers=NocaseDict({})), "
+    "'UI16': CIMProperty(name=u'UI16', value=Uint16(cimtype='uint16', minvalue"
+    "=0, maxvalue=65535, 4216), type='uint16', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, class_origin=None,"
+    " propagated=None, qualifiers=NocaseDict({})), 'UI32': CIMProperty("
+    "name=u'UI32', value=Uint32(cimtype='uint32', minvalue=0, maxvalue="
+    "4294967295, 4232), type='uint32', reference_class=None, embedded_object"
+    "=None, is_array=False, array_size=None, class_origin=None, propagated="
+    "None, qualifiers=NocaseDict({})), 'UI64': CIMProperty(name=u'UI64', "
+    "value=Uint64(cimtype='uint64', minvalue=0, maxvalue=18446744073709551615"
+    ", 4264), type='uint64', reference_class=None, embedded_object=None, "
+    "is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict({})), 'UI8': CIMProperty(name=u'UI8', "
+    "value=Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 42), "
+    "type='uint8', reference_class=None, embedded_object=None, is_array=False"
+    ", array_size=None, class_origin=None, propagated=None, qualifiers="
+    "NocaseDict({}))}), property_list=None, qualifiers=NocaseDict({})))")
+
+
+class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
     """
     Test staging for different cim_operations.  This defines fixed
     parameters for the before and after staging, stages (which creates
@@ -525,31 +649,26 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
     """
     @log_capture()
     def test_create_connection(self, lc):
-        self.test_recorder = _LogOperationRecorder()
-
-        self.test_recorder.reset()
-        self.test_recorder.enable()
+        """Create connection with default parameters"""
+        self.recorder_setup()
         # Fake the connection to create a fixed data environment
         conn = WBEMConnection('http://blah')
         conn.conn_id = '%s-%s' % (22, "1234:34")
         self.test_recorder.stage_wbem_connection(conn)
-        if VERBOSE:
-            print(lc)
+
         lc.check(
             ("pywbem.ops", "DEBUG",
-             "Connection: WBEMConnection(url='http://blah', creds=None, "
-             "conn_id=22-1234:34, "
+             "Connection:22-1234:34 WBEMConnection(url='http://blah', "
+             "creds=None, conn_id=22-1234:34, "
              "default_namespace='root/cimv2', x509=None, verify_callback=None, "
              'ca_certs=None, no_verification=False, timeout=None, '
-             'use_pull_operations=False, stats=Statistics(\n'
-             '), recorders=[])'),)
+             'use_pull_operations=False, stats=False, '
+             'recorders=[])'),)
 
     @log_capture()
     def test_create_connection2(self, lc):
-        self.test_recorder = _LogOperationRecorder()
+        self.recorder_setup()
 
-        self.test_recorder.reset()
-        self.test_recorder.enable()
         x509_dict = {"cert_file": 'Certfile.x', 'key_file': 'keyfile.x'}
         conn = WBEMConnection('http://blah',
                               default_namespace='root/blah',
@@ -559,43 +678,70 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                               timeout=10,
                               use_pull_operations=True,
                               enable_stats=True)
-        self.test_recorder.stage_wbem_connection(conn)
         conn.conn_id = '%s-%s' % (23, "1234:34")
-
-        if VERBOSE:
-            print(lc)
+        self.test_recorder.stage_wbem_connection(conn)
 
         lc.check((
             "pywbem.ops", "DEBUG",
-            "Connection: WBEMConnection(url='http://blah', "
+            "Connection:23-1234:34 WBEMConnection(url='http://blah', "
             "creds=('username', ...), conn_id=23-1234:34, "
             "default_namespace='root/blah', "
             "x509='cert_file': 'Certfile.x', 'key_file': 'keyfile.x', "
             "verify_callback=None, ca_certs=None, no_verification=True, "
-            "timeout=10, use_pull_operations=True, stats=Statistics(\n), "
+            "timeout=10, use_pull_operations=True, stats=True, "
             "recorders=[])"),)
 
     @log_capture()
-    def test_getinstance_args(self, lc):
+    def test_stage_result_exception(self, lc):
+        """Test the ops result log None return, HTTPError exception."""
+        self.recorder_setup(max_log_entry_size=10)
+        ce = CIMError(6, "Fake CIMError")
+        exc = HTTPError(500, "Fake Reason", cimerror='%s' % ce)
+        self.test_recorder.stage_pywbem_result(None, exc)
+
+        lc.check(
+            ("pywbem.ops", "DEBUG",
+             "Exception:test_id None('HTTPError...)"))
+
+    @log_capture()
+    def test_stage_result_exception_all(self, lc):
+        """Test the ops result log None return, HTTPError exception."""
+        self.recorder_setup(log_detail_level='all')
+        ce = CIMError(6, "Fake CIMError")
+        exc = HTTPError(500, "Fake Reason", cimerror='%s' % ce)
+        self.test_recorder.stage_pywbem_result(None, exc)
+
+        # TODO. V2 valid string has extra single quote after CIMError
+        if six.PY2:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 "Exception:test_id None('HTTPError(500 (Fake Reason), "
+                 "CIMError: 6: Fake CIMError)')"),)
+        else:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 "Exception:test_id None('HTTPError(500 (Fake Reason), "
+                 "CIMError: 6: Fake CIMError)')"),)
+
+    @log_capture()
+    def test_stage_getinstance_args(self, lc):
         """
         Emulates call to getInstance to test parameter processing.
         Currently creates the pywbem_request component.
         """
 
-        InstanceName = self.create_ciminstancename()
+        inst_name = self.create_ciminstancename()
 
-        self.recorder_setup(10)
+        self.recorder_setup(max_log_entry_size=10)
 
         self.test_recorder.stage_pywbem_args(
             method='GetInstance',
-            InstanceName=InstanceName,
+            InstanceName=inst_name,
             LocalOnly=True,
             IncludeQualifiers=True,
             IncludeClassOrigin=True,
             PropertyList=['propertyblah'])
 
-        if VERBOSE:
-            print(lc)
         # pywbem 2 and 3 differ in only the use of unicode for certain
         # string properties. (ex. classname)
         if six.PY2:
@@ -620,17 +766,186 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "PropertyList=['propertyblah'])"),)
 
     @log_capture()
-    def test_getinstance_result(self, lc):
+    def test_stage_instance_result(self, lc):
+        instance = self.create_ciminstance()
+        self.recorder_setup(max_log_entry_size=10)
+        exc = None
+        self.test_recorder.stage_pywbem_result(instance, exc)
+
+        if six.PY2:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 'Return:test_id None(CIMInstanc...)'))
+        else:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 'Return:test_id None(CIMInstanc...)'))
+
+    @log_capture()
+    def test_stage_instance_result_default(self, lc):
+        instance = self.create_ciminstance()
+        self.recorder_setup()
+        exc = None
+        self.test_recorder.stage_pywbem_result(instance, exc)
+
+        if six.PY2:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 "Return:test_id None(CIMInstance(classname=u'CIM_Foo', "
+                 "path=None,"
+                 " properties=NocaseDict({'Bool': CIMProperty(name=u'Bool', "
+                 "value=True, type='boolean', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})),"
+                 " 'DTF': CIMProperty(name=u'DTF', value=CIMDateTime(cimtype"
+                 "='datetime', '20160331193040.654321+120'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name=u'DTI', "
+                 "value=CIMDateTime(cimtype='datetime', "
+                 "'00000010000049.000020:000'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name=u'DTP', "
+                 "value=CIMDateTime(cimtype='datetime', "
+                 "'20140922104920.524789-399'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, ...)"),)
+        else:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 "Return:test_id None(CIMInstance(classname='CIM_Foo', "
+                 "path=None, "
+                 "properties=NocaseDict({'Bool': CIMProperty(name='Bool', "
+                 "value=True, "
+                 "type='boolean', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTF': CIMProperty(name='DTF', "
+                 "value=CIMDateTime(cimtype='datetime', "
+                 "'20160331193040.654321+120'), "
+                 "type='datetime', reference_class=None, embedded_object=None, "
+                 'is_array=False, array_size=None, class_origin=None, '
+                 'propagated=None, '
+                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name='DTI', "
+                 "value=CIMDateTime(cimtype='datetime', "
+                 "'00000010000049.000020:000'), "
+                 "type='datetime', reference_class=None, embedded_object=None, "
+                 'is_array=False, array_size=None, class_origin=None, '
+                 'propagated=None, '
+                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name='DTP', "
+                 "value=CIMDateTime(cimtype='datetime', "
+                 "'20140922104920.524789-399'), "
+                 "type='datetime', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propa...)"),)
+
+    @log_capture()
+    def test_stage_instance_result_all(self, lc):
+        instance = self.create_ciminstance()
+        self.recorder_setup(log_detail_level='all')
+        exc = None
+        self.test_recorder.stage_pywbem_result(instance, exc)
+
+        if six.PY2:
+            lc.check(
+                ("pywbem.ops", "DEBUG",
+                 "Return:test_id None(CIMInstance(classname=u'CIM_Foo', "
+                 "path=None, properties=NocaseDict({'Bool': CIMProperty("
+                 "name=u'Bool', value=True, type='boolean', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTF': CIMProperty(name=u'DTF',"
+                 " value=CIMDateTime(cimtype='datetime', "
+                 "'20160331193040.654321+120'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name=u'DTI',"
+                 " value=CIMDateTime(cimtype='datetime', "
+                 "'00000010000049.000020:000'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name=u'DTP',"
+                 " value=CIMDateTime(cimtype='datetime', "
+                 "'20140922104920.524789-399'), type='datetime', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'R32': CIMProperty(name=u'R32',"
+                 " value=Real32(cimtype='real32', 42.0), type='real32', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'R64': CIMProperty(name=u'R64',"
+                 " value=Real64(cimtype='real64', 42.64), type='real64', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'S1': CIMProperty(name=u'S1',"
+                 " value=u'Ham', type='string', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, qualifiers=NocaseDict("
+                 "{})), 'SI16': CIMProperty(name=u'SI16', "
+                 "value=Sint16(cimtype='sint16', minvalue=-32768,"
+                 " maxvalue=32767, -4216), type='sint16', "
+                 "reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict({})), 'SI32': "
+                 "CIMProperty(name=u'SI32', value=Sint32(cimtype='sint32', "
+                 "minvalue=-2147483648, maxvalue=2147483647, -4232), "
+                 "type='sint32', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict({})), 'SI64': "
+                 "CIMProperty(name=u'SI64', value=Sint64(cimtype='sint64', "
+                 "minvalue=-9223372036854775808, maxvalue=9223372036854775807,"
+                 " -4264), type='sint64', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, qualifiers=NocaseDict("
+                 "{})), 'SI8': CIMProperty(name=u'SI8', value=Sint8("
+                 "cimtype='sint8', minvalue=-128, maxvalue=127, -42), "
+                 "type='sint8', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict({})), 'UI16': "
+                 "CIMProperty(name=u'UI16', value=Uint16(cimtype='uint16', "
+                 "minvalue=0, maxvalue=65535, 4216), type='uint16', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({})), 'UI32': CIMProperty(name=u'UI32',"
+                 " value=Uint32(cimtype='uint32', minvalue=0, "
+                 "maxvalue=4294967295, 4232), type='uint32', reference_class="
+                 "None, embedded_object=None, is_array=False, array_size=None,"
+                 " class_origin=None, propagated=None, qualifiers=NocaseDict("
+                 "{})), 'UI64': CIMProperty(name=u'UI64', value=Uint64(cimtype"
+                 "='uint64', minvalue=0, maxvalue=18446744073709551615, 4264), "
+                 "type='uint64', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict({})), 'UI8': "
+                 "CIMProperty(name=u'UI8', value=Uint8(cimtype='uint8', "
+                 "minvalue=0, maxvalue=255, 42), type='uint8', reference_"
+                 "class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict({}))}), property_list=None, "
+                 "qualifiers=NocaseDict({})))"),)
+        else:
+            none_result_all = get_inst_return_all_log.replace('GetInstance',
+                                                              'None')
+            lc.check(
+                ("pywbem.ops", "DEBUG", none_result_all))
+
+
+class LogOperationRecorderTests(BaseLogOperationRecorderTests):
+    """Test args and resutls logging"""
+
+    @log_capture()
+    def test_getinstance(self, lc):
         """Test the ops result log for get instance"""
 
-        InstanceName = self.create_ciminstancename()
+        inst_name = self.create_ciminstancename()
 
         # set recorder to limit response to length of 10
-        self.recorder_setup(10)
+        self.recorder_setup(max_log_entry_size=10)
 
         self.test_recorder.stage_pywbem_args(
             method='GetInstance',
-            InstanceName=InstanceName,
+            InstanceName=inst_name,
             LocalOnly=True,
             IncludeQualifiers=True,
             IncludeClassOrigin=True,
@@ -638,9 +953,6 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         instance = self.create_ciminstance()
         exc = None
         self.test_recorder.stage_pywbem_result(instance, exc)
-
-        if VERBOSE:
-            print(lc)
 
         if six.PY2:
             lc.check(
@@ -669,13 +981,13 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
     def test_getinstance_exception(self, lc):
         """Test the ops result log for get instance"""
 
-        InstanceName = self.create_ciminstancename()
+        inst_name = self.create_ciminstancename()
 
-        self.recorder_setup(10)
+        self.recorder_setup(max_log_entry_size=11)
 
         self.test_recorder.stage_pywbem_args(
             method='GetInstance',
-            InstanceName=InstanceName,
+            InstanceName=inst_name,
             LocalOnly=True,
             IncludeQualifiers=True,
             IncludeClassOrigin=True,
@@ -683,9 +995,6 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         instance = None
         exc = CIMError(6, "Fake CIMError")
         self.test_recorder.stage_pywbem_result(instance, exc)
-
-        if VERBOSE:
-            print(lc)
 
         if six.PY2:
             lc.check(
@@ -696,7 +1005,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception:test_id GetInstance(CIMError(6...)"))
+                 "Exception:test_id GetInstance('CIMError(6...)"))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
@@ -706,25 +1015,22 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "'Ham'}), namespace='root/cimv2', host='woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception:test_id GetInstance(CIMError(6...)"))
+                 "Exception:test_id GetInstance('CIMError(6...)"))
 
     @log_capture()
-    def test_getinstance_exception2(self, lc):
-        """Test the ops result log for get instance"""
+    def test_getinstance_exception_all(self, lc):
+        """Test the ops result log for get instance CIMError exception"""
 
-        InstanceName = self.create_ciminstancename()
+        inst_name = self.create_ciminstancename()
 
-        self.recorder_setup()
+        self.recorder_setup(log_detail_level='all')
 
         self.test_recorder.stage_pywbem_args(
             method='GetInstance',
-            InstanceName=InstanceName)
+            InstanceName=inst_name)
         instance = None
         exc = CIMError(6, "Fake CIMError")
         self.test_recorder.stage_pywbem_result(instance, exc)
-
-        if VERBOSE:
-            print(lc)
 
         if six.PY2:
             lc.check(
@@ -733,8 +1039,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'))"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception:test_id GetInstance("
-                 "CIMError(6: Fake CIMError))"))
+                 "Exception:test_id GetInstance('CIMError(6: Fake "
+                 "CIMError)')"),)
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
@@ -742,20 +1048,20 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "classname='CIM_Foo', keybindings=NocaseDict({'Chicken': "
                  "'Ham'}), namespace='root/cimv2', host='woot.com'))"),
                 ("pywbem.ops", "DEBUG",
-                 "Exception:test_id GetInstance("
-                 "CIMError(6: Fake CIMError))"))
+                 "Exception:test_id GetInstance('CIMError(6: Fake "
+                 "CIMError)')"),)
 
     @log_capture()
     def test_getinstance_result_all(self, lc):
         """Test the ops result log for get instance"""
 
-        InstanceName = self.create_ciminstancename()
+        inst_name = self.create_ciminstancename()
 
-        self.recorder_setup()
+        self.recorder_setup(log_detail_level='all')
 
         self.test_recorder.stage_pywbem_args(
             method='GetInstance',
-            InstanceName=InstanceName,
+            InstanceName=inst_name,
             LocalOnly=True,
             IncludeQualifiers=True,
             IncludeClassOrigin=True,
@@ -764,8 +1070,6 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         exc = None
         self.test_recorder.stage_pywbem_result(instance, exc)
 
-        if VERBOSE:
-            print(lc)
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
@@ -776,26 +1080,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops',
                  'DEBUG',
-                 "Return:test_id GetInstance(CIMInstance(classname=u'CIM_Foo'"
-                 ", path=None, properties=NocaseDict({'Bool': CIMProperty("
-                 "name=u'Bool', value=True, type='boolean', reference_class="
-                 "None, embedded_object=None, is_array=False, array_size=None,"
-                 " class_origin=None, propagated=None, qualifiers=NocaseDict({"
-                 "})), 'DTF': CIMProperty(name=u'DTF', value=CIMDateTime("
-                 "cimtype='datetime', '20160331193040.654321+120'), "
-                 "type='datetime', reference_class=None, embedded_object=None,"
-                 " is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict({})), 'DTI': "
-                 "CIMProperty(name=u'DTI', value=CIMDateTime(cimtype="
-                 "'datetime', '00000010000049.000020:000'), type='datetime',"
-                 " reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name=u'DTP',"
-                 " value=CIMDateTime(cimtype='datetime', '20140922104920."
-                 "524789-399'), type='datetime', reference_class=None, "
-                 "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, ...)"))
-
+                 get_inst_return_all_log_PY2))
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
@@ -806,40 +1091,14 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "namespace='root/cimv2', "
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),
-                ("pywbem.ops", "DEBUG",
-                 "Return:test_id GetInstance(CIMInstance(classname='CIM_Foo',"
-                 " path=None, "
-                 "properties=NocaseDict({'Bool': CIMProperty(name='Bool', "
-                 "value=True, "
-                 "type='boolean', reference_class=None, embedded_object=None, "
-                 'is_array=False, array_size=None, class_origin=None, '
-                 'propagated=None, '
-                 "qualifiers=NocaseDict({})), 'DTF': CIMProperty(name='DTF', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'20160331193040.654321+120'), "
-                 "type='datetime', reference_class=None, embedded_object=None, "
-                 'is_array=False, array_size=None, class_origin=None, '
-                 'propagated=None, '
-                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name='DTI', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'00000010000049.000020:000'), "
-                 "type='datetime', reference_class=None, "
-                 "embedded_object=None, "
-                 'is_array=False, array_size=None, class_origin=None, '
-                 'propagated=None, '
-                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name='DTP', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'20140922104920.524789-399'), "
-                 "type='datetime', reference_class=None, embedded_object=None, "
-                 'is_array=False, array_size=None, '
-                 'class_origin=None, propa...)'))
+                ("pywbem.ops", "DEBUG", get_inst_return_all_log),)
 
     @log_capture()
     def test_enuminstances_result(self, lc):
         """Test the ops result log for enumerate instances"""
 
         # set recorder to limit response to length of 10
-        self.recorder_setup(10)
+        self.recorder_setup(max_log_entry_size=10)
 
         self.test_recorder.stage_pywbem_args(
             method='EnumerateInstances',
@@ -852,9 +1111,6 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         instance = self.create_ciminstance()
         exc = None
         self.test_recorder.stage_pywbem_result([instance, instance], exc)
-
-        if VERBOSE:
-            print(lc)
 
         if six.PY2:
             lc.check(
@@ -879,7 +1135,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
         """Test the ops result log for enumerate instances"""
 
         # set recorder to limit response to length of 10
-        self.recorder_setup(10)
+        self.recorder_setup(max_log_entry_size=10)
 
         self.test_recorder.stage_pywbem_args(
             method='EnumerateInstanceNames',
@@ -890,12 +1146,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
             PropertyList=['propertyblah', 'blah2'])
 
         exc = None
-        instance_name = self.create_ciminstancename()
-        self.test_recorder.stage_pywbem_result([instance_name, instance_name],
-                                               exc)
-
-        if VERBOSE:
-            print(lc)
+        inst_name = self.create_ciminstancename()
+        self.test_recorder.stage_pywbem_result([inst_name, inst_name], exc)
 
         if six.PY2:
             lc.check(
@@ -917,10 +1169,12 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
     @log_capture()
     def test_openenuminstances_result_all(self, lc):
-        """Test the ops result log for enumerate instances"""
+        """Test the ops result log for enumerate instances. Returns no
+        instances.
+        """
 
         # set recorder to limit response to length of 10
-        self.recorder_setup()
+        self.recorder_setup(log_detail_level='all')
 
         self.test_recorder.stage_pywbem_args(
             method='OpenEnumerateInstances',
@@ -939,31 +1193,138 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
 
         self.test_recorder.stage_pywbem_result(result_tuple, exc)
 
-        if VERBOSE:
-            print(lc)
+        lc.check(
+            ("pywbem.ops", "DEBUG",
+             "Request:test_id OpenEnumerateInstances(ClassName='CIM_Foo', "
+             "IncludeClassOrigin=True, IncludeQualifiers=True, "
+             "LocalOnly=True, PropertyList=['propertyblah'])"),
+            ('pywbem.ops', 'DEBUG',
+             "Return:test_id OpenEnumerateInstances(pull_inst_result_tuple("
+             "context=('test_rtn_context', 'root/blah'), eos=False, "
+             "instances=[]))"),)
+
+    @log_capture()
+    def test_openenuminstancepaths_result_all(self, lc):
+        """Test the ops result log for enumerate instances paths with
+        data in the paths component"""
+
+        # set recorder to limit response to length of 10
+        self.recorder_setup(log_detail_level='all')
+
+        self.test_recorder.stage_pywbem_args(
+            method='OpenEnumerateInstancePaths',
+            ClassName='CIM_Foo',
+            FilterQueryLanguage='FQL',
+            FilterQuery='SELECT A from B',
+            OperationTimeout=10,
+            ContinueOnError=None,
+            MaxObjectCount=100)
+
+        inst_name = self.create_ciminstancename()
+        result = [inst_name, inst_name]
+        exc = None
+
+        context = ('test_rtn_context', 'root/blah')
+        result_tuple = pull_path_result_tuple(result, False, context)
+
+        self.test_recorder.stage_pywbem_result(result_tuple, exc)
 
         if six.PY2:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request:test_id OpenEnumerateInstances(ClassName='CIM_Foo', "
-                 "IncludeClassOrigin=True, IncludeQualifiers=True, "
-                 "LocalOnly=True, PropertyList=['propertyblah'])"),
+                 "Request:test_id OpenEnumerateInstancePaths(ClassName="
+                 "'CIM_Foo', ContinueOnError=None, FilterQuery='SELECT A "
+                 "from B', FilterQueryLanguage='FQL', MaxObjectCount=100, "
+                 "OperationTimeout=10)"),
                 ('pywbem.ops', 'DEBUG',
-                 "Return:test_id OpenEnumerateInstances("
-                 "pull_inst_result_tuple(instances=[], eos=False, "
-                 "context=('test_rtn_context', 'root/blah')))"))
+                 "Return:test_id OpenEnumerateInstancePaths("
+                 "pull_path_result_tuple(context=('test_rtn_context', "
+                 "'root/blah'), eos=False, paths=[CIMInstanceName("
+                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
+                 "'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
+                 "CIMInstanceName(classname=u'CIM_Foo', keybindings="
+                 "NocaseDict({'Chicken': 'Ham'}), namespace=u'root/cimv2',"
+                 " host=u'woot.com')]))"))
+
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
-                 "Request:test_id OpenEnumerateInstances(ClassName='CIM_Foo', "
-                 'IncludeClassOrigin=True, IncludeQualifiers=True, '
-                 'LocalOnly=True, '
-                 "PropertyList=['propertyblah'])"),
-
+                 "Request:test_id OpenEnumerateInstancePaths("
+                 "ClassName='CIM_Foo', "
+                 "ContinueOnError=None, FilterQuery='SELECT A from B', "
+                 "FilterQueryLanguage='FQL', MaxObjectCount=100, "
+                 "OperationTimeout=10)"),
                 ('pywbem.ops', 'DEBUG',
-                 "Return:test_id OpenEnumerateInstances("
-                 "pull_inst_result_tuple(instances=[], eos=False, "
-                 "context=('test_rtn_context', 'root/blah')))"))
+                 'Return:test_id '
+                 "OpenEnumerateInstancePaths(pull_path_result_tuple("
+                 "context=('test_rtn_context', "
+                 "'root/blah'), eos=False, paths=[CIMInstanceName("
+                 "classname='CIM_Foo', "
+                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "namespace='root/cimv2', "
+                 "host='woot.com'), CIMInstanceName(classname='CIM_Foo', "
+                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "namespace='root/cimv2', "
+                 "host='woot.com')]))"),)
+
+    @log_capture()
+    def test_associators_result(self, lc):
+        """Test the ops result log for Associators that returns nothing"""
+
+        inst_name = self.create_ciminstancename()
+
+        # set recorder to limit response to length of 10
+        self.recorder_setup(max_log_entry_size=10)
+
+        self.test_recorder.stage_pywbem_args(
+            method='Associators',
+            InstanceName=inst_name,
+            AssocClass='BLAH_Assoc',
+            ResultClass='BLAH_Result',
+            IncludeQualifiers=True,
+            IncludeClassOrigin=True,
+            PropertyList=['propertyblah', 'propertyblah2'])
+        exc = None
+        self.test_recorder.stage_pywbem_result([], exc)
+
+        if six.PY2:
+            lc.check(
+                ('pywbem.ops', 'DEBUG',
+                 "Request:test_id Associators(AssocClass='BLAH_Assoc', "
+                 "IncludeClassOrigin=True, IncludeQualifiers=True, "
+                 "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
+                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "namespace=u'root/cimv2', host=u'woot.com'), "
+                 "PropertyList=['propertyblah', 'propertyblah2'], "
+                 "ResultClass='BLAH_Result')"),
+                ('pywbem.ops', 'DEBUG', 'Return:test_id Associators([])'))
+
+        else:
+            lc.check(
+                ('pywbem.ops', 'DEBUG',
+                 "Request:test_id Associators(AssocClass='BLAH_Assoc', "
+                 'IncludeClassOrigin=True, IncludeQualifiers=True, '
+                 "InstanceName=CIMInstanceName(classname='CIM_Foo', "
+                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "namespace='root/cimv2', "
+                 "host='woot.com'), PropertyList=['propertyblah', "
+                 "'propertyblah2'], "
+                 "ResultClass='BLAH_Result')"),
+                ('pywbem.ops', 'DEBUG', 'Return:test_id Associators([])'))
+
+    @log_capture()
+    def test_associators_result_exception(self, lc):
+        """Test the ops result log for associators that returns exception"""
+
+        # set recorder to limit response to length of 10
+        self.recorder_setup(max_log_entry_size=11)
+
+        exc = CIMError(6, "Fake CIMError")
+        self.test_recorder.stage_pywbem_result([], exc)
+
+        lc.check(
+            ('pywbem.ops', 'DEBUG',
+             "Exception:test_id None('CIMError(6...)"),)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This creates the components in cim_operations and the recorder to log wbem method request and response information and  http requests/responses.  It resolves the issues documented in #728 and #729 also since once we broke up the original pr, we had time to extend the functionality for these issues.

This modifies cim_operations to handle logging and allow multiple loggers and.  It modifies the recorder to add the LogOperationRecorder