### PR TITLE
Fixes #808: Fix more pylint issues

### DIFF
--- a/os_setup.py
+++ b/os_setup.py
@@ -174,6 +174,7 @@ else:
     string_types = str,             # noqa: F821
     text_type = str                 # noqa: F821
     binary_type = bytes             # noqa: F821
+    # pylint: disable=import-error
     from xmlrpc.client import ServerProxy as xmlrpc_ServerProxy
 # pylint: enable=invalid-name
 

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -538,7 +538,8 @@ class LogOperationRecorder(BaseOperationRecorder):
             else:    # format result
                 # test if type is tuple (subclass of tuple but not type tuple)
                 # pylint: disable=unidiomatic-typecheck
-                if isinstance(ret, tuple) and type(ret) is not tuple:
+                if isinstance(ret, tuple) and \
+                        type(ret) is not tuple:  # pylint: disable=C0123
                     try:    # test if field instances or paths
                         rtn_data = ret.instances
                         data_str = 'instances'

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -607,6 +607,7 @@ class Statistics(object):
             # Test to see if any server time is non-zero
             include_svr = False
             for name, stats in snapshot:  # pylint: disable=unused-variable
+                # pylint: disable=protected-access
                 if stats._server_time_stored:
                     include_svr = True
             if include_svr:

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -539,7 +539,6 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                     else:
                         ctx.load_verify_locations(cafile=self.ca_certs)
                 try:
-                    # pylint: disable=redefined-variable-type
                     self.sock = SSL.Connection(ctx, self.sock)
 
                     # Below is a body of SSL.Connection.connect() method
@@ -685,7 +684,6 @@ def wbem_request(url, data, creds, headers=None, debug=False, x509=None,
                                  timeout=timeout)
     else:
         if url.startswith('http'):
-            # pylint: disable=redefined-variable-type
             client = HTTPConnection(host=host, port=port, timeout=timeout)
         else:
             if url.startswith('file:'):

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -3760,6 +3760,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                            OperationTimeout=None, ContinueOnError=None,
                            MaxObjectCount=DEFAULT_ITER_MAXOBJECTCOUNT,
                            **extra):
+        # pylint: disable=line-too-long
         """
         Execute a query in a namespace,
         using the corresponding pull operations if supported by the WBEM server
@@ -3919,6 +3920,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             for inst in result.generator:
                 print('instance %s' % inst.tomof())
         """  # noqa: E501
+        # pylint: enable=line-too-long
 
         class IterQueryInstancesReturn(object):
             """
@@ -3980,7 +3982,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                         pull_result.query_result_class
 
                     while not pull_result.eos:
-                        # pylint: disable=redefined-variable-type
                         pull_result = self.PullInstances(
                             pull_result.context, MaxObjectCount=MaxObjectCount)
                         _instances.extend(pull_result.instances)

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -22,6 +22,8 @@
 
 # TODO 2/16 KS: Sort this issue out and see if we need to fix. These two
 #               issues are found repeatedly in this file so pylint disabled.
+#               Throughout the code, the classes __init__ from Element, not
+#               a direct superclass is used.
 # pylint: disable=non-parent-init-called,super-init-not-called
 
 """
@@ -165,7 +167,7 @@ def _pcdata_nodes(pcdata):
         # The following automatically uses XML entity references
         # for escaping.
 
-        node = _text(pcdata)  # pylint: disable=redefined-variable-type
+        node = _text(pcdata)
 
         nodelist.append(node)
 
@@ -345,7 +347,7 @@ class QUALIFIER_DECLARATION(CIMElement):
             if is_array:
                 xval = VALUE_ARRAY(value)
             else:
-                xval = VALUE(value)  # pylint: disable=redefined-variable-type
+                xval = VALUE(value)
             self.appendOptionalChild(xval)
 
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -768,7 +768,6 @@ def p_classDeclaration(p):
             else:  # superclass
                 superclass = p[4]
                 cfl = p[6]
