### PR TITLE
Fixes #941: (1) Preserved order when iterating child elements of CIM objects

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -78,6 +78,242 @@ This documentation uses a few special terms to refer to Python types:
    CIM object
       one of the types listed in :ref:`CIM objects`.
 
+   keybindings input object
+      a Python object used as input for initializing an ordered list of
+      keybindings in a parent object (i.e. a :class:`~pywbem.CIMInstanceName`
+      object).
+
+      `None` will result in an an empty list of keybindings.
+
+      Otherwise, the type of the input object must be one of:
+
+      * iterable of :class:`~pywbem.CIMProperty`
+      * iterable of tuple(key, value)
+      * :class:`~py:collections.OrderedDict` with key and value
+      * :class:`py:dict` with key and value (will not preserve order)
+
+      with the following definitions for key and value:
+
+      * key (:term:`string`):
+        Keybinding name.
+
+        Must not be `None`.
+
+        The lexical case of the string is preserved. Object comparison
+        and hash value calculation are performed case-insensitively.
+
+      * value (:term:`CIM data type` or :term:`number` or :class:`~pywbem.CIMProperty`):
+        Keybinding value.
+
+        If specified as :term:`CIM data type` or :term:`number`, the provided
+        object will be stored unchanged as the keybinding value.
+
+        If specified as a :class:`~pywbem.CIMProperty` object, its `name`
+        attribute must match the key (case insensitively), and a copy of its
+        value (a :term:`CIM data type`) will be stored as the keybinding value.
+
+        `None` for the keybinding value will be stored unchanged.
+
+      The order of keybindings in the parent object is preserved if the input
+      object is an iterable or a :class:`~py:collections.OrderedDict` object,
+      but not when it is a :class:`py:dict` object.
+
+      The resulting set of keybindings in the parent object is independent of
+      the input object (except for unmutable objects), so that subsequent
+      modifications of the input object by the caller do not affect the parent
+      object.
+
+   methods input object
+      a Python object used as input for initializing an ordered list of
+      methods represented as :class:`~pywbem.CIMMethod` objects in a parent
+      object that is a :class:`~pywbem.CIMClass`.
+
+      `None` will result in an an empty list of methods.
+
+      Otherwise, the type of the input object must be one of:
+
+      * iterable of :class:`~pywbem.CIMMethod`
+      * iterable of tuple(key, value)
+      * :class:`~py:collections.OrderedDict` with key and value
+      * :class:`py:dict` with key and value (will not preserve order)
+
+      with the following definitions for key and value:
+
+      * key (:term:`string`):
+        Method name.
+
+        Must not be `None`.
+
+        The lexical case of the string is preserved. Object comparison
+        and hash value calculation are performed case-insensitively.
+
+      * value (:class:`~pywbem.CIMMethod`):
+        Method declaration.
+
+        Must not be `None`.
+
+        The `name` attribute of the :class:`~pywbem.CIMMethod` object must
+        match the key (case insensitively).
+
+        The provided object is stored in the parent object without making a
+        copy of it.
+
+      The order of methods in the parent object is preserved if the input
+      object is an iterable or a :class:`~py:collections.OrderedDict` object,
+      but not when it is a :class:`py:dict` object.
+
+      The resulting set of methods in the parent object is independent of the
+      input collection object, but consists of the same
+      :class:`~pywbem.CIMMethod` objects that were provided in the input
+      collection. Therefore, a caller must be careful to not accidentally
+      modify the provided :class:`~pywbem.CIMMethod` objects.
+
+   parameters input object
+      a Python object used as input for initializing an ordered list of
+      parameters represented as :class:`~pywbem.CIMParameter` objects in a
+      parent object that is a :class:`~pywbem.CIMMethod`.
+
+      `None` will result in an an empty list of parameters.
+
+      Otherwise, the type of the input object must be one of:
+
+      * iterable of :class:`~pywbem.CIMParameter`
+      * iterable of tuple(key, value)
+      * :class:`~py:collections.OrderedDict` with key and value
+      * :class:`py:dict` with key and value (will not preserve order)
+
+      with the following definitions for key and value:
+
+      * key (:term:`string`):
+        Parameter name.
+
+        Must not be `None`.
+
+        The lexical case of the string is preserved. Object comparison
+        and hash value calculation are performed case-insensitively.
+
+      * value (:class:`~pywbem.CIMParameter`):
+        Parameter (declaration).
+
+        Must not be `None`.
+
+        The `name` attribute of the :class:`~pywbem.CIMParameter` object must
+        match the key (case insensitively).
+
+        The provided object is stored in the parent object without making a
+        copy of it.
+
+      The order of parameters in the parent object is preserved if the input
+      object is an iterable or a :class:`~py:collections.OrderedDict` object,
+      but not when it is a :class:`py:dict` object.
+
+      The resulting set of parameters in the parent object is independent of
+      the input collection object, but consists of the same
+      :class:`~pywbem.CIMParameter` objects that were provided in the input
+      collection. Therefore, a caller must be careful to not accidentally
+      modify the provided :class:`~pywbem.CIMParameter` objects.
+
+   properties input object
+      a Python object used as input for initializing an ordered list of
+      properties represented as :class:`~pywbem.CIMProperty` objects, in a
+      parent object.
+
+      The :class:`~pywbem.CIMProperty` objects represent property values when
+      the parent object is a :class:`~pywbem.CIMInstance`, and property
+      declarations when the parent object is a :class:`~pywbem.CIMClass`.
+
+      `None` will result in an an empty list of properties.
+
+      Otherwise, the type of the input object must be one of:
+
+      * iterable of :class:`~pywbem.CIMProperty`
+      * iterable of tuple(key, value)
+      * :class:`~py:collections.OrderedDict` with key and value
+      * :class:`py:dict` with key and value (will not preserve order)
+
+      with the following definitions for key and value:
+
+      * key (:term:`string`):
+        Property name.
+
+        Must not be `None`.
+
+        The lexical case of the string is preserved. Object comparison
+        and hash value calculation are performed case-insensitively.
+
+      * value (:term:`CIM data type` or :class:`~pywbem.CIMProperty`):
+        Property (value or declaration).
+
+        Must not be `None`.
+
+        :class:`~pywbem.CIMProperty` objects can be used as input for both
+        property values and property declarations. :term:`CIM data type`
+        objects can only be used for property values.
+
+        If specified as a :term:`CIM data type`, a new
+        :class:`~pywbem.CIMProperty` object will be created from the provided
+        value, inferring its CIM data type from the provided value.
+
+        If specified as a :class:`~pywbem.CIMProperty` object, its `name`
+        attribute must match the key (case insensitively), and the provided
+        object is stored in the parent object without making a copy of it.
+
+      The order of properties in the parent object is preserved if the input
+      object is an iterable or a :class:`~py:collections.OrderedDict` object,
+      but not when it is a :class:`py:dict` object.
+
+      The resulting set of properties in the parent object is independent of
+      the input collection object, but consists of the same
+      :class:`~pywbem.CIMProperty` objects that were provided in the input
+      collection. Therefore, a caller must be careful to not accidentally
+      modify the provided :class:`~pywbem.CIMProperty` objects.
+
+   qualifiers input object
+      a Python object used as input for initializing an ordered list of
+      qualifiers represented as :class:`~pywbem.CIMQualifier` objects in a
+      parent object (e.g. in a :class:`~pywbem.CIMClass` object).
+
+      `None` will result in an an empty list of qualifiers.
+
+      Otherwise, the type of the input object must be one of:
+
+      * iterable of :class:`~pywbem.CIMQualifier`
+      * iterable of tuple(key, value)
+      * :class:`~py:collections.OrderedDict` with key and value
+      * :class:`py:dict` with key and value (will not preserve order)
+
+      with the following definitions for key and value:
+
+      * key (:term:`string`):
+        Qualifier name.
+
+        Must not be `None`.
+
+        The lexical case of the string is preserved. Object comparison
+        and hash value calculation are performed case-insensitively.
+
+      * value (:term:`CIM data type` or :class:`~pywbem.CIMQualifier`):
+        Qualifier (value).
+
+        Must not be `None`.
+
+        If specified as a :term:`CIM data type`, a new
+        :class:`~pywbem.CIMQualifier` object will be created from the provided
+        value, inferring its CIM data type from the provided value.
+
+        If specified as a :class:`~pywbem.CIMQualifier` object, its `name`
+        attribute must match the key (case insensitively), and the provided
+        object is stored in the parent object without making a copy of it.
+
+      The order of qualifiers in the parent object is preserved if the input
+      object is an iterable or a :class:`~py:collections.OrderedDict` object,
+      but not when it is a :class:`py:dict` object.
+
+      The resulting set of qualifiers in the parent object is independent of
+      the input collection object, but consists of the same
+      :class:`~pywbem.CIMQualifier` objects that were provided in the input
+      collection. Therefore, a caller must be careful to not accidentally
+      modify the provided :class:`~pywbem.CIMQualifier` objects.
 
 .. _`Troubleshooting`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -221,6 +221,21 @@ Enhancements
 * Docs: Improved the descriptions of CIM objects and their attributes to
   describe how the attributes are used to determine object equality and
   the hash value of the object.
