### PR TITLE
Fixes #349: Added class path to CIMClass

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -106,6 +106,17 @@ Enhancements
 * Clarify documentation on wbem operation recorder in client.rst. see
   issue #741
 
+* Added an optional class path to the `CIMClass` class, as a convenience for
+  the user in order so that `CIMClass` objects are self-contained w.r.t. their
+  path. The class path is set in `CIMClass` objects returned by the `GetClass`,
+  `EmumerateClasses`, and the class-level `Associators` and `References`
+  operations. The path is added purely on the client side, based on existing
+  information returned from WBEM server. This change does therefore not affect
+  the interactions with WBEM servers at all.  issue #349.
+
+* Added a ``host`` property to ``WBEMConnection`` which contains the host:port
+  component of the WBEM server's URL.  This helps addressing issue #349.
+
 
 Bug fixes
 ^^^^^^^^^
@@ -183,7 +194,7 @@ Bug fixes
 
 * Modify mof_compiler documentation to indication issues with property
   names that are compiler keywords. See issue #62.
-  
+
 * Correct issue where dependency pip installs end up with old version
   of coverage package. This old version generates unwanted deprecation
   messages that are fixed after version 4.03. This requires a change to

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1618,7 +1618,7 @@ class CIMClassName(_CIMComparisonMixin):
         which the object is used.
 
         `None` means that the WBEM server is unspecified.
-"""
+    """
 
     def __init__(self, classname, host=None, namespace=None):
         """
@@ -1779,7 +1779,7 @@ class CIMClassName(_CIMComparisonMixin):
 
 class CIMClass(_CIMComparisonMixin):
     """
-    A CIM class.
+    A CIM class, optionally including its class path.
 
     Attributes:
 
@@ -1822,11 +1822,25 @@ class CIMClass(_CIMComparisonMixin):
         * value (:class:`~pywbem.CIMQualifier`): Qualifier value
 
         This variable will never be `None`.
+
+      path (:class:`~pywbem.CIMClassName`):
+        Class path of the class.
+
+        `None` means that the class path is unspecified.
+
+        This attribute has been added in pywbem v0.11.0 as a convenience for
+        the user in order so that :class:`~pywbem.CIMClass` objects can be
+        self-contained w.r.t. their class path. This attribute will be set in
+        in any :class:`~pywbem.CIMClass` objects returned by
+        :class:`~pywbem.WBEMConnection` methods.
+
+        This attribute is set in the pywbem client, based on information
+        in the standard response returned by the WBEM server.
     """
 
     # pylint: disable=too-many-arguments
     def __init__(self, classname, properties=None, methods=None,
-                 superclass=None, qualifiers=None):
+                 superclass=None, qualifiers=None, path=None):
         """
         Parameters:
 
@@ -1863,6 +1877,11 @@ class CIMClass(_CIMComparisonMixin):
             attribute.
 
             If `None`, the class will have no qualifiers.
+
+          path (:class:`~pywbem.CIMClassName`):
+            Class path for the class.
+
+            `None` means that the class path will be unspecified.
         """
 
         self.classname = _ensure_unicode(classname)
@@ -1870,13 +1889,14 @@ class CIMClass(_CIMComparisonMixin):
         self.methods = NocaseDict(methods)
         self.superclass = _ensure_unicode(superclass)
         self.qualifiers = NocaseDict(qualifiers)
+        self.path = path
 
     def _cmp(self, other):
         """
         Comparator function for two :class:`~pywbem.CIMClass` objects.
 
         The comparison is based on the `classname`, `superclass`, `qualifiers`,
-        `properties` and `methods` instance attributes, in descending
+        `properties`, `methods` and `path` instance attributes, in descending
         precedence.
 
         The `classname` and `superclass` attributes are compared
@@ -1891,7 +1911,8 @@ class CIMClass(_CIMComparisonMixin):
                 cmpname(self.superclass, other.superclass) or
                 cmpitem(self.qualifiers, other.qualifiers) or
                 cmpitem(self.properties, other.properties) or
-                cmpitem(self.methods, other.methods))
+                cmpitem(self.methods, other.methods) or
+                cmpitem(self.path, other.path))
 
     def __str__(self):
         """
@@ -1909,9 +1930,11 @@ class CIMClass(_CIMComparisonMixin):
     """
 
         return '%s(classname=%r, superclass=%r, ' \