-    # pylint: disable=redefined-variable-type
     quals = dict([(x.name, x) for x in quals])
     methods = {}
     props = {}
@@ -1086,7 +1085,6 @@ def p_referenceDeclaration(p):
         pname = p[2]
         if len(p) == 5:
             dv = p[3]
-    # pylint: disable=redefined-variable-type
     quals = dict([(x.name, x) for x in quals])
     p[0] = CIMProperty(pname, dv, type='reference',
                        reference_class=cname, qualifiers=quals)
@@ -1112,7 +1110,6 @@ def p_methodDeclaration(p):
         mname = p[3]
         if p[5] != ')':
             paramlist = p[5]
-    # pylint: disable=redefined-variable-type
     params = dict([(param.name, param) for param in paramlist])
     quals = dict([(q.name, q) for q in quals])
     p[0] = CIMMethod(mname, return_type=dt, parameters=params,

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -498,7 +498,6 @@ def parse_value_namedobject(tup_tree):
     elif len(k) == 2:
         path = parse_instancename(kids(tup_tree)[0])
 
-        # pylint: disable=redefined-variable-type
         # redefines _object from pywbem.cim_obj.CIMClass to ...CIMInstance
         _object = parse_instance(kids(tup_tree)[1])
 
@@ -530,7 +529,6 @@ def parse_value_objectwithlocalpath(tup_tree):
                    parse_class(kids(tup_tree)[1]))
     else:
         path = parse_localinstancepath(kids(tup_tree)[0])
-        # pylint: disable=redefined-variable-type
         # redefines _object from tuple to CIMInstance
         _object = parse_instance(kids(tup_tree)[1])
         _object.path = path
@@ -557,7 +555,6 @@ def parse_value_objectwithpath(tup_tree):
         _object = (parse_classpath(k[0]), parse_class(k[1]))
     else:
         path = parse_instancepath(k[0])
-        # pylint: disable=redefined-variable-type
         # redefines _object from tuple to CIMInstance
         _object = parse_instance(k[1])
         _object.path = path
@@ -1349,14 +1346,15 @@ def parse_message(tup_tree):
 
 
 def parse_multireq(tup_tree):   # pylint: disable=unused-argument
-    """Not Implemented"""
-    # TODO: Implement MULTIREQ parser
+    """Not Implemented. Because this request is generally not implemented
+       by platforms, It will probably never be implemented
+    """
     raise ParseError('MULTIREQ parser not implemented')
 
 
 def parse_multiexpreq(tup_tree):   # pylint: disable=unused-argument
-    """Not Implemented"""
-    # TODO: Implement MULTIEXPREQ parser
+    """Not Implemented. Because this request is generally not implemented
+       by platforms, It will probably never be implemented"""
     raise ParseError('MULTIEXPREQ parser not implemented')
 
 
@@ -1535,14 +1533,15 @@ def parse_expparamvalue(tup_tree):
 
 
 def parse_multirsp(tup_tree):   # pylint: disable=unused-argument
-    """This Function not implemented"""
-    # TODO: Implement MULTIRSP parser
+    """This function not implemented. Because this request is generally not
+       implemented. It will probably never be implemented"""
     raise ParseError('MULTIRSP parser not implemented')
 
 
 def parse_multiexprsp(tup_tree):   # pylint: disable=unused-argument
-    """This Function not implemented"""
-    # TODO: Implement MULTIEXPRSP parser
+    """This function not implemented. Because this request is generally not
+       implemented. It will probably never be implemented
+    """
     raise ParseError('MULTIEXPRSP parser not implemented')
 
 
@@ -1562,8 +1561,10 @@ def parse_simplersp(tup_tree):
 
 
 def parse_simpleexprsp(tup_tree):   # pylint: disable=unused-argument
-    """This Function not implemented"""
-    # TODO: Implement SIMPLEEXPRSP parser
+    """This Function not implemented. This response is for export senders
+       (indication senders) so it is not implemented in the pywbem
+       client.
+    """
     raise ParseError('SIMPLEEXPRSP parser not implemented')
 
 
