### PR TITLE
Fixes #871: InvokeMethod mock support

### DIFF
--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -357,24 +357,13 @@ output parameters.
 
 The user must create a function that will be executed as a callback for each
 method that is to be tested. This method is attached to the mock repository
-through :meth:`~pywbem_mock.FakedWBEMConnection.subscribe_method` which
+through :meth:`~pywbem_mock.FakedWBEMConnection.add_method_callback` which
 defines the namespace, class, and methodname for the InvokeMethod and the
 callback method to be executed.
 
 
 This user defined callback method should have the signature defined in
-:meth:`~pywbem_mock.FakedWBEMConnection.subscribe_method`.
-
-Generally callback input and output are as follows:
-
-- **conn**: The handle to the mock repository
-
-- **objectname**: The CIMClassName or CIMInstanceName from the InvokeMethod
-  call including the execution namespace.
-
-- **methodname**: The methodname to execute from the client InvokeMethod call
-
-- **params**: The Params input parameter from the client InvokeMethod call.
+:meth:`~pywbem_mock.FakedWBEMConnection.add_method_callback`.
 
 The callback is expected to return a tuple consiting of ReturnValue and
 a `NocaseDict` containing any output parameters. The following is an example
@@ -427,7 +416,7 @@ of the definition and execution of InvokeMethod.
 
     # Subscribe the defined Class and method. In this case it is for the
     # default namespace.