+ 
+* The child elements of CIM objects (e.g. properties of `CIMClass`) now
+  preserve the order in which they had been added to their parent object.
+  Methods such as `tomof()`, `tocimxml()`, and `to_wbem_uri()` now
+  output the child elements of the target object in the preserved order.
+  If a child element is initialized with an object that does not preserve
+  order of items (e.g. a standard dict), a UserWarning is now issued.
+
+* Added a new kind of input object for initializing CIM objects: An iterable
+  of the desired CIM object type, and documented the already supported iterable
+  of tuple(key, value) as a further input type.
+
+* Improved checking of input objects when initializing a list of child
+  elements in a CIM object(e.g.  properties of `CIMClass`), and raise
+  TypeError if not supported.
 
 * Docs: Editorial improvements in the documentation (links, typos, formatting).
 
@@ -289,6 +304,14 @@ Bug fixes
   and consistent with the other iteration mechanisms for CIM objects.
   The test cases that were supposed to verify that did not perform the
   correct check and were also fixed.
+
+* Docs: Fixed the documentation of the CIMInstanceName.keybindings setter
+  method, by adding 'number' as an allowed input type.
+
+* Docs: Moved the detail documentation of input to child element lists (e.g.
+  for properties of `CIMInstance`) as a data type 'properties input object',
+  etc., into the glossary. These types are now referenced as the type of
+  the corresponding parameter.
 
 * Docs: Clarified that the return type of `BaseOperationRecorder.open_file()`
   is a file-like object and that the caller is responsible for closing that

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -437,8 +437,10 @@ class NocaseDict(object):
             if isinstance(arg, (list, tuple)):
                 # Initialize from iterable of: tuple(key,value), or object
                 try:
+                    # This is used for iterables:
                     iterator = arg.items()
                 except AttributeError:
+                    # This is used for dictionaries:
                     iterator = arg
                 for item in iterator:
                     try:
@@ -1753,8 +1755,10 @@ class CIMInstanceName(_CIMComparisonMixin):
         self._keybindings = NocaseDict()
         if keybindings:
             try:
+                # This is used for iterables:
                 iterator = keybindings.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = keybindings
             for item in iterator:
                 if isinstance(item, CIMProperty):
@@ -2644,8 +2648,10 @@ class CIMInstance(_CIMComparisonMixin):
         self._properties = NocaseDict()
         if properties:
             try:
+                # This is used for iterables:
                 iterator = properties.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = properties
             for item in iterator:
                 if isinstance(item, CIMProperty):
@@ -2695,8 +2701,10 @@ class CIMInstance(_CIMComparisonMixin):
         self._qualifiers = NocaseDict()
         if qualifiers:
             try:
+                # This is used for iterables:
                 iterator = qualifiers.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = qualifiers
             for item in iterator:
                 if isinstance(item, CIMQualifier):
@@ -3732,8 +3740,10 @@ class CIMClass(_CIMComparisonMixin):
         self._properties = NocaseDict()
         if properties:
             try:
+                # This is used for iterables:
                 iterator = properties.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = properties
             for item in iterator:
                 if isinstance(item, CIMProperty):
@@ -3788,8 +3798,10 @@ class CIMClass(_CIMComparisonMixin):
         self._methods = NocaseDict()
         if methods:
             try:
+                # This is used for iterables:
                 iterator = methods.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = methods
             for item in iterator:
                 if isinstance(item, CIMMethod):
@@ -3845,8 +3857,10 @@ class CIMClass(_CIMComparisonMixin):
         self._qualifiers = NocaseDict()
         if qualifiers:
             try:
+                # This is used for iterables:
                 iterator = qualifiers.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = qualifiers
             for item in iterator:
                 if isinstance(item, CIMQualifier):
@@ -4566,8 +4580,10 @@ class CIMProperty(_CIMComparisonMixin):
         self._qualifiers = NocaseDict()
         if qualifiers:
             try:
+                # This is used for iterables:
                 iterator = qualifiers.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = qualifiers
             for item in iterator:
                 if isinstance(item, CIMQualifier):
@@ -5117,8 +5133,10 @@ class CIMMethod(_CIMComparisonMixin):
         self._parameters = NocaseDict()
         if parameters:
             try:
+                # This is used for iterables:
                 iterator = parameters.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = parameters
             for item in iterator:
                 if isinstance(item, CIMParameter):
@@ -5174,8 +5192,10 @@ class CIMMethod(_CIMComparisonMixin):
         self._qualifiers = NocaseDict()
         if qualifiers:
             try:
+                # This is used for iterables:
                 iterator = qualifiers.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = qualifiers
             for item in iterator:
                 if isinstance(item, CIMQualifier):
@@ -5609,8 +5629,10 @@ class CIMParameter(_CIMComparisonMixin):
         self._qualifiers = NocaseDict()
         if qualifiers:
             try:
+                # This is used for iterables:
                 iterator = qualifiers.items()
             except AttributeError:
+                # This is used for dictionaries:
                 iterator = qualifiers
             for item in iterator:
                 if isinstance(item, CIMQualifier):

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -71,6 +71,10 @@ import sys
 import os
 import re
 from abc import ABCMeta, abstractmethod
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 import six
 from ply import yacc, lex
@@ -776,9 +780,9 @@ def p_classDeclaration(p):
             else:  # superclass
                 superclass = p[4]
                 cfl = p[6]
-    quals = dict([(x.name, x) for x in quals])
-    methods = {}
-    props = {}
+    quals = OrderedDict([(x.name, x) for x in quals])
+    methods = OrderedDict()
+    props = OrderedDict()
     for item in cfl:
         item.class_origin = cname
         if isinstance(item, CIMMethod):
@@ -842,15 +846,15 @@ def _assoc_or_indic_decl(quals, p):
     else:
         superclass = p[7]
         cfl = p[9]