@@ -1586,8 +1587,7 @@ def parse_methodresponse(tup_tree):
 
 
 def parse_expmethodresponse(tup_tree):  # pylint: disable=unused-argument
-    """This function not implemented"""
-    # TODO: Implement EXPMETHODRESPONSE parser
+    """This function not implemented. """
     raise ParseError('EXPMETHODRESPONSE parser not implemented')
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if sys.version_info[0:2] == (2, 6):
 if sys.version_info[0] == 2:
     from xmlrpclib import Fault
 else:
-    from xmlrpc.client import Fault
+    from xmlrpc.client import Fault  # pylint: disable=import-error
 
 _VERBOSE = True
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -108,8 +108,6 @@ class ClientTest(unittest.TestCase):
     # pylint: disable=arguments-differ
     def setUp(self, use_pull_operations=None):
         """Create a connection."""
-        # pylint: disable=global-variable-not-assigned
-        global CLI_ARGS
 
         self.system_url = CLI_ARGS['url']
         self.namespace = CLI_ARGS['namespace']

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -236,7 +236,8 @@ class Callback(object):
         raise socket.error(32, "Broken pipe.")
 
     @staticmethod
-    def socket_timeout(request, uri, headers):  # pylint: disable=unused-argument # noqa: E501
+    def socket_timeout(request, uri, headers):
+        # pylint: disable=unused-argument
         """HTTPretty callback function that raises socket.timeout error.
            The socket.timeout is just a string, no status.
         """
@@ -779,7 +780,6 @@ class ClientTest(unittest.TestCase):
                     NocaseDict(exp_result_obj[1])
                 )
             else:
-                # pylint: disable=redefined-variable-type
                 _exp_result_obj = exp_result_obj
 
             # If result items are tuple, convert to lists. This is for
@@ -793,7 +793,6 @@ class ClientTest(unittest.TestCase):
                     else:
                         _result.append(item)
             else:
-                # pylint: disable=redefined-variable-type
                 _result = result
 
             if _result != _exp_result_obj:

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -195,7 +195,6 @@ def test_cimerror_2(status_tuple):  # pylint: disable=redefined-outer-name
     status_code_name = status_tuple[1]
 
     invalid_code_name = 'Invalid status code %s' % status_code
-    _invalid_code_desc = 'Invalid status code %s' % status_code  # noqa: F841
 
     input_desc = 'foo'
 

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -344,6 +344,8 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.file, _file)
             self.assertEqual(pe.lineno, 16)
+            # pylint: disable=unsubscriptable-object
+            # This may be a pylint issue
             self.assertEqual(pe.context[5][1:5], '^^^^')
             self.assertEqual(pe.context[4][1:5], 'size')
 
@@ -357,6 +359,7 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.file, _file)
             self.assertEqual(pe.lineno, 6)
+            # pylint: disable=unsubscriptable-object
             self.assertEqual(pe.context[5][7:13], '^^^^^^')
             self.assertEqual(pe.context[4][7:13], 'weight')
 
@@ -371,6 +374,7 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.file, _file)
             self.assertEqual(pe.lineno, 24)
+            # pylint: disable=unsubscriptable-object
             self.assertEqual(pe.context[5][53], '^')
             self.assertEqual(pe.context[4][53], '}')
 

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -185,8 +185,8 @@ class ToYaml(ClientRecorderTests):
         self.assertEqual(dti['type'], 'datetime')
         self.assertEqual(dti['value'], '00000010000049.000020:000')
 
-        # TODO reference properties
-        # TODO embedded object property
+        # TODO add test for reference properties
+        # TODO add test for embedded object property
 
     def test_inst_to_yaml_array_props(self):
         """Test  property with array toyaml"""
