### PR TITLE
Made ordering of array items within CIM objects reliable in repr() and str()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -117,6 +117,13 @@ Enhancements
 * Added a ``host`` property to ``WBEMConnection`` which contains the host:port
   component of the WBEM server's URL.  This helps addressing issue #349.
 
+* Made sure that ``repr()`` on CIM objects produces a reliable order of
+  items such as properties, qualifiers, methods, parameters, scopes, by
+  ordering them by their names. This makes debugging using ``repr()`´ easier
+  for pywbem users, and it also helps in some unit test cases of pywbem itself.
+
+* Made sure that ``str()`` on ``CIMInstanceName`` produces reliable order of
+  key bindings in the returned WBEM URI, by ordering them by key name.
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -203,7 +203,6 @@ Bug fixes
 
 * Fix minor doc issue in client.rst. See issue #740.
 
-
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -227,6 +226,9 @@ Build, test, quality
   created it. That bypasses the checks in its ``__init__()`` method.
   This has been improved to pass these values in when creating the object.
 
+* Tolerated incorrect Unicode characters in output of commands invoked by
+  ``os_setup.py`` (used for installation) that sometimes occurred on Windows
+  (e.g. on the Appveyor CI with Python 3).
 
 Documentation
 ^^^^^^^^^^^^^

--- a/os_setup.py
+++ b/os_setup.py
@@ -1561,9 +1561,9 @@ def shell(command, display=False, ignore_notfound=False):
                 "Cannot execute %s: %s" % (command.split(' ')[0], exc))
 
     if isinstance(stdout, binary_type):
-        stdout = stdout.decode("utf-8")
+        stdout = stdout.decode('utf-8', 'replace')
     if isinstance(stderr, binary_type):
-        stderr = stderr.decode("utf-8")
+        stderr = stderr.decode('utf-8', 'replace')
 
     # TODO: Add support for printing while command executes, like with 'tee'
     if display:

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -334,10 +334,10 @@ class NocaseDict(object):
         Return a string representation of the `NocaseDict`_ object that is
         suitable for debugging.
 
-        The order of dictionary items is the iteration order of `iteritems()`.
+        The order of dictionary items in the result will be sorted by keys.
         """
-        items = ', '.join([('%r: %r' % (key, value))
-                           for key, value in self.iteritems()])
+        items = ', '.join([('%r: %r' % (key, self[key]))
+                           for key in sorted(self.iterkeys())])
         return 'NocaseDict({%s})' % items
 
     def update(self, *args, **kwargs):
@@ -923,6 +923,9 @@ class CIMInstanceName(_CIMComparisonMixin):
         by the :class:`~pywbem.CIMInstanceName` object.
 
         The returned WBEM URI is consistent with :term:`DSP0207`.
+
+        The key properties in the returned WBEM URI will be ordered by their
+        names.
         """
 
         ret_str = ''
@@ -935,7 +938,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
         ret_str += '%s.' % self.classname
 
-        for key, value in self.keybindings.items():
+        for key in sorted(self.keybindings.iterkeys()):
+            value = self.keybindings[key]
 
             ret_str += '%s=' % key
 
@@ -956,6 +960,8 @@ class CIMInstanceName(_CIMComparisonMixin):
         Return a string representation of the
         :class:`~pywbem.CIMInstanceName` object that is suitable for
         debugging.
+
+        The key bindings will be ordered by their names in the result.
         """
 
         return '%s(classname=%r, keybindings=%r, ' \
@@ -1336,6 +1342,9 @@ class CIMInstance(_CIMComparisonMixin):
         """
         Return a string representation of the :class:`~pywbem.CIMInstance`
         object that is suitable for debugging.
+
+        The properties and qualifiers will be ordered by their names in the
+        result.
         """
 
         return '%s(classname=%r, path=%r, ' \
@@ -1927,7 +1936,10 @@ class CIMClass(_CIMComparisonMixin):
         """
         Return a string representation of the :class:`~pywbem.CIMClass`
         object that is suitable for debugging.
-    """
+
+        The properties, method and qualifiers will be ordered by their names in
+        the result.
+        """
 
         return '%s(classname=%r, superclass=%r, ' \
                'properties=%r, methods=%r, qualifiers=%r, ' \
@@ -2537,6 +2549,8 @@ class CIMProperty(_CIMComparisonMixin):
         """
         Return a string representation of the :class:`~pywbem.CIMProperty`
         object that is suitable for debugging.
+
+        The qualifiers will be ordered by their names in the result.
         """
         return '%s(name=%r, value=%r, type=%r, ' \
                'reference_class=%r, embedded_object=%r, ' \
@@ -2936,6 +2950,9 @@ class CIMMethod(_CIMComparisonMixin):
         """
         Return a string representation of the :class:`~pywbem.CIMMethod`
         object that is suitable for debugging.
+
+        The parameters and qualifiers will be ordered by their names in the
+        result.
         """
         return '%s(name=%r, return_type=%r, ' \
                'class_origin=%r, propagated=%r, ' \
@@ -3203,6 +3220,8 @@ class CIMParameter(_CIMComparisonMixin):
         """
         Return a string representation of the :class:`~pywbem.CIMParameter`
         object that is suitable for debugging.
+
+        The qualifiers will be ordered by their names in the result.
         """
         return '%s(name=%r, type=%r, ' \
                'reference_class=%r, ' \
@@ -3982,6 +4001,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         Return a string representation of the
         :class:`~pywbem.CIMQualifierDeclaration` object that is suitable for
         debugging.
+
+        The scopes will be ordered by their names in the result.
         """
         return '%s(name=%r, value=%r, type=%r, ' \
                'is_array=%r, array_size=%r, ' \

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -481,5 +481,24 @@ class TestIteritems(BaseTest):
         self.assertTrue(items, set([('Budgie', 'Fish'), ('Dog', 'Cat')]))
 
 
+class TestRepr(unittest.TestCase):
+
+    def test_reliable_order(self):
+        """Test that repr() has a reliable result despite different orders of
+        insertion into the dictionary."""
+
+        dic1 = NocaseDict()
+        dic1['Budgie'] = 'Fish'
+        dic1['Dog'] = 'Cat'
+        dic1['Foo'] = 'Bla'
+
+        dic2 = NocaseDict()
+        dic2['Foo'] = 'Bla'
+        dic2['Dog'] = 'Cat'
+        dic2['Budgie'] = 'Fish'
+
+        self.assertEqual(repr(dic1), repr(dic2))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Note:** This PR is on top of PR #758.

Ready for review and merge.
For details, see the commit message.