-               'properties=%r, methods=%r, qualifiers=%r)' % \
+               'properties=%r, methods=%r, qualifiers=%r, ' \
+               'path=%r)' % \
                (self.__class__.__name__, self.classname, self.superclass,
-                self.properties, self.methods, self.qualifiers)
+                self.properties, self.methods, self.qualifiers,
+                self.path)
 
     def copy(self):
         """
@@ -1922,6 +1945,8 @@ class CIMClass(_CIMComparisonMixin):
         result.methods = self.methods.copy()
         result.superclass = self.superclass
         result.qualifiers = self.qualifiers.copy()
+        result.path = (self.path is not None and
+                       [self.path.copy()] or [None])[0]
 
         return result
 
@@ -1932,6 +1957,9 @@ class CIMClass(_CIMComparisonMixin):
         as an instance of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is consistent with :term:`DSP0201`.
+
+        The :attr:`~pywbem.CIMClass.path` attribute of this object will not be
+        included in the returned CIM-XML representation.
         """
         return cim_xml.CLASS(
             self.classname,
@@ -1946,6 +1974,9 @@ class CIMClass(_CIMComparisonMixin):
         :class:`~pywbem.CIMClass` object, as a :term:`unicode string`.
 
         The returned CIM-XML representation is consistent with :term:`DSP0201`.
+
+        The :attr:`~pywbem.CIMClass.path` attribute of this object will not be
+        included in the returned CIM-XML representation.
 
         Parameters:
 
@@ -1970,6 +2001,9 @@ class CIMClass(_CIMComparisonMixin):
         Return a :term:`unicode string` that is a MOF fragment with the
         class definition represented by the :class:`~pywbem.CIMClass`
         object.
+
+        The :attr:`~pywbem.CIMClass.path` attribute of this object will not be
+        included in the returned MOF string.
         """
 
         indent = MOF_INDENT

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -861,6 +861,15 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         self._last_server_response_time = None
 
     @property
+    def host(self):
+        """
+        :term:`unicode string`: The ``{host}[:{port}]``component of the
+        WBEM server's URL, as specified in the ``url`` attribute.
+        """
+        host = self.url.split('://')[-1]
+        return host
+
+    @property
     def stats_enabled(self):
         """
         :class:`py:bool`: Statistics enablement status for this connection.
@@ -6631,7 +6640,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                   information.
 
               * class (:class:`~pywbem.CIMClass`): The representation of the
-                class.
+                class, with its `path` attribute set to the `classpath` tuple
+                item.
 
         Raises:
 
@@ -6680,6 +6690,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 objects = []
             else:
                 objects = [x[2] for x in result[0][2]]
+            if not isinstance(objectname, CIMInstanceName):
+                for classpath, klass in objects:
+                    klass.path = classpath
             return objects
 
         except Exception as exce:
@@ -6957,7 +6970,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                   information.
 
               * class (:class:`~pywbem.CIMClass`): The representation of the
-                class.
+                class, with its `path` attribute set to the `classpath` tuple
+                item.
 
         Raises:
 
@@ -7002,6 +7016,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 objects = []
             else:
                 objects = [x[2] for x in result[0][2]]
+            if not isinstance(objectname, CIMInstanceName):
+                for classpath, klass in objects:
+                    klass.path = classpath
             return objects
 
         except Exception as exce:
@@ -7482,7 +7499,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         Returns:
 
             A list of :class:`~pywbem.CIMClass` objects that are
-            representations of the enumerated classes.
+            representations of the enumerated classes, with their `path`
+            attributes set.
 
         Raises:
 
@@ -7527,6 +7545,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 classes = []
             else:
                 classes = result[0][2]
+            for klass in classes:
+                klass.path = CIMClassName(
+                    classname=klass.classname, host=self.host,
+                    namespace=namespace)
             return classes
 
         except Exception as exce:
@@ -7619,7 +7641,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         Returns:
 
             A :class:`~pywbem.CIMClass` object that is a representation of the
-            retrieved class.
+            retrieved class, with its `path` attribute set.
 
         Raises:
 
@@ -7662,6 +7684,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
 
             klass = result[0][2][0]
+            klass.path = CIMClassName(
+                classname=klass.classname, host=self.host, namespace=namespace)
             return klass
         except Exception as exce:
             exc = exce

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -2426,14 +2426,22 @@ class InitCIMClass(unittest.TestCase):
 
         CIMClass('CIM_Foo', qualifiers={'Key': CIMQualifier('Key', True)})
 
+        # Initialise with path
+
+        path = CIMClassName('CIM_Bar', host='fred', namespace='root/cimv2')
+        CIMClass('CIM_Foo', path=path)
+
 
 class CopyCIMClass(unittest.TestCase):
 
     def test_all(self):
 
+        path = CIMClassName('CIM_Bar', host='fred', namespace='root/cimv2')
+
         c = CIMClass('CIM_Foo',
                      methods={'Delete': CIMMethod('Delete', 'uint32')},
-                     qualifiers={'Key': CIMQualifier('Value', True)})
+                     qualifiers={'Key': CIMQualifier('Value', True)},
+                     path=path)
 
         co = c.copy()
 
