### PR TITLE
Ignoring files ending with tilde.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.log
 *.tmp
 tmp.*
+*~
+.*~
 pywbem.egg-info
 MANIFEST
 parser.out


### PR DESCRIPTION
Reason for this change is that on CygWin, the vi editor leaves files around that end with tilde. They should be ignored in git.