### PR TITLE
Fixes #899: Deprecated CIMInstance.property_list

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -3224,8 +3224,13 @@ class CIMProperty(_CIMComparisonMixin):
     @qualifiers.setter
     def qualifiers(self, qualifiers):
         """Setter method; for a description see the getter method."""
+        # We make sure that the dictionary is a NocaseDict object, and that the
+        # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict(qualifiers)
+        self._qualifiers = NocaseDict()
+        if qualifiers:
+            for key, value in qualifiers.items():
+                self._qualifiers[key] = _cim_qualifier(key, value)
 
     def copy(self):
         """
@@ -3760,8 +3765,13 @@ class CIMMethod(_CIMComparisonMixin):
     @qualifiers.setter
     def qualifiers(self, qualifiers):
         """Setter method; for a description see the getter method."""
+        # We make sure that the dictionary is a NocaseDict object, and that the
+        # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict(qualifiers)
+        self._qualifiers = NocaseDict()
+        if qualifiers:
+            for key, value in qualifiers.items():
+                self._qualifiers[key] = _cim_qualifier(key, value)
 
     def _cmp(self, other):
         """
@@ -4136,8 +4146,13 @@ class CIMParameter(_CIMComparisonMixin):
     @qualifiers.setter
     def qualifiers(self, qualifiers):
         """Setter method; for a description see the getter method."""
+        # We make sure that the dictionary is a NocaseDict object, and that the
+        # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict(qualifiers)
+        self._qualifiers = NocaseDict()
+        if qualifiers:
+            for key, value in qualifiers.items():
+                self._qualifiers[key] = _cim_qualifier(key, value)
 
     @property
     def value(self):
@@ -4146,17 +4161,16 @@ class CIMParameter(_CIMComparisonMixin):
         this attribute does not make any sense. Accessing it will cause a
         :term:`DeprecationWarning` to be issued.
         """
-        warnings.warn(
-            "The value attribute of CIMParameter is deprecated",
-            DeprecationWarning)
         return self._value
 
     @value.setter
     def value(self, value):
         """Setter method; for a description see the getter method."""
-        warnings.warn(
-            "The value attribute of CIMParameter is deprecated",
-            DeprecationWarning)
+        if value is not None:
+            warnings.warn(
+                "The value attribute of CIMParameter (name=%r) is deprecated" %
+                self.name,
+                DeprecationWarning)
         # pylint: disable=attribute-defined-outside-init
         self._value = cimvalue(value, self.type)
 
@@ -5861,17 +5875,20 @@ def _check_array_parms(is_array, array_size, value, element_txt):
     # _infer_is_array() ensures that, and is supposed to be called
 
     if array_size and not is_array:
-        raise ValueError("The array_size parameter of %s is not None but "
-                         "the is_array parameter is False." % element_txt)
+        raise ValueError("The array_size parameter of %s is %r but "
+                         "the is_array parameter is False." %
+                         (element_txt, array_size))
 
     if value is not None:
         value_is_array = isinstance(value, (list, tuple))
         if not is_array and value_is_array:
             raise ValueError("The is_array parameter of %s is False but "
-                             "the value is an array." % element_txt)
+                             "value %r is an array." %
+                             (element_txt, value))
         if is_array and not value_is_array:
             raise ValueError("The is_array parameter of %s is True but "
-                             "the value is not an array." % element_txt)
+                             "value %r is not an array." %
+                             (element_txt, value))
 
 
 def _infer_embedded_object(value):

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1535,6 +1535,10 @@ class CIMInstance(_CIMComparisonMixin):
             same-named attribute in the ``CIMInstance`` object will also be
             `None`.
 
+            **Deprecated:** This parameter has been deprecated in pywbem
+            0.12.0. Set only the desired properties on the object, instead of
+            working with this property filter.
+
         Raises:
 
           ValueError: classname is `None`, a property or qualifier name is
@@ -1702,6 +1706,10 @@ class CIMInstance(_CIMComparisonMixin):
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
+
+        **Deprecated:** This attribute has been deprecated in pywbem v0.12.0.
+        Set only the desired properties on the object, instead of working with
+        this property filter.
         """
         return self._property_list
 
@@ -1709,6 +1717,9 @@ class CIMInstance(_CIMComparisonMixin):
     def property_list(self, property_list):
         """Setter method; for a description see the getter method."""
         if property_list is not None:
+            warnings.warn("The 'property_list' init parameter and attribute "
+                          "of CIMInstance is deprecated; Set only the desired "
+                          "properties instead.", DeprecationWarning)
             property_list = [_ensure_unicode(x).lower()
                              for x in property_list]
         # pylint: disable=attribute-defined-outside-init
@@ -1766,9 +1777,14 @@ class CIMInstance(_CIMComparisonMixin):
 
     def __setitem__(self, key, value):
 
-        # Ignore properties that are excluded via property list, except
-        # if they are used in the instance path.
-        # TODO: Clarify why we ignore such properties.
+        # The property_list attribute has been deprecated in pywbem 0.12.0.
+        # It is used to ignore the setting of properties under certain
+        # conditions. Note that the purpose of these conditions is unclear,
+        # given the code below (whose logic is unchanged since at least as far
+        # back as pywbem 0.7.0): For instances that do not have a path set,
+        # the property_list is effectively disabled. Nevertheless, the logic
+        # has been kept in place because the property_list feature may be
+        # removed anyway in a future release of pywbem.
         if self.property_list is not None and \
                 key.lower() not in self.property_list and \
                 self.path is not None and \


### PR DESCRIPTION
**Note:** This PR is on top of PR #886.

Ready for review and merge, except that issue #899 still contains a discussion point.
For details, see the commit message.
This PR has become somewhat larger than intended, plus it caused some Todos to be added that I'd like to leave in for now, and resolve later (because they drive some more changes like converting test cases from unittest2 to pytest, or adding expected warnings to testcase definitions).