-    conn.subscribe_method('TST_Class', 'Method1',
+    conn.add_method_callback('TST_Class', 'Method1',
                           self.method1_callback)
 
     # execute the InvokeMethod as a static (class level) method.

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -93,7 +93,7 @@ class FakedWBEMConnection(WBEMConnection):
     :class:`pywbem.WBEMConnection`.
 
     Each object of this class has its own mock repository. A mock repository
-    contains multiple CIM namespaces, and each namespace contains CIM
+    contains multiple CIM namespaces, and each namespace may contain CIM
     qualifier types (declarations), CIM classes and CIM instances.
 
     This class provides only a subset of the parameters defined for
@@ -169,6 +169,8 @@ class FakedWBEMConnection(WBEMConnection):
         #  it is probably not important for initial release.
         self.instances = NocaseDict()
 
+        self.methods = NocaseDict()
+
         self._repo_lite = repo_lite
 
         # Open Pull Contexts. The key for each context is an enumeration
@@ -188,7 +190,6 @@ class FakedWBEMConnection(WBEMConnection):
         self.logfile = 'wbemconnection.log'
 
         if self.logfile:
-            # TODO make a more flexible and integrated logger.
             logging.basicConfig(filename=self.logfile, level=logging.INFO)
 
         self._imethodcall = Mock(side_effect=self._mock_imethodcall)
@@ -449,7 +450,117 @@ class FakedWBEMConnection(WBEMConnection):
                 except KeyError:
                     self.qualifiers[namespace] = NocaseDict({qual.name: qual})
             else:
-                assert False, 'add_cimobjects. %s not valid.' % type(obj)
+                assert False, 'Object to add_cimobjects. %s invalid type' \
+                              % type(obj)
+
+    def subscribe_method(self, classname, methodname, method_callback,
+                         namespace=None,):
+        """
+        Add a callback for a method that will be called by the client when
+        InvokeMethod is executed.  This method does no real validation of
+        the classname, methodname or method_callback in put parameters.
+
+          Parameters:
+            classname (:term:`string`):
+                The classname for the method defined by methodname.
+
+            methodname (:term: `string`):
+                Name of the method to be executed.
+
+            method_callback (:term:`callable`):
+                The user-defined function or method that well be called when by
+                FakeWBEMConnection when the InvokeMethod for the defined
+                class and methodname is received.  This method will be called
+                with the parameters defined on the InvokeMethod call
+
+                The callback method defined by the user is expected to comply
+                with the following signature:
+
+                Parameters:
+
+                  conn (:class:`~pywbem.WBEMConnection`):
+                    Connection to the FakeWBEMConnection and its
+                    repository. This can be used to execute requests
+                    on the mock repository to manipulate objects in the
+                    repository (ex. cc = conn.GetClass(objectname)
+
+                  objectname:
+                    The object path of the target object, as follows:
+
+                    * Instance-level call: The instance path of the
+                      target instance, as a :class:`~pywbem.CIMInstanceName`
+                      object including the execution namespace (either the
+                      namespace defined by the client
+                      InvokeMethod or the WBEMConnection default namespace).
+
+                    * Class-level call: The class path of the target
+                      class, as a :class:`~pywbem.CIMClassName` object
+                      including the execution namespace (either the
+                      namespace defined by the client nvokeMethod or the
+                      WBEMConnection default namespace).
+
+                      The :class:`~pywbem.CIMClassName` object,  `host`
+                      attribute will be ignored.
+
+                  methodname(:term:`string`):
+                    The methodname from the InvokeMethod call. This allows
+                    a single callback function to be used as the responder
+                    for multiple methods.
+
+                  params (:term:`py:iterable` of tuples of name,value):
+                    Input parameters from the InvokeMethod Params input.
+
+                    An iterable of input parameters for the CIM method.
+
+                    Each iterated item represents a single input parameter
+                    for the CIM method and must be a ``tuple(name, value)``,
+                    with these tuple items:
+
+                    * name (:term:`string`):
+                      Parameter name (case independent)
+                    * value (:term:`CIM data type`):
+                      Parameter value
+
+                Return:
+                  * The user written callback method must return a tuple
+                    consisting of
+                      * ReturnValue (:term:`CIM data type`):
+                          Return value from the executed method.
+
+                      * outparams (`NocaseDict`_):
+                          Dictionary with all provided output parameters of
+                          the CIM method, with:
+
+                          * key (:term:`unicode string`):
+                            Parameter name, preserving its lexical case
+                          * value (:term:`CIM data type`):
+                            Parameter value
+
+                      This is the same format as defined in
+                      :meth:`~pywbem.WBEMConnection.InvokeMethod` Return.
+
+                Exceptions:
+                  Since the user defined callback method is mocking a
+                  WBEMServer method, it should return :class:`~pywbem.CIM_Error`
+                  exceptions.
+
+                  The fake InvokeMethod implementation will convert any
+                  unknown exceptions to :class:`~pywbem.CIM_Error`
+                  (CIM_ERR_FAILED).
+        """
+        if namespace is None:
+            namespace = self.default_namespace
+
+        if not self.methods:
+            self.methods[namespace] = NocaseDict()
+            self.methods[namespace][classname] = NocaseDict()
+
+        # Test for dictionary already exists. If not, create it
+        try:
+            self.methods[namespace][classname][methodname] = method_callback
+        except KeyError:
+            mth = NocaseDict(NocaseDict({methodname: method_callback}))
+            self.methods[namespace] = NocaseDict({classname: mth})
 
     def display_repository(self, namespaces=None, dest=None, summary=False,
                            output_format='mof'):
@@ -487,6 +598,10 @@ class FakedWBEMConnection(WBEMConnection):
         self._display_objects('Instances', self.instances, namespaces,
                               dest=dest, summary=summary,
                               output_format=output_format)
+        self._display_objects('Methods', self.methods, namespaces,
+                              dest=dest, summary=summary,
+                              output_format=output_format)
+
         _display(dest, '============End Repository=================')
 
     @staticmethod
@@ -531,7 +646,14 @@ class FakedWBEMConnection(WBEMConnection):
                         else:
                             _display(dest, 'Path=%s\n%s' % (inst.path,
                                                             inst.tomof()))
-
+                elif obj_type == 'Methods':
+                    methods = objects_repo[ns]
+                    for cln in methods:
+                        for method in methods[cln]:
+                            _display(dest, 'Class: %s, method: %s, '
+                                           'callback: %s' %
+                                     (cln, method,
+                                      methods[cln][method].__name__))
                 else:
                     for objects in six.itervalues(objects_repo):
                         for obj in six.itervalues(objects):
@@ -660,6 +782,8 @@ class FakedWBEMConnection(WBEMConnection):
         if self.verbose:
             print('mock result %s' % result)
 
+        return result
+
     #####################################################################
     #
     #     Common methods that the Fake... WBEMConnection methods use to
@@ -746,15 +870,17 @@ class FakedWBEMConnection(WBEMConnection):
         The class repository is a NocaseDict with class as key and
         the CIMClass as value.
 
-          Parameters:
+        Parameters:
 
-            namespace(:term:`string`):
-                String containing the name of the namespace to get
+          namespace(:term:`string`):
+              String containing the name of the namespace to get
 
-          Returns: Dictionary containing classes that have been inserted
+        Returns:
+          Dictionary containing classes that have been inserted
           into the repository
 
-          Exception: CIM_Error, CIM_ERR_INVALID_NAMESPACE if this namespace
+        Raises:
+          CIM_Error, CIM_ERR_INVALID_NAMESPACE if this namespace
           does not exist in the  classrepository
         """
         return self._validate_repo(namespace, self.classes, 'classes')
@@ -768,14 +894,15 @@ class FakedWBEMConnection(WBEMConnection):
         The instance repository is a list if instances within the
         defined namespace
 
-          Parameters:
+        Parameters:
 
-            namespace(:term:`string`):
-                String containing the name of the namespace to get
+          namespace(:term:`string`):
+            String containing the name of the namespace to get
 
-          Returns: List of instances
+        Returns: List of instances
 
-          Exception: CIM_Error, CIM_ERR_INVALID_NAMESPACE if this namespace
+        Raises:
+           CIM_Error, CIM_ERR_INVALID_NAMESPACE if this namespace
           does not exist in the  classrepository
         """
         return self._validate_repo(namespace, self.instances, 'instances')
@@ -789,17 +916,28 @@ class FakedWBEMConnection(WBEMConnection):
         The instance repository is a list if instances within the
         defined namespace
 
-          Parameters:
+        Parameters:
 
-            namespace(:term:`string`):
-                String containing the name of the namespace to get
+          namespace(:term:`string`):
+              String containing the name of the namespace to get
 
-          Returns: Dictionary of QualifierDeclaration objects in the repo
+        Returns:
+           Dictionary of QualifierDeclaration objects in the repo
 
-          Exception: CIM_Error, CIM_ERR_INVALID_NAMESPACE if this namespace
+        Raises:
+          CIM_Error: CIM_ERR_INVALID_NAMESPACE if this namespace
           does not exist in the  classrepository
         """
         return self._validate_repo(namespace, self.qualifiers, 'qualifiers')
+
+    def _get_methods_repo(self, namespace=None):
+        """
+        Validate that the table of methods exists for this namespace and if
+        it does, return the handle to the dictionary that represents the
+        methods defined for this namespce.  If that repo does not exist,
+        generate a CIM_Error.
+        """
+        return self._validate_repo(namespace, self.methods, 'methods')
 
     def _get_superclassnames(self, cn, namespace):
         """
@@ -879,12 +1017,13 @@ class FakedWBEMConnection(WBEMConnection):
             IncludeQualifiers, and IncludeClassOrigin.
 
         Returns:
+
             Copy of the class if found with superclass properties installed and
             filtered per the keywords in params.
 
-        Exceptions:
-            CIMError (CIM_ERR_NOT_FOUND) if class Not found in repository or
-            CIMError (CIM_ERR_INVALID_NAMESPACE) if namespace does not exist
+        Raises:
+            CIMError: (CIM_ERR_NOT_FOUND) if class Not found in repository or
+            CIMError: (CIM_ERR_INVALID_NAMESPACE) if namespace does not exist
         """
         classes_repo = self._get_class_repo(namespace)
 
@@ -948,10 +1087,17 @@ class FakedWBEMConnection(WBEMConnection):
         Find an instance in the instance repo by iname and return the
         index of that instance.
 
+        Parameters:
+
+          iname: CIMInstancename to find
+
+          inst_repo: the instance repo to search
+
         Return (None, None if not found. Otherwise return tuple of
                index, instance
 
-        Exceptions:
+        Raises:
+
           CIMError: Failed if repo invalid.
         """
         rtn_inst = None
@@ -1140,10 +1286,13 @@ class FakedWBEMConnection(WBEMConnection):
         :meth:`~pywbem.WBEMConnection.EnumerateClassNames`.
 
         Returns:
+
             returns classnames.
-        Exceptions:
-            invalid namespace,
-            Classname not found
+
+        Raises:
+
+            CIMError: CIM_ERR_INVALID_NAMESPACE if invalid namespace,
+            CIMError: CIM_ERR_NOT_FOUND if Classname not found
         """
         clns = self._get_subclass_names(params.get('classname', None),
                                         namespace,
@@ -1186,10 +1335,14 @@ class FakedWBEMConnection(WBEMConnection):
         if the class repository for this namespace does not
         exist, this method creates it.
 
-        Returns:
-            None
-        Exceptions:
-            CIMError
+        Raises:
+            CIMError: CIM_ERR_INVALID_SUPERCLASS if superclass specified bu
+              does not exist
+
+            CIMError: CIM_ERR_INVALID_PARAMETER if NewClass parameter not a
+              class
+
+            CIMError: CIM_ERR_ALREADY_EXISTS if class already exists
         """
         new_class = params['NewClass']
         if namespace not in self.classes:
@@ -1233,10 +1386,9 @@ class FakedWBEMConnection(WBEMConnection):
         if the class repository for this namespace does not
         exist, this method creates it.
 
-        Returns:
-            None
-        Exceptions:
-            CIMError
+        Raises:
+
+            CIMError: CIM_ERR_NOT_SUPPORTED
         """
         print('ModifyClass not supported %s %s' % (namespace, params))
         self._get_class_repo(namespace)
@@ -1257,8 +1409,10 @@ class FakedWBEMConnection(WBEMConnection):
 
         Nothing is returned.
 
-        Exceptions:
-            CIMError CIM_ERR_NOT_FOUND
+        Raises:
+
+            CIMError: CIM_ERR_NOT_FOUND if ClassName defines class not in
+                repository
         """
         class_repo = self._get_class_repo(namespace)
 
@@ -1312,11 +1466,14 @@ class FakedWBEMConnection(WBEMConnection):
         namespace.
 
         Return:
+
           Returns a tuple representing the _imethodcall return for this
           method where the data is a QualifierDeclaration
 
-        Exceptions:
-            CIMError CIM_ERR_INVALID_NAMESPACE, CIM_ERR_NOT_FOUND
+        Raises:
+            CIMError: CIM_ERR_INVALID_NAMESPACE
+
+            CIMError: CIM_ERR_NOT_FOUND
         """
         qualifier_repo = self._get_qualifier_repo(namespace)
 
@@ -1340,9 +1497,10 @@ class FakedWBEMConnection(WBEMConnection):
         class.  This method will create a new namespace for the qualifier
         if none is defined.
 
-        Exceptions:
-            CIMError CIM_ERR_INVALID_PARAMETER or
-            CIMError(CIM_ERR_ALREADY_EXISTS
+        Raises:
+
+            CIMError: CIM_ERR_INVALID_PARAMETER
+            CIMError: CIM_ERR_ALREADY_EXISTS
         """
         qual = params['QualifierDeclaration']
 
@@ -1374,8 +1532,9 @@ class FakedWBEMConnection(WBEMConnection):
         Deletes a single qualifier if it is in the
         repository for this class and namespace
 
-        Exceptions;
-            CIMError CIM_ERR_INVALID_NAMESPACE, CIM_ERR_NOT_FOUND
+        Raises;
+
+            CIMError: CIM_ERR_INVALID_NAMESPACE, CIM_ERR_NOT_FOUND
         """
         qualifier_repo = self._get_qualifier_repo(namespace)
 
@@ -1405,8 +1564,11 @@ class FakedWBEMConnection(WBEMConnection):
         pywbem.CreateInstance has captured any namespace in the instance
         path component.
 
-        Exceptions:
-            CIMError CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_CLASS
+        Raisess:
+
+            CIMError: CIM_ERR_ALREADY_EXISTS
+
+            CIMError: CIM_ERR_INVALID_CLASS
         """
 
         new_instance = params['NewInstance']
@@ -1502,8 +1664,9 @@ class FakedWBEMConnection(WBEMConnection):
 
         Modify a CIM instance in the local repository.
 
-        Exceptions:
-            CIMError CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_CLASS
+        Raises:
+
+            CIMError: CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_CLASS
         """
         if self._repo_lite:
             raise CIMError(CIM_ERR_NOT_SUPPORTED, 'ModifyInstance not '
@@ -1654,8 +1817,9 @@ class FakedWBEMConnection(WBEMConnection):
         This method uses a common repository access method _get_instance to
         get, copy, and process the instance.
 
-        Exceptions:
-            CIMError  CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_PARAMETER
+        Raises:
+
+            CIMError:  CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_PARAMETER
               CIM_ERR_NOT_FOUND
         """
         iname = params['InstanceName']
@@ -1728,8 +1892,9 @@ class FakedWBEMConnection(WBEMConnection):
         then executes getInstance for each to create the list of instances
         to be returned.
 
-        Exceptions:
-            CIMError CIM_ERR_INVALID_NAMESPACE
+        Raises:
+
+            CIMError: CIM_ERR_INVALID_NAMESPACE
         """
         inst_repo = self._get_instance_repo(namespace)
 
@@ -2306,8 +2471,9 @@ class FakedWBEMConnection(WBEMConnection):
 
         This method assumes the same context_id throughout the sequence.
 
-        Exceptions:
-            CIMError- CIM_ERR_INVALID_ENUMERATION_CONTEXT
+        Raises:
+
+            CIMError: CIM_ERR_INVALID_ENUMERATION_CONTEXT
         """
         self._get_instance_repo(namespace)
         context_id = params['EnumerationContext']
@@ -2468,7 +2634,7 @@ class FakedWBEMConnection(WBEMConnection):
                                    'PullInstancesWithPath', **params)
 
     def _fake_openqueryinstances(self, namespace, **params):
