### PR TITLE
Fixes #974: Added support for binary,octal,hex number formats in MOF compiler

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -327,6 +327,10 @@ Bug fixes
 * Docs: Fixed the type `string` for the keys of the `CIMInstance.qualifiers`
   attribute to be `unicode string`.
 
+* Added support for octal, binary and hex numbers when parsing MOF
+  using the MOFCompiler class, in compliance with DSP0004 (Issue #974).
+  Extended the testcases to cover such numbers.
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -224,11 +224,13 @@ def t_MCOMMENT(t):
 
 def t_floatValue(t):
     r'[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?'
+    t.value = float(t.value)
     return t
 
 
 def t_hexValue(t):
     r'[+-]?0[xX][0-9a-fA-F]+'
+    t.value = int(t.value, 16)
     return t
 
 
@@ -239,6 +241,7 @@ def t_binaryValue(t):
     # zeros not allowed for decimal) would match 'decimalValue' and only
     # the zero would be taken out.
     if re.search(r'[2-9]', t.value) is not None:
+        # TODO 01/18 AM Replace skipping with raising an error
         msg = "Skipping invalid binary number '%s' in line %d" % \
             (t.value, t.lineno)
         try:
@@ -248,6 +251,8 @@ def t_binaryValue(t):
         t.lexer.parser.log(msg)
         t.type = 'error'
         t.lexer.skip(len(t.value))
+    else:
+        t.value = int(t.value[0:-1], 2)
     return t
 
 
@@ -258,6 +263,7 @@ def t_octalValue(t):
     # zeros not allowed for decimal) would match 'decimalValue' and only
     # the zero would be taken out, and the 8 would be another decimalValue.
     if re.search(r'[8-9]', t.value) is not None:
+        # TODO 01/18 AM Replace skipping with raising an error
         msg = "Skipping invalid octal number '%s' in line %d" % \
             (t.value, t.lineno)
         try:
@@ -267,6 +273,8 @@ def t_octalValue(t):
         t.lexer.parser.log(msg)
         t.type = 'error'
         t.lexer.skip(len(t.value))
+    else:
+        t.value = int(t.value, 8)
     return t
 
 
@@ -274,6 +282,7 @@ def t_octalValue(t):
 # the 0. If not at the end, 0 would match at the begin of e.g. an octal value.
 def t_decimalValue(t):
     r'[+-]?([1-9][0-9]*|0)'
+    t.value = int(t.value)
     return t
 
 
@@ -321,7 +330,7 @@ t_ignore = ' \r\t'
 def t_error(t):
     """ Lexer error callback from PLY Lexer with token in error.
     """
-
+    # TODO 01/18 AM Replace skipping with raising an error
     msg = "Skipping first character of invalid token '%s' in line %d" % \
         (t.value, t.lineno)
     try:
@@ -1347,6 +1356,7 @@ def p_constantValue(p):
                      | booleanValue
                      | nullValue
                      """
+    # The lexer functions (t_floatValue(), etc.) return a properly typed value.
     p[0] = p[1]
 
 
@@ -1356,8 +1366,8 @@ def p_integerValue(p):
                     | decimalValue
                     | hexValue
                     """
-    p[0] = int(p[1])
-    # TODO deal with non-decimal values.
+    # The lexer functions (t_binaryValue(), etc.) return a properly typed value.
+    p[0] = p[1]
 
 
 def p_referenceInitializer(p):

--- a/testsuite/testmofs/test_instance.mof
+++ b/testsuite/testmofs/test_instance.mof
@@ -18,6 +18,8 @@ instance of EX_AllTypes as $inner
     psi16 = +32767;
     psi32 = +2147483647;
     psi64 = +9223372036854775807;
+    pr32  = 1.175494351E-38;
+    pr64  = 4.9E-324;
     ps    = "abcdefg";
     pc    = 'a';
     pb    = false;
@@ -38,6 +40,8 @@ instance of EX_AllTypes as $outer
     psi16 = -32768;
     psi32 = -2147483648;
     psi64 = -9223372036854775808;
+    pr32  = 3.402823466E38;
+    pr64  = 1.7976931348623157E308;
     ps    = "abcdefg";
     pc    = 'a';
     pb    = true;
@@ -46,4 +50,34 @@ instance of EX_AllTypes as $outer
 //    pei   = $inner;
 };
 
+instance of EX_AllTypes as $values1
+{
+    k1 = 9923;
+    k2 = "SampleLabelValues1";
+    pui8  = 0101b;
+    pui16 = 077;
+    pui32 = 88;
+    pui64 = 0xabc;
+    psi8  = -0101B;
+    psi16 = -077;
+    psi32 = -88;
+    psi64 = -0xdef;
+    pr32  = .1;
+    pr64  = -1.1e-15;
+};
 
+instance of EX_AllTypes as $zeroes
+{
+    k1 = 9924;
+    k2 = "SampleLabelZeroes";
+    pui8  = 0;
+    pui16 = -0;
+    pui32 = 0b;
+    pui64 = -0b;
+    psi8  = -0x0;
+    psi16 = Null;
+    psi32 = Null;
+    psi64 = Null;
+    pr32  = .0;
+    pr64  = -.0e-0;
+};

--- a/testsuite/testmofs/test_types.mof
+++ b/testsuite/testmofs/test_types.mof
@@ -14,6 +14,8 @@ class EX_AllTypes
     sint16 psi16;
     sint32 psi32;
     sint64 psi64;
+    real32 pr32;
+    real64 pr64;
     string ps;
     char16 pc;
     boolean pb;


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.