### PR TITLE
Fixes #895: Fixed local authentication for OpenWBEM and OpenPegasus

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -216,6 +216,10 @@ Bug fixes
   the values were not properly converted to CIM-XML. They are now properly
   converted using `atomic_to_cim_xml()`.
 
+* Fixed local authentication for OpenWBEM and OpenPegasus. Due to one bug
+  introduced in pywbem 0.9.0, it was disabled by accident. A second bug in
+  local authentication has been there at least since pywbem 0.7.0.
+
 * Docs: Clarified that the return type of `BaseOperationRecorder.open_file()`
   is a file-like object and that the caller is responsible for closing that
   file.


### PR DESCRIPTION
For details, see commit message.
Ready for review and merge.
This change should be tested against a real environment, and local authentication should be used.
**Note:** PR #922 is on top of this PR and has changes in exception handling. The two changes can be tested together by using PR #922.