-        # pylint: disable=invalid_name
+        # pylint: disable=invalid-name
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenQueryInstances`
@@ -2543,19 +2709,69 @@ class FakedWBEMConnection(WBEMConnection):
     #
     #####################################################################
 
-    def _fake_invokemethod(self, methodname, localobject, Params=None,
+    def _fake_invokemethod(self, methodname, objectname, Params=None,
                            **params):
         # pylint: disable=invalid-name
         """
         Implements a mock WBEM server responder for
         :meth:`~pywbem.WBEMConnection.InvokeMethod`
 
-        with data from the instance repository.
+        This responder calls a function defined by an entry in the methods
+        repository. The return from that function is returned to the user.
 
         Input params are MethodName, ObjectName, and Params
 
+        The return is espected to be the same as the return defined by
+        WBEMConnection.InvokeMethod (ReturnValue, OutputParameters).
+
         """
-        # TODO implement _fake_invoke_method
-        print('fake_invokemethod %s, %s, %s %s' % (methodname, localobject,
-                                                   Params, params))
-        raise CIMError(CIM_ERR_NOT_SUPPORTED, 'InvokeMethod Not Implemented!')
+        if isinstance(objectname, (CIMInstanceName, CIMClassName)):
+            localobject = objectname.copy()
+            if localobject.namespace is None:
+                localobject.namespace = self.default_namespace
+                localobject.host = None
+
+        elif isinstance(objectname, six.string_types):
+            # a string is always interpreted as a class name
+            localobject = CIMClassName(objectname,
+                                       namespace=self.default_namespace)
+
+        else:
+            raise TypeError('FakeWBEMConnection InvokeMethod invalid type for '
+                            'objectname: %s' % type(objectname))
+
+        namespace = localobject.namespace
+        try:
+            methodsrepo = self._get_methods_repo(namespace)
+        except KeyError:
+            raise CIMError(CIM_ERR_NOT_FOUND, 'Method %s in namespace %s not '
+                                              'registered in repo' %
+                           (methodname, namespace))
+        try:
+            methods = methodsrepo[localobject.classname]
+        except KeyError:
+            raise CIMError(CIM_ERR_NOT_FOUND, 'Class %s for Method %s in'
+                                              'namespace %s not '
+                                              'registered in repo' %
+                           (localobject.classname, methodname, namespace))
+        try:
+            method_ = methods[methodname]
+        except KeyError:
+            raise CIMError(CIM_ERR_NOT_FOUND, 'Method %s in namespace %s not '
+                                              'registered in repo' %
+                           (methodname, namespace))
+
+        # Call the registered method and catch exceptions.
+        try:
+            result = method_(self, methodname, localobject, params=Params)
+
+        except CIMError:
+            raise
+        except Exception as ex:
+            raise CIMError(CIM_ERR_FAILED, 'General failure of invoked method='
+                                           '%s in namespace=%s with input='
+                                           'localobject %r,parameters=%s, '
+                                           'exception=%r' %
+                           (methodname, namespace, localobject, params, ex))
+
+        return result

--- a/testsuite/test_wbemconnection_mock.py
+++ b/testsuite/test_wbemconnection_mock.py
@@ -40,7 +40,7 @@ from testfixtures import OutputCapture
 
 from pywbem import CIMClass, CIMProperty, CIMInstance, CIMMethod, \
     CIMInstanceName, CIMClassName, CIMQualifier, CIMQualifierDeclaration, \
-    CIMError, DEFAULT_NAMESPACE, Uint32
+    CIMError, DEFAULT_NAMESPACE, Uint32, CIM_ERR_FAILED
 
 from pywbem.cim_obj import NocaseDict
 
@@ -97,10 +97,10 @@ def equal_ciminstnames(p1, p2):
     if not equal_model_path(p1, p2):
         return False
     if p1.namespace != p2.namespace:
-        print('match failure ns1=%s, ns2=%s' % (p1.namespace, p2.namespace))
+        print('Match failure ns1=%s, ns2=%s' % (p1.namespace, p2.namespace))
         return False
     if p1.host != p2.host:
-        print('match failure nhost1=%s, host2=%s' % (p1.host, p2.host))
+        print('Match failure nhost1=%s, host2=%s' % (p1.host, p2.host))
         return False
     return True
 
@@ -311,8 +311,16 @@ def tst_qualifiers_mof():
             Scope(any),
             Flavor(EnableOverride, ToSubclass, Translatable);
 
+        Qualifier In : boolean = true,
+            Scope(parameter),
+            Flavor(DisableOverride, ToSubclass);
+
         Qualifier Key : boolean = false,
             Scope(property, reference),
+            Flavor(DisableOverride, ToSubclass);
+
+        Qualifier Out : boolean = false,
+            Scope(parameter),
             Flavor(DisableOverride, ToSubclass);
         """
 
@@ -331,7 +339,9 @@ def tst_classes_mof(tst_qualifiers_mof):
                 [Key, Description ("This is key prop")]
             string InstanceID;
                 [Description ("This is a method")]
-            string Fuzzy();
+            uint32 Fuzzy(
+                [IN, Description("TestMethod Param")]
+              string SomeParameter);
             uint32 Delete();
         };
             [Description ("Subclass of CIM_Foo")]
@@ -343,6 +353,26 @@ def tst_classes_mof(tst_qualifiers_mof):
         };
         class CIM_Foo_sub_sub : CIM_Foo_sub {
             string cimfoo_sub_sub;
+                [Description("Sample method with input and output parameters")]
+            uint32 Method1(
+                [IN, Description("Input Param1")]
+              string InputParam1,
+                [IN, Description("Input Param2")]
+              string InputParam2,
+                [IN ( false), OUT, Description("Response param 1")]
+              string OutputParam1,
+                [IN ( false), OUT, Description("Response param 2")]
+              string OutputParam2);
+            uint32 Method2(
+                [IN, Description("Input Param1")]
+              Uint32 InputParam1,
+                [IN, Description("Input Param2")]
+              string InputParam2,
+                [IN ( false), OUT, Description("Response param 1")]
+              string OutputParam1,
+                [IN ( false), OUT, Description("Response param 2")]
+              Uint64 OutputParam2[]);
+
         };
     """
     return tst_qualifiers_mof + '\n\n' + cl_str + '\n\n'
@@ -401,8 +431,16 @@ def tst_assoc_mof():
             Scope(any),
             Flavor(EnableOverride, ToSubclass, Translatable);
 
+        Qualifier In : boolean = true,
+            Scope(parameter),
+            Flavor(DisableOverride, ToSubclass);
+
         Qualifier Key : boolean = false,
             Scope(property, reference),
+            Flavor(DisableOverride, ToSubclass);
+
+        Qualifier Out : boolean = false,
+            Scope(parameter),
             Flavor(DisableOverride, ToSubclass);
 
         class TST_Person{
@@ -939,7 +977,7 @@ class TestRepoMethods(object):
         assert conn.GetQualifier('Key', namespace=ns).name == 'Key'
 
         quals = conn.EnumerateQualifiers(namespace=ns)
-        assert len(quals) == 6
+        assert len(quals) == 8
 
     @pytest.mark.parametrize(
         "ns", [None, 'root/blah'])
@@ -2572,7 +2610,6 @@ class TestPullOperations(object):
                 source_inst_name.namespace = 'BadNamespaceName'
 
             with pytest.raises(CIMError) as exec_info:
-
                 conn.OpenReferenceInstancePaths(source_inst_name,
                                                 ResultClass=rc,
                                                 Role=ro)
@@ -2656,7 +2693,6 @@ class TestPullOperations(object):
                 source_inst_name.namespace = 'BadNamespaceName'
 
             with pytest.raises(CIMError) as exec_info:
-
                 conn.OpenAssociatorInstancePaths(source_inst_name,
                                                  AssocClass=ac,
                                                  Role=ro,
@@ -2743,7 +2779,6 @@ class TestPullOperations(object):
                 source_inst_name.namespace = 'BadNamespaceName'
 
             with pytest.raises(CIMError) as exec_info:
-
                 conn.OpenAssociatorInstances(source_inst_name,
                                              AssocClass=ac,
                                              Role=ro,
@@ -3543,3 +3578,254 @@ class TestAssociationOperations(object):
 
         # TODO expand associator classes test to test for correct properties
         # in response
+
+
+class TestInvokeMethod(object):
+    """
+    Test invoking extrinsic methods in Fake_WBEMConnection
+    """
+    def method1_callback(self, conn, methodname, object_name, params=None):
+        """
+        Callback for InvokeMethod with method name method1. This callback is
+        defined by a subscribe_method method call in the test method.
+
+        This method tests for valid object_name type, methodname and returns
+        the return value and params defined by instance attributes of the
+        TestInvokeMethod class.
+
+        In validates the conn is valid acces to repo by executing repo call
+        for the object_name.
+        """
+        self.executed_method = 'Method1'
+        assert params == self.input_params
+
+        # Test for valid conn by accessing repository for object defined by
+        # object_name. This test should never happen since already
+        # tested in _fake_invokemethod
+        if isinstance(object_name, CIMClassName):
+            cc = conn.GetClass(object_name)
+            assert cc.classname == object_name.classname
+
+        elif isinstance(object_name, CIMInstanceName):
+            inst = conn.GetInstance(object_name)
+            assert inst.classname == object_name.classname
+        else:
+            raise CIMError(CIM_ERR_FAILED,
+                           'Callback Method1 failed because input object_name '
+                           '%r invalid type %s' %
+                           object_name, type(object_name))
+
+        assert object_name.namespace == self.test_namespace
+        rtn_val = self.return_value
+        rtn_params = self.return_params
+
+        return (rtn_val, rtn_params)
+
+    def method2_callback(self, conn, methodname, object_name, params=None):
+        """
+        InvokeMethod callback.  This is a smiple callback that just tests
+        methodname and then returns returnvalue and params from the
+        TestInvokeMethod object attributes.
+        """
+
+        self.executed_method = 'Method2'
+        assert params == self.input_params
+
+        assert object_name.namespace == self.test_namespace
+        rtn_val = self.return_value
+        rtn_params = self.return_params
+
+        # if inputparam 1 has defined value, execute exception to test
+        # exception passback.
+        for param in params:
+            if param[0] == 'InputParam1':
+                if param[1] == 'CIM_ERR_FAILED':
+                    raise CIMError(CIM_ERR_FAILED,
+                                   'Test of exception in callback')
+
+        return (rtn_val, rtn_params)
+
+    @pytest.mark.parametrize(
+        "ns", [None, 'root/blah'])
+    @pytest.mark.parametrize(
+        # description: description of test
+        # input: dictionary of input object_name, methodname, and params
+        # exp_output: dictionary of expected returnvalue ('return') and output
+        #            params('params') as list of tuples.
+        # exp_exception: None or expected exception.
+        # exc_exc_data: None or expected CIMError status msg
+        "description, input, exp_output, exp_exception, exp_exc_data", [
+            ['Execution of Method1 method with single input param',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [('InputParam1', 'FirstData')], },
+             {'return': 0, 'params': [('OutPutParam1', 'SomeString')]},
+             None, None],
+
+            ['Execution of Method1 method with objectname string',
+             {'object_name': 'CIM_Foo_sub_sub',
+              'methodname': 'Method1',
+              'params': [('InputParam1', 'FirstData')], },
+             {'return': 0, 'params': [('OutPutParam1', 'SomeString')]},
+             None, None],
+
+            ['Execution of Method1 method with multiple input params',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [('InputParam1', 'FirstData'),
+                         ('InputParam2', 'SecondData')], },
+             {'return': 0, 'params': [('OutPutParam1', 'SomeString')]},
+             None, None],
+
+            ['Simple Execution of Method2 method with single input param',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method2',
+              'params': [('InputParam1', 'FirstData')], },
+             {'return': 0, 'params': [('OutPutParam1', 'SomeString')]},
+             None, None],
+
+            ['Execute Method1 with no input parameters',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': [('OutPutParam1', 'SomeString')]},
+             None, None],
+
+            ['Execute Method1 with no output parameters',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [('InputParam1', 'FirstData')], },
+             {'return': 0, 'params': []},
+             None, None],
+
+            ['Execute Method1 with no input/output parameters',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             None, None],
+
+            ['Execute Method1 with invalid namespace',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_INVALID_NAMESPACE'],
+
+            ['Execute Method2 with invalid namespace',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method2',
+              'params': [], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_INVALID_NAMESPACE'],
+
+            ['Execute method name with valid instancename',
+             {'object_name':
+              CIMInstanceName('CIM_Foo_sub_sub',
+                              keybindings={'InstanceID': 'CIM_Foo_sub_sub21'}),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             None, None],
+
+            ['Execute method name with CIMInsanceName that does not exist',
+             {'object_name': CIMInstanceName('CIM_Foo_sub_sub',
+                                             keybindings={'InstanceID':
+                                                          'blah'}),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_NOT_FOUND'],
+
+            ['Execute with mathodname that is not in repository',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Methodx',
+              'params': [], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_NOT_FOUND'],
+
+            ['Execute method name with invalid classname',
+             {'object_name': CIMClassName('CIM_Foo_sub_subx'),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_NOT_FOUND'],
+
+            ['Execute objectname invalid type',
+             {'object_name': CIMQualifierDeclaration('Key', 'string'),
+              'methodname': 'Method1',
+              'params': [], },
+             {'return': 0, 'params': []},
+             TypeError, None],
+
+            ['Execute Method2 with input param flag to cause exception',
+             {'object_name': CIMClassName('CIM_Foo_sub_sub'),
+              'methodname': 'Method2',
+              'params': [('InputParam1', 'CIM_ERR_FAILED')], },
+             {'return': 0, 'params': []},
+             CIMError, 'CIM_ERR_FAILED'],
+        ]
+    )
+    def test_invokemethod(self, conn, ns, description, input, exp_output,
+                          exp_exception, exp_exc_data, tst_instances_mof):
+        """
+        Test extrinnsic method invocation through the InvokeMethod
+        WBEMConnection method
+        """
+        conn.compile_mof_str(tst_instances_mof, namespace=ns)
+
+        # Save expected info so that callbacks can use in in returns and tests
+        # Maps to NocaseDict which is expected return type
+        self.return_value = exp_output['return']
+        if exp_output['params']:
+            self.rtn_params = NocaseDict()
+            for param in exp_output['params']:
+                self.rtn_params[param[0]] = param[1]
+        else:
+            self.return_params = NocaseDict()
+
+        self.return_params = exp_output['params']
+        self.input_params = input['params']
+
+        # Subscribe to InvokeMethod callback methods in the class.
+        conn.subscribe_method('CIM_Foo_sub_sub', 'Method1',
+                              self.method1_callback,
+                              namespace=ns)
+        conn.subscribe_method('CIM_Foo_sub_sub', 'Method2',
+                              self.method2_callback,
+                              namespace=ns)
+
+        # set namespace in object_name if required.
+        object_name = input['object_name']
+        tst_ns = conn.default_namespace if ns is None else ns
+        self.test_namespace = tst_ns
+
+        if isinstance(object_name, (CIMClassName, CIMInstanceName)):
+            object_name.namespace = ns
+        else:
+            # String object_name does not allow anything but default namespace
+            # Bypass test if ns is not None
+            if ns:
+                return
+
+        if not exp_exception:
+            result = conn.InvokeMethod(input['methodname'],
+                                       object_name,
+                                       Params=input['params'])
+
+            # Test return values and confirm correct method executed
+            assert result[0] == exp_output['return']
+            assert result[1] == exp_output['params']
+            assert self.executed_method == input['methodname']
+
+        else:
+            if exp_exc_data == 'CIM_ERR_INVALID_NAMESPACE':
+                object_name.namespace = 'Reallybadnamespace'
+
+            with pytest.raises(exp_exception) as exec_info:
+                conn.InvokeMethod(input['methodname'],
+                                  object_name,
+                                  Params=input['params'])
+            exc = exec_info.value
+            if isinstance(exp_exception, CIMError):
+                assert exc.status_code_name == exp_exc_data


### PR DESCRIPTION
InvokeMethod implementation.

Ready for review and merge

Includes:

1. subscribe_method - Method that adds method subscription to repository by (namespace, classname, methodname, call_back_method_name)

2. Implementation of InvokeMethod itself (i.e. _mock_call mock) That gets the  method subscription info from the repo and calls the method to be invoked.

3. definition of the input params and return for the method to be invoked. 
 Input parameters to the callback are:  
      <handle of repo>, MethodName, LocalObject, Namespace, Input_Params.

The callback executor returns
    (return_value, Dict of OutputParameters)

4. Modification to cim_operations.py.InvokeMethod to move some low level code from InvokeMethod to _methodcall so that the response to InvokeMethod from _methodcall is simply the tuple of (return_value, output_params_dictionary).  That way the implementer of the callback simply creates the return_value and
the dictionary of output params exactly as defined in the return definition of WBEMConnection.InvokeMethod.

5. Expansion of mockspport.rst to include InvokeMethod

The limitation of this approach is that we are not really considering the concept of the provider as a contained entity with its own responder and method definitions but are attaching the invokemethod to the repository itself.  

Ont the other hand it is simple, allows execution of InvokeMethod by the client and can use data in the repository to respond and can also modify the repository.