-    props = {}
-    methods = {}
+    props = OrderedDict()
+    methods = OrderedDict()
     for item in cfl:
         item.class_origin = cname
         if isinstance(item, CIMMethod):
             methods[item.name] = item
         else:
             props[item.name] = item
-    quals = dict([(x.name, x) for x in quals])
+    quals = OrderedDict([(x.name, x) for x in quals])
     cc = CIMClass(cname, properties=props, methods=methods,
                   superclass=superclass, qualifiers=quals)
     if alias:
@@ -1046,21 +1050,21 @@ def p_propertyDeclaration_4(p):
 
 def p_propertyDeclaration_5(p):
     """propertyDeclaration_5 : qualifierList dataType propertyName ';'"""
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], None, type=p[2], qualifiers=quals)
 
 
 def p_propertyDeclaration_6(p):
     # pylint: disable=line-too-long
     """propertyDeclaration_6 : qualifierList dataType propertyName defaultValue ';'"""  # noqa: E501
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], tocimobj(p[2], p[4]),
                        type=p[2], qualifiers=quals)
 
 
 def p_propertyDeclaration_7(p):
     """propertyDeclaration_7 : qualifierList dataType propertyName array ';'"""
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], None, type=p[2], qualifiers=quals,
                        is_array=True, array_size=p[4])
 
@@ -1068,7 +1072,7 @@ def p_propertyDeclaration_7(p):
 def p_propertyDeclaration_8(p):
     # pylint: disable=line-too-long
     """propertyDeclaration_8 : qualifierList dataType propertyName array defaultValue ';'"""  # noqa: E501
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMProperty(p[3], tocimobj(p[2], p[5]),
                        type=p[2], qualifiers=quals, is_array=True,
                        array_size=p[4])
@@ -1094,7 +1098,7 @@ def p_referenceDeclaration(p):
         pname = p[2]
         if len(p) == 5:
             dv = p[3]
-    quals = dict([(x.name, x) for x in quals])
+    quals = OrderedDict([(x.name, x) for x in quals])
     p[0] = CIMProperty(pname, dv, type='reference',
                        reference_class=cname, qualifiers=quals)
 
@@ -1119,8 +1123,8 @@ def p_methodDeclaration(p):
         mname = p[3]
         if p[5] != ')':
             paramlist = p[5]
-    params = dict([(param.name, param) for param in paramlist])
-    quals = dict([(q.name, q) for q in quals])
+    params = OrderedDict([(param.name, param) for param in paramlist])
+    quals = OrderedDict([(q.name, q) for q in quals])
     p[0] = CIMMethod(mname, return_type=dt, parameters=params,
                      qualifiers=quals)
 
@@ -1207,7 +1211,7 @@ def p_parameter_2(p):
     if len(p) == 5:
         args['is_array'] = True
         args['array_size'] = p[4]
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMParameter(p[3], p[2], qualifiers=quals, **args)
 
 
@@ -1230,7 +1234,7 @@ def p_parameter_4(p):
     if len(p) == 5:
         args['is_array'] = True
         args['array_size'] = p[4]
-    quals = dict([(x.name, x) for x in p[1]])
+    quals = OrderedDict([(x.name, x) for x in p[1]])
     p[0] = CIMParameter(p[3], 'reference', qualifiers=quals,
                         reference_class=p[2], **args)
 

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -4154,8 +4154,8 @@ class PegasusTestEmbeddedInstance(PegasusServerTestBase, RegexpMixin):
                 self.assertRegexpMatches(
                     str_mof, r"instance of Test_CLITestEmbeddedClass {")
                 self.assertRegexpContains(
-                    str_mof,
-                    r"embeddedInst = \"instance of Test_CLITestEmbedded1 {")
+                    str_mof.replace('\n', ' '),
+                    r"embeddedInst = +\"instance of Test_CLITestEmbedded1 {")
 
                 # get the embedded instance property
                 prop = inst.properties[prop_name]

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -11,6 +11,11 @@ import os
 import unittest
 import six
 from ply import lex
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 from pywbem.cim_operations import CIMError
 from pywbem.mof_compiler import MOFCompiler, MOFWBEMConnection, MOFParseError
 from pywbem.cim_constants import CIM_ERR_FAILED, CIM_ERR_INVALID_PARAMETER, \
@@ -726,10 +731,16 @@ def _build_scope(set_true=None):
         for tests. Required because the compiler supplies all
         values in the scope list whether true or false
     """
-    dict_ = {'CLASS': False, 'ANY': False, 'ASSOCIATION': False,
-             'INDICATION': False, 'METHOD': False,
-             'PARAMETER': False, 'PROPERTY': False,
-             'REFERENCE': False}
+    dict_ = OrderedDict([
+        ('CLASS', False),
+        ('ANY', False),
+        ('ASSOCIATION', False),
+        ('INDICATION', False),
+        ('METHOD', False),
+        ('PARAMETER', False),
+        ('PROPERTY', False),
+        ('REFERENCE', False),
+    ])
     for n in set_true:
         dict_[n] = True
     return dict_

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -116,9 +116,18 @@ class BaseTest(unittest.TestCase):
     """
     def setUp(self):
         """unittest setUp creates NoCaseDict"""
+
         self.dic = NocaseDict()
         self.dic['Dog'] = 'Cat'
         self.dic['Budgie'] = 'Fish'
+
+        self.order_tuples = (
+            ('Dog', 'Cat'),
+            ('Budgie', 'Fish'),
+            ('Ham', 'Jam'),
+            ('Sofi', 'Blue'),
+            ('Gabi', 'Red'),
+        )
 
 
 class TestGetitem(BaseTest):
@@ -673,6 +682,7 @@ class TestContains(BaseTest):
 
 class TestForLoop(BaseTest):
     """Class for test for loop with dictionary"""
+
     def test_all(self):
         """Test method for TestForLoop"""
         keys = set()
@@ -680,15 +690,40 @@ class TestForLoop(BaseTest):
             keys.add(key)
         self.assertEqual(keys, set(['Budgie', 'Dog']))
 
+    def test_order_preservation(self):
+        """Test order preservation of for loop on dict"""
+        dic = NocaseDict()
+        for key, value in self.order_tuples:
+            dic[key] = value
+        i = 0
+        for key in dic:
+            item = (key, dic[key])
+            exp_item = self.order_tuples[i]
+            self.assertEqual(item, exp_item)
+            i += 1
+
 
 class TestIterkeys(BaseTest):
     """Class for iterkeys test"""
+
     def test_all(self):
         """iterkeys test method"""
         keys = set()
         for key in self.dic.iterkeys():
             keys.add(key)
         self.assertEqual(keys, set(['Budgie', 'Dog']))
+
+    def test_order_preservation(self):
+        """Test order preservation of iterkeys()"""
+        dic = NocaseDict()
+        for key, value in self.order_tuples:
+            dic[key] = value
+        i = 0
+        for key in dic.iterkeys():
+            item = (key, dic[key])
+            exp_item = self.order_tuples[i]
+            self.assertEqual(item, exp_item)
+            i += 1
 
 
 class TestItervalues(BaseTest):
@@ -700,9 +735,21 @@ class TestItervalues(BaseTest):
             vals.add(val)
         self.assertEqual(vals, set(['Cat', 'Fish']))
 
