### PR TITLE
Clear a number of pylint issues

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Bug fixes
 
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
+* Cleaned up a lot of pylint warnings, for things like missing-doc, etc. so that
+  we can actually review the remainder.  See issue #808.
 
 Documentation
 ^^^^^^^^^^^^^

--- a/os_setup.py
+++ b/os_setup.py
@@ -327,9 +327,11 @@ class BaseOsCommand(Command):
         self.installer = OSInstaller().platform_installer()
 
     def initialize_options(self):
+        """ Base for initiaise_options"""
         pass
 
     def finalize_options(self):
+        """Base empty method for finalize options"""
         pass
 
 
@@ -853,7 +855,7 @@ class PythonInstaller(BaseInstaller):
             # __init__() on Python 3.x on Windows. See also
             # https://cbuelter.wordpress.com/2015/12/15/you-detach-me-i-
             # detach-you/
-            rc, out, _ = shell(cmd_args, display=True)
+            rc, out, _ = shell(cmd_args, display=True)  # pylint: disable=W0612
             if rc == 127:
                 raise DistutilsSetupError("Pip command is not available")
             elif rc != 0:
@@ -998,6 +1000,7 @@ class OSInstaller(BaseInstaller):
     def authorized(self):
         """Determine whether the current userid is authorized to install
         OS packages."""
+        # pylint: disable=simplifiable-if-statement
         if self.system == "Linux":
             # TODO: Using sudo may ask for the sudo password. Find a better
             #       way of testing for authorization to install packages.

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -427,7 +427,7 @@ class OperationStatistic(object):
 
         For an example, see :meth:`pywbem.Statistics.formatted`.
         """
-        if include_server_time:
+        if include_server_time:  # pylint: disable=no-else-return
             return ('{0:5d} {1:5d} '
                     '{2:7.3f} {3:7.3f} {4:7.3f} '
                     '{5:7.3f} {6:7.3f} {7:7.3f} '

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -1139,7 +1139,7 @@ class WBEMSubscriptionManager(object):
                              uuid.uuid4())
         dest_inst['Destination'] = listener_url
 
-        if owned:
+        if owned:  # pylint: disable=no-else-return
             for i, inst in enumerate(self._owned_destinations[server_id]):
                 if inst.path == dest_path:
                     # It already exists, now check its properties
@@ -1232,7 +1232,7 @@ class WBEMSubscriptionManager(object):
         filter_inst['Query'] = query
         filter_inst['QueryLanguage'] = query_language
 
-        if owned:
+        if owned:  # pylint: disable=no-else-return
             for i, inst in enumerate(self._owned_filters[server_id]):
                 if inst.path == filter_path:
                     # It already exists, now check its properties
@@ -1298,7 +1298,7 @@ class WBEMSubscriptionManager(object):
         sub_inst['Filter'] = filter_path
         sub_inst['Handler'] = dest_path
 
-        if owned:
+        if owned:  # pylint: disable=no-else-return
             for inst in self._owned_subscriptions[server_id]:
                 if inst.path == sub_path:
                     # It does not have any properties besides its keys,

--- a/pywbem/cim_constants.py
+++ b/pywbem/cim_constants.py
@@ -250,4 +250,3 @@ PROVIDERTYPE_CONSUMER = 6               # Indication consumer
 PROVIDERTYPE_QUERY = 7
 
 DEFAULT_NAMESPACE = 'root/cimv2'        #: Default CIM namespace
-

--- a/testsuite/test_cim_types.py
+++ b/testsuite/test_cim_types.py
@@ -40,11 +40,13 @@ from pywbem import CIMType, CIMInt, CIMFloat, Uint8, Uint16, Uint32, Uint64, \
     (Sint64, 'sint64', -2**63, 2**63 - 1),
 ], scope='module')
 def integer_tuple(request):
+    """Utility function to return param from request"""
     return request.param
 
 
 def test_integer_class_attrs_class(integer_tuple):
     """Test class attrs via class level"""
+    # pylint: disable=redefined-outer-name
     obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
     assert obj_type.cimtype == exp_cimtype
     assert obj_type.minvalue == exp_minvalue
@@ -53,6 +55,7 @@ def test_integer_class_attrs_class(integer_tuple):
 
 def test_integer_class_attrs_inst(integer_tuple):
     """Test class attrs via instance level"""
+    # pylint: disable=redefined-outer-name
     obj_type, exp_cimtype, exp_minvalue, exp_maxvalue = integer_tuple
     obj = obj_type(42)
     assert obj.cimtype == exp_cimtype
@@ -62,6 +65,7 @@ def test_integer_class_attrs_inst(integer_tuple):
 
 def test_integer_inheritance(integer_tuple):
     """Test inheritance"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     obj = obj_type(42)
     assert isinstance(obj, obj_type)
