### PR TITLE
Fixes #844: Fix issue with _get_rslt_params documented in issue #844

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -172,6 +172,10 @@ Bug fixes
   is `CIMInstanceName`, for keys that are references. Now, `TypeError` is
   raised in that case.
 
+* Fix issues in cim_operations.py where a open or pull that returned with
+  missing enumeration_context and eos would pass one of the internal tests.
+  See issue #844
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1948,8 +1948,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         rtn_objects = []
         end_of_sequence = False
         enumeration_context = None
-        end_of_sequence_found = False
-        enumeration_context_found = False
+        end_of_sequence_found = False  # flag True if found and valid value
+        enumeration_context_found = False  # flag True if ec tuple found
         for p in result:
             if p[0] == 'EndOfSequence':
                 if isinstance(p[2], six.string_types):
@@ -1962,19 +1962,19 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                        'value %s on EndOfSequence' % p[2])
 
             elif p[0] == 'EnumerationContext':
+                enumeration_context_found = True
                 if isinstance(p[2], six.string_types):
                     enumeration_context = p[2]
-                    enumeration_context_found = True
 
             elif p[0] == "IRETURNVALUE":
                 rtn_objects = p[2]
 
         if not end_of_sequence_found and not enumeration_context_found:
             raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence "
-                           "or EnumerationContext required")
+                           "or EnumerationContext required in response.")
         if not end_of_sequence and enumeration_context is None:
             raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence False"
-                           "and invalid EnumerationContext found")
+                           "and EnumerationContext Null value or missing.")
 
         # Drop enumeration_context if eos True
         # Returns tuple of enumeration context and namespace

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1950,7 +1950,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         enumeration_context = None
         end_of_sequence_found = False
         enumeration_context_found = False
-
         for p in result:
             if p[0] == 'EndOfSequence':
                 if isinstance(p[2], six.string_types):
@@ -1973,6 +1972,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         if not end_of_sequence_found and not enumeration_context_found:
             raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence "
                            "or EnumerationContext required")
