### PR TITLE
Fixes #1069: Cleanup TODOs in FakeWBEMConnection; Added from_instance()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -334,6 +334,10 @@ Enhancements
   of CIM objects are now checked for validity, and `ValueError` is raised
   if not valid (Issue 1043).
 
+* Add new method to CIMInstanceName (from_instance) to create CIMInstanceName
+  element from class and instance.  This was done as part of building the
+  pywbem_mock environment.  See issue #1069.
+
 Bug fixes
 ^^^^^^^^^
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2552,21 +2552,25 @@ class CIMInstanceName(_CIMComparisonMixin):
         :class:`~pywbem.CIMInstanceName` from the class key properties and
         instance key property values.
 
-        If the `strict` parameter is True, and a property value does not exist
-        in the instance the values are retrieved from the class default_value.
+        If the `strict` parameter is False, and a property value does not exist
+        in the `instance` that entry is not included in the constructed
+        CIMInstanceName
 
-        If the `strict` parameter is False all key properties in the `class_`
+        If the `strict` parameter is True all key properties in the `class_`
         must exist in the `instance` or a ValueError exception is raised.
 
         Parameters:
 
-            class_ (:class:`~pywbem.CIMClass`):
+            `class_` (:class:`~pywbem.CIMClass`):
                 CIMClass from which the list of key properties will be
                 retrieved. The class MUST contain all of the key properties
                 that are required to create the CIMInstanceName. Thus, for
                 example, if the class were retrieved from a server, generally,
                 the request `LocalOnly` parameter should be False to assure all
-                superclass properties are retrieved.
+                superclass properties are retrieved.  It need not be the
+                same class as the instance. Thus, it could be a
+                superclass if the key properties were the same for both the
+                instance and class
 
             instance (:class:`~pywbem.CIMInstance`):
                 CIMInstance containing the key property values.
@@ -2578,8 +2582,8 @@ class CIMInstanceName(_CIMComparisonMixin):
                 Host name to include in created CIMInstanceName or None.
 
             strict (:class:`py:bool`):
-                If True, all key properties are required in instance. Default
-                False.
+                If True, all key properties in the class must have values in
+                the  instance. Default False.
 
         Returns:
             :class:`~pywbem.CIMInstanceName`:
@@ -2588,16 +2592,11 @@ class CIMInstanceName(_CIMComparisonMixin):
                 `instance` parameter.
 
         Raises:
-          ValueError: Class and instance names do not match or the
-            strict attribute is True and key property does not exist in
-            the instance.
+          ValueError: The strict attribute is True and key property does not
+          exist in the instance.
 
         """
         keybindings = NocaseDict()
-        if class_.classname != instance.classname:
-            raise ValueError('Class name %s does not match instance '
-                             'classname %s' %
-                             (class_.classname, instance.classname))
 
         for prop in class_.properties:
             if 'key' in class_.properties[prop].qualifiers:
@@ -2610,9 +2609,6 @@ class CIMInstanceName(_CIMComparisonMixin):
                         raise ValueError('Key property %r of class %r '
                                          'missing in instance.' %
                                          (pname, class_.classname))
-                    else:
-                        default_value = class_.properties[prop].value
-                        keybindings[pname] = default_value
 
         return CIMInstanceName(class_.classname,
                                keybindings,

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2548,38 +2548,47 @@ class CIMInstanceName(_CIMComparisonMixin):
     def from_instance(class_, instance, namespace=None, host=None,
                       strict=False):
         """
-        Given a class and corresponding instance, create and return the
-        CIMInstanceName from the class key properties and instance key
-        property values.
+        Given a class and corresponding instance, create and return a
+        :class:`~pywbem.CIMInstanceName` from the class key properties and
+        instance key property values.
 
-        If a property value does not exist in the instance it gets the
-        value from the class default_value unless strict is set. If strict
-        is True, all key properties must exist in the instance
+        If the `strict` parameter is True, and a property value does not exist
+        in the instance the values are retrieved from the class default_value.
+
+        If the `strict` parameter is False all key properties in the `class_`
+        must exist in the `instance` or a ValueError exception is raised.
 
         Parameters:
 
-            class_ (:class:~pywbem.CIMClass`):
-                CIMClass from which the key properties will be retrieved.
+            class_ (:class:`~pywbem.CIMClass`):
+                CIMClass from which the list of key properties will be
+                retrieved. The class MUST contain all of the key properties
+                that are required to create the CIMInstanceName. Thus, for
+                example, if the class were retrieved from a server, generally,
+                the request `LocalOnly` parameter should be False to assure all
+                superclass properties are retrieved.
 
-            instance: (:class:~pywbem.CIMInstance`):
+            instance (:class:`~pywbem.CIMInstance`):
                 CIMInstance containing the key property values.
 
-            namespace: (:term:``string`):
+            namespace (:term:`string`):
                 Namespace to include in created CIMInstanceName or None.
 
-            host:  (:term:``string`):
+            host (:term:`string`):
                 Host name to include in created CIMInstanceName or None.
 
-            strict: (:class:`py:bool`):
+            strict (:class:`py:bool`):
                 If True, all key properties are required in instance. Default
-                False
+                False.
 
         Returns:
-            :class:`CIMInstanceName` built from the key properties in the
-            class using the key property values in the instance.
+            :class:`~pywbem.CIMInstanceName`:
+                :class:`~pywbem.CIMInstanceName` built from the key properties
+                in the `class_` parameter using the key property values in the
+                `instance` parameter.
 
         Raises:
-            ValueError: Class and instance names do not match or the
+          ValueError: Class and instance names do not match or the
             strict attribute is True and key property does not exist in
             the instance.
 
@@ -2598,8 +2607,8 @@ class CIMInstanceName(_CIMComparisonMixin):
                     keybindings[pname] = instance[prop]
                 else:
                     if strict:
-                        raise ValueError('Key Property %s in class %s '
-                                         'but not in instance.' %
+                        raise ValueError('Key property %r of class %r '
+                                         'missing in instance.' %
                                          (pname, class_.classname))
                     else:
                         default_value = class_.properties[prop].value

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -395,9 +395,9 @@ class MOFParseError(Error):
         return self._msg
 
     def __str__(self):
-        ret_str = 'MOFParseError: '
+        ret_str = 'MOFParseError:\n'
         if self.lineno is not None:
-            ret_str += '%s:%s: %smsg=%s\n%s' % \
+            ret_str += '%s:%s:%s msg=%s\n%s' % \
                 (self.file, self.lineno, self.column, self.msg, self.context)
         else:
             ret_str += '%s' % self.msg
@@ -414,9 +414,10 @@ class MOFParseError(Error):
             <context - MOF segment>
             <context - location indicator>
         """
-        ret_str = 'Syntax error in '
-        if self.file is not None and self.lineno is not None:
-            ret_str += '%s line %s:' % (self.file, self.lineno)
+        ret_str = 'Syntax error:'
+        disp_file = 'NoFile' if self.file is None else self.file
+        if self.lineno is not None:
+            ret_str += '%s:%s:%s' % (disp_file, self.lineno, self.column)
         if self.msg:
             ret_str += " %s" % self.msg
         if self.context is not None:

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -50,12 +50,11 @@ from pywbem import WBEMConnection, CIMClass, CIMClassName, \
     CIM_ERR_INVALID_PARAMETER, CIM_ERR_INVALID_CLASS, CIM_ERR_ALREADY_EXISTS, \
     CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED, \
-    DEFAULT_NAMESPACE, \
-    MOFCompiler, MOFWBEMConnection
+    DEFAULT_NAMESPACE, MOFCompiler, MOFWBEMConnection
 from pywbem.cim_obj import NocaseDict
 
 
-__all__ = ['FakedWBEMConnection']
+__all__ = ['FakedWBEMConnection', 'PYWBEM_MOCK_LOGGER']
 
 # Fake Server default values for parameters that apply to repo and operations
 
@@ -72,10 +71,14 @@ DEFAULT_DEEP_INHERITANCE = True
 # allowed output formats for the repository display
 OUTPUT_FORMATS = ['mof', 'xml', 'repr']
 
-# TODO: Future We have not considered that iq and ico are deprecated in DSP0200.
-# We should set up a default to ignore these parameters for the operations
-# in which they are deprecated and we should/could ignore them. We need to
-# document our behavior in relation to the spec.
+# The logger for pywbem_mock is defined with the following name
+PYWBEM_MOCK_LOGGER = 'pywbem.mock'
+
+
+# TODO: ks Future We have not considered that iq and ico are deprecated in
+# DSP0200 we should set up a default to ignore these parameters for the
+# operations in which they are deprecated and we should/could ignore them. We
+# need to document our behavior in relation to the spec.
 
 
 STDOUT_ENCODING = getattr(sys.stdout, 'encoding', None)
@@ -234,10 +237,26 @@ class FakedWBEMConnection(WBEMConnection):
     connection to a WBEM server. It uses a faked and fixed URL for the WBEM
     server (``http://FakedUrl``) as a means of identifying the connection by
     users.
+
+    Logging of the calls and returns is implemented using the Python logging
+    facility.  To enable logging, the user must define the logger
+    PYWBEM_MOCK_LOGGER before FakedWBEMConnection is executed including
+    setting the destination, and log leve. Logging is only output if the
+    log level is DEBUG For example the following code enables the a
+    stream logger to the console:
+
+        logger = logging.getLogger(PYWBEM_MOCK_LOGGER)
+        logger.setLevel(logging.getLevelName('DEBUG'))
+        handler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
     """
     def __init__(self, default_namespace=DEFAULT_NAMESPACE,
                  use_pull_operations=False, enable_stats=False,
-                 response_delay=None, repo_lite=False, verbose=False):
+                 response_delay=None, repo_lite=False):
         """
         Parameters:
 
@@ -269,9 +288,6 @@ class FakedWBEMConnection(WBEMConnection):
             requiring that the corresponding classes exist in the mock
             repository, and class operations without the corresponding
             qualifier types.
-
-          verbose (:class:`py:bool`):
-            Controls whether to print more messages to stdout.
         """
         super(FakedWBEMConnection, self).__init__(
             'http://FakedUrl',
@@ -299,7 +315,7 @@ class FakedWBEMConnection(WBEMConnection):
         # the CIM namespace name and the value is a list of CIM instances in
         # that namespace, represented as CIMInstance objects.
         # TODO: ks. FUTURE maybe we should really have a subdict per class but
-        #  it is probably not important for initial release.
+        #           it is not important for initial release.
         self.instances = NocaseDict()
 
         self.methods = NocaseDict()
@@ -312,18 +328,11 @@ class FakedWBEMConnection(WBEMConnection):
         # this list is still open.
         self.enumeration_contexts = {}
 
-        # TODO drop this and corresponding init param in favor of logging
-        # for all output.
-        self.verbose = verbose
-
         # Response delay in seconds. Any operation is delayed by this time.
         self._response_delay = response_delay
 
-        # TODO: Improve logging so we have user options..
-        self.logfile = 'wbemconnection.log'
-
-        if self.logfile:
-            logging.basicConfig(filename=self.logfile, level=logging.INFO)
+        # Set logger for this instance of FakedWBEMConnection
+        self.logger = logging.getLogger(PYWBEM_MOCK_LOGGER)
 
         self._imethodcall = Mock(side_effect=self._mock_imethodcall)
         self._methodcall = Mock(side_effect=self._mock_methodcall)
@@ -401,27 +410,18 @@ class FakedWBEMConnection(WBEMConnection):
           MOFParseError: Syntax error in the MOF. A compile error terminates
             the compile and nothing is added to the mock repository.
         """
-
-        # TODO clean up the moflog and make it part of our logging
-        def moflog(msg):
-            """Display message to moflog2"""
-            print(msg, file=self.logfile)
-
         if not namespace:
             namespace = self.default_namespace
 
-        moflog_file = 'moflog_fake.log'
+        mofcomp = MOFCompiler(MOFWBEMConnection(),
+                              search_paths=search_paths,
+                              verbose=verbose)
+        mof_repo = mofcomp.handle
+        self._setup_mof_repo(mof_repo)
 
-        with open(moflog_file, 'w') as self.logfile:
-            mofconn = MOFWBEMConnection()
-            mofcomp = MOFCompiler(mofconn,
-                                  search_paths=search_paths,
-                                  verbose=verbose,
-                                  log_func=moflog)
-            mof_repo = mofcomp.handle
-            self._setup_mof_repo(mof_repo)
-            mofcomp.compile_file(mof_file, namespace)
-            self._merge_repos(mof_repo)
+        mofcomp.compile_file(mof_file, namespace)
+
+        self._merge_repos(mof_repo)
 
     def compile_mof_str(self, mof_str, namespace=None, search_paths=None,
                         verbose=None):
@@ -467,31 +467,22 @@ class FakedWBEMConnection(WBEMConnection):
 
           : Any exceptions that are raised by the repository connection class.
         """
-
-        def moflog(msg):
-            """Display message to moflog_fake_str"""
-            print(msg, file=self.logfile)
-
         if not namespace:
             namespace = DEFAULT_NAMESPACE
 
-        moflog_file = 'moflog_fake.log'
+        # TODO:ks Future we might be able to use MOFWBEMConnection to
+        # directly insert into our repository instead of copying them
+        # after the compile.
+        mofcomp = MOFCompiler(MOFWBEMConnection(),
+                              search_paths=search_paths,
+                              verbose=verbose)
 
-        with open(moflog_file, 'w') as self.logfile:
-            # TODO: Future we should be able to use MOFWBEMConnection to
-            # directly insert into our repository instead of copying them
-            # after the compile.
-            mofconn = MOFWBEMConnection()
-            mofcomp = MOFCompiler(mofconn,
-                                  search_paths=search_paths,
-                                  verbose=verbose,
-                                  log_func=moflog)
+        mof_repo = mofcomp.handle
+        self._setup_mof_repo(mof_repo)
 
-            mof_repo = mofcomp.handle
-            self._setup_mof_repo(mof_repo)
-            mofcomp.compile_string(mof_str, namespace)
+        mofcomp.compile_string(mof_str, namespace)
 
-            self._merge_repos(mof_repo)
+        self._merge_repos(mof_repo)
 
     def add_cimobjects(self, objects, namespace=None):
         # pylint: disable=line-too-long
@@ -714,8 +705,7 @@ class FakedWBEMConnection(WBEMConnection):
         type of object (instance, class, qualifier declaration).
 
         """
-        # TODO: FUTURE Consider sorting to perserve order of compile/add.
-
+        # TODO:ks FUTURE Consider sorting to perserve order of compile/add.
         if namespace in objects_repo:
             if obj_type == 'Methods':
                 _uprint(dest, '%sNamespace %s: contains %s %s:%s\n' %
@@ -735,7 +725,7 @@ class FakedWBEMConnection(WBEMConnection):
                 except KeyError:
                     return
 
-                # TODO: Future sort insts by path order.
+                # TODO:ks Future: Possibly sort insts by path order.
                 for inst in insts:
                     if output_format == 'xml':
                         _uprint(dest, '%s Path=%s %s\n%s' %
@@ -822,7 +812,7 @@ class FakedWBEMConnection(WBEMConnection):
                                            LocalOnly=False,
                                            IncludeQualifiers=True,
                                            IncludeClassOrigin=True)
-                        inst.path = self._create_instance_path(cc, inst, ns)
+                        inst.path = CIMInstanceName.from_instance(cc, inst, ns)
                     try:
                         self.instances[ns].append(inst)
                     except KeyError:
@@ -857,40 +847,59 @@ class FakedWBEMConnection(WBEMConnection):
         Each function is named with the lower case method namd prepended with
         '_fake_'.
         """
-        logging.debug('mock_imethodcall method=%s, namespace=%s, '
-                      'response_params_rqd=%s\nparams=%s',
-                      methodname, namespace, response_params_rqd, params)
+        self.logger.debug('Mock_method=%s, namespace=%s, '
+                          'response_params_rqd=%s, params=%s',
+                          methodname, namespace, response_params_rqd, params)
 
         method_name = '_fake_' + methodname.lower()
 
         method_name = getattr(self, method_name)
-        result = method_name(namespace, **params)
+        try:
+            result = method_name(namespace, **params)
+        except CIMError as ce:
+            self.logger.debug('CIMError exception:%s Err: %s:%s "%s"',
+                              methodname, ce.status_code,
+                              ce.status_code_name, ce.status_description)
+            raise
+        except Exception as ex:
+            self.logger.debug('%s Exception %r', methodname, ex)
+            raise
 
         # sleep for defined number of seconds
         if self._response_delay:
             time.sleep(self._response_delay)
 
-        logging.debug('mock result %s', result)
+        self.logger.debug('Mock result %s', result)
 
         return result
 
     def _mock_methodcall(self, methodname, localobject, Params=None, **params):
         # pylint: disable=invalid-name
         """
-        Mocks the WBEMConnection._methodcall() method.
+        Mocks the WBEMConnection._methodcall() method. This calls the
+        server execution function of extrinsic methods (InvokeMethod).
         """
-        logging.debug('mock_methodcall method=%s, namespace=%s, '
-                      'Params=%s\nparams=%s',
-                      methodname, localobject, Params, params)
+        self.logger.debug('Mock InvokeMethod method=%s object=%s '
+                          'Params=%s: params=%s',
+                          methodname, localobject, Params, params,)
 
-        result = self._fake_invokemethod(methodname, localobject, Params,
-                                         **params)
+        try:
+            result = self._fake_invokemethod(methodname, localobject, Params,
+                                             **params)
+        except CIMError as ce:
+            self.logger.debug('CIMError exception:InvokeMethod Err: %s:%s %s',
+                              ce.status_code, ce.status_code_name,
+                              ce.status_description)
+            raise
+        except Exception as ex:
+            self.logger.debug('InvokeMethod Exception %r', ex)
+            raise
 
         # Sleep for defined number of seconds
         if self._response_delay:
             time.sleep(self._response_delay)
 
-        logging.debug('mock result %s', result)
+        self.logger.debug('Mock InvokeMethod result %s', result)
 
         return result
 
@@ -1194,7 +1203,7 @@ class FakedWBEMConnection(WBEMConnection):
 
         Returns: Returns list of classes.
         """
-        # TODO: Future. this could become an iterator for efficiency.
+        # TODO:ks Future. this could become an iterator for efficiency.
         class_repo = self._get_class_repo(namespace)
         associator_classes = []
         for cl in six.itervalues(class_repo):
@@ -1226,7 +1235,7 @@ class FakedWBEMConnection(WBEMConnection):
         for index, inst in enumerate(inst_repo):
             if iname == inst.path:
                 if rtn_inst is not None:
-                    # TODO: Future Remove this test since we should be
+                    # TODO:ks Future Remove dup test since we should be
                     # insuring no dups on instance creation
                     raise CIMError(CIM_ERR_FAILED, 'Invalid Repository. '
                                    'Multiple instances with same path %s'
@@ -1256,8 +1265,7 @@ class FakedWBEMConnection(WBEMConnection):
 
         rtn_tup = self._find_instance(iname, inst_repo)
         inst = rtn_tup[1]
-        # TODO review code to confirm we are consistent with path output
-        # in error messages. Should show the same rep for all messages, string.
+
         if not inst:
             raise CIMError(CIM_ERR_NOT_FOUND,
                            'Instance not found in repository namespace %s. '
@@ -1333,34 +1341,10 @@ class FakedWBEMConnection(WBEMConnection):
             are allowed in the list and ignored.
         """
         if property_list is not None:
-            # TODO. FUTURE Should be able to delete following.  We should be
-            #       receiving a good property list from WBEMConnection
-            if isinstance(property_list, six.string_types):
-                property_list = [property_list]
             property_list = [p.lower() for p in property_list]
             for pname in obj.properties.keys():
                 if pname.lower() not in property_list:
                     del obj.properties[pname]
-
-    @staticmethod
-    def _create_instance_path(class_, instance, namespace):
-        """
-        Given a class and corresponding instance, create the instance path
-        TODO. Future This code should exist in cim_obj or cim_operations and
-              not just here.
-        """
-        kb = NocaseDict()
-        assert class_.classname == instance.classname
-        for prop in class_.properties:
-            if 'key' in class_.properties[prop].qualifiers:
-                pname = class_.properties[prop].name  # get original case name
-                if prop in instance:
-                    kb[pname] = instance[prop]
-                else:
-                    default_value = class_.properties[prop]
-                    instance[pname] = default_value
-
-        return CIMInstanceName(class_.classname, kb, namespace=namespace)
 
     #####################################################################
     #
@@ -1473,7 +1457,7 @@ class FakedWBEMConnection(WBEMConnection):
 
         if not isinstance(new_class, CIMClass):
             raise CIMError(CIM_ERR_INVALID_PARAMETER,
-                           'NewClass not valid class type: %s' %
+                           'NewClass not valid CIMClass. Rcvd type: %s' %
                            type(new_class))
 
         if new_class.superclass:
@@ -1627,20 +1611,21 @@ class FakedWBEMConnection(WBEMConnection):
         """
         qual = params['QualifierDeclaration']
 
-        # TODO FUTURE implement set... method for instance, qualifier, class as
-        # general means to put new data into the repo.
+        # TODO:ks FUTURE implement set... method for instance, qualifier, class
+        # as general means to put new data into the repo.
         if namespace not in self.qualifiers:
             self.qualifiers[namespace] = NocaseDict({})
 
         if not isinstance(qual, CIMQualifierDeclaration):
             raise CIMError(CIM_ERR_INVALID_PARAMETER,
                            'QualifierDeclaration parameter is not a '
-                           'valid CIMQualifierDeclaration type: %s' %
+                           'valid CIMQualifierDeclaration. Rcvd type: %s' %
                            type(qual))
 
         if qual.name in self.qualifiers[namespace]:
             raise CIMError(CIM_ERR_ALREADY_EXISTS,
-                           'Qualifier declaration %s not found in namspace %s.'
+                           'Qualifier declaration %s already exists in '
+                           'namespace %s.'
                            % (qual.name, namespace))
         try:
             self.qualifiers[namespace][qual.name] = qual
@@ -1703,7 +1688,8 @@ class FakedWBEMConnection(WBEMConnection):
         if not isinstance(new_instance, CIMInstance):
             raise CIMError(CIM_ERR_INVALID_PARAMETER,
                            'NewInstance parameter is not a '
-                           'valid CIMInstance type: %s' % type(new_instance))
+                           'valid CIMInstance. Rcvd type: %s' %
+                           type(new_instance))
 
         # Requires corresponding class to build path to be returned
         try:
@@ -1724,8 +1710,6 @@ class FakedWBEMConnection(WBEMConnection):
         # Test all key properties in instance. This is our repository limit
         # since the repository cannot add values for key properties. We do
         # no allow creating key properties from class defaults.
-        # TODO Discussion. Should we allow key properties from class, in
-        # particular if they have a default value.
         key_props = [p.name for p in six.itervalues(target_class.properties)
                      if 'key' in p.qualifiers]
         for pn in key_props:
@@ -1759,11 +1743,12 @@ class FakedWBEMConnection(WBEMConnection):
                                    (ipname, iprop, cprop))
 
         # Build instance path. We build the complete instance path
-        new_instance.path = self._create_instance_path(target_class,
-                                                       new_instance,
-                                                       namespace)
+        new_instance.path = CIMInstanceName.from_instance(
+            target_class,
+            new_instance,
+            namespace=namespace)
         try:
-            # TODO: Future use internal function of repo to create namespace
+            # TODO:ks Future use internal function of repo to create namespace
             #       for this repo. ex. _set_instance
             for inst in self.instances[namespace]:
                 if inst.path == new_instance.path:
@@ -1776,8 +1761,6 @@ class FakedWBEMConnection(WBEMConnection):
             self.instances[namespace] = [new_instance]
 
         # Create instance returns model path, path relative to namespace
-        # TODO: Questions per DMTF spec. path returned if any keys are
-        # dynamically allocated. We are not doing that; We always return path.
         return self._make_tuple([new_instance.path.copy()])
 
     def _fake_modifyinstance(self, namespace, **params):
@@ -1809,7 +1792,7 @@ class FakedWBEMConnection(WBEMConnection):
         if not isinstance(modified_instance, CIMInstance):
             raise CIMError(CIM_ERR_INVALID_PARAMETER,
                            'The ModifiedInstance parameter is not a '
-                           'valid CIMInstance type: %s' %
+                           'valid CIMInstance. Rcvd type: %s' %
                            type(modified_instance))
 
         # Classnames in instance and path must match
@@ -1994,8 +1977,8 @@ class FakedWBEMConnection(WBEMConnection):
                     raise CIMError(CIM_ERR_FAILED, 'Internal Error: Invalid '
                                    ' Repository. Multiple instances with same '
                                    ' path %s' % inst.path)
-                # TODO: Future remove this test for duplicate inst paths since
-                # we test for dups on insertion
+                # TODO:ks Future remove this test for duplicate inst paths since
+                #       we test for dups on insertion
                 else:
                     del insts_repo[index]
                     del_inst = iname
@@ -2259,8 +2242,8 @@ class FakedWBEMConnection(WBEMConnection):
         instname.namespace = namespace
         rtn_instpaths = []
         role = role.lower() if role else role
-        # TODO make list from _get_reference_classnames if classes exist.
-        # Otherwise set list to insts_repo to search every instance
+        # TODO:ks FUTURE: Make list from _get_reference_classnames if classes
+        #       exist. Otherwise set list to insts_repo to search every instance
         for inst in insts_repo:
             for prop in six.itervalues(inst.properties):
                 if prop.type == 'reference':
@@ -2563,10 +2546,10 @@ class FakedWBEMConnection(WBEMConnection):
         else:
             eos = u'FALSE'
             context_id = self._create_contextid()
-            # TODO Future. Use the timeout along with response delay. Then
+            # TODO:ks Future. Use the timeout along with response delay. Then
             # user could timeout pulls. This means adding timer test to
-            # pulls and close. Response delay could then be used to test
-            # timeouts
+            # pulls and close. Timer should be used to close old contexts
+            # also.
             self.enumeration_contexts[context_id] = {'pull_type': pull_type,
                                                      'data': objects,
                                                      'namespace': namespace,
@@ -2809,7 +2792,7 @@ class FakedWBEMConnection(WBEMConnection):
         try:
             context_data = self.enumeration_contexts[context_id]
             # This is probably relatively useless because pywbem handles
-            # namespace internally but it could catch an if user plays
+            # namespace internally but it could catch an error if user plays
             # with the context.
             if context_data['namespace'] != namespace:
                 raise CIMError(CIM_ERR_INVALID_NAMESPACE,
@@ -2862,7 +2845,7 @@ class FakedWBEMConnection(WBEMConnection):
             methodsrepo = self._get_methods_repo(namespace)
         except KeyError:
             raise CIMError(CIM_ERR_NOT_FOUND, 'Method %s in namespace %s not '
-                                              'registered in repo' %
+                                              'registered in repository' %
                            (methodname, namespace))
 
         # find the methods entry corresponding to classname. It must be in
@@ -2886,19 +2869,19 @@ class FakedWBEMConnection(WBEMConnection):
         except KeyError:
             raise CIMError(CIM_ERR_NOT_FOUND, 'Class %s for Method %s in '
                                               'namespace %s not '
-                                              'registered in repo' %
+                                              'registered in repository' %
                            (localobject.classname, methodname, namespace))
         try:
             bound_method = methods[methodname]
         except KeyError:
             raise CIMError(CIM_ERR_NOT_FOUND, 'Method %s in namespace %s not '
-                                              'registered in repo' %
+                                              'registered in repository' %
                            (methodname, namespace))
 
         if bound_method is None:
             raise CIMError(CIM_ERR_NOT_FOUND, 'Class %s for Method %s in'
                                               'namespace %s not '
-                                              'registered in repo' %
+                                              'registered in repoository' %
                            (localobject.classname, methodname, namespace))
 
         # Map the Params and **params into a single no-case dictionary

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -933,7 +933,7 @@ class FakedWBEMConnection(WBEMConnection):
     @staticmethod
     def _remove_qualifiers(obj):
         """
-        Remove all qualifiers from the input object.  The object may
+        Remove all qualifiers from the input objectwhere the object may
         be an CIMInstance or CIMClass. Removes qualifiers from the object and
         from properties, methods, and parameters
 
@@ -1203,7 +1203,8 @@ class FakedWBEMConnection(WBEMConnection):
 
         Returns: Returns list of classes.
         """
-        # TODO:ks Future. this could become an iterator for efficiency.
+        # TODO:ks Future. this could become an generator expression for
+        # efficiency.
         class_repo = self._get_class_repo(namespace)
         associator_classes = []
         for cl in six.itervalues(class_repo):
@@ -1373,11 +1374,6 @@ class FakedWBEMConnection(WBEMConnection):
             namespace,
             params['DeepInheritance'])
 
-        try:
-            del params['classname']
-        except KeyError:
-            pass
-
         classes = [
             self._get_class(cn, namespace,
                             local_only=params['LocalOnly'],
@@ -1392,9 +1388,12 @@ class FakedWBEMConnection(WBEMConnection):
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.EnumerateClassNames`.
 
+        Enumerates the classnames of the classname in the 'classname' parameter
+        or from the top of the tree if 'classname is None.
+
         Returns:
 
-            returns classnames.
+            return tuple including list of classnames
 
         Raises:
 

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -2411,7 +2411,7 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={'P1': 'Ham', 'P2': 'Cheese'}
+                keybindings=[('P1', 'Ham'), ('P2', 'Cheese')]
             ),
             # strict, condition
             True, True,
@@ -2482,7 +2482,7 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={'P1': None, 'P2': 'DEFAULT'}
+                keybindings=[('P1', None), ('P2', 'DEFAULT')]
             ),
             # strict,condition
             False, True,

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -2365,7 +2365,7 @@ class Test_CIMInstanceName_from_instance(object):
         # * strict: Value of strict attribute on from_instance call
         # * condition: Condition for testcase to run.
         (
-            "Verify class with single key type string works",
+            "Verify class with single key works",
             dict(
                 classname='CIM_Foo',
                 properties=[
@@ -2390,7 +2390,7 @@ class Test_CIMInstanceName_from_instance(object):
             True, True,
         ),
         (
-            "Verify class with two keys type string works",
+            "Verify class with two keys  works",
             dict(
                 classname='CIM_Foo',
                 properties=[
@@ -2456,8 +2456,7 @@ class Test_CIMInstanceName_from_instance(object):
                 ]
             ),
             dict(
-                classname='CIM_Foo',
-                keybindings={'P1': None}
+                classname='CIM_Foo'
             ),
             # strict, condition
             False, True,
@@ -2481,8 +2480,7 @@ class Test_CIMInstanceName_from_instance(object):
                 ]
             ),
             dict(
-                classname='CIM_Foo',
-                keybindings=[('P1', None), ('P2', 'DEFAULT')]
+                classname='CIM_Foo'
             ),
             # strict,condition
             False, True,

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -1541,6 +1541,7 @@ def test_CIMInstanceName_hash(
 
 
 class Test_CIMInstanceName_repr(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMInstanceName.__repr__().
     """
@@ -1667,6 +1668,7 @@ class CIMInstanceNameToXML(ValidationTestCase):
 
 
 class Test_CIMInstanceName_from_wbem_uri(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMInstanceName.from_wbem_uri().
     """
@@ -2343,7 +2345,209 @@ class Test_CIMInstanceName_from_wbem_uri(object):
             assert isinstance(obj.host, type(exp_host))
 
 
+class Test_CIMInstanceName_from_instance(object):
+    # pylint: disable=too-few-public-methods
+    """
+    Test the static method that creates CIMInstance name from the combination
+    of a CIMClass and CIMInstance.
+    """
+    testcases = [
+        # Testcases for CIMInstanceName.from_instance().
+        # Each testcase has these items:
+        # * desc: Short testcase description.
+        # * cls_kwargs: Dict with Attributes from which test class is
+        #   constructed
+        # * inst_kwargs: Dict with Attributes from which test inst is
+        #   constructed
+        # * exp_result: Dict of all expected attributes of resulting
+        #     CIMInstanceName without host and namespace if expected to suceed.
+        #     Exception type, if expected to fail.
+        # * strict: Value of strict attribute on from_instance call
+        # * condition: Condition for testcase to run.
+        (
+            "Verify class with single key type string works",
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', value='Ham'),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                keybindings={('P1', 'Ham')}
+            ),
+            # strict, condition
+            True, True,
+        ),
+        (
+            "Verify class with two keys type string works",
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('P2', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', value='Ham'),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                keybindings={('P1', 'Ham'), ('P2', 'Cheese')}
+            ),
+            # strict, condition
+            True, True,
+        ),
+        (
+            "Verify class with single key type strict=true, no key in inst"
+            ' fails.',
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            ValueError,
+            # strict, condition
+            True, True,
+        ),
+        (
+            "Verify class strict=False and no key prop in instace passes",
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                keybindings={('P1', None)}
+            ),
+            # strict, condition
+            False, True,
+        ),
+        (
+            "Verify class with two not in instance strict=false works",
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', None, type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('P2', 'DEFAULT', type='string',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                properties=[
+                ]
+            ),
+            dict(
+                classname='CIM_Foo',
+                keybindings={('P1', None), ('P2', 'DEFAULT')}
+            ),
+            # strict,condition
+            False, True,
+        ),
+
+
+        # TODO add tests for reference property as key, strict=False,
+        # mismatch of class/instance name
+    ]
+
+    @pytest.mark.parametrize(
+        # * ns: Namespace for CIMInstanceName on from_instance call or None
+        # * host: Host for CIMInstanceName on from_instance call or None
+        'ns, host', [
+            [None, None],
+            ['root/blah', None],
+            [None, 'Fred'],
+            ['root/blah', 'Fred'],
+        ]
+    )
+    @pytest.mark.parametrize(
+        "desc, cls_kwargs, inst_kwargs, exp_result, strict, condition",
+        testcases)
+    def test_CIMInstanceName_from_instance(
+            self, desc, cls_kwargs, inst_kwargs, exp_result, strict, ns, host,
+            condition):
+        """All test cases for CIMInstanceName.from_instance."""
+
+        if not condition:
+            pytest.skip("Condition for test case not met")
+
+        if condition == 'pdb':
+            import pdb
+            pdb.set_trace()
+
+        cls = CIMClass(**cls_kwargs)
+
+        inst = CIMInstance(**inst_kwargs)
+
+        if isinstance(exp_result, dict):
+            exp_inst_name = CIMInstanceName(**exp_result)
+            # Add correct expected instance name namespace and host attributes
+            exp_inst_name.namespace = ns
+            exp_inst_name.host = host
+
+            # Create the test CIMInstanceName with method being tested
+            act_name = CIMInstanceName.from_instance(cls, inst,
+                                                     namespace=ns,
+                                                     host=host,
+                                                     strict=strict)
+
+            assert isinstance(act_name, CIMInstanceName)
+            assert exp_inst_name == act_name
+
+        else:
+            with pytest.raises(exp_result):
+
+                CIMInstanceName.from_instance(cls, inst,
+                                              namespace=ns,
+                                              host=host,
+                                              strict=strict)
+
+
 class Test_CIMInstanceName_to_wbem_uri_str(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMInstanceName.to_wbem_uri() and .__str__().
     """
@@ -4365,7 +4569,7 @@ def test_CIMInstance_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMInstance_str(object):
+class Test_CIMInstance_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMInstance.__str__().
 
@@ -4420,7 +4624,7 @@ class Test_CIMInstance_str(object):
         assert exp_path in s
 
 
-class Test_CIMInstance_repr(object):
+class Test_CIMInstance_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMInstance.__repr__().
     """
@@ -7079,7 +7283,7 @@ def test_CIMProperty_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMProperty_str(object):
+class Test_CIMProperty_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMProperty.__str__().
 
@@ -7173,7 +7377,7 @@ class Test_CIMProperty_str(object):
         assert exp_is_array in s
 
 
-class Test_CIMProperty_repr(object):
+class Test_CIMProperty_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMProperty.__repr__().
     """
@@ -8649,7 +8853,7 @@ def test_CIMQualifier_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMQualifier_str(object):
+class Test_CIMQualifier_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMQualifier.__str__().
 
@@ -8695,7 +8899,7 @@ class Test_CIMQualifier_str(object):
         assert exp_type in s
 
 
-class Test_CIMQualifier_repr(object):
+class Test_CIMQualifier_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMQualifier.__repr__().
     """
@@ -8771,7 +8975,7 @@ class CIMQualifierToXML(ValidationTestCase):
                       root_elem_CIMQualifier)
 
 
-class Test_CIMQualifier_tomof(object):
+class Test_CIMQualifier_tomof(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMQualifier.tomof().
     """
@@ -9596,7 +9800,7 @@ def test_CIMClassName_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMClassName_repr(object):
+class Test_CIMClassName_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMClassName.__repr__().
     """
@@ -9678,6 +9882,7 @@ class CIMClassNameToXML(ValidationTestCase):
 
 
 class Test_CIMClassName_from_wbem_uri(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMClassName.from_wbem_uri().
     """
@@ -9985,6 +10190,7 @@ class Test_CIMClassName_from_wbem_uri(object):
 
 
 class Test_CIMClassName_to_wbem_uri_str(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMClassName.to_wbem_uri() and .__str__().
     """
@@ -11504,7 +11710,7 @@ def test_CIMClass_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMClass_str(object):
+class Test_CIMClass_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMClass.__str__().
 
@@ -11556,7 +11762,7 @@ class Test_CIMClass_str(object):
         assert exp_classname in s
 
 
-class Test_CIMClass_repr(object):
+class Test_CIMClass_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMClass.__repr__().
     """
@@ -11648,7 +11854,7 @@ class CIMClassToXML(ValidationTestCase):
                       root_elem_CIMClass)
 
 
-class Test_CIMClass_tomof(object):
+class Test_CIMClass_tomof(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMClass.tomof().
     """
@@ -12771,7 +12977,7 @@ def test_CIMMethod_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMMethod_str(object):
+class Test_CIMMethod_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMMethod.__str__().
 
@@ -12820,7 +13026,7 @@ class Test_CIMMethod_str(object):
         assert exp_return_type in s
 
 
-class Test_CIMMethod_repr(object):
+class Test_CIMMethod_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMMethod.__repr__().
     """
@@ -12907,7 +13113,7 @@ class CIMMethodToXML(ValidationTestCase):
             root_elem_CIMMethod)
 
 
-class Test_CIMMethod_tomof(object):
+class Test_CIMMethod_tomof(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMMethod.tomof().
     """
@@ -14305,7 +14511,7 @@ def test_CIMParameter_hash(
     assert (hash1 == hash2) == exp_hash_equal
 
 
-class Test_CIMParameter_str(object):
+class Test_CIMParameter_str(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMParameter.__str__().
 
@@ -14361,7 +14567,7 @@ class Test_CIMParameter_str(object):
         assert exp_is_array in s
 
 
-class Test_CIMParameter_repr(object):
+class Test_CIMParameter_repr(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMParameter.__repr__().
     """
@@ -14486,7 +14692,7 @@ class CIMParameterToXML(ValidationTestCase):
                       root_elem_CIMParameter_refarray)
 
 
-class Test_CIMParameter_tomof(object):
+class Test_CIMParameter_tomof(object):  # pylint: disable=too-few-public-methods
     """
     Test CIMParameter.tomof().
     """
@@ -15886,6 +16092,7 @@ def test_CIMQualifierDeclaration_hash(
 
 
 class Test_CIMQualifierDeclaration_str(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMQualifierDeclaration.__str__().
 
@@ -15943,6 +16150,7 @@ class Test_CIMQualifierDeclaration_str(object):
 
 
 class Test_CIMQualifierDeclaration_repr(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMQualifierDeclaration.__repr__().
     """
@@ -16021,6 +16229,7 @@ class CIMQualifierDeclarationToXML(unittest.TestCase):
 
 
 class Test_CIMQualifierDeclaration_tomof(object):
+    # pylint: disable=too-few-public-methods
     """
     Test CIMQualifierDeclaration.tomof().
     """
@@ -16466,7 +16675,7 @@ Qualifier Q1 : string,
             assert mof == exp_mof
 
 
-class Test_tocimxml(object):
+class Test_tocimxml(object):  # pylint: disable=too-few-public-methods
 
     @unimplemented
     def test_all(self):
@@ -16809,7 +17018,7 @@ class Test_cimvalue(object):
                 cimvalue(value, type)
 
 
-class Test_mofstr(object):
+class Test_mofstr(object):  # pylint: disable=too-few-public-methods
     """Test cases for cim_obj.mofstr()."""
 
     # Default input arguments if not specified in testcase

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -2384,7 +2384,7 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={('P1', 'Ham')}
+                keybindings={'P1': 'Ham'}
             ),
             # strict, condition
             True, True,
@@ -2411,7 +2411,7 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={('P1', 'Ham'), ('P2', 'Cheese')}
+                keybindings={'P1': 'Ham', 'P2': 'Cheese'}
             ),
             # strict, condition
             True, True,
@@ -2457,13 +2457,13 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={('P1', None)}
+                keybindings={'P1': None}
             ),
             # strict, condition
             False, True,
         ),
         (
-            "Verify class with two not in instance strict=false works",
+            "Verify class with two keys not in instance strict=false works",
             dict(
                 classname='CIM_Foo',
                 properties=[
@@ -2482,15 +2482,36 @@ class Test_CIMInstanceName_from_instance(object):
             ),
             dict(
                 classname='CIM_Foo',
-                keybindings={('P1', None), ('P2', 'DEFAULT')}
+                keybindings={'P1': None, 'P2': 'DEFAULT'}
             ),
             # strict,condition
             False, True,
         ),
-
-
-        # TODO add tests for reference property as key, strict=False,
-        # mismatch of class/instance name
+        (
+            "Verify class with reference properies as keys",
+            dict(
+                classname='CIM_Ref',
+                properties=[
+                    CIMProperty('R1', None, type='reference',
+                                qualifiers={'Key': CIMQualifier('Key',
+                                                                value=True)}),
+                    CIMProperty('R2', type='string', value='Cheese'),
+                ]
+            ),
+            dict(
+                classname='CIM_Ref',
+                properties=[
+                    CIMProperty('R1', value=CIMInstanceName('CIM_X',
+                                                            {'x': "X"})),
+                ]
+            ),
+            dict(
+                classname='CIM_Ref',
+                keybindings={'R1': CIMInstanceName('CIM_X', {'x': "X"})}
+            ),
+            # strict, condition
+            True, True,
+        ),
     ]
 
     @pytest.mark.parametrize(

--- a/testsuite/test_wbemconnection_mock.py
+++ b/testsuite/test_wbemconnection_mock.py
@@ -628,7 +628,6 @@ class TestFakedWBEMConnection(object):
         conn = FakedWBEMConnection(response_delay=3)
         repr_ = '%r' % conn
         assert repr_.startswith('FakedWBEMConnection(response_delay=3,')
-        # print(repr_)
 
     def test_attr(self):
         # pylint: disable=no-self-use
@@ -1361,8 +1360,6 @@ class TestRepoMethods(object):
             conn.add_cimobjects(tst_class)
             if exp_err is None:
                 cls = conn.GetClass(cls, IncludeQualifiers=False)
-                print('GetClass Finished')
-                print(l)
                 l.check
                 (
                     ('pywbem.mock', 'DEBUG', result[0]),
@@ -1372,7 +1369,6 @@ class TestRepoMethods(object):
             else:
                 with pytest.raises(exp_err):
                     cls = conn.GetClass(cls, IncludeQualifiers=False)
-                    print(l)
                     l.check(
                         ('pywbem.mock', 'DEBUG', result[0]),
                         ('pywbem.mock', 'DEBUG', result[1]),
@@ -2350,7 +2346,6 @@ class TestInstanceOperations(object):
         if not exp_err:
             for inst in new_insts:
                 rtn_inst_name = conn.CreateInstance(inst, ns)
-                print('\nrtn_inst_name %r' % rtn_inst_name)
                 rtn_inst = conn.GetInstance(rtn_inst_name)
 
                 inst.path.namespace = rtn_inst.path.namespace


### PR DESCRIPTION
Updated with comments from Friday 9 Feb.  Note that I made one change that we had not discussed. The previous from_instance defaulted to getting property value from class if strict=false and no property in instance.  Removed the code so it simply does not put that property into the keybindings.
DISCUSSION if you would prefer the original.

Cleaned up tests for get_class and enumerateclasses to more throughly test the lo, iq, and ico attributes.
This and some other test changes to get rid of TODOs  sort of bumped up the test count from 650 to 900. 

1. Modified logging

2. Removed the write to file from mofcompiler errors.  Now writes error
information to stdout.

3. Modified the compiler error message format. New format is:

Syntax error:NoFile:3:24
            Qualifier Association : boolean = false,
                Scope(associations),
                      ^^^^^^^^^^^^
Old format did not put context on separate lines and only showed line
number if there was a file name.  i.e. Showed nothing for String input
to compiler.

Note that the display message still shows error as Syntax error but the
interrupt is MOFParaseError and that the MOFParseError __str__ output
does not format the context.

4.  Moved function to create CIMNamespaceName from Class and instance to
method of cim_obj.CIMInstanceName and created tests. Now static
method named from_instance(...)

5. Remove some TODOs that were not revalent any more.