### PR TITLE
Fixes #936, association class with alias breaks mof_compiler

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -236,6 +236,10 @@ Bug fixes
   the return value of CIM methods, by raising `ValueError` if
   `CIMMethod.return_value` is initialized or set to "reference".
 
+* Fixed issue introduced in mof_compiler when atomic_to_cimxml was cleaned up
+  that did not allow using alias with some association classes.  Also
+  added test for this issue. See issue #936
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -84,7 +84,6 @@ from .cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, _statuscode2string
 from .exceptions import Error, CIMError
-from .cim_types import atomic_to_cim_xml
 
 __all__ = ['MOFParseError', 'MOFWBEMConnection', 'MOFCompiler',
            'BaseRepositoryConnection']
@@ -1633,7 +1632,7 @@ def p_instanceDeclaration(p):
             inst.properties[pname] = pprop
             # if alias and this is key property, add keybinding
             if alias and 'key' in cprop.qualifiers:
-                keybindings[pname] = atomic_to_cim_xml(pprop.value)
+                keybindings[pname] = pprop.value
 
         except ValueError as ve:
             ce = CIMError(CIM_ERR_INVALID_PARAMETER,


### PR DESCRIPTION
Changed compiler to let CIMinstanceName stringify keybinding values.

Added test for compile of association instances with reference property
keys which is what was broken.