### PR TITLE
Fixes #750: Temp fix for opensslconf.h not found on py26 and ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 # Must be located in the root directory of the Git repository.
 
 sudo: required
+
+# Disabling the distro, so we get the latest:
+# dist:
+#   - trusty
+
 language: python
 python:
   - "2.6"
@@ -14,14 +19,20 @@ python:
 install:
   - python -c "import platform; print('Demonstration of incorrect distro returned by platform.linux_distribution():'); print(repr(platform.linux_distribution()))"
   - python -c "import pip, os; print('Site-packages directory of system Python:'); print(os.path.dirname(os.path.dirname(pip.__file__)))"
+  - env |sort
   - pip list
 # TODO: Replace the following quick fix for installing swig with a real fix.
-  - sudo apt-get install -y swig
+  - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo apt-get install -y swig; fi
 # end of swig quick fix
   - pip install --upgrade pip
   - python uninstall_pbr_on_py26.py
   - make clobber
   - pip list
+# TODO: Replace the following quick fix for installing M2Crypto with a real fix.
+# The problem happens only with Python 2.6 on Ubuntu 16.04, see pywbem issue #750.
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 && -f /usr/include/x86_64-linux-gnu/openssl/opensslconf.h && ! -f /usr/include/openssl/opensslconf.h ]]; then echo "Linking openssl/opensslconf.h"; sudo ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/opensslconf.h; fi
+  - find /usr/include -name "openssl*.h" -ls 2>/dev/null || true
+# end of m2crypto quick fix
   - make develop
   - pip install python-coveralls
 # Update coverage because the version defined for python-coveralls breaks


### PR DESCRIPTION
Ready for review and merge.
For details, see the commit message.