### PR TITLE
Fixes #768: Pinned wheel to <0.30.0 for Python 2.6.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -240,6 +240,9 @@ Build, test, quality
 * Improved the build process to ensure that half-built artefacts are
   removed before building (issue #754).
 
+* Pinned the version of the ``wheel`` package to <0.30.0 for Python 2.6,
+  because wheel removed Python 2.6 support in its 0.30.0 version.
+
 Documentation
 ^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,8 @@ def main():
         ],
         'develop_requires': [
             # Wheel may not be installed in every system Python.
-            'wheel',
+            # Wheel 0.30.0 removed Python 2.6 support.
+            'wheel<0.30.0' if sys.version_info[0:2] == (2, 6) else 'wheel',
             # Python prereqs for 'develop' command. Handled by os_setup module.
             "coverage>=4.3",
             "pytest>=2.4",


### PR DESCRIPTION
Ready for review and merge.
This PR addresses issue #768 by pinning wheel to <0.30.0 when installing on Python 2.6.