+    def test_order_preservation(self):
+        """Test order preservation of itervalues()"""
+        dic = NocaseDict()
+        for key, value in self.order_tuples:
+            dic[key] = value
+        i = 0
+        for value in dic.itervalues():
+            exp_value = self.order_tuples[i][1]
+            self.assertEqual(value, exp_value)
+            i += 1
+
 
 class TestIteritems(BaseTest):
     """Class to test iteritems for dict"""
+
     def test_all(self):
         """Method for test iteritems for dict"""
         items = set()
@@ -710,22 +757,34 @@ class TestIteritems(BaseTest):
             items.add(item)
         self.assertEqual(items, set([('Budgie', 'Fish'), ('Dog', 'Cat')]))
 
+    def test_order_preservation(self):
+        """Test order preservation of iteritems()"""
+        dic = NocaseDict()
+        for key, value in self.order_tuples:
+            dic[key] = value
+        i = 0
+        for item in dic.iteritems():
+            exp_item = self.order_tuples[i]
+            self.assertEqual(item, exp_item)
+            i += 1
+
 
 class TestRepr(unittest.TestCase):
     """Class to test repr functionality for NocaseDict"""
+
     def test_reliable_order(self):
-        """Test that repr() has a reliable result despite different orders of
-        insertion into the dictionary."""
+        """Test that repr() has a reliable result for two dicts with the same
+        insertion order."""
 
         dic1 = NocaseDict()
         dic1['Budgie'] = 'Fish'
-        dic1['Dog'] = 'Cat'
         dic1['Foo'] = 'Bla'
+        dic1['Dog'] = 'Cat'
 
         dic2 = NocaseDict()
+        dic2['Budgie'] = 'Fish'
         dic2['Foo'] = 'Bla'
         dic2['Dog'] = 'Cat'
-        dic2['Budgie'] = 'Fish'
 
         self.assertEqual(repr(dic1), repr(dic2))
 

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -19,6 +19,10 @@ from io import open as _open
 import yaml
 import six
 from testfixtures import LogCapture, log_capture
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 from pywbem import CIMInstanceName, CIMInstance, MinutesFromUTC, \
     Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, \
@@ -63,24 +67,24 @@ class BaseRecorderTests(unittest.TestCase):
                       second=40, microsecond=654321,
                       tzinfo=MinutesFromUTC(120))
         cim_dt = CIMDateTime(dt)
-        props_input = {
-            'S1': b'Ham',
-            'Bool': True,
-            'UI8': Uint8(42),
-            'UI16': Uint16(4216),
-            'UI32': Uint32(4232),
-            'UI64': Uint64(4264),
-            'SI8': Sint8(-42),
-            'SI16': Sint16(-4216),
-            'SI32': Sint32(-4232),
-            'SI64': Sint64(-4264),
-            'R32': Real32(42.0),
-            'R64': Real64(42.64),
-            'DTI': CIMDateTime(timedelta(10, 49, 20)),
-            'DTF': cim_dt,
-            'DTP': CIMDateTime(datetime(2014, 9, 22, 10, 49, 20, 524789,
-                                        tzinfo=TZ())),
-        }
+        props_input = OrderedDict([
+            ('S1', b'Ham'),
+            ('Bool', True),
+            ('UI8', Uint8(42)),
+            ('UI16', Uint16(4216)),
+            ('UI32', Uint32(4232)),
+            ('UI64', Uint64(4264)),
+            ('SI8', Sint8(-42)),
+            ('SI16', Sint16(-4216)),
+            ('SI32', Sint32(-4232)),
+            ('SI64', Sint64(-4264)),
+            ('R32', Real32(42.0)),
+            ('R64', Real64(42.64)),
+            ('DTI', CIMDateTime(timedelta(10, 49, 20))),
+            ('DTF', cim_dt),
+            ('DTP', CIMDateTime(datetime(2014, 9, 22, 10, 49, 20, 524789,
+                                         tzinfo=TZ()))),
+        ])
         # TODO python 2.7 will not write the following unicode character
         # For the moment, only add this property in python 3 test
         if six.PY3:
@@ -90,7 +94,7 @@ class BaseRecorderTests(unittest.TestCase):
         return inst
 
     def create_ciminstancename(self):
