### PR TITLE
Fixed _uprint() and added tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -469,6 +469,11 @@ endif
 
 $(test_log_file): makefile $(package_name)/*.py testsuite/*.py coveragerc
 	@echo "makefile: Running tests"
+ifeq ($(PLATFORM),Windows)
+	testsuite\test_uprint.bat
+else
+	testsuite/test_uprint.sh
+endif
 	rm -f $(test_log_file)
 	bash -c "set -o pipefail; PYTHONWARNINGS=default py.test --cov $(package_name) --cov $(mock_package_name) $(coverage_report) --cov-config coveragerc --ignore=attic --ignore=releases --ignore=testsuite/testclient -s 2>&1 |tee $(test_tmp_file)"
 	mv -f $(test_tmp_file) $(test_log_file)

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -35,6 +35,7 @@ import uuid
 import time
 import logging
 import sys
+import locale
 import traceback
 import re
 from xml.dom import minidom
@@ -77,23 +78,32 @@ OUTPUT_FORMATS = ['mof', 'xml', 'repr']
 # document our behavior in relation to the spec.
 
 
+STDOUT_ENCODING = getattr(sys.stdout, 'encoding', None)
+if not STDOUT_ENCODING:
+    STDOUT_ENCODING = locale.getpreferredencoding()
+if not STDOUT_ENCODING:
+    STDOUT_ENCODING = 'utf-8'
+
+
 def _uprint(dest, text):
     """
-    Display to dest defined by text. This function appends the data
-    in text to the file defined by dest or to stdout of dest is None
-    """
-    # replace errors since there are issues with some windows versions.
-    if sys.version_info[0] == 2 and sys.version_info[1] == 6:
-        text = text.encode("utf-8")  # python 2.6 does not support errors=
-    else:
-        text = text.encode("utf-8", errors='replace')
+    Write text to dest, adding a newline character.
 
+    Text must be a unicode string and must not be None.
+
+    If dest is a file path, the text is encoded to a UTF-8 Byte sequence and
+    is appended to the file (opening and closing the file).
+
+    If dest is None, the text is encoded to a codepage suitable for the current
+    stdout and is written to stdout.
+    """
     if not dest:
-        print(text)
+        btext = text.encode(STDOUT_ENCODING, 'replace')
+        print(btext)
     else:
+        btext = text.encode('utf-8')
         with open(dest, 'a') as f:
-            print(text, file=f)
-        f.close()
+            print(btext, file=f)
 
 
 def method_callback_interface(conn, objectname, methodname, Params, **params):

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -82,8 +82,7 @@ def _display(dest, text):
     Display to dest defined by text. This function appends the data
     in text to the file defined by dest or to stdout of dest is None
     """
-    if six.PY2:
-        text = text.encode("utf-8")
+    text = text.encode("utf-8", errors='replace')
     if not dest:
         print(text)
     else:

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -82,7 +82,8 @@ def _display(dest, text):
     Display to dest defined by text. This function appends the data
     in text to the file defined by dest or to stdout of dest is None
     """
-    # TODO make this unicode file for python 2
+    if six.PY2:
+        text = text.encode("utf-8")
     if not dest:
         print(text)
     else:
@@ -709,7 +710,7 @@ class FakedWBEMConnection(WBEMConnection):
         type of object (instance, class, qualifier declaration).
 
         """
-        # TODO: FUTUREConsider sorting to perserve order of compile/add.
+        # TODO: FUTURE Consider sorting to perserve order of compile/add.
 
         if namespace in objects_repo:
             if obj_type == 'Methods':
@@ -1213,7 +1214,7 @@ class FakedWBEMConnection(WBEMConnection):
             if iname == inst.path:
                 if rtn_inst is not None:
                     # TODO: Future Remove this test since we should be
-                    # insuring no dups on creation
+                    # insuring no dups on instance creation
                     raise CIMError(CIM_ERR_FAILED, 'Invalid Repository. '
                                    'Multiple instances with same path %s'
                                    % rtn_inst.path)
@@ -1331,7 +1332,8 @@ class FakedWBEMConnection(WBEMConnection):
     def _create_instance_path(class_, instance, namespace):
         """
         Given a class and corresponding instance, create the instance path
-        TODO. Future This code should exist in cim_obj or cim_operations.
+        TODO. Future This code should exist in cim_obj or cim_operations and
+              not just here.
         """
         kb = NocaseDict()
         assert class_.classname == instance.classname
@@ -1705,7 +1707,7 @@ class FakedWBEMConnection(WBEMConnection):
             else:
                 raise
 
-        # test all key properties in instance. This is our repository limit
+        # Test all key properties in instance. This is our repository limit
         # since the repository cannot add values for key properties. We do
         # no allow creating key properties from class defaults.
         # TODO Discussion. Should we allow key properties from class, in
@@ -2318,7 +2320,7 @@ class FakedWBEMConnection(WBEMConnection):
         rtn_instpaths = []
         role = role.lower() if role else role
         result_role = result_role.lower() if result_role else result_role
-        # TODO the above and all similar do not need the else component.
+
         ref_paths = self._get_reference_instnames(inst_name, namespace,
                                                   assoc_class, role)
         # Get associated instance names

--- a/testsuite/run_uprint.py
+++ b/testsuite/run_uprint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""
+Python script for testing the internal _uprint() function with destination
+stdout, in a Python environment that is as close as possible to what a pywbem
+user uses.
+
+Specifically, because py.test captures stdout, this program should not run
+under py.test (unless there is a separate shell in between this program and
+py.test).
+
+If the _uprint() function succeeds, the script exits with exit code 0, and a
+test string has been written to stdout.
+
+Otherwise, the script exits with an exit code other than 0, and an error
+message has been written to stderr (and possibly stdout).
+
+This test script can be invoked with a command line argument that determines
+the test case that is run:
+
+* run_uprint.py small - A small string of selected unicode characters
+* run_uprint.py ucs2 - All Unicode characters in UCS-2 (U+0000 to U+FFFF)
+* run_uprint.py all - All Unicode characters up to the max character supported
+  by the Python build that is used. A wide build supports up to U+10FFFF. A
+  narrow build supports up to U+FFFF. If the Python build supports less than
+  U+10FFFF, an info message is written to stderr, but this does not cause the
+  test to fail.
+"""
+
+from __future__ import absolute_import, print_function
+import sys
+import locale
+import six
+from pywbem_mock._wbemconnection_mock import _uprint
+
+
+def main():
+
+    if len(sys.argv) > 1:
+        mode = sys.argv[1]  # 'small', 'ucs2', 'all'
+    else:
+        mode = 'small'
+
+    print("Debug: mode=%s; sys.stdout: isatty=%r, encoding=%r" %
+          (mode, sys.stdout.isatty(), getattr(sys.stdout, 'encoding', None)),
+          file=sys.stderr)
+    print("Debug: sys.getfilesystemencoding=%r locale.getpreferredencoding=%r" %
+          (sys.getfilesystemencoding(), locale.getpreferredencoding()),
+          file=sys.stderr)
+
+    if mode == 'small':
+        test_string = u'\u212b \u0420 \u043e \u0441 \u0441 \u0438 \u044f \u00e0'
+        _uprint(None, test_string)
+    elif mode == 'ucs2':
+        for cp in six.moves.xrange(0, 0xFFFF):
+            test_string = six.unichr(cp)
+            _uprint(None, test_string)
+    elif mode == 'all':
+        test_string = u''
+        if sys.maxunicode < 0x10FFFF:
+            print("Info: Testing Unicode range of only up to U+%.6X "
+                  "(out of U+10FFFF)" % sys.maxunicode,
+                  file=sys.stderr)
+        for cp in six.moves.xrange(0, sys.maxunicode):
+            test_string = six.unichr(cp)
+            _uprint(None, test_string)
+
+
+if __name__ == '__main__':
+    main()

--- a/testsuite/test_uprint.bat
+++ b/testsuite/test_uprint.bat
@@ -1,0 +1,45 @@
+@setlocal enableextensions
+@echo off
+rem Windows batch script that runs the run_uprint.py script in different
+rem scenarios. If the tests succeed, this script exits with exit code 0.
+
+set mydir=%~d0%~p0
+set err_log=%mydir%test_uprint_err.log
+set out_log=%mydir%test_uprint_out.log
+
+call :run_test -         python %mydir%run_uprint.py small
+call :run_test nul       python %mydir%run_uprint.py small
+call :run_test %out_log% python %mydir%run_uprint.py small
+
+rem call :run_test -         python %mydir%run_uprint.py ucs2
+call :run_test nul       python %mydir%run_uprint.py ucs2
+call :run_test %out_log% python %mydir%run_uprint.py ucs2
+
+rem call :run_test -         python %mydir%run_uprint.py all
+call :run_test nul       python %mydir%run_uprint.py all
+call :run_test %out_log% python %mydir%run_uprint.py all
+
+endlocal
+exit /b 0
+
+:run_test
+set out=%1
+set cmd=%2 %3 %4 %5
+if "%out%"=="-" (
+  set cmd_out=%cmd%
+) else (
+  set cmd_out=%cmd% ^>%out%
+)
+call %cmd_out% 2>%err_log%
+set rc=%errorlevel%
+if errorlevel 1 (
+  echo Error: Test failed with rc=%rc% for: %cmd%    %out%
+  echo === begin of stderr ===
+  type %err_log%
+  echo === end of stderr ===
+  exit /b %rc%
+) else (
+  echo Success for: %cmd%    %out%
+  type %err_log%
+)
+exit /b 0

--- a/testsuite/test_uprint.sh
+++ b/testsuite/test_uprint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Shell script that runs the run_uprint.py script in different scenarios.
+# If the tests succeed, this script exits with exit code 0.
+
+function run_test {
+  cmd="$@"
+
+  sh -c "$cmd" 2>$err_log
+  rc=$?
+
+  if [[ $rc != 0 ]]; then
+    echo "Error: Test failed with rc=$rc for: $cmd"
+    echo "=== begin of stderr ==="
+    cat $err_log
+    echo "=== end of stderr ==="
+    exit $rc
+  else
+    echo "Success for: $cmd"
+    # In this case, stderr may contain debug messages
+    cat $err_log
+  fi
+}
+
+mydir=$(dirname $0)
+err_log="$mydir/test_uprint_err.log"
+out_log="$mydir/test_uprint_out.log"
+
+run_test "python $mydir/run_uprint.py small"
+run_test "python $mydir/run_uprint.py small >/dev/null"
+run_test "python $mydir/run_uprint.py small >$out_log"
+
+#run_test "python $mydir/run_uprint.py ucs2"
+run_test "python $mydir/run_uprint.py ucs2 >/dev/null"
+run_test "python $mydir/run_uprint.py ucs2 >$out_log"
+
+#run_test "python $mydir/run_uprint.py all"
+run_test "python $mydir/run_uprint.py all >/dev/null"
+run_test "python $mydir/run_uprint.py all >$out_log"
+

--- a/testsuite/test_wbemconnection_mock.py
+++ b/testsuite/test_wbemconnection_mock.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # (C) Copyright 2018 InovaDevelopment.com
 #
@@ -1030,6 +1031,46 @@ class TestRepoMethods(object):
 
         quals = conn.EnumerateQualifiers(namespace=ns)
         assert len(quals) == 8
+
+    def test_unicode(self, conn):
+        """
+        Test compile and display repository with unicode in mof string
+        """
+        ns = 'root/blah'
+
+        qmof = """
+        Qualifier Description : string = null,
+            Scope(any),
+            Flavor(EnableOverride, ToSubclass, Translatable);
+
+        Qualifier Key : boolean = false,
+            Scope(property, reference),
+            Flavor(DisableOverride, ToSubclass);
+        Qualifier Description : string = null,
+            Scope(any),
+            Flavor(EnableOverride, ToSubclass, Translatable);
+        """
+
+        cmof = u"""
+        class CIM_Foo {
+                [Key,
+                 Description ("Å \u0420\u043e\u0441\u0441\u0438\u044f"
+                              "\u00E0 voil\u00e0")]
+            string InstanceID;
+        };
+        """
+
+        conn.compile_mof_str(qmof, ns)
+        conn.compile_mof_str(cmof, ns)
+
+        with OutputCapture() as output:  # noqa: F841
+            conn.display_repository()
+        tst_file_name = 'test_wbemconnection_mock_repo_unicode.txt'
+        tst_file = os.path.join(SCRIPT_DIR, tst_file_name)
+
+        conn.display_repository(dest=tst_file)
+        assert os.path.isfile(tst_file)
+        os.remove(tst_file)
 
     @pytest.mark.parametrize(
         "ns", [None, 'root/blah'])


### PR DESCRIPTION
This fixes `_uprint()` as discussed in PR #1006, and adds corresponding tests to Travis and Appveyor.

Instead of merging this PR, it can be cherry-picked into the branch of PR #1006.