### PR TITLE
Fixes #765: Fixed TypeError: Error when calling the metaclass bases

### DIFF
--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -158,7 +158,6 @@ class PywbemLoggers(six.with_metaclass(MetaPywbemLoggers)):
 
     **Experimental:** The logging support is experimental for this release.
     """
-    __metaclass__ = MetaPywbemLoggers
 
     @classmethod
     def create_loggers(cls, input_str, log_filename=None):


### PR DESCRIPTION
This error was triggered by the release of six 1.11.0, but was caused by pywbem incorrectly using both `six.with_metaclass()` and setting the `__metaclass__` attribute.
Ready for review and merge, once it passes all tests.