-        kb = {'Chicken': 'Ham'}
+        kb = [('Chicken', 'Ham')]
         obj_name = CIMInstanceName('CIM_Foo',
                                    kb,
                                    namespace='root/cimv2',
@@ -192,15 +196,17 @@ class ToYaml(ClientRecorderTests):
         """Test  property with array toyaml"""
         str_data = "The pink fox jumped over the big blue dog"
         dt = datetime(2014, 9, 22, 10, 49, 20, 524789)
-        array_props = {'MyString': str_data,
-                       'MyUint8Array': [Uint8(1), Uint8(2)],
-                       'MySint8Array': [Sint8(1), Sint8(2)],
-                       'MyUint64Array': [Uint64(123456789),
-                                         Uint64(123456789),
-                                         Uint64(123456789)],
-                       'MyUint32Array': [Uint32(9999), Uint32(9999)],
-                       'MyDateTimeArray': [dt, dt, dt],
-                       'MyStrLongArray': [str_data, str_data, str_data]}
+        array_props = [
+            ('MyString', str_data),
+            ('MyUint8Array', [Uint8(1), Uint8(2)]),
+            ('MySint8Array', [Sint8(1), Sint8(2)]),
+            ('MyUint64Array', [Uint64(123456789),
+                               Uint64(123456789),
+                               Uint64(123456789)]),
+            ('MyUint32Array', [Uint32(9999), Uint32(9999)]),
+            ('MyDateTimeArray', [dt, dt, dt]),
+            ('MyStrLongArray', [str_data, str_data, str_data]),
+        ]
         inst = CIMInstance('CIM_FooArray', array_props)
         test_yaml = self.test_recorder.toyaml(inst)
 
@@ -498,130 +504,151 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
 # Long log entry for getInstance return all log
 get_inst_return_all_log = (
     u"Return:test_id GetInstance(CIMInstance(classname='CIM_Foo', path=None, "
-    u"properties=NocaseDict({'Bool': CIMProperty(name='Bool', value=True, "
-    u"type='boolean', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'DTF': CIMProperty(name='DTF', "
-    u"value=CIMDateTime(cimtype='datetime', '20160331193040.654321+120'), "
-    u"type='datetime', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'DTI': CIMProperty(name='DTI', "
-    u"value=CIMDateTime(cimtype='datetime', '00000010000049.000020:000'), "
-    u"type='datetime', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'DTP': CIMProperty(name='DTP', "
-    u"value=CIMDateTime(cimtype='datetime', '20140922104920.524789-399'), "
-    u"type='datetime', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'R32': CIMProperty(name='R32', "
-    u"value=Real32(cimtype='real32', 42.0), type='real32', "
+    u"properties=NocaseDict(["
+    u"('S1', CIMProperty(name='S1', value='Ham', type='string', "
     u"reference_class=None, embedded_object=None, is_array=False, "
     u"array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'R64': CIMProperty(name='R64', "
-    u"value=Real64(cimtype='real64', 42.64), type='real64', "
+    u"qualifiers=NocaseDict([]))), "
+    u"('Bool', CIMProperty(name='Bool', value=True, type='boolean', "
     u"reference_class=None, embedded_object=None, is_array=False, "
     u"array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'S1': CIMProperty(name='S1', value='Ham', "
-    u"type='string', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'S2': CIMProperty(name='S2', value='H\u00E4m'"
-    u", type='string', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'SI16': CIMProperty(name='SI16', "
-    u"value=Sint16(cimtype='sint16', minvalue=-32768, maxvalue=32767, -4216), "
-    u"type='sint16', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'SI32': CIMProperty(name='SI32', "
-    u"value=Sint32(cimtype='sint32', minvalue=-2147483648, "
-    u"maxvalue=2147483647, -4232), type='sint32', reference_class=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('UI8', CIMProperty(name='UI8', value=Uint8(cimtype='uint8', "
+    u"minvalue=0, maxvalue=255, 42), type='uint8', reference_class=None, "
     u"embedded_object=None, is_array=False, array_size=None, "
-    u"class_origin=None, propagated=None, qualifiers=NocaseDict({})), 'SI64': "
-    u"CIMProperty(name='SI64', value=Sint64(cimtype='sint64', "
+    u"class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('UI16', CIMProperty(name='UI16', value=Uint16(cimtype='uint16', "
+    u"minvalue=0, maxvalue=65535, 4216), type='uint16', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('UI32', CIMProperty(name='UI32', value=Uint32(cimtype='uint32', "
+    u"minvalue=0, maxvalue=4294967295, 4232), type='uint32', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('UI64', CIMProperty(name='UI64', value=Uint64(cimtype='uint64', "
+    u"minvalue=0, maxvalue=18446744073709551615, 4264), type='uint64', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('SI8', CIMProperty(name='SI8', value=Sint8(cimtype='sint8', "
+    u"minvalue=-128, maxvalue=127, -42), type='sint8', reference_class=None, "
+    u"embedded_object=None, is_array=False, array_size=None, "
+    u"class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('SI16', CIMProperty(name='SI16', value=Sint16(cimtype='sint16', "
+    u"minvalue=-32768, maxvalue=32767, -4216), type='sint16', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('SI32', CIMProperty(name='SI32', value=Sint32(cimtype='sint32', "
+    u"minvalue=-2147483648, maxvalue=2147483647, -4232), type='sint32', "
+    u"reference_class=None, embedded_object=None, is_array=False, "
+    u"array_size=None, class_origin=None, propagated=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('SI64', CIMProperty(name='SI64', value=Sint64(cimtype='sint64', "
     u"minvalue=-9223372036854775808, maxvalue=9223372036854775807, -4264), "
     u"type='sint64', reference_class=None, embedded_object=None, "
     u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'SI8': CIMProperty(name='SI8', "
-    u"value=Sint8(cimtype='sint8', minvalue=-128, maxvalue=127, -42), "
-    u"type='sint8', reference_class=None, embedded_object=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('R32', CIMProperty(name='R32', value=Real32(cimtype='real32', 42.0), "
+    u"type='real32', reference_class=None, embedded_object=None, "
     u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'UI16': CIMProperty(name='UI16', "
-    u"value=Uint16(cimtype='uint16', minvalue=0, maxvalue=65535, 4216), "
-    u"type='uint16', reference_class=None, embedded_object=None, "
+    u"qualifiers=NocaseDict([]))), "
+    u"('R64', CIMProperty(name='R64', value=Real64(cimtype='real64', 42.64), "
+    u"type='real64', reference_class=None, embedded_object=None, "
     u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'UI32': CIMProperty(name='UI32', "
-    u"value=Uint32(cimtype='uint32', minvalue=0, maxvalue=4294967295, 4232), "
-    u"type='uint32', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'UI64': CIMProperty(name='UI64', "
-    u"value=Uint64(cimtype='uint64', minvalue=0, "
-    u"maxvalue=18446744073709551615, 4264), type='uint64', "
+    u"qualifiers=NocaseDict([]))), "
+    u"('DTI', CIMProperty(name='DTI', value=CIMDateTime(cimtype='datetime', "
+    u"'00000010000049.000020:000'), type='datetime', reference_class=None, "
+    u"embedded_object=None, is_array=False, array_size=None, "
+    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    u"('DTF', CIMProperty(name='DTF', value=CIMDateTime(cimtype='datetime', "
+    u"'20160331193040.654321+120'), type='datetime', reference_class=None, "
+    u"embedded_object=None, is_array=False, array_size=None, "
+    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    u"('DTP', CIMProperty(name='DTP', value=CIMDateTime(cimtype='datetime', "
+    u"'20140922104920.524789-399'), type='datetime', reference_class=None, "
+    u"embedded_object=None, is_array=False, array_size=None, "
+    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    u"('S2', CIMProperty(name='S2', value='H\u00E4m', type='string', "
     u"reference_class=None, embedded_object=None, is_array=False, "
     u"array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({})), 'UI8': CIMProperty(name='UI8', "
-    u"value=Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 42), "
-    u"type='uint8', reference_class=None, embedded_object=None, "
-    u"is_array=False, array_size=None, class_origin=None, propagated=None, "
-    u"qualifiers=NocaseDict({}))}), property_list=None, "
-    u"qualifiers=NocaseDict({})))")
+    u"qualifiers=NocaseDict([])))"
+    u"]), property_list=None, qualifiers=NocaseDict([])))")
 
 
 get_inst_return_all_log_PY2 = (
     "Return:test_id GetInstance(CIMInstance(classname=u'CIM_Foo', path=None, "
-    "properties=NocaseDict({'Bool': CIMProperty(name=u'Bool', value=True, "
-    "type=u'boolean', reference_class=None, embedded_object=None, is_array="
-    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
-    "NocaseDict({})), 'DTF': CIMProperty(name=u'DTF', value=CIMDateTime("
-    "cimtype='datetime', '20160331193040.654321+120'), type=u'datetime', "
-    "reference_class=None, embedded_object=None, is_array=False, array_size="
-    "None, class_origin=None, propagated=None, qualifiers=NocaseDict({})), "
-    "'DTI': CIMProperty(name=u'DTI', value=CIMDateTime(cimtype='datetime', "
+    "properties=NocaseDict(["
+    "('S1', CIMProperty(name=u'S1', value=u'Ham', type=u'string', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('Bool', CIMProperty(name=u'Bool', value=True, type=u'boolean', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('UI8', CIMProperty(name=u'UI8', value=Uint8(cimtype='uint8', "
+    "minvalue=0, maxvalue=255, 42), type=u'uint8', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, "
+    "class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    "('UI16', CIMProperty(name=u'UI16', value=Uint16(cimtype='uint16', "
+    "minvalue=0, maxvalue=65535, 4216), type=u'uint16', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, class_origin=None, "
+    "propagated=None, qualifiers=NocaseDict([]))), "
+    "('UI32', CIMProperty(name=u'UI32', value=Uint32(cimtype='uint32', "
+    "minvalue=0, maxvalue=4294967295, 4232), type=u'uint32', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('UI64', CIMProperty(name=u'UI64', value=Uint64(cimtype='uint64', "
+    "minvalue=0, maxvalue=18446744073709551615, 4264), type=u'uint64', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('SI8', CIMProperty(name=u'SI8', value=Sint8(cimtype='sint8', "
+    "minvalue=-128, maxvalue=127, -42), type=u'sint8', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, "
+    "class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    "('SI16', CIMProperty(name=u'SI16', value=Sint16(cimtype='sint16', "
+    "minvalue=-32768, maxvalue=32767, -4216), type=u'sint16', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('SI32', CIMProperty(name=u'SI32', value=Sint32(cimtype='sint32', "
+    "minvalue=-2147483648, maxvalue=2147483647, -4232), type=u'sint32', "
+    "reference_class=None, embedded_object=None, is_array=False, "
+    "array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('SI64', CIMProperty(name=u'SI64', value=Sint64(cimtype='sint64', "
+    "minvalue=-9223372036854775808, maxvalue=9223372036854775807, -4264), "
+    "type=u'sint64', reference_class=None, embedded_object=None, "
+    "is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('R32', CIMProperty(name=u'R32', value=Real32(cimtype='real32', 42.0), "
+    "type=u'real32', reference_class=None, embedded_object=None, "
+    "is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('R64', CIMProperty(name=u'R64', value=Real64(cimtype='real64', 42.64), "
+    "type=u'real64', reference_class=None, embedded_object=None, "
+    "is_array=False, array_size=None, class_origin=None, propagated=None, "
+    "qualifiers=NocaseDict([]))), "
+    "('DTI', CIMProperty(name=u'DTI', value=CIMDateTime(cimtype='datetime', "
     "'00000010000049.000020:000'), type=u'datetime', reference_class=None, "
     "embedded_object=None, is_array=False, array_size=None, class_origin=None,"
-    " propagated=None, qualifiers=NocaseDict({})), 'DTP': CIMProperty(name="
-    "u'DTP', value=CIMDateTime(cimtype='datetime', '20140922104920.524789-399')"
-    ", type=u'datetime', reference_class=None, embedded_object=None, is_array="
-    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
-    "NocaseDict({})), 'R32': CIMProperty(name=u'R32', value=Real32(cimtype="
-    "'real32', 42.0), type=u'real32', reference_class=None, embedded_object="
-    "None, is_array=False, array_size=None, class_origin=None, propagated="
-    "None, qualifiers=NocaseDict({})), 'R64': CIMProperty(name=u'R64', "
-    "value=Real64(cimtype='real64', 42.64), type=u'real64', reference_class="
-    "None, embedded_object=None, is_array=False, array_size=None, "
-    "class_origin=None, propagated=None, qualifiers=NocaseDict({})), 'S1': "
-    "CIMProperty(name=u'S1', value=u'Ham', type=u'string', reference_class=None"
-    ", embedded_object=None, is_array=False, array_size=None, class_origin="
-    "None, propagated=None, qualifiers=NocaseDict({})), 'SI16': CIMProperty("
-    "name=u'SI16', value=Sint16(cimtype='sint16', minvalue=-32768, maxvalue="
-    "32767, -4216), type=u'sint16', reference_class=None, embedded_object=None"
-    ", is_array=False, array_size=None, class_origin=None, propagated=None, "
-    "qualifiers=NocaseDict({})), 'SI32': CIMProperty(name=u'SI32', value="
-    "Sint32(cimtype='sint32', minvalue=-2147483648, maxvalue=2147483647, -4232"
-    "), type=u'sint32', reference_class=None, embedded_object=None, is_array="
-    "False, array_size=None, class_origin=None, propagated=None, qualifiers="
-    "NocaseDict({})), 'SI64': CIMProperty(name=u'SI64', value=Sint64(cimtype="
-    "'sint64', minvalue=-9223372036854775808, maxvalue=9223372036854775807, "
-    "-4264), type=u'sint64', reference_class=None, embedded_object=None, "
-    "is_array=False, array_size=None, class_origin=None, propagated=None, "
-    "qualifiers=NocaseDict({})), 'SI8': CIMProperty(name=u'SI8', value=Sint8("
-    "cimtype='sint8', minvalue=-128, maxvalue=127, -42), type=u'sint8', "
+    " propagated=None, qualifiers=NocaseDict([]))), "
+    "('DTF', CIMProperty(name=u'DTF', value=CIMDateTime("
+    "cimtype='datetime', '20160331193040.654321+120'), type=u'datetime', "
     "reference_class=None, embedded_object=None, is_array=False, array_size="
-    "None, class_origin=None, propagated=None, qualifiers=NocaseDict({})), "
-    "'UI16': CIMProperty(name=u'UI16', value=Uint16(cimtype='uint16', minvalue"
-    "=0, maxvalue=65535, 4216), type=u'uint16', reference_class=None, "
-    "embedded_object=None, is_array=False, array_size=None, class_origin=None,"
-    " propagated=None, qualifiers=NocaseDict({})), 'UI32': CIMProperty("
-    "name=u'UI32', value=Uint32(cimtype='uint32', minvalue=0, maxvalue="
-    "4294967295, 4232), type=u'uint32', reference_class=None, embedded_object"
-    "=None, is_array=False, array_size=None, class_origin=None, propagated="
-    "None, qualifiers=NocaseDict({})), 'UI64': CIMProperty(name=u'UI64', "
-    "value=Uint64(cimtype='uint64', minvalue=0, maxvalue=18446744073709551615"
-    ", 4264), type=u'uint64', reference_class=None, embedded_object=None, "
-    "is_array=False, array_size=None, class_origin=None, propagated=None, "
-    "qualifiers=NocaseDict({})), 'UI8': CIMProperty(name=u'UI8', "
-    "value=Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 42), "
-    "type=u'uint8', reference_class=None, embedded_object=None, is_array=False"
-    ", array_size=None, class_origin=None, propagated=None, qualifiers="
-    "NocaseDict({}))}), property_list=None, qualifiers=NocaseDict({})))")
+    "None, class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
+    "('DTP', CIMProperty(name=u'DTP', value=CIMDateTime(cimtype='datetime', "
+    "'20140922104920.524789-399'), type=u'datetime', reference_class=None, "
+    "embedded_object=None, is_array=False, array_size=None, "
+    "class_origin=None, propagated=None, qualifiers=NocaseDict([])))"
+    "]), property_list=None, qualifiers=NocaseDict([])))")
 
 
 class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
@@ -734,7 +761,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
                  "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
                  "classname=u'CIM_Foo', keybindings=NocaseDict("
-                 "{'Chicken': u'Ham'}), namespace=u'root/cimv2', "
+                 "[('Chicken', u'Ham')]), namespace=u'root/cimv2', "
                  "host=u'woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),)
 
@@ -744,7 +771,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
                  'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),)
@@ -776,54 +803,52 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
             lc.check(
                 ("pywbem.ops", "DEBUG",
                  "Return:test_id None(CIMInstance(classname=u'CIM_Foo', "
-                 "path=None,"
-                 " properties=NocaseDict({'Bool': CIMProperty(name=u'Bool', "
-                 "value=True, type=u'boolean', reference_class=None, "
+                 "path=None, properties=NocaseDict(["
+                 "('S1', CIMProperty(name=u'S1', value=u'Ham', "
+                 "type=u'string', reference_class=None, "
                  "embedded_object=None, is_array=False, array_size=None, "
                  "class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})),"
-                 " 'DTF': CIMProperty(name=u'DTF', value=CIMDateTime(cimtype"
-                 "='datetime', '20160331193040.654321+120'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False, "
-                 "array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name=u'DTI', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'00000010000049.000020:000'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False, "
-                 "array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name=u'DTP', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'20140922104920.524789-399'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False, "
-                 "array_size=None, class_origin=No...)"),)
+                 "qualifiers=NocaseDict([]))), "
+                 "('Bool', CIMProperty(name=u'Bool', value=True, "
+                 "type=u'boolean', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('UI8', CIMProperty(name=u'UI8', value=Uint8("
+                 "cimtype='uint8', minvalue=0, maxvalue=255, 42), "
+                 "type=u'uint8', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI16', CIMProperty(name=u'UI16', value=Uint16("
+                 "cimtype='uint16', minvalue=0, maxvalue=65535, 4216), "
+                 "type=u'uint16', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI32', CIMPr...)"),)
         else:
             lc.check(
                 ("pywbem.ops", "DEBUG",
                  "Return:test_id None(CIMInstance(classname='CIM_Foo', "
-                 "path=None, "
-                 "properties=NocaseDict({'Bool': CIMProperty(name='Bool', "
-                 "value=True, "
+                 "path=None, properties=NocaseDict(["
+                 "('S1', CIMProperty(name='S1', value='Ham', type='string', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('Bool', CIMProperty(name='Bool', value=True, "
                  "type='boolean', reference_class=None, embedded_object=None, "
                  "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTF': CIMProperty(name='DTF', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'20160331193040.654321+120'), "
-                 "type='datetime', reference_class=None, embedded_object=None, "
-                 'is_array=False, array_size=None, class_origin=None, '
-                 'propagated=None, '
-                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name='DTI', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'00000010000049.000020:000'), "
-                 "type='datetime', reference_class=None, embedded_object=None, "
-                 'is_array=False, array_size=None, class_origin=None, '
-                 'propagated=None, '
-                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name='DTP', "
-                 "value=CIMDateTime(cimtype='datetime', "
-                 "'20140922104920.524789-399'), "
-                 "type='datetime', reference_class=None, embedded_object=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI8', CIMProperty(name='UI8', value=Uint8(cimtype='uint8', "
+                 "minvalue=0, maxvalue=255, 42), type='uint8', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
+                 "array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('UI16', CIMProperty(name='UI16', value=Uint16("
+                 "cimtype='uint16', minvalue=0, maxvalue=65535, 4216), "
+                 "type='uint16', reference_class=None, embedded_object=None, "
                  "is_array=False, array_size=None, class_origin=None, "
-                 "propa...)"),)
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI32', CIMProperty(nam...)"),)
 
     @log_capture()
     def test_stage_instance_result_all(self, lc):
@@ -836,78 +861,88 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
             lc.check(
                 ("pywbem.ops", "DEBUG",
                  "Return:test_id None(CIMInstance(classname=u'CIM_Foo', "
-                 "path=None, properties=NocaseDict({'Bool': CIMProperty("
-                 "name=u'Bool', value=True, type=u'boolean', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTF': CIMProperty(name=u'DTF',"
-                 " value=CIMDateTime(cimtype='datetime', "
-                 "'20160331193040.654321+120'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTI': CIMProperty(name=u'DTI',"
-                 " value=CIMDateTime(cimtype='datetime', "
-                 "'00000010000049.000020:000'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'DTP': CIMProperty(name=u'DTP',"
-                 " value=CIMDateTime(cimtype='datetime', "
-                 "'20140922104920.524789-399'), type=u'datetime', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'R32': CIMProperty(name=u'R32',"
-                 " value=Real32(cimtype='real32', 42.0), type=u'real32', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'R64': CIMProperty(name=u'R64',"
-                 " value=Real64(cimtype='real64', 42.64), type=u'real64', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'S1': CIMProperty(name=u'S1',"
-                 " value=u'Ham', type=u'string', reference_class=None, "
+                 "path=None, properties=NocaseDict(["
+                 "('S1', CIMProperty(name=u'S1', value=u'Ham', "
+                 "type=u'string', reference_class=None, "
                  "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, propagated=None, qualifiers=NocaseDict("
-                 "{})), 'SI16': CIMProperty(name=u'SI16', "
-                 "value=Sint16(cimtype='sint16', minvalue=-32768,"
-                 " maxvalue=32767, -4216), type=u'sint16', "
-                 "reference_class=None, embedded_object=None, "
-                 "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict({})), 'SI32': "
-                 "CIMProperty(name=u'SI32', value=Sint32(cimtype='sint32', "
-                 "minvalue=-2147483648, maxvalue=2147483647, -4232), "
-                 "type=u'sint32', reference_class=None, embedded_object=None, "
-                 "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict({})), 'SI64': "
-                 "CIMProperty(name=u'SI64', value=Sint64(cimtype='sint64', "
-                 "minvalue=-9223372036854775808, maxvalue=9223372036854775807,"
-                 " -4264), type=u'sint64', reference_class=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('Bool', CIMProperty(name=u'Bool', value=True, "
+                 "type=u'boolean', reference_class=None, "
                  "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, propagated=None, qualifiers=NocaseDict("
-                 "{})), 'SI8': CIMProperty(name=u'SI8', value=Sint8("
-                 "cimtype='sint8', minvalue=-128, maxvalue=127, -42), "
-                 "type=u'sint8', reference_class=None, embedded_object=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('UI8', CIMProperty(name=u'UI8', value=Uint8("
+                 "cimtype='uint8', minvalue=0, maxvalue=255, 42), "
+                 "type=u'uint8', reference_class=None, embedded_object=None, "
                  "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict({})), 'UI16': "
-                 "CIMProperty(name=u'UI16', value=Uint16(cimtype='uint16', "
-                 "minvalue=0, maxvalue=65535, 4216), type=u'uint16', "
-                 "reference_class=None, embedded_object=None, is_array=False,"
-                 " array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({})), 'UI32': CIMProperty(name=u'UI32',"
-                 " value=Uint32(cimtype='uint32', minvalue=0, "
-                 "maxvalue=4294967295, 4232), type=u'uint32', reference_class="
-                 "None, embedded_object=None, is_array=False, array_size=None,"
-                 " class_origin=None, propagated=None, qualifiers=NocaseDict("
-                 "{})), 'UI64': CIMProperty(name=u'UI64', value=Uint64(cimtype"
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI16', CIMProperty(name=u'UI16', value=Uint16("
+                 "cimtype='uint16', minvalue=0, maxvalue=65535, 4216), "
+                 "type=u'uint16', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI32', CIMProperty(name=u'UI32', value=Uint32("
+                 "cimtype='uint32', minvalue=0, maxvalue=4294967295, 4232), "
+                 "type=u'uint32', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('UI64', CIMProperty(name=u'UI64', value=Uint64(cimtype"
                  "='uint64', minvalue=0, maxvalue=18446744073709551615, 4264), "
                  "type=u'uint64', reference_class=None, embedded_object=None, "
                  "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict({})), 'UI8': "
-                 "CIMProperty(name=u'UI8', value=Uint8(cimtype='uint8', "
-                 "minvalue=0, maxvalue=255, 42), type=u'uint8', reference_"
-                 "class=None, embedded_object=None, is_array=False, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('SI8', CIMProperty(name=u'SI8', value=Sint8("
+                 "cimtype='sint8', minvalue=-128, maxvalue=127, -42), "
+                 "type=u'sint8', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('SI16', CIMProperty(name=u'SI16', value=Sint16("
+                 "cimtype='sint16', minvalue=-32768, maxvalue=32767, -4216), "
+                 "type=u'sint16', reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('SI32', CIMProperty(name=u'SI32', value=Sint32("
+                 "cimtype='sint32', minvalue=-2147483648, "
+                 "maxvalue=2147483647, -4232), type=u'sint32', "
+                 "reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('SI64', CIMProperty(name=u'SI64', value=Sint64("
+                 "cimtype='sint64', minvalue=-9223372036854775808, "
+                 "maxvalue=9223372036854775807, -4264), type=u'sint64', "
+                 "reference_class=None, embedded_object=None, is_array=False, "
                  "array_size=None, class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict({}))}), property_list=None, "
-                 "qualifiers=NocaseDict({})))"),)
+                 "qualifiers=NocaseDict([]))), "
+                 "('R32', CIMProperty(name=u'R32', value=Real32("
+                 "cimtype='real32', 42.0), type=u'real32', "
+                 "reference_class=None, embedded_object=None, is_array=False,"
+                 " array_size=None, class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('R64', CIMProperty(name=u'R64', value=Real64("
+                 "cimtype='real64', 42.64), type=u'real64', "
+                 "reference_class=None, embedded_object=None, "
+                 "is_array=False, array_size=None, class_origin=None, "
+                 "propagated=None, qualifiers=NocaseDict([]))), "
+                 "('DTI', CIMProperty(name=u'DTI', value=CIMDateTime("
+                 "cimtype='datetime', '00000010000049.000020:000'), "
+                 "type=u'datetime', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('DTF', CIMProperty(name=u'DTF', value=CIMDateTime("
+                 "cimtype='datetime', '20160331193040.654321+120'), "
+                 "type=u'datetime', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([]))), "
+                 "('DTP', CIMProperty(name=u'DTP', value=CIMDateTime("
+                 "cimtype='datetime', '20140922104920.524789-399'), "
+                 "type=u'datetime', reference_class=None, "
+                 "embedded_object=None, is_array=False, array_size=None, "
+                 "class_origin=None, propagated=None, "
+                 "qualifiers=NocaseDict([])))"
+                 "]), property_list=None, qualifiers=NocaseDict([])))"),)
         else:
             none_result_all = get_inst_return_all_log.replace('GetInstance',
                                                               'None')
@@ -943,8 +978,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "u'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
+                 "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops', 'DEBUG',
                  'Return:test_id GetInstance(CIMInstanc...)'))
@@ -954,7 +989,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),
@@ -985,8 +1020,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "u'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
+                 "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
                  "Exception:test_id GetInstance('CIMError(6...)"))