+        if not end_of_sequence and enumeration_context is None:
+            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence False"
+                           "and invalid EnumerationContext found")
 
         # Drop enumeration_context if eos True
         # Returns tuple of enumeration context and namespace

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -100,7 +100,7 @@ class TestCreateConnection(object):
     Test construction of WBEMConnection and those functions that do not
     depend on actually creating a connection
     """
-    def test_connection_defaults(self):
+    def test_connection_defaults(self):  # pylint: disable=no-self-use
         """Test creation of a connection with default constructor
            parameters.
         """
@@ -111,7 +111,7 @@ class TestCreateConnection(object):
         assert conn.use_pull_operations is False
         assert conn.stats_enabled is False
 
-    def test_no_recorder(self):
+    def test_no_recorder(self):  # pylint: disable=no-self-use
         """Test creation of wbem connection with specific parameters"""
         creds = ('myname', 'mypw')
         x509 = {'cert_file': 'mycertfile.crt', 'key_file': 'mykeyfile.key'}
@@ -126,14 +126,14 @@ class TestCreateConnection(object):
         assert conn.stats_enabled is True
         assert conn.use_pull_operations is True
 
-    def test_add_operation_recorder(self):
+    def test_add_operation_recorder(self):  # pylint: disable=no-self-use
         """Test addition of an operation recorder"""
         conn = WBEMConnection('http://localhost')
         conn.add_operation_recorder(LogOperationRecorder())
         # pylint: disable=protected-access
         assert len(conn._operation_recorders) == 1
 
-    def test_add_operation_recorders(self):
+    def test_add_operation_recorders(self):  # pylint: disable=no-self-use
         """Test addition of multiple operation recorders"""
         conn = WBEMConnection('http://localhost')
         conn.add_operation_recorder(LogOperationRecorder())
@@ -142,7 +142,7 @@ class TestCreateConnection(object):
         # pylint: disable=protected-access
         assert len(conn._operation_recorders) == 2
 
-    def test_add_same_twice(self):
+    def test_add_same_twice(self):  # pylint: disable=no-self-use
         """ Test addition of same recorder twice"""
         conn = WBEMConnection('http://localhost')
         conn.add_operation_recorder(LogOperationRecorder())
@@ -157,12 +157,14 @@ class TestGetRsltParams(object):
     """Test WBEMConnection._get_rslt_params method."""
 
     @pytest.mark.parametrize(
-        'irval, ec, eos, eos_exp', [[None, u'contextblah', u'False', False],
-                                    [None, "", u'True', True],
-                                    [None, u'contextblah', u'True', True]]
+        'irval, ec, eos, eos_exp', [
+            [None, u'contextblah', u'False', False],
+            [None, "", u'True', True],
+            [None, u'contextblah', u'True', True],
+        ]
     )
-    @staticmethod
-    def test_pass(irval, ec, eos, eos_exp):
+    # pylint: disable=no-self-use
+    def test_pass(self, irval, ec, eos, eos_exp):
         """Test good combinations of EndOfSequence and EnumerationContext"""
         result = [
             (u'IRETURNVALUE', {}, irval),
@@ -176,11 +178,12 @@ class TestGetRsltParams(object):
         assert result == (None, eos_exp, ecs)
 
     @pytest.mark.parametrize(
-        'irval, ec, eos', [[None, None, None],
-                           [None, None, u'False']]
+        'irval, ec, eos', [
+            [None, None, None],
+            [None, None, u'False'],
+        ]
     )
-    @staticmethod
-    def test_fail(irval, ec, eos):
+    def test_fail(self, irval, ec, eos):  # pylint: disable=no-self-use
         """Test EndOfSequence and EnumerationContext variations that should
            cause exception."""
         result = [
@@ -195,8 +198,8 @@ class TestGetRsltParams(object):
         exc = exec_info.value
         assert exc.status_code_name == 'CIM_ERR_INVALID_PARAMETER'
 
-    @staticmethod
-    def test_missing():
+    # pylint: disable=no-self-use
+    def test_missing(self):
         """Test both Enum context and EndOfSequence completely missing"""
         result = [
             (u'IRETURNVALUE', {}, {})
@@ -207,27 +210,3 @@ class TestGetRsltParams(object):
 
         exc = exec_info.value
         assert exc.status_code_name == 'CIM_ERR_INVALID_PARAMETER'
-
-    @pytest.mark.parametrize(
-        'result_input, ec_exp, eos_exp, exec_exp', [[
-            (u'IRETURNVALUE', {}, None),
-            (u'EnumerationContext', None, 'context-blah'),
-            (u'EndOfSequence', None, False),
-            ('context-blah', 'ns'), False, None]]
-    )
-    @staticmethod
-    def test_all(result_input, ec_exp, eos_exp, exec_exp):
-        """
-        """
-        if exec_exp:
-            with pytest.raises(CIMError) as exec_info:
-                # pylint: disable=protected-access
-                result = WBEMConnection._get_rslt_params(result_input, 'ns')
-
-            exc = exec_info.value
-            assert exc.status_code_name == 'CIM_ERR_INVALID_PARAMETER'
-
-        else:
-            # pylint: disable=protected-access
-            result = WBEMConnection._get_rslt_params(result_input, 'ns')
-            assert result == (None, eos_exp, ec_exp)

--- a/testsuite/test_client.py
+++ b/testsuite/test_client.py
@@ -752,7 +752,9 @@ class ClientTest(unittest.TestCase):
         else:
             cim_status = 0
         self.assertEqual(cim_status, exp_cim_status,
-                         "WBEMConnection operation CIM status code")
+                         "Error in WBEMConnection operation CIM status code. "
+                         "Expected %s; received %s" %
+                         (exp_cim_status, cim_status))
 
         # Returns either exp_result or exp_pull_result
         if exp_result is not None:

--- a/testsuite/testclient/pullinstancepaths.yaml
+++ b/testsuite/testclient/pullinstancepaths.yaml
@@ -615,5 +615,67 @@
   pywbem_response:
         exception: TypeError
 
+- name: PullInstancePathsF5
+  description: PullInstancePaths request fails. eos and context missing
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: false
+    operation:
+      pywbem_method: PullInstancePaths
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+        cim_status: 4
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstancePaths
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstancePaths">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+
+  http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="PullInstancePaths">
+                            <IRETURNVALUE>
+                            </IRETURNVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
 
 

--- a/testsuite/testclient/pullinstancepaths.yaml
+++ b/testsuite/testclient/pullinstancepaths.yaml
@@ -20,7 +20,7 @@
                 - '50001'
                 -  root/cimv2
             eos: False
-            paths: 
+            paths:
                 -
                     pywbem_object: CIMInstanceName
                     classname: PyWBEM_Person
@@ -144,7 +144,7 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-            
+
 - name: PullInstancePaths2
   description: Pull request and returns two paths with eos=true and no context
   pywbem_request:
@@ -165,7 +165,7 @@
         pullresult:
             context: null
             eos: true
-            paths: 
+            paths:
                 -
                     pywbem_object: CIMInstanceName
                     classname: PyWBEM_Person
@@ -421,7 +421,7 @@
                             <IRETURNVALUE>
                             </IRETURNVALUE>
                             <PARAMVALUE NAME="EndOfSequence">
-                                <VALUE>TFALSE</VALUE>
+                                <VALUE>FALSE</VALUE>
                             </PARAMVALUE>
                             <PARAMVALUE NAME="EnumerationContext">
                                 <VALUE>50001</VALUE>
@@ -430,7 +430,7 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
-            
+
 - name: PullInstancePaths5
   description: Pull request and returns zero instances with eos=True and no context
   pywbem_request:


### PR DESCRIPTION
Fixes for andy's comments done.

Removed WIP status

1. Fixed the issue in the function noted in pr #813.  However we fixed
it with different code than the original pr.

2. Created a complete test for this function.

3. Converted  other tests in test_operation.py to pytest.

5. Added note to changes.rst

If we agree to this, we should also close pr #813

This code is ready for review.  I have one more test I would like to add but the complexity of the parametrize is defeating me right now.  Note that this appears to be a fairly complete test and also actually found an error in one of the test_client YAML files (had TFALSE where should have been FALSE).