@@ -72,6 +76,7 @@ def test_integer_inheritance(integer_tuple):
 
 def test_integer_init_int(integer_tuple):
     """Test initialization from integer value"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     obj = obj_type(42)
     assert obj == 42
@@ -79,6 +84,7 @@ def test_integer_init_int(integer_tuple):
 
 def test_integer_init_str(integer_tuple):
     """Test initialization from string value"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     obj = obj_type('42')
     assert obj == 42
@@ -86,6 +92,7 @@ def test_integer_init_str(integer_tuple):
 
 def test_integer_init_str_base10(integer_tuple):
     """Test initialization from string value with base 10"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     obj = obj_type('42', 10)
     assert obj == 42
@@ -93,6 +100,7 @@ def test_integer_init_str_base10(integer_tuple):
 
 def test_integer_init_str_base16(integer_tuple):
     """Test initialization from string value with base 16"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     obj = obj_type('2A', 16)
     assert obj == 42
@@ -100,6 +108,7 @@ def test_integer_init_str_base16(integer_tuple):
 
 def test_integer_init_minimum(integer_tuple):
     """Test initialization from integer value at minimum"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     exp_minvalue = integer_tuple[2]
     obj = obj_type(exp_minvalue)
@@ -108,6 +117,7 @@ def test_integer_init_minimum(integer_tuple):
 
 def test_integer_init_maximum(integer_tuple):
     """Test initialization from integer value at maximum"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     exp_maxvalue = integer_tuple[3]
     obj = obj_type(exp_maxvalue)