@@ -243,7 +243,7 @@ class ToYaml(ClientRecorderTests):
         test_yaml = self.test_recorder.toyaml(inst_name)
         self.assertEqual(test_yaml['pywbem_object'], 'CIMInstanceName')
         self.assertEqual(test_yaml['classname'], 'CIM_Foo')
-        # TODO host does not appear in output yaml
+        # TODO host does not appear in output yaml. Is that correct???
         # ##self.assertEqual[test_yaml['host'], 'woot.com']
         kbs = test_yaml['keybindings']
         self.assertEqual(len(kbs), 1)
@@ -286,7 +286,7 @@ class LogOperationStageTests(ClientRecorderTests):
         # TODO the following fails because of issues with timedelta
         # params = [('Date2', timedelta(60))]
         params = [('StringParam', 'Spotty')]
-        # TODO fix the error we have masked above
+
         self.test_recorder.stage_pywbem_args(method='InvokeMethod',
                                              MethodName='Blah',
                                              ObjectName=obj_name,
@@ -493,6 +493,7 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
                                     log_filename=TEST_OUTPUT_LOG,
                                     log_detail_level=log_detail_level)
 
+        # pylint: disable=attribute-defined-outside-init
         self.test_recorder = _LogOperationRecorder(max_log_entry_size)
 
         # Set a conn id into the connection. Saves testing the connection

--- a/testsuite/test_statistics.py
+++ b/testsuite/test_statistics.py
@@ -379,7 +379,9 @@ class StatisticsOutputTests(unittest.TestCase, RegexpMixin):
         stat_repr = repr(statistics)
 
         # test repr output
-        self.assertRegexpMatches(stat_repr, 'Statistics\(')
+        self.assertRegexpMatches(
+            stat_repr,
+            'Statistics\(')  # pylint: disable=anomalous-backslash-in-string
 
         self.assertRegexpContains(
             stat_repr,

--- a/testsuite/unittest_extensions.py
+++ b/testsuite/unittest_extensions.py
@@ -17,7 +17,8 @@ class RegexpMixin(object):
     """Mixin class for classes derived from unittest.TestCase, providing
     assertion functions for regular expression tests."""
 
-    def assertRegexpContains(self, text, pattern, msg=None):
+    @staticmethod
+    def assertRegexpContains(text, pattern, msg=None):
         """Assert that a string text *contains* a particular regular expression
         pattern.
 
@@ -34,7 +35,8 @@ class RegexpMixin(object):
                 "    text:    %r\n"
                 "    pattern: %r" % (text, pattern))
 
-    def assertRegexpMatches(self, text, pattern, msg=None):
+    @staticmethod
+    def assertRegexpMatches(text, pattern, msg=None):
         """Assert that a string text matches a particular regular expression
         pattern.
 
@@ -59,12 +61,14 @@ class FileMixin(object):
     """Mixin class for classes derived from unittest.TestCase, providing
     assertion functions for file related tests."""
 
-    def assertFileExists(self, filename):
+    @staticmethod
+    def assertFileExists(filename):
         """Test assert file exists"""
         assert os.path.exists(filename), \
             ("File does not exist but should: %s" % filename)
 
-    def assertFileNotExists(self, filename):
+    @staticmethod
+    def assertFileNotExists(filename):
         """Test assert file exists but should not"""
         assert not os.path.exists(filename), \
             ("File exists but should not: %s" % filename)


### PR DESCRIPTION
This change cleans up or hides several more minor pylint issues.  

Note that there is one change in the tests where it removes a one line test because that test appears to do nothing except cause a lint (unused variable).  See test_exceptions.py line 198

I consider this an extension of issue #808, cleaning up pylint issues.

One change was to remove several disable=redefined-variable-type comments because apparently that particular message is no longer in pylint.

Modifies some methods to staticmethod in unittest_extensions to get rid of pylint warnings.

There was one change where the pylint message is defined before and after the line of code once iwht the text and the second time with the warning code.  For some reason the first was not working and I used the code the second time because it was shorter.