@@ -995,8 +1030,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
-                 "classname='CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "'Ham'}), namespace='root/cimv2', host='woot.com'), "
+                 "classname='CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "'Ham')]), namespace='root/cimv2', host='woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ("pywbem.ops", "DEBUG",
                  "Exception:test_id GetInstance('CIMError(6...)"))
@@ -1020,8 +1055,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
             lc.check(
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(InstanceName=CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "u'Ham'}), namespace=u'root/cimv2', host=u'woot.com'))"),
+                 "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'))"),
                 ("pywbem.ops", "DEBUG",
                  "Exception:test_id GetInstance('CIMError(6: Fake "
                  "CIMError)')"),)
@@ -1029,8 +1064,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
             lc.check(
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(InstanceName=CIMInstanceName("
-                 "classname='CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "'Ham'}), namespace='root/cimv2', host='woot.com'))"),
+                 "classname='CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "'Ham')]), namespace='root/cimv2', host='woot.com'))"),
                 ("pywbem.ops", "DEBUG",
                  "Exception:test_id GetInstance('CIMError(6: Fake "
                  "CIMError)')"),)
@@ -1059,8 +1094,8 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                 ("pywbem.ops", "DEBUG",
                  "Request:test_id GetInstance(IncludeClassOrigin=True, "
                  "IncludeQualifiers=True, InstanceName=CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "u'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
+                 "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'), "
                  "LocalOnly=True, PropertyList=['propertyblah'])"),
                 ('pywbem.ops',
                  'DEBUG',
@@ -1071,7 +1106,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  'Request:test_id GetInstance(IncludeClassOrigin=True, '
                  'IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com'), LocalOnly=True, "
                  "PropertyList=['propertyblah'])"),