@@ -116,6 +126,7 @@ def test_integer_init_maximum(integer_tuple):
 
 def test_integer_init_too_low(integer_tuple):
     """Test initialization from integer value below minimum"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     exp_minvalue = integer_tuple[2]
     try:
@@ -128,6 +139,7 @@ def test_integer_init_too_low(integer_tuple):
 
 def test_integer_init_too_high(integer_tuple):
     """Test initialization from integer value above maximum"""
+    # pylint: disable=redefined-outer-name
     obj_type = integer_tuple[0]
     exp_maxvalue = integer_tuple[3]
     try:
@@ -155,24 +167,28 @@ def test_integer_init_too_high(integer_tuple):
     (Real64, 'real64'),
 ], scope='module')
 def real_tuple(request):
+    """pytest.fixture returns Real types"""
     return request.param
 
 
 def test_real_class_attrs_class(real_tuple):
-    """Test class attrs via class level"""
+    """Test class attrs via class level using real_tuple fixture"""
+    # pylint: disable=redefined-outer-name
     obj_type, exp_cimtype = real_tuple
     assert obj_type.cimtype == exp_cimtype
 
 
 def test_real_class_attrs_inst(real_tuple):
-    """Test class attrs via instance level"""
+    """Test class attrs via instance level using real_tuple fixture"""
+    # pylint: disable=redefined-outer-name
     obj_type, exp_cimtype = real_tuple
     obj = obj_type(42)
     assert obj.cimtype == exp_cimtype
 
 
 def test_real_inheritance(real_tuple):
-    """Test inheritance"""
+    """Test inheritance  using real_tuple fixture"""
+    # pylint: disable=redefined-outer-name
     obj_type = real_tuple[0]
     obj = obj_type(42)
     assert isinstance(obj, obj_type)
@@ -183,13 +199,15 @@ def test_real_inheritance(real_tuple):
 
 def test_real_init_float(real_tuple):
     """Test initialization from floating point value"""
+    # pylint: disable=redefined-outer-name
     obj_type = real_tuple[0]
     obj = obj_type(42.0)
     assert obj == 42.0
 
 
 def test_real_init_str(real_tuple):
-    """Test initialization from string value"""
+    """Test initialization from string value using real_tuple fixture"""
+    # pylint: disable=redefined-outer-name
     obj_type = real_tuple[0]
     obj = obj_type('42.0')
     assert obj == 42.0
@@ -330,10 +348,11 @@ def test_real_init_str(real_tuple):
     ),
 ], scope='module')
 def datetime_init_tuple(request):
+    """pytest.fixture that returns datatetime tuple info"""
     return request.param
 
 
-def test_datetime_class_attrs_class():
+def test_datetime_class_attrs_class():  # pylint: disable=invalid-name
     """Test class attrs via class level"""
     assert CIMDateTime.cimtype == 'datetime'
 
@@ -354,12 +373,15 @@ def test_datetime_inheritance():
 
 
 def test_datetime_init(datetime_init_tuple):
-    """Test initialization from all input types"""
+    """Test initialization from all input types using
+       datetime_init_tuple pytest.fixture.
+    """
+    # pylint: disable=redefined-outer-name
     (dtarg, exp_kind, exp_datetime, exp_timedelta, exp_minutesfromutc,
      exp_str) = datetime_init_tuple
     try:
         obj = CIMDateTime(dtarg)
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         assert isinstance(exc, exp_kind)
     else:
         assert obj.is_interval == (exp_kind == 'interval')

--- a/testsuite/test_cim_xml.py
+++ b/testsuite/test_cim_xml.py
@@ -58,15 +58,18 @@ def LOCALNAMESPACEPATH():   # pylint: disable=invalid-name
 
 
 def NAMESPACEPATH():   # pylint: disable=invalid-name
+    """Return predefined NAMESPACEPATH"""
     return cim_xml.NAMESPACEPATH(
         cim_xml.HOST('leonardo'), LOCALNAMESPACEPATH())
 
 
 def CLASSNAME():  # pylint: disable=invalid-name
+    """return predefined CLASSNAME, CIM_Foo"""
     return cim_xml.CLASSNAME('CIM_Foo')
 
 
 def INSTANCENAME():  # pylint: disable=invalid-name
+    """Return predefinedINSTANCENAME"""
     return cim_xml.INSTANCENAME(
         'CIM_Pet',
         [cim_xml.KEYBINDING('type', cim_xml.KEYVALUE('dog', 'string')),
@@ -94,6 +97,7 @@ class CIMXMLTest(unittest.TestCase):
         validate_xml(xml, dtd_directory='../..')
 
     def test_all(self):
+        """Loop over xml to execute tests"""
 
         for i in range(0, len(self.xml)):
 
@@ -114,9 +118,10 @@ class CIMXMLTest(unittest.TestCase):
 
 # pylint: disable=too-few-public-methods
 class UnimplementedTest(object):
-
+    """Test unimplemented. Raise AssertionError"""
     @staticmethod
     def test_all():
+        """raise Assertion Error"""
         raise AssertionError('Unimplemented test')
 
 
@@ -128,7 +133,9 @@ class UnimplementedTest(object):
 
 
 class CIM(CIMXMLTest):
+    """CIM Top level element as class"""
     def setUp(self):
+        """setUp for CIM class"""
         super(CIM, self).setUp()
         self.xml.append(cim_xml.CIM(
             cim_xml.MESSAGE(

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -14,7 +14,7 @@ from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError,\
 
 
 def _assert_subscription(exc):
-
+    """Test the exception defined by exc for required args"""
     # Access by subscription is only supported in Python 2:
     if six.PY2:
         assert exc[:] == exc.args
@@ -43,6 +43,9 @@ def _assert_subscription(exc):
     Error, ConnectionError, AuthError, TimeoutError, ParseError, VersionError
 ], scope='module')
 def simple_class(request):
+    """Return request.param as defined by the fixture. Representing
+       the exception classes.
+    """
     return request.param
 
 
@@ -53,10 +56,17 @@ def simple_class(request):
     ('foo', 42),
 ], scope='module')
 def simple_args(request):
+    """Return request.param defined by the pytest.fixture
+       representing arguments for the exception class
+    """
     return request.param
 
 
 def test_simple(simple_class, simple_args):
+    """Test exceptions classes and arguments using the
+      testfixtures.
+    """
+    # pylint: disable=redefined-outer-name
 
     exc = simple_class(*simple_args)
 
@@ -79,11 +89,14 @@ def test_simple(simple_class, simple_args):
     (404, 'Not Found', 'instance xyz not found', 'foo'),
 ], scope='module')
 def httperror_args(request):
+    """Returns init arguments for the HTTPError exception class as
+       pytest.fixture
+    """
     return request.param
 
 
-def test_httperror(httperror_args):
-
+def test_httperror(httperror_args):  # pylint: disable=redefined-outer-name
+    """Test httperror arguments from test fixture"""
     exc = HTTPError(*httperror_args)
 
     assert exc.status == httperror_args[0]
@@ -144,11 +157,14 @@ def test_httperror(httperror_args):
     (30, None),
 ], scope='module')
 def status_tuple(request):
+    """pytest.fixture returns status codes for CIMError
+       exception
+    """
     return request.param
 
 
-def test_cimerror_1(status_tuple):
-
+def test_cimerror_1(status_tuple):  # pylint: disable=redefined-outer-name
+    """Test cimerror"""
     status_code = status_tuple[0]
     status_code_name = status_tuple[1]
 
@@ -172,7 +188,8 @@ def test_cimerror_1(status_tuple):
     _assert_subscription(exc)
 
 
-def test_cimerror_2(status_tuple):
+def test_cimerror_2(status_tuple):  # pylint: disable=redefined-outer-name
+    """Test cimerror status tuple from date in status-tuple fixture"""
 
     status_code = status_tuple[0]
     status_code_name = status_tuple[1]

--- a/testsuite/test_indicationlistener.py
+++ b/testsuite/test_indicationlistener.py
@@ -94,7 +94,7 @@ def send_indication(url, headers, payload, verbose):
 
     try:
         response = requests.post(url, headers=headers, data=payload, timeout=4)
-    except Exception as ex:
+    except Exception as ex:  # pylint: disable=broad-except
         print('Exception %s' % ex)
         return False
 
@@ -121,8 +121,8 @@ def _process_indication(indication, host):
     if there is a mismatch.
     """
 
