### PR TITLE
0.10.1: Made CIMDateTime always timezone-aware, re-enabled test_cim_types.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 # commands to install dependencies
 install:
@@ -30,4 +31,4 @@ script:
   - make test
 
 after_success:
-  - coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,83 @@
 
 environment:
   matrix:
-    - PYTHON: C:\Python27
-      PYTHON_VERSION: 2.7.12
+# Python 2.6 is disabled because ion Windows, pywbem uses M2Crypto via the
+# M2CryptoWin32 package. That package is not supported for Pathon 2.6, and its
+# __m2crypto.pyd file depends on python27.dll. As a result, importing M2Crypto
+# on Python 2.6 fails with:
+# ImportError: Module use of python27.dll conflicts with this version of Python.
+# To support Python 2.6, M2Crypto would need to be built upon install from
+# the M2Crypto package. See https://github.com/dsoprea/M2CryptoWindows for
+# details onhow to build it.
+#    - PYTHON_VERSION: 2.6
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python26
+    - PYTHON_VERSION: 2.7
       PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python27
+# 64-bit Windows versions with libxslt devel packages from ftp.zlatkovic.com
+# cannot be used currently, because these packages provide libs in .a format,
+# and the lxml build process wants them in .lib format. Disabled for now.
+#    - PYTHON_VERSION: 2.7
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python27-x64
+    - PYTHON_VERSION: 3.4
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python34
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python35
+    - PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:\Python36
 
 install:
 
-  # Examine the environment
-  - echo %PATH%
-  - echo %INCLUDE%
-  - echo %LIB%
+  # Verify that the commands used in this file are available
+  - where where
+  - where choco
+  - choco --version
+
+  # Examine the initial environment
+  - ver
+  - 'echo "%PATH%"'
+  - 'echo "%PYTHONPATH%"'
+  - 'echo "%INCLUDE%"'
+  - 'echo "%LIB%"'
   - choco source list
   - dir C:\
   - dir
 
+  # Remove Python 2.7 from PATH.
+  # Note that YAML interprets some characters in a special way (including '!' and '#')
+  # so we have to use single quotes to protect some CMD commands from YAML.
+  # Note that for some reason, "setlocal EnableDelayedExpansion" needs to be on the
+  # same line as the command you want to execute under that setting. Using !abc! variable
+  # expansion requires EnableDelayedExpansion.
+  - 'set $line=%PATH%'
+  - 'set $line=%$line: =#%'
+  - 'set $line=%$line:;= %'
+  - 'set $line=%$line:)=^^)%'
+  - 'setlocal EnableDelayedExpansion & for %%a in (%$line%) do echo %%a | find /i "Python27" || set $newpath=!$newpath!;%%a'
+  - 'set $newpath=%$newpath:#= %'
+  - 'set $newpath=%$newpath:^^=%'
+  - 'set PATH=%$newpath%'
+
+  # Add CygWin
+  - set PATH=C:\cygwin\bin;%PATH%
+
+  # Verify that the commands provided by CygWin and used in this file are available
+  - where wget
+  - wget --version
+  - where unzip
+  - unzip --help
+  - where 7z
+  - 7z --help
+
   # Add Python
-  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
-  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - reg ADD HKCU\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
 
   ## Install InnoSetup - disabled because it is not needed
   #- choco install -y InnoSetup
@@ -27,9 +86,6 @@ install:
   ## Install pip - disabled because pip is already installed
   #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
   #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
-
-  # Add CygWin
-  - set PATH=C:\cygwin\bin;%PATH%
 
   ## Disabled: The following is an attempt to install the lxml installation
   ## prereqs with choco. The lxml installation currently fails with unresolved
@@ -70,72 +126,139 @@ install:
   # Install OS-level prereqs for lxml installation: libxml2, libxslt, zlib,
   # libiconv (needs iconv.lib). This approach uses the binary libraries
   # that are linked from the lxml site.
-
   - echo set _PWD=%%%%~dp0>tmp_prereq_dir.bat
   - call tmp_prereq_dir.bat
   - rm tmp_prereq_dir.bat
-
   - set _PREREQ_DIR=prereqs
   - set _PREREQ_ABSDIR=%_PWD%%_PREREQ_DIR%
   - echo Installing lxml prereqs into %_PREREQ_ABSDIR%
   - mkdir %_PREREQ_DIR%
 
-  - set _PKGFILE=libxml2-2.7.8.win32.zip
-  - set _PKGDIR=libxml2-2.7.8.win32
-  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
-  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
-  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
-  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
-  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+  # Add OS-level prereq: libxml2
+  - if %PYTHON_ARCH%.==32. (
+      set _PKGFILE=libxml2-2.7.8.win32.zip&
+      set _PKGZIPDIR=libxml2-2.7.8.win32&
+      set _PKGLOCALDIR=.)
+    else (
+      set _PKGFILE=libxml2-2.9.3-win32-x86_64.7z&
+      set _PKGZIPDIR=.&
+      set _PKGLOCALDIR=libxml2-2.9.3.win32-x86_64)
+  - if %PYTHON_ARCH%.==32. (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%&
+      unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%)
+    else (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/64bit/%_PKGFILE%&
+      mkdir %_PREREQ_DIR%\%_PKGLOCALDIR%&
+      7z x -o%_PREREQ_DIR%/%_PKGLOCALDIR% %_PREREQ_DIR%/%_PKGFILE%)
+  - if %PYTHON_ARCH%.==32. (
+      set INCLUDE=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\include;%INCLUDE%)
+    else (
+      set INCLUDE=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\include\libxml2;%INCLUDE%)
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\bin;%PATH%
 