@@ -2442,10 +2450,12 @@ class CopyCIMClass(unittest.TestCase):
         co.classname = 'CIM_Bar'
         del co.methods['Delete']
         del co.qualifiers['Key']
+        co.path = None
 
         self.assertEqual(c.classname, 'CIM_Foo')
         self.assertTrue(c.methods['Delete'])
         self.assertTrue(c.qualifiers['Key'])
+        self.assertEqual(c.path, path)
 
 
 class CIMClassAttrs(unittest.TestCase):
@@ -2460,6 +2470,7 @@ class CIMClassAttrs(unittest.TestCase):
         self.assertEqual(obj.qualifiers, {})
         self.assertEqual(obj.methods, {})
         self.assertEqual(obj.qualifiers, {})
+        self.assertEqual(obj.path, None)
 
 
 class CIMClassEquality(unittest.TestCase):
@@ -2480,6 +2491,8 @@ class CIMClassEquality(unittest.TestCase):
 
         qualifiers = {'Key': CIMQualifier('Key', True)}
 
+        path = CIMClassName('CIM_Bar', host='fred', namespace='root/cimv2')
+
         self.assertNotEqual(CIMClass('CIM_Foo'),
                             CIMClass('CIM_Foo', properties=properties))
 
@@ -2488,6 +2501,9 @@ class CIMClassEquality(unittest.TestCase):
 
         self.assertNotEqual(CIMClass('CIM_Foo'),
                             CIMClass('CIM_Foo', qualifiers=qualifiers))
+
+        self.assertNotEqual(CIMClass('CIM_Foo'),
+                            CIMClass('CIM_Foo', path=path))
 
         self.assertEqual(CIMClass('CIM_Foo', superclass='CIM_Bar'),
                          CIMClass('CIM_Foo', superclass='cim_bar'))

--- a/testsuite/testclient/associatorclasses.yaml
+++ b/testsuite/testclient/associatorclasses.yaml
@@ -1,5 +1,5 @@
 - name: AssociatorsClass1
-  description: Associator with classname PyWBEM. Returns one instance
+  description: Associator with classname PyWBEM. Returns one class
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -28,6 +28,11 @@
       - pywbem_object: CIMClass
         classname: CIM_Collection
         superclass: CIM_ManagedElement
+        path:
+          pywbem_object: CIMClassName
+          classname: CIM_Collection
+          host: sheldon
+          namespace: root/cimv2
         properties:
           instanceid:
             pywbem_object: CIMProperty

--- a/testsuite/testclient/embeddedobjects.yaml
+++ b/testsuite/testclient/embeddedobjects.yaml
@@ -528,6 +528,11 @@
             pywbem_object: CIMClass
             classname: PyWBEM_Person
             superclass: PyWBEM_Object
+            path:
+              pywbem_object: CIMClassName
+              classname: PyWBEM_Person
+              host: acme.com:80
+              namespace: root/cimv2
             properties:
                 Name:
                     pywbem_object: CIMProperty

--- a/testsuite/testclient/getclass.yaml
+++ b/testsuite/testclient/getclass.yaml
@@ -22,6 +22,11 @@
       pywbem_object: CIMClass
       classname: CIM_ComputerSystem
       superclass: CIM_System
+      path:
+        pywbem_object: CIMClassName
+        classname: CIM_ComputerSystem
+        host: acme.com:80
+        namespace: root/cimv2
       properties:
         powermanagementcapabilities:
           pywbem_object: CIMProperty

--- a/testsuite/testclient/referencesclass.yaml
+++ b/testsuite/testclient/referencesclass.yaml
@@ -25,6 +25,11 @@
       - pywbem_object: CIMClass
         classname: PyWBEM_MemberOfPersonCollection
         superclass: CIM_MemberOfCollection
+        path:
+          pywbem_object: CIMClassName
+          classname: PyWBEM_MemberOfPersonCollection
+          host: sheldon
+          namespace: root/cimv2
         properties:
           member:
             pywbem_object: CIMProperty


### PR DESCRIPTION
Ready for review and merge.
For details, see the commit message.

One particular review point would be that the CIM-XML and MOF representations of a class returned by the respective methods of `CIMClass` do not allow representing the class path we now added to `CIMClass`. That is not necessarily a problem, but it is inconsistent.