### PR TITLE
Tolerated incorrect Unicode characters in os_setup.py output.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -203,7 +203,6 @@ Bug fixes
 
 * Fix minor doc issue in client.rst. See issue #740.
 
-
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -227,6 +226,9 @@ Build, test, quality
   created it. That bypasses the checks in its ``__init__()`` method.
   This has been improved to pass these values in when creating the object.
 
+* Tolerated incorrect Unicode characters in output of commands invoked by
+  ``os_setup.py`` (used for installation) that sometimes occurred on Windows
+  (e.g. on the Appveyor CI with Python 3).
 
 Documentation
 ^^^^^^^^^^^^^

--- a/os_setup.py
+++ b/os_setup.py
@@ -1561,9 +1561,9 @@ def shell(command, display=False, ignore_notfound=False):
                 "Cannot execute %s: %s" % (command.split(' ')[0], exc))
 
     if isinstance(stdout, binary_type):
-        stdout = stdout.decode("utf-8")
+        stdout = stdout.decode('utf-8', 'replace')
     if isinstance(stderr, binary_type):
-        stderr = stderr.decode("utf-8")
+        stderr = stderr.decode('utf-8', 'replace')
 
     # TODO: Add support for printing while command executes, like with 'tee'
     if display:


### PR DESCRIPTION
Ready for review and merge.
For details, see commit message.