-  - set _PKGFILE=libxslt-1.1.26.win32.zip
-  - set _PKGDIR=libxslt-1.1.26.win32
-  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
-  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
-  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
-  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
-  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+  # Add OS-level prereq: libxslt
+  - if %PYTHON_ARCH%.==32. (
+      set _PKGFILE=libxslt-1.1.26.win32.zip&
+      set _PKGZIPDIR=libxslt-1.1.26.win32&
+      set _PKGLOCALDIR=.)
+    else (
+      set _PKGFILE=libxslt-1.1.28-win32-x86_64.7z&
+      set _PKGZIPDIR=.&
+      set _PKGLOCALDIR=libxslt-1.1.28.win32-x86_64)
+  - if %PYTHON_ARCH%.==32. (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%&
+      unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%)
+    else (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/64bit/%_PKGFILE%&
+      echo mkdir %_PREREQ_DIR%\%_PKGLOCALDIR%&
+      7z x -o%_PREREQ_DIR%/%_PKGLOCALDIR% %_PREREQ_DIR%/%_PKGFILE%)
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\bin;%PATH%
 
-  - set _PKGFILE=zlib-1.2.5.win32.zip
-  - set _PKGDIR=zlib-1.2.5
-  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
-  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
-  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
-  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
-  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+  # Add OS-level prereq: zlib
+  - if %PYTHON_ARCH%.==32. (
+      set _PKGFILE=zlib-1.2.5.win32.zip&
+      set _PKGZIPDIR=zlib-1.2.5&
+      set _PKGLOCALDIR=.)
+    else (
+      set _PKGFILE=zlib-1.2.8-win32-x86_64.7z&
+      set _PKGZIPDIR=.&
+      set _PKGLOCALDIR=zlib-1.2.8.win32-x86_64)
+  - if %PYTHON_ARCH%.==32. (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%&
+      unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%)
+    else (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/64bit/%_PKGFILE%&
+      echo mkdir %_PREREQ_DIR%\%_PKGLOCALDIR%&
+      7z x -o%_PREREQ_DIR%/%_PKGLOCALDIR% %_PREREQ_DIR%/%_PKGFILE%)
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\bin;%PATH%
 
-  - set _PKGFILE=iconv-1.9.2.win32.zip
-  - set _PKGDIR=iconv-1.9.2.win32
-  - wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
-  - unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
-  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
-  - set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
-  - set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+  # Add OS-level prereq: iconv
+  - if %PYTHON_ARCH%.==32. (
+      set _PKGFILE=iconv-1.9.2.win32.zip&
+      set _PKGZIPDIR=iconv-1.9.2.win32&
+      set _PKGLOCALDIR=.)
+    else (
+      set _PKGFILE=iconv-1.14-win32-x86_64.7z&
+      set _PKGZIPDIR=.&
+      set _PKGLOCALDIR=iconv-1.14.win32-x86_64)
+  - if %PYTHON_ARCH%.==32. (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%&
+      unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%)
+    else (
+      wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/64bit/%_PKGFILE%&
+      echo mkdir %_PREREQ_DIR%\%_PKGLOCALDIR%&
+      7z x -o%_PREREQ_DIR%/%_PKGLOCALDIR% %_PREREQ_DIR%/%_PKGFILE%)
+  - set INCLUDE=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\include;%INCLUDE%
+  - set LIB=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\lib;%LIB%
+  - set PATH=%_PREREQ_ABSDIR%\%_PKGLOCALDIR%\%_PKGZIPDIR%\bin;%PATH%
 
-  - find %_PREREQ_DIR%
-  - echo %PATH%
-  - echo %INCLUDE%
-  - echo %LIB%
+  # Examine files in OS-level prereq subtree
+  - find %_PREREQ_DIR% -type f
+
+  # Examine the final environment
+  - 'echo "%PATH%"'
+  - 'echo "%PYTHONPATH%"'
+  - 'echo "%INCLUDE%"'
+  - 'echo "%LIB%"'
 
   # Install tox
+  - where pip
+  - pip --version
   - pip install tox==2.0.0
 
   # Verify that the commands used in tox.ini are available
+  - where tox
   - tox --version
+  - where make
   - make --version
+  - where pip
   - pip --version
+  - where python
   - python --version
 
   # Verify that the commands used in makefile are available
+  - where sh
   - sh --version
+  - where bash
   - bash --version
+  - where rm
   - rm --version
+  - where mv
   - mv --version
-  #- mkdir --version
+  - where xargs
   - xargs --version
+  - where grep
   - grep --version
+  - where sed
   - sed --version
+  - where tar
   - tar --version
+  - where find
   - find --version
 
 build: false # Not a C# project, build stuff at the test step instead.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,11 @@ Enhancements
   the IUS version of the Python development packages should be used,
   dependent on whether the Python package is from IUS.
 
+* Ensured that `CIMDateTime` objects for point in time values are
+  timezone-aware when supplied with a timezone-naive `datetime` object.
+  This does not change the behavior, but increases code clarity.
+  Clarified that in the documentation of  `CIMDateTime`. See issue #698.
+
 Bug fixes
 ^^^^^^^^^
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,10 @@ Incompatible changes
 Enhancements
 ^^^^^^^^^^^^
 
+* Added support for automatically finding out whether for RHEL/CentOS/Fedora,
+  the IUS version of the Python development packages should be used,
+  dependent on whether the Python package is from IUS.
+
 Bug fixes
 ^^^^^^^^^
 
@@ -39,11 +43,36 @@ Bug fixes
   Also extends these requests to test the Pull.. methods for valid
   MaxObjectCount and context parameters. See issue #656.
 