-    global RCV_COUNT
-    global RCV_FAIL
+    global RCV_COUNT  # pylint: disable=global-statement
+    global RCV_FAIL  # pylint: disable=global-statement
 
     counter = indication.properties['SequenceNumber'].value
     if int(counter) != RCV_COUNT:
@@ -146,11 +146,13 @@ class TestIndications(unittest.TestCase):
     @staticmethod
     def createlistener(host, http_port=None, https_port=None,
                        certfile=None, keyfile=None):
-
-        global RCV_COUNT
-        global LISTENER
-        global RCV_FAIL
-        RCV_FAIL = False
+        """
+        Create and start a listener based on host, ports, etc.
+        """
+        global RCV_COUNT  # pylint: disable=global-statement
+        global LISTENER  # pylint: disable=global-statement
+        global RCV_FAIL  # pylint: disable=global-statement
+        RCV_FAIL = False  # pylint: disable=global-statement
 
         _logging.basicConfig(stream=_sys.stderr, level=_logging.WARNING,
                              format='%(levelname)s: %(message)s')
@@ -176,8 +178,8 @@ class TestIndications(unittest.TestCase):
         """
 
         # pylint: disable=global-variable-not-assigned
-        global VERBOSE
-        global RCV_FAIL
+        global VERBOSE  # pylint: disable=global-statement
+        global RCV_FAIL  # pylint: disable=global-statement
         RCV_FAIL = False
         host = 'localhost'
 

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-#
-# Test case-insensitive dictionary implementation.
-#
+"""
+    Test case-insensitive dictionary implementation.
+"""
 
 from __future__ import absolute_import
 
@@ -13,9 +13,9 @@ from pywbem.cim_obj import NocaseDict
 
 
 class TestInit(unittest.TestCase):
-
+    """Test initialization"""
     def test_all(self):
-
+        """Test all init options"""
         # Empty
 
         dic = NocaseDict()
@@ -94,16 +94,20 @@ class TestInit(unittest.TestCase):
 
 
 class BaseTest(unittest.TestCase):
-
+    """Base class for following unit test. Does common setup which
+       creates a NoCaseDict.
+    """
     def setUp(self):
+        """unittest setUp creates NoCaseDict"""
         self.dic = NocaseDict()
         self.dic['Dog'] = 'Cat'
         self.dic['Budgie'] = 'Fish'
 
 
 class TestGetitem(BaseTest):
-
+    """Tests for getitem"""
     def test_all(self):
+        """All tests"""
         self.assertTrue(self.dic['dog'] == 'Cat')
         self.assertTrue(self.dic['DOG'] == 'Cat')
 
@@ -116,15 +120,16 @@ class TestGetitem(BaseTest):
 
 
 class TestLen(BaseTest):
-
+    """Tests for len of dict"""
     def test_all(self):
+        """Test method"""
         self.assertTrue(len(self.dic) == 2)
 
 
 class TestSetitem(BaseTest):
-
+    """Test setting items"""
     def test_all(self):
-
+        """All setitem tests"""
         self.dic['DOG'] = 'Kitten'
         self.assertTrue(self.dic['DOG'] == 'Kitten')
         self.assertTrue(self.dic['Dog'] == 'Kitten')
@@ -141,8 +146,9 @@ class TestSetitem(BaseTest):
 
 
 class TestDelitem(BaseTest):
-
+    """Class for del items from dictionary"""
     def test_all(self):
+        """All tests"""
         del self.dic['DOG']
         del self.dic['budgie']
         self.assertTrue(self.dic.keys() == [])
@@ -156,16 +162,18 @@ class TestDelitem(BaseTest):
 
 
 class TestHasKey(BaseTest):
-
+    """Class to test haskey on dict"""
     def test_all(self):
+        """Method to test haskey"""
         self.assertTrue('DOG' in self.dic)
         self.assertTrue('budgie' in self.dic)
         self.assertTrue(1234 not in self.dic)
 
 
 class TestKeys(BaseTest):
-
+    """Class for TestKeys method"""
     def test_all(self):
+        """All tests in single method"""
         keys = self.dic.keys()
         animals = ['Budgie', 'Dog']
         for ani in animals:
@@ -175,8 +183,9 @@ class TestKeys(BaseTest):
 
 
 class TestValues(BaseTest):
-
+    """Class for values tests"""
     def test_all(self):
+        """Test all for TestValues"""
         values = self.dic.values()
         animals = ['Cat', 'Fish']
         for ani in animals:
@@ -186,8 +195,9 @@ class TestValues(BaseTest):
 
 
 class TestItems(BaseTest):
-
+    """Class for Test items"""
     def test_all(self):
+        """All tests for item"""
         items = self.dic.items()
         animals = [('Dog', 'Cat'), ('Budgie', 'Fish')]
         for ani in animals:
@@ -197,15 +207,17 @@ class TestItems(BaseTest):
 
 
 class TestClear(BaseTest):
-
+    """Class for dict clear method"""
     def test_all(self):
+        """All clear method tests"""
         self.dic.clear()
         self.assertTrue(len(self.dic) == 0)
 
 
 class TestUpdate(BaseTest):
-
+    """Class for test update method"""
     def test_all(self):
+        """All methods for TestUpdate"""
         self.dic.clear()
         self.dic.update({'Chicken': 'Ham'})
         self.assertTrue(self.dic.keys() == ['Chicken'])
@@ -231,8 +243,9 @@ class TestUpdate(BaseTest):
 
 
 class TestCopy(BaseTest):
-
+    """Class to test dict copy"""
     def test_all(self):
+        """All tests for dict copy"""
         cp = self.dic.copy()
         self.assertEqual(cp, self.dic)
         self.assertTrue(isinstance(cp, NocaseDict))
@@ -242,16 +255,18 @@ class TestCopy(BaseTest):
 
 
 class TestGet(BaseTest):
-
+    """Class to test get method"""
     def test_all(self):
+        """Test get method"""
         self.assertTrue(self.dic.get('Dog', 'Chicken') == 'Cat')
         self.assertTrue(self.dic.get('Ningaui') is None)
         self.assertTrue(self.dic.get('Ningaui', 'Chicken') == 'Chicken')
 
 
 class TestSetDefault(BaseTest):
-
+    """Class for setdefault test methods"""
     def test_all(self):
+        """All tests for setdefault of dict"""
         self.dic.setdefault('Dog', 'Kitten')
         self.assertTrue(self.dic['Dog'] == 'Cat')
         self.dic.setdefault('Ningaui', 'Chicken')
@@ -259,8 +274,9 @@ class TestSetDefault(BaseTest):
 
 
 class TestPopItem(BaseTest):
-
+    """Class for PopItem"""
     def test_all(self):
+        """This test does nothing"""
         pass
 
 
@@ -280,9 +296,9 @@ def swapcase2(text):
 
 
 class TestEqual(BaseTest):
-
+    """Class for test equal for dict items"""
     def assertDictEqual(self, dic1, dic2, msg):
-
+        """method to test for dict items equal"""
         self.assertTrue(dic1 == dic2, msg)
         self.assertFalse(dic1 != dic2, msg)
 
@@ -290,7 +306,7 @@ class TestEqual(BaseTest):
         self.assertFalse(dic2 != dic1, msg)
 
     def assertDictNotEqual(self, dic1, dic2, msg):
-
+        """Method to test for unequal dict methods"""
         self.assertTrue(dic1 != dic2, msg)
         self.assertFalse(dic1 == dic2, msg)
 
@@ -298,7 +314,7 @@ class TestEqual(BaseTest):
         self.assertFalse(dic2 == dic1, msg)
 
     def run_test_dicts(self, base_dict, test_dicts):
-
+        """General test_dictionaries"""
         for test_dict, relation, comment in test_dicts:
             if relation == 'eq':
                 self.assertDictEqual(test_dict, base_dict,
@@ -320,7 +336,7 @@ class TestEqual(BaseTest):
                                      (relation, comment))
 
     def test_all(self):
-
+        """Class for overall test"""
         # The base dictionary that is used for all comparisons
         base_dict = dict({'Budgie': 'Fish', 'Dog': 'Cat'})
 
@@ -404,13 +420,14 @@ class TestOrdering(BaseTest):
     TypeError."""
 
     def assertWarning(self, comp_str):
