### PR TITLE
pylint cleanup

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -248,6 +248,8 @@ Bug fixes
   rejected on some older Linux distros during make develop or make install,
   by upgrading them in these steps. See issues #759 and #760.
 
+* Clean up pylint new messages tied to use of len and if else. See issue #770
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/mof_compiler
+++ b/mof_compiler
@@ -116,6 +116,7 @@ Example:
              ' client does not have certificates.')
     security_arggroup.add_argument(
         '--cacerts', dest='ca_certs', metavar='cacerts',
+        # pylint: disable=bad-continuation
         help='R|File or directory containing certificates that will be\n'
              'matched against a certificate received from the WBEM\n'
              'server. Set the --no-verify-cert option to bypass\n'
@@ -244,7 +245,6 @@ Example:
 
     if args.remove or args.dry_run:
         # Only record the changes to the repository, but do not perform them.
-        # pylint: disable=redefined-variable-type
         conn = MOFWBEMConnection(conn=conn)
 
     # conn.debug = True

--- a/os_setup.py
+++ b/os_setup.py
@@ -360,7 +360,7 @@ class install_os(BaseOsCommand):  # pylint: disable=invalid-name
         self.installer.install_system(
             self.distribution.install_os_requires, self.dry_run, self.verbose)
 
-        if len(self.installer.errors) > 0:
+        if self.installer.errors:
             self.installer.print_errors()
             raise DistutilsSetupError(
                 "Errors occurred (see previous messages)"
@@ -397,7 +397,7 @@ class develop_os(BaseOsCommand):  # pylint: disable=invalid-name
         self.installer.install_system(
             self.distribution.develop_os_requires, self.dry_run, self.verbose)
 
-        if len(self.installer.errors) > 0:
+        if self.installer.errors:
             self.installer.print_errors()
             raise DistutilsSetupError(
                 "Errors occurred (see previous messages)"
@@ -429,7 +429,7 @@ class develop(_develop):  # pylint: disable=invalid-name
         self.installer.install_reqlist(
             self.distribution.develop_requires, self.dry_run, self.verbose)
 
-        if len(self.installer.errors) > 0:
+        if self.installer.errors:
             self.installer.print_errors()
             raise DistutilsSetupError(
                 "Errors occurred (see previous messages)"
@@ -634,7 +634,7 @@ class BaseInstaller(object):
             if req_string is not None:
                 for req in req_string.split(','):
                     req = req.strip()
-                    if len(req) == 0:
+                    if not req:
                         continue  # ignore empty requirements
                     if req[0] not in "<=>!":
                         req = '==' + req  # add default operator
@@ -876,7 +876,7 @@ class PythonInstaller(BaseInstaller):
         lines = out.splitlines()
         version_lines = [line for line in lines
                          if line.startswith("Version:")]
-        if len(version_lines) == 0:
+        if not version_lines:
             raise DistutilsSetupError(
                 "Unexpected output from command '%s': No version line:\n%s" %
                 (cmd, out))
@@ -1263,7 +1263,7 @@ class YumInstaller(OSInstaller):
         if not self.installer_cmd:
             return (False, False, None)
         cmd = "%s list installed %s" % (self.installer_cmd, pkg_name)
-        rc, out, err = shell(cmd)
+        rc, out, err = shell(cmd)  # pylint: disable=unused-variable
         if rc != 0:
             return (False, False, None)
         info_words = out.splitlines()[-1].strip("\n").split()
@@ -1292,7 +1292,7 @@ class YumInstaller(OSInstaller):
         if not self.installer_cmd:
             return (False, False, None)
         cmd = "%s list %s" % (self.installer_cmd, pkg_name)
-        rc, out, err = shell(cmd)
+        rc, out, err = shell(cmd)  # pylint: disable=unused-variable
         if rc != 0:
             return (False, False, None)
         info_words = out.splitlines()[-1].strip("\n").split()
@@ -1350,7 +1350,7 @@ class AptInstaller(OSInstaller):
         if not self.installer_cmd:
             return (False, False, None)
         cmd = "dpkg -s %s" % pkg_name
-        rc, out, err = shell(cmd)
+        rc, out, err = shell(cmd)  # pylint: disable=unused-variable
         if rc != 0:
             return (False, False, None)
 
@@ -1457,7 +1457,7 @@ class ZypperInstaller(OSInstaller):
         if not self.installer_cmd:
             return (False, False, None)
         cmd = "%s info %s" % (self.installer_cmd, pkg_name)
-        rc, out, err = shell(cmd)
+        rc, out, err = shell(cmd)  # pylint: disable=unused-variable
         if rc != 0:
             return (False, False, None)
 
@@ -1491,7 +1491,7 @@ class ZypperInstaller(OSInstaller):
         # zypper always returns 0, and writes everything to stdout.
         lines = out.splitlines()
         version_lines = [line for line in lines if line.startswith("Version:")]
-        if len(version_lines) == 0:
+        if not version_lines:
             return (False, False, None)
 
         version_words = version_lines[0].split()

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -467,7 +467,7 @@ class WBEMServer(object):
             ObjectName=profile_path,
             AssocClass="CIM_ElementConformsToProfile",
             ResultRole="ManagedElement")
-        if len(ci_paths) > 0:
+        if ci_paths:
             return ci_paths
 
         # Try scoping methodology
@@ -484,7 +484,7 @@ class WBEMServer(object):
             ObjectName=profile_path,
             AssocClass="CIM_ReferencedProfile",
             ResultRole="Dependent")
-        if len(referencing_profile_paths) == 0:
+        if not referencing_profile_paths:
             raise ValueError("No referencing profile found")
         elif len(referencing_profile_paths) > 1:
             raise ValueError("More than one referencing profile found")
@@ -501,7 +501,7 @@ class WBEMServer(object):
         scoping_inst_paths = self.get_central_instances(
             referencing_profile_paths[0],
             upper_central_class, scoping_class, upper_scoping_path)
-        if len(scoping_inst_paths) == 0:
+        if not scoping_inst_paths:
             raise ValueError("No scoping instances found")
 
         # Go down one level on the resource side (using the last
@@ -513,7 +513,7 @@ class WBEMServer(object):
                 ObjectName=ip,
                 AssocClass=assoc_class,
                 ResultClass=central_class)
-            if len(ci_paths) == 0:
+            if not ci_paths:
                 # At least one central instance for each scoping instance
                 raise ValueError("No central instances found traversing down "
                                  "across %s to %s" %

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -625,7 +625,7 @@ class WBEMSubscriptionManager(object):
         # Verify referencing subscriptions.
         ref_paths = server.conn.ReferenceNames(
             dest_path, ResultClass=SUBSCRIPTION_CLASSNAME)
-        if len(ref_paths) > 0:
+        if ref_paths:
             # DSP1054 1.2 defines that this CIM error is raised by the server
             # in that case, so we simulate that behavior on the client side.
             raise CIMError(CIM_ERR_FAILED,
@@ -855,7 +855,7 @@ class WBEMSubscriptionManager(object):
         # Verify referencing subscriptions.
         ref_paths = server.conn.ReferenceNames(
             filter_path, ResultClass=SUBSCRIPTION_CLASSNAME)
-        if len(ref_paths) > 0:
+        if ref_paths:
             # DSP1054 1.2 defines that this CIM error is raised by the server
             # in that case, so we simulate that behavior on the client side.
             raise CIMError(CIM_ERR_FAILED,

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -434,7 +434,7 @@ class NocaseDict(object):
         # a case sensitive comparison, but that will be better than the faulty
         # algorithm that was used before. It will raise TypeError "unorderable
         # types" in Python 3.
-        return self._data < other._data
+        return self._data < other._data  # pylint: disable=protected-access
 
     def __gt__(self, other):
         """
@@ -524,10 +524,7 @@ def cmpname(name1, name2):
     lower_name2 = name2.lower()
     if lower_name1 == lower_name2:
         return 0
-    if lower_name1 < lower_name2:
-        return -1
-    else:
-        return 1
+    return -1 if lower_name1 < lower_name2 else 1
 
 
 def cmpitem(item1, item2):
@@ -638,7 +635,7 @@ def _makequalifiers(qualifiers, indent):
 
       indent (:term:`integer`): Indent level for this set of qualifiers.
     """
-    if len(qualifiers) == 0:
+    if not qualifiers:
         return ''
     qual_list = [q.tomof(indent + 2) for q in sorted(qualifiers.values())]
     qual_str = ',\n '.ljust(indent + 2).join(qual_list)
@@ -2375,7 +2372,7 @@ class CIMProperty(_CIMComparisonMixin):
             if reference_class is not None:
                 raise ValueError(
                     'Array property %r cannot specify reference_class' % name)
-            elif value is None or len(value) == 0 or value[0] is None:
+            elif not value or value[0] is None:
                 # Cannot infer from value, look at embedded_object and type
                 if embedded_object == 'instance':
                     msg = 'Array property %r contains embedded instances' % name
@@ -2513,7 +2510,6 @@ class CIMProperty(_CIMComparisonMixin):
             else:  # type is specified and value is not Null
                 # Make sure the value is of the corresponding Python type.
                 _type_obj = type_from_name(type_)
-                # pylint: disable=redefined-variable-type
                 value = _type_obj(value)
                 msg = 'Property %r has a simple typed value ' \
                       'and specifies CIM data type %r' % (name, type_)
@@ -2629,7 +2625,6 @@ class CIMProperty(_CIMComparisonMixin):
                     value = value.tocimxml().toxml()
                 else:
                     value = atomic_to_cim_xml(value)
-                # pylint: disable=redefined-variable-type
                 value = cim_xml.VALUE(value)
 
             return cim_xml.PROPERTY(
@@ -2742,7 +2737,7 @@ class CIMProperty(_CIMComparisonMixin):
                 array_str = ''
 
             mof = '\n'
-            if len(self.qualifiers) != 0:
+            if self.qualifiers:
                 mof += '%s\n' % ((_makequalifiers(self.qualifiers,
                                                   (indent + MOF_INDENT))))
 
@@ -3040,7 +3035,7 @@ class CIMMethod(_CIMComparisonMixin):
 
         ret_str = ''
 
-        if len(self.qualifiers) != 0:
+        if self.qualifiers:
             ret_str += '%s\n' % (_makequalifiers(self.qualifiers,
                                                  (indent + MOF_INDENT)))
         # TODO is None allowed for return type.
@@ -3050,7 +3045,7 @@ class CIMMethod(_CIMComparisonMixin):
             # TODO CIM-XML does not support methods returning reference
             # types(the CIM architecture does).
 
-        if len(self.parameters.values()) != 0:
+        if self.parameters.values():
             ret_str += '%s(\n' % (self.name)
             ret_str += ',\n'.join([
                 p.tomof(indent + MOF_INDENT)
@@ -3358,7 +3353,7 @@ class CIMParameter(_CIMComparisonMixin):
             array_str = ''
 
         rtn_str = ''
-        if len(self.qualifiers) != 0:
+        if self.qualifiers:
             rtn_str = '%s\n' % (_makequalifiers(self.qualifiers,
                                                 indent + 2))
         rtn_str += '%s%s %s%s' % (_indent_str(indent),
@@ -3569,7 +3564,7 @@ class CIMQualifier(_CIMComparisonMixin):
 
                 # Determine type for list value
 
-                if len(value) == 0:
+                if not value:
                     raise TypeError(
                         'Empty qualifier array "%s" must have a type' % name)
 
@@ -3665,7 +3660,6 @@ class CIMQualifier(_CIMComparisonMixin):
         if isinstance(self.value, list):
             value = cim_xml.VALUE_ARRAY([cim_xml.VALUE(v) for v in self.value])
         elif self.value is not None:
-            # pylint: disable=redefined-variable-type
             # used as VALUE.ARRAY and the as VALUE
             value = cim_xml.VALUE(self.value)
 
@@ -4165,10 +4159,7 @@ def tocimxml(value):
     #       int. Bool is a subtype of int, so bool probably matches in the test
     #       above.
     if isinstance(value, bool):
-        if value:
-            return cim_xml.VALUE('TRUE')
-        else:
-            return cim_xml.VALUE('FALSE')
+        return cim_xml.VALUE('TRUE') if value else cim_xml.VALUE('FALSE')
 
     # Iterable of values
 
@@ -4413,7 +4404,7 @@ def tocimobj(type_, value):
                         if val.lower() in ('true', 'false'):
                             val = val.lower() == 'true'
                         elif val.isdigit():
-                            val = int(val)   # pylint: disable=R0204
+                            val = int(val)
                         else:
                             try:
                                 val = float(val)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -232,13 +232,11 @@ def _iparam_propertylist(property_list):
     """Validate property_list and if it is not iterable convert to list.
 
     This is a test for a particular issue where the user supplies a single
-    string in stead of a list for a PropertyList parameter. It prevents
+    string instead of a list for a PropertyList parameter. It prevents
     an XML error.
     """
-    if isinstance(property_list, six.string_types):
-        return [property_list]
-    else:
-        return property_list
+    return [property_list] if isinstance(property_list, six.string_types) \
+        else property_list
 
 
 def check_utf8_xml_chars(utf8_xml, meaning):
@@ -351,7 +349,7 @@ def check_utf8_xml_chars(utf8_xml, meaning):
         ifs_pos = m.start(1)
         ifs_seq = m.group(1)
         ifs_list.append((ifs_pos, ifs_seq))
-    if len(ifs_list) > 0:
+    if ifs_list:
         exc_txt = "Ill-formed (surrogate) UTF-8 Byte sequences found in %s:" %\
                   meaning
         for (ifs_pos, ifs_seq) in ifs_list:
@@ -397,7 +395,7 @@ def check_utf8_xml_chars(utf8_xml, meaning):
         if ixc_pos > last_ixc_pos + 1:
             ixc_list.append((ixc_pos, ixc_char_u))
         last_ixc_pos = ixc_pos
-    if len(ixc_list) > 0:
+    if ixc_list:
         exc_txt = "Invalid XML characters found in %s:" % meaning
         for (ixc_pos, ixc_char_u) in ixc_list:
             cpos1 = max(ixc_pos - context_before, 0)
@@ -1315,9 +1313,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # or None if there was no child nodes of the IMETHODRESPONSE
         # element.
 
-        if tup_tree is None:
-            return None
-        if len(tup_tree) == 0:
+        if not tup_tree:
             return None
 
         # ERROR | ...
@@ -1394,10 +1390,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             elif isinstance(obj, (CIMClass, CIMInstance)):
                 return 'string'
             elif isinstance(obj, list):
-                if obj:
-                    return paramtype(obj[0])
-                else:
-                    return None
+                return paramtype(obj[0]) if obj else None
             raise TypeError('Unsupported parameter type "%s"' % type(obj))
 
         def paramvalue(obj):
@@ -1563,7 +1556,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # At this point we have an optional RETURNVALUE and zero or
         # more PARAMVALUE elements representing output parameters.
 
-        if len(tt) > 0 and tt[0][0] == 'ERROR':
+        if tt and tt[0][0] == 'ERROR':
             code = int(tt[0][1]['CODE'])
             if 'DESCRIPTION' in tt[0][1]:
                 raise CIMError(code, tt[0][1]['DESCRIPTION'])
@@ -7457,7 +7450,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             returnvalue = None
 
-            if len(result) > 0 and result[0][0] == 'RETURNVALUE':
+            if result and result[0][0] == 'RETURNVALUE':
 
                 returnvalue = tocimobj(result[0][1]['PARAMTYPE'], result[0][2])
                 result = result[1:]

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -73,8 +73,8 @@ from __future__ import absolute_import
 from datetime import tzinfo, datetime, timedelta
 import re
 import warnings
-import six
 import copy
+import six
 
 from . import config
 
@@ -419,8 +419,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
         local = datetime.now()
         if local < utc:
             return - int(float((utc - local).seconds) / 60 + .5)
-        else:
-            return int(float((local - utc).seconds) / 60 + .5)
+        return int(float((local - utc).seconds) / 60 + .5)
 
     @classmethod
     def now(cls, tzi=None):
@@ -739,7 +738,7 @@ def cimtype(obj):
         # accept both possible types
         return 'string'
     if isinstance(obj, list):
-        if len(obj) == 0:
+        if not obj:
             raise ValueError(
                 "Cannot determine CIM data type from an empty array")
         return cimtype(obj[0])
@@ -827,10 +826,7 @@ def atomic_to_cim_xml(obj):
     # pylint: disable=too-many-return-statements
     from .cim_obj import _ensure_unicode, _convert_unicode  # due to cycles
     if isinstance(obj, bool):
-        if obj:
-            return u"true"
-        else:
-            return u"false"
+        return u"true" if obj else u"false"
     elif isinstance(obj, CIMDateTime):
         return six.text_type(obj)
     elif isinstance(obj, datetime):
@@ -843,5 +839,4 @@ def atomic_to_cim_xml(obj):
         return u'%.16E' % obj
     elif isinstance(obj, six.string_types):
         return _ensure_unicode(obj)
-    else:  # e.g. int
-        return _convert_unicode(obj)
+    return _convert_unicode(obj)  # e.g. int

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -702,7 +702,7 @@ def p_compilerDirective(p):
     param = p[5]
     if directive == 'include':
         fname = param
-        if len(os.path.dirname(p.parser.file)) != 0:
+        if os.path.dirname(p.parser.file):
             fname = os.path.dirname(p.parser.file) + '/' + fname
         p.parser.mofcomp.compile_file(fname, p.parser.handle.default_namespace)
     elif directive == 'namespace':
@@ -1984,8 +1984,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         """Return either connection default or universal default namespace"""
         if self.conn is not None:
             return self.conn.default_namespace
-        else:
-            return self.__default_namespace
+        return self.__default_namespace
 
     def _setns(self, value):
         """ Set the namespace in value into either the connection default or
@@ -2030,7 +2029,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         :meth:`pywbem.WBEMConnection.CreateInstance`.
         """
 
-        inst = len(args) > 0 and args[0] or kwargs['NewInstance']
+        inst = args[0] if args else kwargs['NewInstance']
         try:
             self.instances[self.default_namespace].append(inst)
         except KeyError:
@@ -2051,7 +2050,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         :meth:`pywbem.WBEMConnection.GetClass`.
         """
 
-        cname = len(args) > 0 and args[0] or kwargs['ClassName']
+        cname = args[0] if args else kwargs['ClassName']
         try:
             cc = self.classes[self.default_namespace][cname]
         except KeyError:
@@ -2070,7 +2069,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                     del kwargs['ClassName']
                 except KeyError:
                     pass
-                if len(args) > 0:
+                if args:
                     args = args[1:]
                 super_ = self.GetClass(cc.superclass, *args, **kwargs)
                 for prop in super_.properties.values():
@@ -2097,7 +2096,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         :meth:`pywbem.WBEMConnection.CreateClass`.
         """
 
-        cc = len(args) > 0 and args[0] or kwargs['NewClass']
+        cc = args[0] if args else kwargs['NewClass']
         # TODO 2016/03 AM: Dubious stmt above.
         if cc.superclass:
             try:
@@ -2158,7 +2157,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         :meth:`pywbem.WBEMConnection.GetQualifier`.
         """
 
-        qualname = len(args) > 0 and args[0] or kwargs['QualifierName']
+        qualname = args[0] if args else kwargs['QualifierName']
         try:
             qual = self.qualifiers[self.default_namespace][qualname]
         except KeyError:
@@ -2175,7 +2174,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         :meth:`pywbem.WBEMConnection.SetQualifier`.
         """
 
-        qual = len(args) > 0 and args[0] or kwargs['QualifierDeclaration']
+        qual = args[0] if args else kwargs['QualifierDeclaration']
         try:
             self.qualifiers[self.default_namespace][qual.name] = qual
         except KeyError:

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1156,7 +1156,7 @@ def parse_property_reference(tup_tree):
 
     value = list_of_matching(tup_tree, ['VALUE.REFERENCE'])
 
-    if value is None or not value:
+    if not value:
         value = None
     elif len(value) == 1:
         value = value[0]

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -96,10 +96,7 @@ def filter_tuples(list_):
     In a tupletree, tuples correspond to XML elements.  Useful for
     stripping out whitespace data in a child list."""
 
-    if list_ is None:
-        return []
-    else:
-        return [x for x in list_ if isinstance(x, tuple)]
+    return [] if list_ is None else [x for x in list_ if isinstance(x, tuple)]
 
 
 def pcdata(tup_tree):
@@ -168,7 +165,7 @@ def check_node(tup_tree, nodename, required_attrs=None, optional_attrs=None,
             if attr in tt_attrs:
                 del tt_attrs[attr]
 
-    if len(tt_attrs.keys()) > 0:
+    if tt_attrs.keys():
         raise ParseError('invalid extra attributes %s' % tt_attrs.keys())
 
     if allowed_children is not None:
@@ -601,7 +598,7 @@ def parse_localnamespacepath(tup_tree):
 
     check_node(tup_tree, 'LOCALNAMESPACEPATH', [], [], ['NAMESPACE'])
 
-    if len(kids(tup_tree)) == 0:
+    if not kids(tup_tree):
         raise ParseError('Expecting one or more of NAMESPACE, got nothing')
 
     ns_list = list_of_various(tup_tree, ['NAMESPACE'])
@@ -746,7 +743,7 @@ def parse_instancename(tup_tree):
 
     check_node(tup_tree, 'INSTANCENAME', ['CLASSNAME'])
 
-    if len(kids(tup_tree)) == 0:
+    if not kids(tup_tree):
         # probably not ever going to see this, but it's valid
         # according to the grammar
         return CIMInstanceName(attrs(tup_tree)['CLASSNAME'], {})
@@ -1159,7 +1156,7 @@ def parse_property_reference(tup_tree):
 
     value = list_of_matching(tup_tree, ['VALUE.REFERENCE'])
 
-    if value is None or len(value) == 0:
+    if value is None or not value:
         value = None
     elif len(value) == 1:
         value = value[0]
@@ -1790,7 +1787,7 @@ def unpack_value(tup_tree):
     valtype = attrs(tup_tree)['TYPE']
 
     raw_val = list_of_matching(tup_tree, ['VALUE', 'VALUE.ARRAY'])
-    if len(raw_val) == 0:
+    if not raw_val:
         return None
     elif len(raw_val) > 1:
         raise ParseError('more than one VALUE or VALUE.ARRAY under %s' %
@@ -1800,10 +1797,9 @@ def unpack_value(tup_tree):
 
     if isinstance(raw_val, list):
         return [tocimobj(valtype, x) for x in raw_val]
-    elif len(raw_val) == 0 and valtype != 'string':
+    elif not raw_val and valtype != 'string':
         return None
-    else:
-        return tocimobj(valtype, raw_val)
+    return tocimobj(valtype, raw_val)
 
 
 def unpack_boolean(data):

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -320,7 +320,8 @@ class ClientTest(unittest.TestCase):
 
             if includes_path:
                 self.assertTrue(isinstance(instance.path, CIMInstanceName))
-                self.assertTrue(instance.path.namespace, 'Includes namespace')
+                self.assertTrue(instance.path.namespace,
+                                'Instance path missing in instance path.')
 
                 if namespace is None:
                     namespace = self.namespace
@@ -331,7 +332,10 @@ class ClientTest(unittest.TestCase):
                                  (instance.path.namespace, namespace))
 
             if prop_count is not None:
-                self.assertEqual(len(instance.properties), prop_count)
+                self.assertEqual(len(instance.properties), prop_count,
+                                 'Expected %s properties; tested instance has '
+                                 '%s properties' % (prop_count,
+                                                    len(instance.properties)))
 
             if property_list is not None:
                 for p in property_list:
@@ -1138,7 +1142,7 @@ class PullEnumerateInstances(ClientTest):
     def test_get_onebyone(self):
         """Get instances with MaxObjectCount = 1).
         This test is subject to differences between the pull and non
-    gy s    pull sequence because it is getting live instances from the
+        pull sequence because it is getting live instances from the
         server and they may change between the requests.
         """
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -228,17 +228,6 @@ class ClientTest(unittest.TestCase):
         if self.verbose:
             print('{}'.format(data_))
 
-    def assertRegexp(self, str_, regex):
-        """
-        This function eliminates the issue between the unittest assertRegex
-        and assertRegexpMatches functions between unittiest in python 2 and 3
-        """
-        if six.PY3:
-            return self.assertRegex(str_, regex)  # pylint: disable=no-member
-        else:
-            return self.assertRegexpMatches(str_,
-                                            regex)  # pylint: disable=no-member
-
     def pywbem_person_class_exists(self):
         """
         Test this class if it exists in the root/cimv2 namespace.
@@ -295,7 +284,7 @@ class ClientTest(unittest.TestCase):
         else:
             path = paths
             self.assertTrue(isinstance(path, CIMInstanceName))
-            self.assertTrue(len(path.namespace) > 0)
+            self.assertTrue(path.namespace)
 
             if namespace is None:
                 self.assertTrue(paths.namespace == self.namespace)
@@ -331,7 +320,7 @@ class ClientTest(unittest.TestCase):
 
             if includes_path:
                 self.assertTrue(isinstance(instance.path, CIMInstanceName))
-                self.assertTrue(len(instance.path.namespace) > 0)
+                self.assertTrue(instance.path.namespace, 'Includes namespace')
 
                 if namespace is None:
                     namespace = self.namespace
@@ -342,7 +331,7 @@ class ClientTest(unittest.TestCase):
                                  (instance.path.namespace, namespace))
 
             if prop_count is not None:
-                self.assertTrue(len(instance.properties) == prop_count)
+                self.assertEqual(len(instance.properties), prop_count)
 
             if property_list is not None:
                 for p in property_list:
@@ -370,7 +359,7 @@ class ClientTest(unittest.TestCase):
             path = paths
             self.assertTrue(isinstance(path, CIMInstanceName))
             if includes_namespace:
-                self.assertTrue(len(path.namespace) > 0)
+                self.assertTrue(path.namespace)
             if includes_keybindings:
                 self.assertTrue(path.keybindings is not None)
             if namespace is not None:
@@ -390,8 +379,7 @@ class ClientTest(unittest.TestCase):
             self.assertTrue(isinstance(op_result, tuple))
 
             self.assertTrue(isinstance(op_result[0], CIMClassName))
-            self.assertTrue(len(op_result[0].namespace) > 0)
-
+            self.assertTrue(op_result[0].namespace)
             self.assertTrue(isinstance(op_result[1], CIMClass))
 
     def inst_in_list(self, inst, instances, ignore_host=False):
@@ -1150,7 +1138,7 @@ class PullEnumerateInstances(ClientTest):
     def test_get_onebyone(self):
         """Get instances with MaxObjectCount = 1).
         This test is subject to differences between the pull and non
-        pull sequence because it is getting live instances from the
+    gy s    pull sequence because it is getting live instances from the
         server and they may change between the requests.
         """
 
@@ -1171,6 +1159,8 @@ class PullEnumerateInstances(ClientTest):
         # get with EnumInstances
         insts_enum = self.cimcall(  # noqa: F841
             self.conn.EnumerateInstances, TOP_CLASS)
+
+        self.assertEqual(len(insts_pulled), len(insts_enum))
 
     def test_bad_namespace(self):
         """Call with explicit CIM namespace that does not exist."""
@@ -1288,7 +1278,7 @@ class PullEnumerateInstancePaths(ClientTest):
         if result.eos:
             self.assertTrue(result.context is None)
         else:
-            self.assertTrue(len(result.context) != 0)
+            self.assertTrue(result.context)
 
         # loop to complete the enumeration session
         while not result.eos:
@@ -1300,7 +1290,7 @@ class PullEnumerateInstancePaths(ClientTest):
 
         paths_enum = self.cimcall(self.conn.EnumerateInstanceNames, TEST_CLASS)
 
-        self.assertTrue(len(paths_pulled) == len(paths_enum))
+        self.assertEqual(len(paths_pulled), len(paths_enum))
 
     def test_open_complete_with_ns(self):
         """Simplest invocation. Everything comes back in
@@ -1318,7 +1308,7 @@ class PullEnumerateInstancePaths(ClientTest):
         if result.eos:
             self.assertTrue(result.context is None)
         else:
-            self.assertTrue(len(result.context) != 0)
+            self.assertTrue(result.context)
 
         while not result.eos:
             result = self.cimcall(self.conn.PullInstancePaths,
@@ -1527,7 +1517,7 @@ class PullReferences(ClientTest):
             self.assertInstancesValid(result.instances)
 
             insts_enum = self.cimcall(self.conn.References, pathi)
-            if len(insts_enum) != 0:
+            if insts_enum:
                 print('References %s count %s' % (pathi, len(insts_enum)))
             self.assertTrue(len(insts_pulled) == len(insts_enum))
 
@@ -1652,7 +1642,7 @@ class PullReferencePaths(ClientTest):
                 paths.extend(result.paths)
 
             paths_enum = self.cimcall(self.conn.ReferenceNames, pathi)
-            if len(paths_enum) != 0:
+            if paths_enum:
                 print('References %s count %s' % (pathi, len(paths_enum)))
             self.assertTrue(len(paths) == len(paths_enum))
 
@@ -1764,7 +1754,7 @@ class PullAssociators(ClientTest):
 
             insts_enum = self.cimcall(self.conn.References, pathi)
 
-            if len(insts_enum) != 0:
+            if insts_enum:
                 print('Associators %s count %s' % (insts_pulled,
                                                    len(insts_enum)))
             self.assertTrue(len(insts_pulled) == len(insts_enum))
@@ -1891,9 +1881,9 @@ class PullAssociatorPaths(ClientTest):
                 paths_pulled.extend(result.paths)
 
             paths_enum = self.cimcall(self.conn.AssociatorNames, pathi)
-            if len(paths_enum) != 0:
+            if paths_enum:
                 print('Associator Names %s count %s' % (pathi, len(paths_enum)))
-            self.assertTrue(len(paths_pulled) == len(paths_enum))
+            self.assertEqual(len(paths_pulled), len(paths_enum))
             # TODO ks 5/30 2016 add tests here
             # Do this as a loop for all instances above.
 
@@ -4159,7 +4149,7 @@ class PegasusTestEmbeddedInstance(PegasusServerTestBase, RegexpMixin):
                     print('======%s XML=====\n%s' % (inst.path, str_xml))
 
                 # confirm general characteristics of mof output
-                self.assertRegexp(
+                self.assertRegexpMatches(
                     str_mof, r"instance of Test_CLITestEmbeddedClass {")
                 self.assertRegexpContains(
                     str_mof,
@@ -4267,7 +4257,7 @@ class PyWBEMServerClass(PegasusServerTestBase):
 
         if self.is_pegasus_server():
             self.assertEqual(server.brand, 'OpenPegasus')
-            self.assertRegexp(server.version, r"^2\.1[0-7]\.[0-7]$")
+            self.assertRegexpMatches(server.version, r"^2\.1[0-7]\.[0-7]$")
         else:
             # Do not know what server it is so just display
             print("Brand: %s" % server.brand)
@@ -5717,7 +5707,7 @@ def consume_indication(indication, host):
     COUNTER_LOCK.release()
 
 
-class PyWBEMListenerClass(PyWBEMServerClass):
+class PyWBEMListenerClass(PyWBEMServerClass, RegexpMixin):
     """Test the management of indications with the listener class.
        All of these functions depend on existence of a WBEM server to
        which subscriptions/filters are sent."""
@@ -5856,21 +5846,21 @@ class PyWBEMListenerClass(PyWBEMServerClass):
 
         filters = sub_mgr.get_all_filters(server_id)
         owned_filters = sub_mgr.get_owned_filters(server_id)
-        if len(filters) != 0:
+        if filters:
             for i, filter_ in enumerate(filters):
                 print('filter %s %s %s', (i, filter_,
                                           is_owned(filter_, owned_filters)))
 
         subscriptions = sub_mgr.get_all_subscriptions(server_id)
         owned_subs = sub_mgr.get_owned_subscriptions(server_id)
-        if len(subscriptions) != 0:
+        if subscriptions:
             for i, subscription in enumerate(subscriptions):
                 print('subscription %s %s %s', (i, subscription,
                                                 is_owned(subscription,
                                                          owned_subs)))
 
         dests = sub_mgr.get_all_subscriptions(server_id)
-        if len(dests) != 0:
+        if dests:
             for i, dest in enumerate(dests):
                 print('destination %s %s' % (i, dest))
 
@@ -5919,7 +5909,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
                                  subscription_paths)
 
             # confirm destination instance paths match
-            self.assertTrue(len(sub_mgr.get_all_destinations(server_id)) > 0)
+            self.assertTrue(sub_mgr.get_all_destinations(server_id))
             # #TODO: ks Finish this test completely when we add other changes
             # #for filter ids
 
@@ -5977,7 +5967,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             # Confirm structure of the name element without any id components
             # NOTE: The uuid from uuid4 is actually 36 char but not we made it
             # 30-40 in case format changes in future.
-            self.assertRegexp(
+            self.assertRegexpMatches(
                 filter_path.keybindings['Name'],
                 r'^pywbemfilter:owned:fred2:MyfilterId:[0-9a-f-]{30,40}\Z')
             subscriptions = sub_mgr.add_subscriptions(server_id,
@@ -6070,7 +6060,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             self.assertEqual(len(owned_filter_paths), 1)
             for path in owned_filter_paths:
                 name = path.keybindings['Name']
-                self.assertRegexp(
+                self.assertRegexpMatches(
                     name,
                     r'^pywbemfilter:owned:pegTestListener:fred:' +
                     r'[0-9a-f-]{30,40}\Z')
@@ -6082,7 +6072,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
                 query_language="DMTF:CQL", filter_id='test_id_attributes1')
             filter_path2 = filter2.path
 
-            self.assertRegexp(
+            self.assertRegexpMatches(
                 filter_path2.keybindings['Name'],
                 r'^pywbemfilter:owned:pegTestListener:test_id_attributes1:' +
                 r'[0-9a-f-]{30,40}\Z')
@@ -6093,7 +6083,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
                 query_language="DMTF:CQL", filter_id='test_id_attributes2')
             filter_path3 = filter3.path
 
-            self.assertRegexp(
+            self.assertRegexpMatches(
                 filter_path3.keybindings['Name'],
                 r'^pywbemfilter:owned:pegTestListener:test_id_attributes2:' +
                 r'[0-9a-f-]{30,40}\Z')
@@ -6176,7 +6166,7 @@ class PyWBEMListenerClass(PyWBEMServerClass):
             self.assertEqual(len(owned_filter_paths), 1)
             for path in owned_filter_paths:
                 name = path.keybindings['Name']
-                self.assertRegexp(
+                self.assertRegexpMatches(
                     name,
                     r'^pywbemfilter:owned:pegTestMgr:fred:[0-9a-f-]{30,40}\Z')
             self.assertTrue(filter_path in owned_filter_paths)

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -67,10 +67,7 @@ def str_tuple(tuple_):
 
     Returns str rep of tuple on None if tuple_ is None
     """
-    if tuple_ is None:
-        return 'NoneType'
-    else:
-        return '%s' % (tuple_,)
+    return 'NoneType' if tuple_ is None else '%s' % (tuple_,)
 
 
 class ClientTestError(Exception):
@@ -447,7 +444,7 @@ class ClientTest(unittest.TestCase):
             for tag, attr in sort_elements:
                 # elems is a list of elements with this tag name
                 elems = root.xpath("//*[local-name() = $tag]", tag=tag)
-                if len(elems) > 0:
+                if elems:
                     parent = elems[0].getparent()
                     first = None
                     after = None
@@ -788,7 +785,7 @@ class ClientTest(unittest.TestCase):
             # If result items are tuple, convert to lists. This is for
             # class ref and assoc results.
             if isinstance(result, list) and \
-                    len(result) > 0 and isinstance(result[0], tuple):
+                    result and isinstance(result[0], tuple):
                 _result = []
                 for item in result:
                     if isinstance(item, tuple):
@@ -899,8 +896,7 @@ def result_tuple(value, tc_name):
         if "query_result_class" in value:
             return result(objs, value["eos"], value["context"],
                           value["query_result_class"])
-        else:
-            return result(objs, value["eos"], value["context"])
+        return result(objs, value["eos"], value["context"])
 
     else:
         raise AssertionError("WBEMConnection operation invalid tuple "

--- a/testsuite/wbemcli_quit_script.py
+++ b/testsuite/wbemcli_quit_script.py
@@ -3,8 +3,9 @@ Pywbem scriptlet to quit wbemcli. It is used
 by test_wbemcli.py to force wbemcli to terminate after each test.
 """
 
-# this displays the connection info.  Required because what you see in
+# This script displays the connection info.  Required because what you see in
 # wbemcli startup is through the python interactive module and not to
 # stdout
+# pylint: disable=undefined-variable
 print(_get_connection_info())  # noqa: F821
 quit()

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -135,9 +135,9 @@ def _remote_connection(server, opts, argparser_):
 # Create convenient global functions to reduce typing
 #
 
-# pylint: disable=too-many-arguments
 def iei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
         fq=None, ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT,):
+    # pylint: disable=too-many-arguments, redefined-outer-name
     """
     WBEM operation: IterEnumerateInstances
 
@@ -254,9 +254,9 @@ def iei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
                                        MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def ieip(cn, ns=None, fl=None, fq=None, ot=None, coe=None,
          moc=DEFAULT_ITER_MAXOBJECTCOUNT,):
+    # pylint: disable=too-many-arguments
     """
     WBEM operation: IterEnumerateInstancePaths
 
@@ -357,9 +357,9 @@ def ieip(cn, ns=None, fl=None, fq=None, ot=None, coe=None,
                                            MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def iri(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
         ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT):
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: IterReferenceInstances
 
@@ -466,9 +466,9 @@ def iri(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
                                        MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def irip(op, rc=None, r=None, fl=None, fq=None, ot=None, coe=None,
          moc=DEFAULT_ITER_MAXOBJECTCOUNT):
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: IterReferenceInstancePaths
 
@@ -554,9 +554,9 @@ def irip(op, rc=None, r=None, fl=None, fq=None, ot=None, coe=None,
                                            MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def iai(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None, pl=None,
         fl=None, fq=None, ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT):
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: IterAssociatorInstances
 
@@ -678,9 +678,9 @@ def iai(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None, pl=None,
                                         MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def iaip(op, ac=None, rc=None, r=None, rr=None, fl=None, fq=None, ot=None,
          coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT):
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: IterAssociatorInstancePaths
 
@@ -912,9 +912,8 @@ def ein(cn, ns=None):
     return CONN.EnumerateInstanceNames(cn, ns)
 
 
-# pylint: disable=too-many-arguments
 def ei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None):
-    # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name, too-many-arguments
     """
     WBEM operation: EnumerateInstances
 
@@ -1145,8 +1144,8 @@ def di(ip):
     CONN.DeleteInstance(ip)
 
 
-def an(op, ac=None, rc=None, r=None, rr=None):  # pylint: disable=invalid-name
-    # pylint: disable=redefined-outer-name
+def an(op, ac=None, rc=None, r=None, rr=None):
+    # pylint: disable=redefined-outer-name, invalid-name
     """
     WBEM operation: AssociatorNames
 
@@ -1219,9 +1218,8 @@ def an(op, ac=None, rc=None, r=None, rr=None):  # pylint: disable=invalid-name
                                 ResultRole=rr)
 
 
-# pylint: disable=too-many-arguments
 def a(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None, pl=None):
-    # pylint: disable=redefined-outer-name, invalid-name
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: Associators
 
@@ -1466,10 +1464,9 @@ def r(op, rc=None, r=None, iq=None, ico=None, pl=None):
                            PropertyList=pl)
 
 
-# pylint: disable=too-many-arguments
 def oei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
         fq=None, ot=None, coe=None, moc=None):
-    # pylint: disable=redefined-outer-name
+    # pylint: disable=too-many-arguments, redefined-outer-name
     """
     WBEM operation: OpenEnumerateInstances
 
@@ -1590,8 +1587,8 @@ def oei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
                                        MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def oeip(cn, ns=None, fl=None, fq=None, ot=None, coe=None, moc=None):
+    # pylint: disable=too-many-arguments
     """
     WBEM operation: OpenEnumerateInstancePaths
 
@@ -1685,10 +1682,9 @@ def oeip(cn, ns=None, fl=None, fq=None, ot=None, coe=None, moc=None):
                                            MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def ori(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
         ot=None, coe=None, moc=None):
-    # pylint: disable=redefined-outer-name, invalid-name
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: OpenReferenceInstances
 
@@ -1799,9 +1795,8 @@ def ori(op, rc=None, r=None, iq=None, ico=None, pl=None, fl=None, fq=None,
                                        MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def orip(op, rc=None, r=None, fl=None, fq=None, ot=None, coe=None, moc=None):
-    # pylint: disable=redefined-outer-name, invalid-name
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: OpenReferenceInstancePaths
 
@@ -1891,10 +1886,9 @@ def orip(op, rc=None, r=None, fl=None, fq=None, ot=None, coe=None, moc=None):
                                            MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def oai(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None, pl=None,
         fl=None, fq=None, ot=None, coe=None, moc=None):
-    # pylint: disable=redefined-outer-name, invalid-name
+    # pylint: disable=too-many-arguments,redefined-outer-name, invalid-name
     """
     WBEM operation: OpenAssociatorInstances
 
@@ -2019,10 +2013,9 @@ def oai(op, ac=None, rc=None, r=None, rr=None, iq=None, ico=None, pl=None,
                                         MaxObjectCount=moc)
 
 
-# pylint: disable=too-many-arguments
 def oaip(op, ac=None, rc=None, r=None, rr=None, fl=None, fq=None, ot=None,
          coe=None, moc=None):
-    # pylint: disable=redefined-outer-name, invalid-name
+    # pylint: disable=too-many-arguments, redefined-outer-name, invalid-name
     """
     WBEM operation: OpenAssociatorInstancePaths
 
@@ -2802,7 +2795,6 @@ def _get_connection_info():
     # pylint: disable=protected-access
     info += ' stats=%s, ' % ('on' if CONN._statistics else 'off')
 
-    # TODO: ks find more complete way to record that we are logging
     info += 'log=%s, ' % ('on' if CONN._operation_recorders else 'off')
 
     return fill(info, 78, subsequent_indent='    ')


### PR DESCRIPTION
Removed a number of issues found by pylint including:

1. The issue with unnecessary else. Changed most of those to use the
ternary form

2. The len(condition) issue which can be generally replaced with 

    if blah:
for cases were something must exist in iterable and 

    if not blah:
if the interable should be empty or None.

3. Couple of pylint messages that pylint is now marking as obsolete.