### PR TITLE
Fixed lexical case when iterating over CIMInstance/CIMInstanceName

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -263,6 +263,13 @@ Bug fixes
   embedded objects. This could have caused low-level exceptions to be raised
   at the pywbem API.
 
+* Fixed the problem that a `for`-loop over `CIMInstance` / `CIMInstanceName`
+  objects iterated over the lower-case-converted property/key names. They now
+  iterate over the names in their original lexical case, as documented,
+  and consistent with the other iteration mechanisms for CIM objects.
+  The test cases that were supposed to verify that did not perform the
+  correct check and were also fixed.
+
 * Docs: Clarified that the return type of `BaseOperationRecorder.open_file()`
   is a file-like object and that the caller is responsible for closing that
   file.

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -384,7 +384,7 @@ class NocaseDict(object):
 
         The returned keys have their original case.
         """
-        return six.iterkeys(self._data)
+        return self.iterkeys()
 
     # Other stuff
 

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -517,7 +517,7 @@ class TestForLoop(BaseTest):
         keys = set()
         for key in self.dic:
             keys.add(key)
-        self.assertTrue(keys, set(['Budgie', 'Dog']))
+        self.assertEqual(keys, set(['Budgie', 'Dog']))
 
 
 class TestIterkeys(BaseTest):
@@ -527,7 +527,7 @@ class TestIterkeys(BaseTest):
         keys = set()
         for key in self.dic.iterkeys():
             keys.add(key)
-        self.assertTrue(keys, set(['Budgie', 'Dog']))
+        self.assertEqual(keys, set(['Budgie', 'Dog']))
 
 
 class TestItervalues(BaseTest):
@@ -537,7 +537,7 @@ class TestItervalues(BaseTest):
         vals = set()
         for val in self.dic.itervalues():
             vals.add(val)
-        self.assertTrue(vals, set(['Cat', 'Fish']))
+        self.assertEqual(vals, set(['Cat', 'Fish']))
 
 
 class TestIteritems(BaseTest):
@@ -547,7 +547,7 @@ class TestIteritems(BaseTest):
         items = set()
         for item in self.dic.iteritems():
             items.add(item)
-        self.assertTrue(items, set([('Budgie', 'Fish'), ('Dog', 'Cat')]))
+        self.assertEqual(items, set([('Budgie', 'Fish'), ('Dog', 'Cat')]))
 
 
 class TestRepr(unittest.TestCase):


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.