### PR TITLE
Fixes #62: Add documentation on limitations of pywbem compiler.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -172,6 +172,9 @@ Bug fixes
   According to DSP0201, reference_class is the declared class, which can be
   a superclass of the  creation class of the referenced instance.
   This is related to issue #598
+
+* Modify mof_compiler documentation to indication issues with property
+  names that are compiler keywords. See issue #62.
   
 * Correct issue where dependency pip installs end up with old version
   of coverage package. This old version generates unwanted deprecation

--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -6,10 +6,10 @@ MOF compiler API
 
 .. automodule:: pywbem.mof_compiler
 
-.. _`MOFCompiler`:
+.. _`MOFCompiler Class`:
 
-MOFCompiler
-------------
+MOFCompiler Class
+-----------------
 
 .. autoclass:: pywbem.MOFCompiler
    :members:

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -27,8 +27,9 @@ The following commands are provided:
 mof_compiler
 ------------
 
-The ``mof_compiler`` command is a MOF compiler. It compiles MOF files, and
-updates the repository of a WBEM server with the result.
+The ``mof_compiler`` command is a command line interface to the pywbem MOF
+compiler. It compiles MOF files, and updates the repository of a WBEM server
+with the result.
 
 The MOF compiler can also be invoked from programs via the
 :ref:`MOF compiler API`.

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -20,25 +20,37 @@
 #
 
 """
-The language in which CIM classes are specified, is called `MOF` (for Managed
-Object Format). It is defined in :term:`DSP0004`.
+The language in which CIM classes, CIM Instances, etc. are specified, is
+called `MOF` (for Managed Object Format). It is defined in the DMTF document
+:term:`DSP0004`.
+
+MOF compilers take MOF files as input, compile them and use the result
+(CIMClasses, CIMInstances, etc.) to update a target CIM repository. The
+repository may initially be empty, or may contain the result of earlier MOF
+compilations that are used to resolve dependencies the new MOF compilation
+may have.
 
 The pywbem package includes a MOF compiler.
 
-MOF compilers take MOF files as input, compile them and the result is used to
-update a target CIM repository. The repository may initially be empty, or may
-contain the result of earlier MOF compilations that are used to resolve
-dependencies the new MOF compilation may have.
+The MOF compiler in this package will compile MOF files whose syntax complies
+with :term:`DSP0004` with some limitations:
 
-The MOF compiler in this package also has an option to remove CIM elements
-from the repository it has a definition for in the MOF files it processes.
+1. Although there is no formal keyword list of illegal words
+for property/parameter.etc. names , there is a list of mof syntax tokens
+in :term:`DSP0004` section A.3.  Generally these should not be used as property
+names.  The pywbem MOF compiler largely enforces this so that words like
+'indication' are not allowed as property/parameter/etc. names.
+
+The pywbem MOF compiler also has an option to remove CIM elements from a
+repository by using the  compiler rollback. This is used in the MOFCompiler
+script. See :ref:`mof_compiler`.
 
 The MOF compiler API provides for invoking the MOF compiler and for plugging in
 your own CIM repository into the MOF compiler.
 
 This chapter has the following sections:
 
-* :ref:`MOFCompiler` - Describes the :class:`~pywbem.MOFCompiler`
+* :ref:`MOFCompiler Class` - Describes the :class:`~pywbem.MOFCompiler`
   class, which allows invoking the MOF compiler programmatically.
 
 * :ref:`Repository connections` - Describes the


### PR DESCRIPTION
1. Added comment about issue with property/etc. names that are also
compiler keywords.

2. Minor edits to the mof compiler doc to clarify some phrases.

3. Changed some section names in the rst documentation to separate
the mof compiler class from the mof compiler cmd line.

4. Added note to changes.rst

