### PR TITLE
Added 'ordereddict' package to reqs for py26 again

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -53,6 +53,8 @@ M2Crypto===0.24.0
 M2CryptoWin32===0.21.1.post3
 M2CryptoWin64===0.21.1.post3
 
+ordereddict===1.1
+
 # Indirect dependencies for runtime (must be consistent with requirements.txt)
 # None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ ply>=3.10
 PyYAML>=3.12  # yaml package
 M2Crypto>=0.24.0,!=0.27.0; (python_version == '2.6' or python_version == '2.7') and sys_platform != 'win32'
 # M2CryptoWin32/64 are specified in win32/64-requirements.txt
+ordereddict>=1.1; python_version == '2.6'


### PR DESCRIPTION
Ready for review and merge.
For details, see the commit message.

Because this fixes an error that happened during the transition to pbr and requirements files, which is not yet released, a change log entry is not needed.