+        """Common function for assert warning"""
         with warnings.catch_warnings(record=True) as wlist:
             warnings.simplefilter("always")
             if six.PY2:
-                eval(comp_str)
+                eval(comp_str)  # pylint: disable=eval-used
             else:
                 try:
-                    eval(comp_str)
+                    eval(comp_str)  # pylint: disable=eval-used
                 except TypeError as exc:
                     msg = str(exc)
                     if "not supported between instances" not in msg and \
@@ -418,7 +435,7 @@ class TestOrdering(BaseTest):
                         self.fail("Applying ordering to a dictionary in "
                                   "Python 3 did raise TypeError but with an "
                                   "unexpected message: %s" % msg)
-                except Exception as exc:
+                except Exception as exc:  # pylint: disable=broad-except
                     msg = str(exc)
                     self.fail("Applying ordering to a dictionary in Python 3 "
                               "did not raise TypeError, but %s: %s" %
@@ -431,6 +448,7 @@ class TestOrdering(BaseTest):
             assert "deprecated" in str(wlist[-1].message)
 
     def test_all(self):
+        """Test for the compare options that should generate assertWarning"""
         self.assertWarning("self.dic < self.dic")
         self.assertWarning("self.dic <= self.dic")
         self.assertWarning("self.dic > self.dic")
@@ -438,16 +456,18 @@ class TestOrdering(BaseTest):
 
 
 class TestContains(BaseTest):
-
+    """Class for dict contains functionality"""
     def test_all(self):
+        """Method for test dict contains functionality"""
         self.assertTrue('dog' in self.dic)
         self.assertTrue('Dog' in self.dic)
         self.assertTrue('Cat' not in self.dic)
 
 
 class TestForLoop(BaseTest):
-
+    """Class for test for loop with dictionary"""
     def test_all(self):
+        """Test method for TestForLoop"""
         keys = set()
         for key in self.dic:
             keys.add(key)
@@ -455,8 +475,9 @@ class TestForLoop(BaseTest):
 
 
 class TestIterkeys(BaseTest):
-
+    """Class for iterkeys test"""
     def test_all(self):
+        """iterkeys test method"""
         keys = set()
         for key in self.dic.iterkeys():
             keys.add(key)
@@ -464,8 +485,9 @@ class TestIterkeys(BaseTest):
 
 
 class TestItervalues(BaseTest):
-
+    """Class for test itervalues test"""
     def test_all(self):
+        """itervalues test method"""
         vals = set()
         for val in self.dic.itervalues():
             vals.add(val)
@@ -473,8 +495,9 @@ class TestItervalues(BaseTest):
 
 
 class TestIteritems(BaseTest):
-
+    """Class to test iteritems for dict"""
     def test_all(self):
+        """Method for test iteritems for dict"""
         items = set()
         for item in self.dic.iteritems():
             items.add(item)
@@ -482,7 +505,7 @@ class TestIteritems(BaseTest):
 
 
 class TestRepr(unittest.TestCase):
-
+    """Class to test repr functionality for NocaseDict"""
     def test_reliable_order(self):
         """Test that repr() has a reliable result despite different orders of
         insertion into the dictionary."""

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -210,7 +210,7 @@ class ParseCIMParameter(TupleTest):
     """Test parsing of CIMParameter objects."""
 
     def test_all(self):
-
+        """All tests for ParseCIMParameter"""
         # Single-valued parameters
 
         self._run_single(CIMParameter('Param', 'string'))
@@ -266,9 +266,9 @@ class ParseCIMParameter(TupleTest):
 
 
 class ParseXMLKeyValue(RawXMLTest):
-
+    """Class for test of Parse XML key values"""
     def test_all(self):
-
+        """All tests for XML key values"""
         self._run_single(
             '<KEYVALUE VALUETYPE="numeric">1234</KEYVALUE>', 1234)
 

--- a/testsuite/test_tupletree.py
+++ b/testsuite/test_tupletree.py
@@ -12,9 +12,9 @@ from pkg_resources import resource_filename
 
 from pywbem import tupletree
 
-pp = pprint.PrettyPrinter(indent=4)
+pp = pprint.PrettyPrinter(indent=4)  # pylint: disable=invalid-name
 
-test_tuple = (u'CIM',
+test_tuple = (u'CIM',  # pylint: disable=invalid-name
               {u'CIMVERSION': u'2.0', u'DTDVERSION': u'2.0'},
               [(u'MESSAGE',
                 {u'ID': u'1001', u'PROTOCOLVERSION': u'1.0'},
@@ -182,6 +182,7 @@ class TestTupleTreeRegression(unittest.TestCase):
     """Setup the TupleTree tests"""
     def setUp(self):
         self.data_dir = resource_filename(__name__, 'tupletree_ok')
+        # pylint: disable=unused-variable
         for path, dirs, files in os.walk(self.data_dir):
             self.filenames = [os.path.join(path, f) for f in files]
 
@@ -203,8 +204,11 @@ class TestTupleTreeRegression(unittest.TestCase):
 
 
 class TestTupleTreeError(unittest.TestCase):
-
+    """Base class for Testing Tuple tree errors. Does setUp and common
+       method to test
+    """
     def setUp(self):
+        """Unittest setUp"""
         self.data_dir = resource_filename(__name__, 'tupletree_error')
 
     def test_to_tupletree_error(self):
@@ -217,7 +221,7 @@ class TestTupleTreeError(unittest.TestCase):
 
 
 class TestTupleTreeSax(unittest.TestCase):
-
+    """Class to execute SaxTupleTree tests"""
     def test_xml_to_tupletree_sax(self):
         """
         XML to tupletree with SAX is accurate.

--- a/testsuite/test_valuemapping.py
+++ b/testsuite/test_valuemapping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-#
-# Test ValueMapping class
-#
+"""
+    Test ValueMapping class
+"""
 
 from __future__ import absolute_import
 
@@ -18,8 +18,12 @@ PROPNAME = 'p1'
 
 
 class TestAll(unittest.TestCase):
+    """
+    Unittest TestClass for ValueMapping. Does setup for tests.
+    """
 
     def setUp(self):
+        """Setup WBEMConnection and WBEMSErver"""
         self.conn = WBEMConnection('dummy')
         self.server = WBEMServer(self.conn)
 
@@ -38,6 +42,9 @@ class TestAll(unittest.TestCase):
         self.conn.GetClass = Mock(return_value=test_class)
 
     def assertOutsideValueMap(self, vm, value):
+        """
+        Test vm.tovalues Exception
+        """
         try:
             vm.tovalues(value)
         except ValueError as exc:
@@ -48,6 +55,7 @@ class TestAll(unittest.TestCase):
             self.fail("ValueError was not raised.")
 
     def test_empty(self):
+        """Test empty ValueMapping"""
         valuemap = []
         values = []
         self.setup_for_property(valuemap, values)
@@ -58,6 +66,7 @@ class TestAll(unittest.TestCase):
         self.assertOutsideValueMap(vm, 0)
 
     def test_zero(self):
+        """Test value map with value zero"""
         valuemap = ['0']
         values = ['zero']
         self.setup_for_property(valuemap, values)
@@ -69,6 +78,7 @@ class TestAll(unittest.TestCase):
         self.assertOutsideValueMap(vm, 1)
 
     def test_one(self):
+        """Test valuemap with value 1"""
         valuemap = ['1']
         values = ['one']
         self.setup_for_property(valuemap, values)
@@ -81,6 +91,7 @@ class TestAll(unittest.TestCase):
         self.assertOutsideValueMap(vm, 2)
 
     def test_one_cimtype(self):
+        """test valuemap for property"""
         valuemap = ['1']
         values = ['one']
         self.setup_for_property(valuemap, values)
@@ -91,6 +102,7 @@ class TestAll(unittest.TestCase):
         self.assertEqual(vm.tovalues(Uint8(1)), 'one')
 
     def test_singles(self):
+        """Test valuemap for property with multiple values"""
         valuemap = ['0', '1', '9']
         values = ['zero', 'one', 'nine']
         self.setup_for_property(valuemap, values)
@@ -106,6 +118,7 @@ class TestAll(unittest.TestCase):
         self.assertOutsideValueMap(vm, 10)
 
     def test_singles_ranges(self):
+        """Test valuemap with ranges in valuemap"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9']
         values = ['zero', 'one', 'two-four', 'five-six', 'seven-eight', 'nine']
         self.setup_for_property(valuemap, values)
@@ -126,6 +139,7 @@ class TestAll(unittest.TestCase):
         self.assertOutsideValueMap(vm, 10)
 
     def test_unclaimed(self):
+        """Test with valuemap '..'"""
         valuemap = ['..']
         values = ['unclaimed']
         self.setup_for_property(valuemap, values)
@@ -138,6 +152,7 @@ class TestAll(unittest.TestCase):
         self.assertEqual(vm.tovalues(2), 'unclaimed')
 
     def test_singles_ranges_unclaimed(self):
+        """Test combination of singles, ranges, unclaimed"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9', '..']
         values = ['zero', 'one', 'two-four', 'five-six', 'seven-eight', 'nine',
                   'unclaimed']
@@ -160,6 +175,7 @@ class TestAll(unittest.TestCase):
         self.assertEqual(vm.tovalues(11), 'unclaimed')
 
     def test_singles_ranges_unclaimed2(self):
+        """Test singles, ranges, unclaimed"""
         valuemap = ['0', '2..4', '..6', '7..', '9', '..']
         values = ['zero', 'two-four', 'five-six', 'seven-eight', 'nine',
                   'unclaimed']

--- a/testsuite/unittest_extensions.py
+++ b/testsuite/unittest_extensions.py
@@ -60,10 +60,12 @@ class FileMixin(object):
     assertion functions for file related tests."""
 
     def assertFileExists(self, filename):
+        """Test assert file exists"""
         assert os.path.exists(filename), \
             ("File does not exist but should: %s" % filename)
 
     def assertFileNotExists(self, filename):
+        """Test assert file exists but should not"""
         assert not os.path.exists(filename), \
             ("File exists but should not: %s" % filename)
 


### PR DESCRIPTION
1. Add comments to all functions, methods, classes.

2. Disabled number of variable-not-used pylint warnings

3. Disabled several no-else-return where we did not want to modify the
code

4. Removed empty lines at end of module

5. Set disable=redefined-outer-name especially in test_cim_types and
other tests where we are uising pytest and fixtures.

6 Disabled several exception too broad

Made comment in changes.rst

Takes about 150 lines off of pylint.log (643 down to about 480 lines)