### PR TITLE
Correct WBEMConnection._get_rslt_params method and update unit tests

### DIFF
--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1945,28 +1945,25 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         rtn_objects = []
         end_of_sequence = False
         enumeration_context = None
-        valid_result = False
+        sequence = None
+        context = None
 
         for p in result:
             if p[0] == 'EndOfSequence':
-                if p[2] is None:
-                    valid_result = True
-                elif isinstance(p[2], six.string_types) and \
+                sequence = True
+                if isinstance(p[2], six.string_types) and \
                     p[2].lower() in ['true', 'false']:  # noqa: E125
-                    valid_result = True if p[2].lower() == 'true' else False
-                    end_of_sequence = valid_result
+                    end_of_sequence = True if p[2].lower() == 'true' else False
 
             elif p[0] == 'EnumerationContext':
-                if p[2] is None:
-                    valid_result = True
+                context = True
                 if isinstance(p[2], six.string_types):
                     enumeration_context = p[2]
-                    valid_result = True
 
             elif p[0] == "IRETURNVALUE":
                 rtn_objects = p[2]
 
-        if not valid_result:
+        if not sequence and not context:
             raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence "
                            "or EnumerationContext required")
 

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -157,5 +157,23 @@ class test_create_connection(unittest.TestCase):
             pass
 
 
+class Test_get_rslt_params(unittest.TestCase):
+    """Test WBEMConnection._get_rslt_params method."""
+    def test_iterability(self):
+        from pywbem import WBEMConnection
+
+        result = [
+            (u'IRETURNVALUE', {}, None),
+            (u'EnumerationContext', None, u'context----------------'),
+            (u'EndOfSequence', None, u'FALSE')
+        ]
+
+        result = WBEMConnection._get_rslt_params(result, 'namespace')
+        self.assertEqual(
+            result,
+            (None, False, (u'context----------------', 'namespace'))
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
From Andy: This PR intends to straighten out the conditions for raising CIM_ERR_INVALID_PARAMETER. Discussion is needed.

KS: Agreed.

Karl created issue # 844 to document this issue and therefore, a new pr, #845  The code changed somewhat in the new code and there is now a complete test for success/failures for this function