### PR TITLE
Issue #915: Travis build issue with missing tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # Control file for Travis CI (http://travis-ci.org)
 # Must be located in the root directory of the Git repository.
 
+# Make a full clone in order to always get the tags (important for pbr)
+git:
+  depth: false
+
 # By default, notification emails are sent to the PR creator and commiter.
 notifications:
   email: false
@@ -114,6 +118,7 @@ before_install:
   - if [[ -n $_NEED_REBASE ]]; then git branch master FETCH_HEAD; fi
   - if [[ -n $_NEED_REBASE ]]; then git rebase master; fi
   - git branch -av
+  - git tag
 
 # commands to install dependencies
 install:

--- a/makefile
+++ b/makefile
@@ -244,7 +244,7 @@ ifeq ($(PYTHON_ARCH),64)
 	$(PIP_CMD) install $(pip_level_opts) -r win64-requirements.txt
 endif
 	$(PIP_CMD) install $(pip_level_opts) -e .
-	$(PYTHON_CMD) -c "import $(package_name); print('ok')"
+	$(PYTHON_CMD) -c "import $(package_name); print('ok, version=%r'%$(package_name).__version__)"
 	@echo "makefile: Done installing Python installation and runtime requirements"
 	@echo "makefile: Target $@ done."
 


### PR DESCRIPTION
This PR fixes a recent Travis build issue. See #915 for details and options how to resolve.
This PR changes the Travis customization to perform a full repo clone, which also clones the repo tags.
Ready for merge, if the PR succeeds.