### PR TITLE
Fixes #833: issues with WBEMConnection iter methods

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,17 @@ Enhancements
 Bug fixes
 ^^^^^^^^^
 
+* Fixed issue in iterReferenceNames and IterAssociatiorNames where it was
+  not passing the IncludeQualifiers input parameter to the OpenReferenceNames.
+  This should not have been a significant issue since in general qualifiers
+  are not parts of instances.  Also changed code in IterQueryInstances were
+  parameters that are required by the called ExecQuery and OpenQueryInstances
+  were defined as NamedArguments where since they are required, the Name
+  component is not required.  This should not change operations except that
+  when we were mocking the methods, it returns sees the parameter as name=value
+  rather than value. See issue #833
+
+
 Build, test, quality
 ^^^^^^^^^^^^^^^^^^^^
 * Cleaned up a lot of pylint warnings, for things like missing-doc, etc. so that

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -3088,6 +3088,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                         InstanceName,
                         ResultClass=ResultClass,
                         Role=Role,
+                        IncludeQualifiers=IncludeQualifiers,
                         IncludeClassOrigin=IncludeClassOrigin,
                         PropertyList=PropertyList,
                         FilterQueryLanguage=FilterQueryLanguage,
@@ -3691,6 +3692,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                         ResultClass=ResultClass,
                         Role=Role,
                         ResultRole=ResultRole,
+                        IncludeQualifiers=IncludeQualifiers,
                         IncludeClassOrigin=IncludeClassOrigin,
                         PropertyList=PropertyList,
                         FilterQueryLanguage=FilterQueryLanguage,
@@ -3968,8 +3970,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
                 try:        # operation try block
                     pull_result = self.OpenQueryInstances(
-                        FilterQueryLanguage=FilterQueryLanguage,
-                        FilterQuery=FilterQuery,
+                        FilterQueryLanguage,
+                        FilterQuery,
                         namespace=namespace,
                         ReturnQueryResultClass=ReturnQueryResultClass,
                         OperationTimeout=OperationTimeout,
@@ -4016,9 +4018,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 raise ValueError('ExecQuery does not support '
                                  'ContinueOnError.')
 
-            _instances = self.ExecQuery(
-                QueryLanguage=FilterQueryLanguage,
-                Query=FilterQuery, **extra)
+            _instances = self.ExecQuery(FilterQuery,
+                                        FilterQueryLanguage,
+                                        namespace=namespace, **extra)
 
             rtn = IterQueryInstancesReturn(_instances)
             return rtn

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -3934,6 +3934,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             """
 
             def __init__(self, instances, query_result_class=None):
+                """Save any query_result_class and instances returned"""
                 self._query_result_class = query_result_class
                 self.instances = instances
 
@@ -3983,13 +3984,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
                     _instances = pull_result.instances
 
-                    qrc = None if ReturnQueryResultClass else \
-                        pull_result.query_result_class
+                    # get QueryResultClass from if returned with open
+                    # request.
+                    qrc = pull_result.query_result_class if \
+                        ReturnQueryResultClass else None
 
-                    while not pull_result.eos:
-                        pull_result = self.PullInstances(
-                            pull_result.context, MaxObjectCount=MaxObjectCount)
-                        _instances.extend(pull_result.instances)
+                    if not pull_result.eos:
+                        while not pull_result.eos:
+                            pull_result = self.PullInstances(
+                                pull_result.context,
+                                MaxObjectCount=MaxObjectCount)
+                            _instances.extend(pull_result.instances)
+
                     rtn = IterQueryInstancesReturn(_instances,
                                                    query_result_class=qrc)
                     pull_result = None   # clear the pull_result


### PR DESCRIPTION
1. Did not include the IncludeQualifiers parameter in two calls to the
underlying functions from the Itermethods (references and associators)

2. Used the name=value call defintion for the calls from
IterQueryInstances to ExecQuery and OpenQueryInstances.  While not
incorrect, these are required parameters so this is confusing in the
code and also means that the mock returns Name=value rather than value
for the test on method input.  I propose that we change these to remove
the Name= component.