@@ -1224,10 +1259,10 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "Return:test_id OpenEnumerateInstancePaths("
                  "pull_path_result_tuple(context=('test_rtn_context', "
                  "'root/blah'), eos=False, paths=[CIMInstanceName("
-                 "classname=u'CIM_Foo', keybindings=NocaseDict({'Chicken': "
-                 "u'Ham'}), namespace=u'root/cimv2', host=u'woot.com'), "
+                 "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
+                 "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'), "
                  "CIMInstanceName(classname=u'CIM_Foo', keybindings="
-                 "NocaseDict({'Chicken': u'Ham'}), namespace=u'root/cimv2',"
+                 "NocaseDict([('Chicken', u'Ham')]), namespace=u'root/cimv2',"
                  " host=u'woot.com')]))"))
 
         else:
@@ -1244,10 +1279,10 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "context=('test_rtn_context', "
                  "'root/blah'), eos=False, paths=[CIMInstanceName("
                  "classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com'), CIMInstanceName(classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com')]))"),)
 
@@ -1277,7 +1312,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "Request:test_id Associators(AssocClass='BLAH_Assoc', "
                  "IncludeClassOrigin=True, IncludeQualifiers=True, "
                  "InstanceName=CIMInstanceName(classname=u'CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': u'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', u'Ham')]), "
                  "namespace=u'root/cimv2', host=u'woot.com'), "
                  "PropertyList=['propertyblah', 'propertyblah2'], "
                  "ResultClass='BLAH_Result')"),