+* Add constructor parameter checking to QualifierDeclaration. See issue #645.
+
+* Fixed TypeError "'str' does not support the buffer interface" during
+  'setup.py develop' on Python 3.x on Windows (issue #661).
+
+* Fixed ValueError "underlying buffer has been detached" during
+  'setup.py develop' on Python 3.x on Windows (issue #661).
+
+* Fixed names of Python development packages for SLES/OpenSUSE.
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 
+* Added Python 3.6 to the environments to be tested in Travis CI and Appveyor
+  CI (issue #661).
+
+* Added Python 2.6, 3.4 and 3.5 to the environments to be tested in Appveyor
+  CI (issue #661).
+
+* Fixed uninstall_pbr_on_py26.py to remove 'pbr' only if installed
+  (issue #661).
+    
+* Fixed TypeError about dict ordering on Python 3.6 in unit test
+  'test_nocasedict.TestOrdering' (issue #661).
+
 Documentation
 ^^^^^^^^^^^^^
+
+* Documented that pywbem is not supported on Python 2.6 on Windows.
+  and that 64-bit versions of Python are not supported on Windows.
 
 
 pywbem v0.10.0

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -170,9 +170,11 @@ their version requirements for a number of Linux distributions:
 |                            +---------------------+--------------------------+
 |                            | python-devel        | for Python 2.6, 2.7      |
 |                            +---------------------+--------------------------+
-|                            | python34u-devel     | for Python 3.4           |
+|                            | python3{N}u-devel   | for Python 3.{N} from IUS|
+|                            |                     | community (python3{N}u)  |
 |                            +---------------------+--------------------------+
-|                            | python35u-devel     | for Python 3.5           |
+|                            | python3{N}-devel    | for Python 3.{N} not from|
+|                            |                     | IUS (python3{N})         |
 |                            +---------------------+--------------------------+
 |                            | swig                | >=2.0                    |
 +----------------------------+---------------------+--------------------------+
@@ -182,7 +184,7 @@ their version requirements for a number of Linux distributions:
 |                            +---------------------+--------------------------+
 |                            | python-dev          | for Python 2.6, 2.7      |
 |                            +---------------------+--------------------------+
-|                            | python3-dev         | for Python 3.4, 3.5      |
+|                            | python3-dev         | for Python 3.4 - 3.6     |
 |                            +---------------------+--------------------------+
 |                            | swig                | >=2.0                    |
 +----------------------------+---------------------+--------------------------+
@@ -190,13 +192,9 @@ their version requirements for a number of Linux distributions:
 |                            +---------------------+--------------------------+
 |                            | gcc-c++             | >=4.4                    |
 |                            +---------------------+--------------------------+
-|                            | libpython26-devel   | for Python 2.6           |
+|                            | python-devel        | for Python 2.6, 2.7      |
 |                            +---------------------+--------------------------+
-|                            | libpython27-devel   | for Python 2.7           |
-|                            +---------------------+--------------------------+
-|                            | libpython34-devel   | for Python 3.4           |
-|                            +---------------------+--------------------------+
-|                            | libpython35-devel   | for Python 3.5           |
+|                            | python3-devel       | for Python 3.4 - 3.6     |
 |                            +---------------------+--------------------------+
 |                            | swig                | >=2.0                    |
 +----------------------------+---------------------+--------------------------+
@@ -251,8 +249,19 @@ Supported environments
 
 Pywbem is supported in these environments:
 
-* Operating Systems: Linux, Windows, OS-X (testing has mostly happened on Linux)
-* Python: 2.6, 2.7, 3.4, 3.5, and higher 3.x
+* Operating Systems: Linux, Windows, OS-X
+* Python: 2.6, 2.7, 3.4, 3.5, 3.6
+
+Limitations:
+
+* On Windows, pywbem is not supported on Python 2.6, because M2Crypto in the
+  M2CryptoWin32/64 package does not support Python 2.6.
+
+* On Windows, pywbem has not been tested on 64-bit versions of Python, because
+  the libxslt etc. development packages needed to install lxml that are used
+  do not provide the link libraries in the format needed by lxml. Because
+  lxml is only used for development and test of pywbem, just running pywbem on
+  64-bit versions of Windows may or may not work.
 
 
 .. _`Standards conformance`:

--- a/os_setup.py
+++ b/os_setup.py
@@ -161,7 +161,6 @@ import getpass
 from distutils.errors import DistutilsSetupError
 from setuptools import Command, Distribution
 from setuptools.command.develop import develop as _develop
-import pip
 
 
 # Some types to avoid dependency on "six" package during installation.
@@ -839,17 +838,26 @@ class PythonInstaller(BaseInstaller):
         `BaseInstaller.do_install()`.
         """
         pkg_req = self.pkg_req(pkg_name, version_reqs)
-        args = ['install']
+        cmd_args = ['pip', 'install']
         if reinstall:
-            args.append('--ignore-installed')
-        args.append(pkg_req)
+            cmd_args.append('--ignore-installed')
+        cmd_args.append(pkg_req)  # blanks inside: "package >=version"
+        cmd = ' '.join(cmd_args)
         if dry_run:
-            print("Dry-running: pip %s" % ' '.join(args))
+            print("Dry-running: %s" % cmd)
         else:
-            print("Running: pip %s" % ' '.join(args))
-            rc = pip.main(args)
-            if rc != 0:
-                raise DistutilsSetupError("Pip returns rc=%d" % rc)
+            print("Running: %s" % cmd)
+            # The following pip invocation was changed from pip.main() to use
+            # the external pip command, due to ValueError "underlying buffer
+            # has been detached" in pip/_vendor/progress/helpers.py, line 58,
+            # __init__() on Python 3.x on Windows. See also
+            # https://cbuelter.wordpress.com/2015/12/15/you-detach-me-i-
+            # detach-you/
+            rc, out, _ = shell(cmd_args, display=True)
+            if rc == 127:
+                raise DistutilsSetupError("Pip command is not available")
+            elif rc != 0:
+                raise DistutilsSetupError("Pip install returns rc=%d" % rc)
 
     def is_installed(self, pkg_name, version_reqs=None):
         """Test whether a Python package is installed, and optionally satisfies
@@ -1220,8 +1228,12 @@ class YumInstaller(OSInstaller):
         rc, _, _ = shell("which dnf")
         if rc == 0:
             self.installer_cmd = "dnf"
-        else:
+            return
+        rc, _, _ = shell("which yum")
+        if rc == 0:
             self.installer_cmd = "yum"
+            return
+        self.installer_cmd = None
 
     def do_install(self, pkg_name, version_reqs=None, dry_run=False,
                    reinstall=False):
@@ -1231,6 +1243,8 @@ class YumInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
+        if not self.installer_cmd:
+            return
         subcmd = 'reinstall' if reinstall else 'install'
         cmd = "sudo %s %s -y %s" % (self.installer_cmd, subcmd, pkg_name)
         if dry_run:
@@ -1246,6 +1260,8 @@ class YumInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_installed()`.
         """
+        if not self.installer_cmd:
+            return (False, False, None)
         cmd = "%s list installed %s" % (self.installer_cmd, pkg_name)
         rc, out, err = shell(cmd)
         if rc != 0:
@@ -1273,6 +1289,8 @@ class YumInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_available()`.
         """
+        if not self.installer_cmd:
+            return (False, False, None)
         cmd = "%s list %s" % (self.installer_cmd, pkg_name)
         rc, out, err = shell(cmd)
         if rc != 0:
@@ -1297,6 +1315,11 @@ class AptInstaller(OSInstaller):
 
     def __init__(self):
         OSInstaller.__init__(self)
+        rc, _, _ = shell("which apt-get")
+        if rc == 0:
+            self.installer_cmd = "apt-get"
+            return
+        self.installer_cmd = None
 
     def do_install(self, pkg_name, version_reqs=None, dry_run=False,
                    reinstall=False):
@@ -1306,8 +1329,11 @@ class AptInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
+        if not self.installer_cmd:
+            return
         reinstall_opt = '--reinstall' if reinstall else ''
-        cmd = "sudo apt-get install -y %s %s" % (reinstall_opt, pkg_name)
+        cmd = "sudo %s install -y %s %s" % (self.installer_cmd,
+                                            reinstall_opt, pkg_name)
         if dry_run:
             print("Dry-running: %s" % cmd)
         else:
@@ -1321,6 +1347,8 @@ class AptInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_installed()`.
         """
+        if not self.installer_cmd:
+            return (False, False, None)
         cmd = "dpkg -s %s" % pkg_name
         rc, out, err = shell(cmd)
         if rc != 0:
@@ -1364,6 +1392,8 @@ class AptInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_available()`.
         """
+        if not self.installer_cmd:
+            return (False, False, None)
         cmd = "apt show %s" % pkg_name
         rc, out, _ = shell(cmd)
         if rc != 0:
@@ -1392,6 +1422,11 @@ class ZypperInstaller(OSInstaller):
 
     def __init__(self):
         OSInstaller.__init__(self)
+        rc, _, _ = shell("which zypper")
+        if rc == 0:
+            self.installer_cmd = "zypper"
+            return
+        self.installer_cmd = None
 
     def do_install(self, pkg_name, version_reqs=None, dry_run=False,
                    reinstall=False):
@@ -1401,8 +1436,11 @@ class ZypperInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.do_install()`.
         """
+        if not self.installer_cmd:
+            return
         reinstall_opt = '-f' if reinstall else ''
-        cmd = "sudo zypper -y %s %s" % (reinstall_opt, pkg_name)
+        cmd = "sudo %s -y %s %s" % (self.installer_cmd, reinstall_opt,
+                                    pkg_name)
         if dry_run:
             print("Dry-running: %s" % cmd)
         else:
@@ -1416,7 +1454,9 @@ class ZypperInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_installed()`.
         """
-        cmd = "zypper info %s" % pkg_name
+        if not self.installer_cmd:
+            return (False, False, None)
+        cmd = "%s info %s" % (self.installer_cmd, pkg_name)
         rc, out, err = shell(cmd)
         if rc != 0:
             return (False, False, None)
@@ -1444,7 +1484,9 @@ class ZypperInstaller(OSInstaller):
         For a description of the parameters, return value and exceptions, see
         `BaseInstaller.is_available()`.
         """
-        cmd = "zypper info %s" % pkg_name
+        if not self.installer_cmd:
+            return (False, False, None)
+        cmd = "%s info %s" % (self.installer_cmd, pkg_name)
         _, out, _ = shell(cmd)
         # zypper always returns 0, and writes everything to stdout.
         lines = out.splitlines()
@@ -1470,7 +1512,13 @@ def shell(command, display=False, ignore_notfound=False):
     Python 2.7, but we want to support Python 2.6 as well.
 
     Parameters:
-      * command: string or list of strings with the command and its parameters.
+      * command: command and arguments, in one of two forms:
+        - as a string: In this case, the string will be split upon blanks, so
+          don't use this unless you know for sure that the arguments do not
+          contain blanks (as opposed to being separated by blanks).
+        - as a list or tuple of strings, representing the command name and
+          each of its arguments as one item.
+        arguments.
       * display: boolean indicating whether the command output will be printed.
       * ignore_notfound: boolean indicating that command not found should be
         ignored. If the command is not found and this argument is True, the
@@ -1487,15 +1535,21 @@ def shell(command, display=False, ignore_notfound=False):
     """
 
     if isinstance(command, string_types):
-        cmd_parts = command.split(" ")
-    else:  # already a list
-        cmd_parts = command
+        command = command.split(" ")
+    elif isinstance(command, (tuple, list)):
+        pass
+    else:
+        raise TypeError("Invalid type for command parameter: %s" %
+                        type(command))
 
-    encoded_cmd_parts = [part.encode("utf-8")
-                         if isinstance(part, text_type)
-                         else part for part in cmd_parts]
+    # Note: On Python 3.x on Windows, passing UTF-8 encoded 'bytes' in the
+    # 'args' parameter of subprocess.Popen() causes a TypeError: "'str' does
+    # not support the buffer interface". This does not happen on Python 3.x
+    # on Linux. Therefore, the following code no longer encodes the command
+    # and arguments to UTF-8 bytes.
+
     try:
-        p = subprocess.Popen(encoded_cmd_parts,
+        p = subprocess.Popen(command,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
@@ -1504,7 +1558,7 @@ def shell(command, display=False, ignore_notfound=False):
             return 10002, "", ""
         else:
             raise DistutilsSetupError(
-                "Cannot execute %s: %s" % (cmd_parts[0], exc))
+                "Cannot execute %s: %s" % (command.split(' ')[0], exc))
 
     if isinstance(stdout, binary_type):
         stdout = stdout.decode("utf-8")
@@ -1526,7 +1580,12 @@ def shell_check(command, display=False, exp_rc=0):
     raise an exception.
 
     Parameters:
-      * command: string or list of strings with the command and its parameters.
+      * command: command and arguments, in one of two forms:
+        - as a string: In this case, the string will be split upon blanks, so
+          don't use this unless you know for sure that the arguments do not
+          contain blanks (as opposed to being separated by blanks).
+        - as a list or tuple of strings, representing the command name and
+          each of its arguments as one item.
       * display: boolean indicating whether the command stdout will be printed.
       * rc: number or list of numbers indicating the allowable return codes.
 
@@ -1537,9 +1596,6 @@ def shell_check(command, display=False, exp_rc=0):
       * If the command is not found, OSError is raised.
       * If the command does not return 0, DistutilsSetupError is raised.
     """
-
-    if isinstance(command, string_types):
-        command = command.split(" ")
 
     if isinstance(exp_rc, int):
         exp_rc = [exp_rc]
@@ -1553,7 +1609,7 @@ def shell_check(command, display=False, exp_rc=0):
         else:
             msg = out
         raise DistutilsSetupError(
-            "%s returns rc=%d: %s" % (command[0], rc, msg))
+            "%s returns rc=%d: %s" % (command.split(' ')[0], rc, msg))
 
     return out
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ from os_setup import shell, shell_check, import_setuptools, YumInstaller
 if sys.version_info[0:2] == (2, 6):
     try:
         # pylint: disable=unused-import
-        import multiprocessing  # noqa: E402, F401
+        import multiprocessing  # noqa: E402,F401
     except ImportError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ import platform
 from distutils.errors import DistutilsSetupError
 
 import os_setup
-from os_setup import shell, shell_check, import_setuptools
+from os_setup import shell, shell_check, import_setuptools, YumInstaller
 
 # Workaround for Python 2.6 issue https://bugs.python.org/issue15881
 # This causes this module to be referenced and prevents the premature
@@ -308,8 +308,9 @@ def main():
             _VERBOSE = self.verbose
             _build_py.run(self)
 
-    py_version_m_n = "%s.%s" % (sys.version_info[0], sys.version_info[1])
+    py_version_mn = "%s%s" % (sys.version_info[0], sys.version_info[1])
     py_version_m = "%s" % sys.version_info[0]
+    yuminst = YumInstaller()
 
     pkg_version = package_version("pywbem/_version.py", "__version__")
 
@@ -393,11 +394,11 @@ def main():
                     "gcc-c++>=4.4",         # for building Swig and for running
                                             #   Swig in M2Crypto install
                     install_swig,           # for running Swig in M2Crypto inst.
-                    # Python-devel provides Python.h for Swig run.
-                    # The following assumes we have python34, not python34u
-                    "python34-devel" if py_version_m_n == "3.4" else \
-                    "python35-devel" if py_version_m_n == "3.5" else \
-                    "python-devel",
+                    # Python*-devel provides Python.h for Swig run.
+                    "python-devel" if py_version_m == "2" else \
+                    "python%su-devel" % py_version_mn if \
+                    yuminst.is_installed('python%su' % py_version_mn)[0] else \
+                    "python%s-devel" % py_version_mn
                 ],
                 'centos': 'redhat',
                 'fedora': 'redhat',
@@ -405,8 +406,8 @@ def main():
                     "libssl-dev>=1.0.1",
                     "g++>=4.4",
                     install_swig,
-                    "python-dev" if py_version_m == "2"
-                    else "python%s-dev" % py_version_m,
+                    "python-dev" if py_version_m == "2" else \
+                    "python%s-dev" % py_version_m,
                 ],
                 'debian': 'ubuntu',
                 'linuxmint': 'ubuntu',
@@ -414,7 +415,8 @@ def main():
                     "openssl-devel>=1.0.1",
                     "gcc-c++>=4.4",
                     install_swig,
-                    "libpython%s-devel" % py_version_m_n,
+                    "python-devel" if py_version_m == "2" else \
+                    "python%s-devel" % py_version_m,
                 ],
             },
             # TODO: Add support for Windows.
@@ -488,6 +490,7 @@ def main():
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: System :: Systems Administration',
         ],

--- a/testsuite/test_cim_types.py
+++ b/testsuite/test_cim_types.py
@@ -43,105 +43,99 @@ def integer_tuple(request):
     return request.param
 
 
-class TestIntegers:
-    """
-    Test CIM integer data type classes.
-    """
+def test_integer_class_attrs_class(integer_tuple):
+    """Test class attrs via class level"""
+    obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
+    assert obj_type.cimtype == exp_cimtype
+    assert obj_type.minvalue == exp_minvalue
+    assert obj_type.maxvalue == exp_maxvalue
 
-    @staticmethod
-    def test_class_attrs_class(integer_tuple):
-        """Test class attrs via class level"""
-        obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
-        assert obj_type.cimtype == exp_cimtype
-        assert obj_type.minvalue == exp_minvalue
-        assert obj_type.maxvalue == exp_maxvalue
 
-    @staticmethod
-    def test_class_attrs_inst(integer_tuple):
-        """Test class attrs via instance level"""
-        obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
-        obj = obj_type(42)
-        assert obj.cimtype == exp_cimtype
-        assert obj.minvalue == exp_minvalue
-        assert obj.maxvalue == exp_maxvalue
+def test_integer_class_attrs_inst(integer_tuple):
+    """Test class attrs via instance level"""
+    obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
+    obj = obj_type(42)
+    assert obj.cimtype == exp_cimtype
+    assert obj.minvalue == exp_minvalue
+    assert obj.maxvalue == exp_maxvalue
 
-    @staticmethod
-    def test_inheritance(integer_tuple):
-        """Test inheritance"""
-        obj_type = integer_tuple[0]
-        obj = obj_type(42)
-        assert isinstance(obj, obj_type)
-        assert isinstance(obj, CIMType)
-        assert isinstance(obj, CIMInt)
-        assert not isinstance(obj, CIMFloat)
 
-    @staticmethod
-    def test_init_int(integer_tuple):
-        """Test initialization from integer value"""
-        obj_type = integer_tuple[0]
-        obj = obj_type(42)
-        assert obj == 42
+def test_integer_inheritance(integer_tuple):
+    """Test inheritance"""
+    obj_type = integer_tuple[0]
+    obj = obj_type(42)
+    assert isinstance(obj, obj_type)
+    assert isinstance(obj, CIMType)
+    assert isinstance(obj, CIMInt)
+    assert not isinstance(obj, CIMFloat)
 
-    @staticmethod
-    def test_init_str(integer_tuple):
-        """Test initialization from string value"""
-        obj_type = integer_tuple[0]
-        obj = obj_type('42')
-        assert obj == 42
 
-    @staticmethod
-    def test_init_str_base10(integer_tuple):
-        """Test initialization from string value with base 10"""
-        obj_type = integer_tuple[0]
-        obj = obj_type('42', 10)
-        assert obj == 42
+def test_integer_init_int(integer_tuple):
+    """Test initialization from integer value"""
+    obj_type = integer_tuple[0]
+    obj = obj_type(42)
+    assert obj == 42
 
-    @staticmethod
-    def test_init_str_base16(integer_tuple):
-        """Test initialization from string value with base 16"""
-        obj_type = integer_tuple[0]
-        obj = obj_type('2A', 16)
-        assert obj == 42
 
-    @staticmethod
-    def test_init_minimum(integer_tuple):
-        """Test initialization from integer value at minimum"""
-        obj_type = integer_tuple[0]
-        exp_minvalue = integer_tuple[2]
-        obj = obj_type(exp_minvalue)
-        assert obj == exp_minvalue
+def test_integer_init_str(integer_tuple):
+    """Test initialization from string value"""
+    obj_type = integer_tuple[0]
+    obj = obj_type('42')
+    assert obj == 42
 
-    @staticmethod
-    def test_init_maximum(integer_tuple):
-        """Test initialization from integer value at maximum"""
-        obj_type = integer_tuple[0]
-        exp_maxvalue = integer_tuple[3]
-        obj = obj_type(exp_maxvalue)
-        assert obj == exp_maxvalue
 
-    @staticmethod
-    def test_init_too_low(integer_tuple):
-        """Test initialization from integer value below minimum"""
-        obj_type = integer_tuple[0]
-        exp_minvalue = integer_tuple[2]
-        try:
-            obj_type(exp_minvalue - 1)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("ValueError was not raised.")
+def test_integer_init_str_base10(integer_tuple):
+    """Test initialization from string value with base 10"""
+    obj_type = integer_tuple[0]
+    obj = obj_type('42', 10)
+    assert obj == 42
 
-    @staticmethod
-    def test_init_too_high(integer_tuple):
-        """Test initialization from integer value above maximum"""
-        obj_type = integer_tuple[0]
-        exp_maxvalue = integer_tuple[3]
-        try:
-            obj_type(exp_maxvalue + 1)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("ValueError was not raised.")
+
+def test_integer_init_str_base16(integer_tuple):
+    """Test initialization from string value with base 16"""
+    obj_type = integer_tuple[0]
+    obj = obj_type('2A', 16)
+    assert obj == 42
+
+
+def test_integer_init_minimum(integer_tuple):
+    """Test initialization from integer value at minimum"""
+    obj_type = integer_tuple[0]
+    exp_minvalue = integer_tuple[2]
+    obj = obj_type(exp_minvalue)
+    assert obj == exp_minvalue
+
+
+def test_integer_init_maximum(integer_tuple):
+    """Test initialization from integer value at maximum"""
+    obj_type = integer_tuple[0]
+    exp_maxvalue = integer_tuple[3]
+    obj = obj_type(exp_maxvalue)
+    assert obj == exp_maxvalue
+
+
+def test_integer_init_too_low(integer_tuple):
+    """Test initialization from integer value below minimum"""
+    obj_type = integer_tuple[0]
+    exp_minvalue = integer_tuple[2]
+    try:
+        obj_type(exp_minvalue - 1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("ValueError was not raised.")
+
+
+def test_integer_init_too_high(integer_tuple):
+    """Test initialization from integer value above maximum"""
+    obj_type = integer_tuple[0]
+    exp_maxvalue = integer_tuple[3]
+    try:
+        obj_type(exp_maxvalue + 1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("ValueError was not raised.")
 
 
 #
@@ -164,47 +158,41 @@ def real_tuple(request):
     return request.param
 
 
-class TestReals:
-    """
-    Test CIM real data type classes.
-    """
+def test_real_class_attrs_class(real_tuple):
+    """Test class attrs via class level"""
+    obj_type, exp_cimtype = real_tuple
+    assert obj_type.cimtype == exp_cimtype
 
-    @staticmethod
-    def test_class_attrs_class(real_tuple):
-        """Test class attrs via class level"""
-        obj_type, exp_cimtype = real_tuple
-        assert obj_type.cimtype == exp_cimtype
 
-    @staticmethod
-    def test_class_attrs_inst(real_tuple):
-        """Test class attrs via instance level"""
-        obj_type, exp_cimtype = real_tuple
-        obj = obj_type(42)
-        assert obj.cimtype == exp_cimtype
+def test_real_class_attrs_inst(real_tuple):
+    """Test class attrs via instance level"""
+    obj_type, exp_cimtype = real_tuple
+    obj = obj_type(42)
+    assert obj.cimtype == exp_cimtype
 
-    @staticmethod
-    def test_inheritance(real_tuple):
-        """Test inheritance"""
-        obj_type = real_tuple[0]
-        obj = obj_type(42)
-        assert isinstance(obj, obj_type)
-        assert isinstance(obj, CIMType)
-        assert isinstance(obj, CIMFloat)
-        assert not isinstance(obj, CIMInt)
 
-    @staticmethod
-    def test_init_float(real_tuple):
-        """Test initialization from floating point value"""
-        obj_type = real_tuple[0]
-        obj = obj_type(42.0)
-        assert obj == 42.0
+def test_real_inheritance(real_tuple):
+    """Test inheritance"""
+    obj_type = real_tuple[0]
+    obj = obj_type(42)
+    assert isinstance(obj, obj_type)
+    assert isinstance(obj, CIMType)
+    assert isinstance(obj, CIMFloat)
+    assert not isinstance(obj, CIMInt)
 
-    @staticmethod
-    def test_init_str(real_tuple):
-        """Test initialization from string value"""
-        obj_type = real_tuple[0]
-        obj = obj_type('42.0')
-        assert obj == 42.0
+
+def test_real_init_float(real_tuple):
+    """Test initialization from floating point value"""
+    obj_type = real_tuple[0]
+    obj = obj_type(42.0)
+    assert obj == 42.0
+
+
+def test_real_init_str(real_tuple):
+    """Test initialization from string value"""
+    obj_type = real_tuple[0]
+    obj = obj_type('42.0')
+    assert obj == 42.0
 
 
 #
@@ -271,6 +259,26 @@ class TestReals:
         '20140924193040.654321+120'
     ),
     (
+        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
+                 microsecond=654321, tzinfo=MinutesFromUTC(0)),
+        'timestamp',
+        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
+                 microsecond=654321, tzinfo=MinutesFromUTC(0)),
+        None,
+        0,
+        '20140924193040.654321+000'
+    ),
+    (
+        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
+                 microsecond=654321),
+        'timestamp',
+        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
+                 microsecond=654321, tzinfo=MinutesFromUTC(0)),
+        None,
+        0,
+        '20140924193040.654321+000'
+    ),
+    (
         '20140924193040.654321+120',
         'timestamp',
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
@@ -325,46 +333,47 @@ def datetime_init_tuple(request):
     return request.param
 
 
-class TestDatetime:
-    """
-    Test CIM real data type classes.
-    """
+def test_datetime_class_attrs_class():
+    """Test class attrs via class level"""
+    assert CIMDateTime.cimtype == 'datetime'
 
-    @staticmethod
-    def test_class_attrs_class():
-        """Test class attrs via class level"""
-        assert CIMDateTime.cimtype == 'datetime'
 
-    @staticmethod
-    def test_class_attrs_inst():
-        """Test class attrs via instance level"""
-        obj = CIMDateTime('00000000000000.000000:000')
-        assert obj.cimtype == 'datetime'
+def test_datetime_class_attrs_inst():
+    """Test class attrs via instance level"""
+    obj = CIMDateTime('00000000000000.000000:000')
+    assert obj.cimtype == 'datetime'
 
-    @staticmethod
-    def test_inheritance():
-        """Test inheritance"""
-        obj = CIMDateTime('00000000000000.000000:000')
-        assert isinstance(obj, CIMDateTime)
-        assert isinstance(obj, CIMType)
-        assert not isinstance(obj, CIMFloat)
-        assert not isinstance(obj, CIMInt)
 
-    @staticmethod
-    def test_init(datetime_init_tuple):
-        """Test initialization from all input types"""
-        (dtarg, exp_kind, exp_datetime, exp_timedelta, exp_minutesfromutc,
-         exp_str) = datetime_init_tuple
-        try:
-            obj = CIMDateTime(dtarg)
-        except Exception as exc:
-            assert isinstance(exc, exp_kind)
-        else:
-            assert obj.is_interval == (exp_kind == 'interval')
-            assert obj.datetime == exp_datetime
-            assert obj.timedelta == exp_timedelta
-            assert obj.minutes_from_utc == exp_minutesfromutc
-            assert str(obj) == exp_str
+def test_datetime_inheritance():
+    """Test inheritance"""
+    obj = CIMDateTime('00000000000000.000000:000')
+    assert isinstance(obj, CIMDateTime)
+    assert isinstance(obj, CIMType)
+    assert not isinstance(obj, CIMFloat)
+    assert not isinstance(obj, CIMInt)
+
+
+def test_datetime_init(datetime_init_tuple):
+    """Test initialization from all input types"""
+    (dtarg, exp_kind, exp_datetime, exp_timedelta, exp_minutesfromutc,
+     exp_str) = datetime_init_tuple
+    try:
+        obj = CIMDateTime(dtarg)
+    except Exception as exc:
+        assert isinstance(exc, exp_kind)
+    else:
+        assert obj.is_interval == (exp_kind == 'interval')
+        assert obj.datetime == exp_datetime
+        if obj.datetime is not None:
+            assert isinstance(obj.datetime, datetime)
+            # We ensure that the datetime is always timezone-aware:
+            assert obj.datetime.tzinfo is not None
+        assert obj.timedelta == exp_timedelta
+        if obj.timedelta is not None:
+            assert isinstance(obj.timedelta, timedelta)
+        assert obj.minutes_from_utc == exp_minutesfromutc
+        assert str(obj) == exp_str
+
 
 # TODO: Add testcases for get_local_utcoffset()
 # TODO: Add testcases for now()

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -400,8 +400,8 @@ class TestEqual(BaseTest):
 
 class TestOrdering(BaseTest):
     """Verify that ordering comparisons between NocaseDict instances
-    issue a deprecation warning, and for Python 3, in addition the usual
-    "TypeError: unorderable types" for standard dicts."""
+    issue a deprecation warning, and for Python 3, in addition raise
+    TypeError."""
 
     def assertWarning(self, comp_str):
         with warnings.catch_warnings(record=True) as wlist:
@@ -412,10 +412,20 @@ class TestOrdering(BaseTest):
                 try:
                     eval(comp_str)
                 except TypeError as exc:
-                    assert "unorderable types" in str(exc)
+                    msg = str(exc)
+                    if "not supported between instances" not in msg and \
+                            "unorderable types" not in msg:
+                        self.fail("Applying ordering to a dictionary in "
+                                  "Python 3 did raise TypeError but with an "
+                                  "unexpected message: %s" % msg)
+                except Exception as exc:
+                    msg = str(exc)
+                    self.fail("Applying ordering to a dictionary in Python 3 "
+                              "did not raise TypeError, but %s: %s" %
+                              (exc.__class__.__name__, msg))
                 else:
-                    self.fail("Ordering a dictionary in Python 3 did not "
-                              "raise TypeError")
+                    self.fail("Applying ordering to a dictionary in Python 3 "
+                              "succeeded (should not happen)")
             assert len(wlist) >= 1
             assert issubclass(wlist[-1].category, DeprecationWarning)
             assert "deprecated" in str(wlist[-1].message)

--- a/tools/debug_dll_dependencies.bat
+++ b/tools/debug_dll_dependencies.bat
@@ -1,0 +1,10 @@
+rem This script is supposed to run on the Appveyor CI.
+echo on
+echo "debug_dll_dependencies: start"
+set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin
+where dumpbin
+dir /s /b .tox\pywin  | grep -E "\.(pyd|dll)$" | sed -e 's!\\\\!/!g' >py_bin.fl
+dir /s /b C:\Python26 | grep -E "\.(pyd|dll)$" | sed -e 's!\\\\!/!g' >>py_bin.fl
+cat py_bin.fl
+cat py_bin.fl | xargs -n 1 dumpbin /dependents 
+echo "debug_dll_dependencies: end"

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,13 @@
 #
 # Supported platforms:
 #   Linux
+#   Windows
 #
 # TODO: Enable use of flake8
 
 [tox]
 minversion = 1.9
-envlist = py26,py27,py34,py35
+envlist = py26,py27,py34,py35,py36
 skip_missing_interpreters = true
 skipsdist = true
 
@@ -46,9 +47,12 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
+[testenv:py36]
+basepython = python3.6
+
 [testenv:pywin]
-basepython = {env:PYTHON:}\python.exe
-passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH INCLUDE LIB
+basepython = {env:PYTHON_HOME:}\python.exe
+passenv = ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE PATH PYTHONPATH INCLUDE LIB
 
 #[testenv:flake8]
 #deps =

--- a/uninstall_pbr_on_py26.py
+++ b/uninstall_pbr_on_py26.py
@@ -3,14 +3,16 @@
 import sys
 import subprocess
 
+print('Removing pbr package on Python 2.6 if installed, see pywbem issue #26')
 if sys.version_info[0:2] == (2,6):
-    print('Removing pbr package on Python 2.6 (see pywbem issue #26)')
-    print('pip uninstall -y pbr')
-    rc = subprocess.call(['pip', 'uninstall', '-y', 'pbr'])
+    try:
+        import pbr
+        print('Removing installed pbr package on this Python 2.6')
+        print('pip uninstall -y pbr')
+        rc = subprocess.call(['pip', 'uninstall', '-y', 'pbr'])
+    except ImportError:
+        print('pbr package is not installed on this Python 2.6')
 else:
-    print('Keeping pbr package on Python %s.%s (see pywbem issue #26)' %\
+    print('Not changing pbr package on this Python %s.%s' %\
           (sys.version_info[0], sys.version_info[1]))
-    rc = 0
-
-sys.exit(rc)
 


### PR DESCRIPTION
This change rolls back GitHub PR #715 from 0.11.0 into 0.10.1.