### PR TITLE
Added fix for Appveyor display of environment.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ install:
   - choco source list
   - dir C:\
   - dir
-  - env |sort
+  - set
 
   # Remove Python 2.7 from PATH.
   # Note that YAML interprets some characters in a special way (including '!' and '#')


### PR DESCRIPTION
It recently started failing on the command "env | sort" which is a stupid copy from Linux. See for example this [Appveyor log](https://ci.appveyor.com/project/andy-maier/pywbem/build/1.0.1362/job/kdbqmjafov08t1mm).