@@ -1289,7 +1324,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "Request:test_id Associators(AssocClass='BLAH_Assoc', "
                  'IncludeClassOrigin=True, IncludeQualifiers=True, '
                  "InstanceName=CIMInstanceName(classname='CIM_Foo', "
-                 "keybindings=NocaseDict({'Chicken': 'Ham'}), "
+                 "keybindings=NocaseDict([('Chicken', 'Ham')]), "
                  "namespace='root/cimv2', "
                  "host='woot.com'), PropertyList=['propertyblah', "
                  "'propertyblah2'], "

--- a/testsuite/test_wbemconnection_mock.py
+++ b/testsuite/test_wbemconnection_mock.py
@@ -29,6 +29,10 @@ from __future__ import absolute_import, print_function
 import os
 from datetime import datetime
 import operator
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 import six
 import pytest
 from testfixtures import OutputCapture
@@ -3226,7 +3230,7 @@ class TestReferenceOperations(object):
 
         insts = conn.References(inst_name, ResultClass=rc, Role=role)
 
-        paths = [str(i.path) for i in insts]
+        paths = [i.path for i in insts]
 
         assert isinstance(insts, list)
         assert len(insts) == len(exp_rtn)
@@ -3236,9 +3240,9 @@ class TestReferenceOperations(object):
         exp_ns = conn.default_namespace if ns is None else ns
 
         # create the expected paths from exp_rtn fixture.
-        exp_path_list = []
+        exp_paths = []
         for exp_path in exp_rtn:
-            kbs = {}
+            kbs = OrderedDict()
             kys = exp_path[1]
             if not isinstance(kys[0], (tuple, list)):
                 kys = [ kys ]  # noqa E201, E202 pylint: disable=bad-whitespace
@@ -3251,11 +3255,9 @@ class TestReferenceOperations(object):
                                                  keybindings={ky[2]: ky[3]})
             path = CIMInstanceName(exp_path[0], namespace=exp_ns,
                                    keybindings=kbs, host=conn.host)
-            exp_path_list.append(path)
+            exp_paths.append(path)
 
-        # TODO use the compare path function instead of cvting to string.
-        exp_path_list_strs = [str(p) for p in exp_path_list]
-        assert set(paths) == set(exp_path_list_strs)
+        assert set(paths) == set(exp_paths)
 
     # TODO test for references propertylist.
 


### PR DESCRIPTION
**Note:** This PR contains a change for the pywbem_mock testcases (in a separate commit).
Ready for review and merge.
For details, see the commit message.