### PR TITLE
Fixes #1033: (8) Added toleration support for xml:lang attributes in tupleparser

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -478,6 +478,10 @@ Bug fixes
   in the `array_size` attribute of the returned `CIMProperty` objects.
   (Issue #1031).
 
+* Fixed the issue that the `xml:lang` attributes that are allowed on some
+  CIM-XML elements have been rejected by raising `ParseError`. They are now
+  tolerated but ignored (Issue #1033).
+
 Cleanup
 ^^^^^^^
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -516,6 +516,13 @@ specified when following the links to the standards:
 * The CIM-XML representation of :ref:`CIM objects` as produced by their
   ``tocimxml()`` and ``tocimxmlstr()`` methods conforms to :term:`DSP0201`.
 
+  Limitations:
+
+  - The `xml:lang` attribute supported by :term:`DSP0201` on some CIM-XML
+    elements that can have string values is tolerated in the CIM-XML received
+    by pywbem, but is ignored and is not represented on the corresponding
+    :ref:`CIM objects`.
+
 * The MOF as produced by the ``tomof()`` methods on :ref:`CIM objects` and as
   parsed by the MOF compiler conforms to :term:`DSP0004`.
 

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1029,12 +1029,15 @@ def parse_instance(tup_tree):
         <!ELEMENT INSTANCE (QUALIFIER*, (PROPERTY | PROPERTY.ARRAY |
                                          PROPERTY.REFERENCE)*)>
         <!ATTLIST INSTANCE
-            %ClassName;>
+            %ClassName;
+            xml:lang NMTOKEN #IMPLIED>
     """
 
-    check_node(tup_tree, 'INSTANCE', ['CLASSNAME'], [],
+    check_node(tup_tree, 'INSTANCE', ['CLASSNAME'], ['xml:lang'],
                ['QUALIFIER', 'PROPERTY', 'PROPERTY.ARRAY',
                 'PROPERTY.REFERENCE'])
+
+    # The 'xml:lang' attribute is tolerated but ignored.
 
     # Note: The check above does not enforce the ordering constraint in the DTD
     # that QUALIFIER elements must appear before PROPERTY* elements.
@@ -1165,13 +1168,16 @@ def parse_qualifier(tup_tree):
             %CIMName;
             %CIMType;              #REQUIRED
             %Propagated;
-            %QualifierFlavor;>
+            %QualifierFlavor;
+            xml:lang NMTOKEN #IMPLIED>
     """
 
     check_node(tup_tree, 'QUALIFIER', ['NAME', 'TYPE'],
                ['OVERRIDABLE', 'TOSUBCLASS', 'TOINSTANCE',
-                'TRANSLATABLE', 'PROPAGATED'],
+                'TRANSLATABLE', 'PROPAGATED', 'xml:lang'],
                ['VALUE', 'VALUE.ARRAY'])
+
+    # The 'xml:lang' attribute is tolerated but ignored.
 
     attrl = attrs(tup_tree)
     val = unpack_value(tup_tree)
@@ -1224,13 +1230,16 @@ def parse_property(tup_tree):
             %CIMType;              #REQUIRED
             %ClassOrigin;
             %Propagated;
-            %EmbeddedObject;>
+            %EmbeddedObject;
+            xml:lang NMTOKEN #IMPLIED>
     """
 
     check_node(tup_tree, 'PROPERTY', ['TYPE', 'NAME'],
                ['CLASSORIGIN', 'PROPAGATED', 'EmbeddedObject',
-                'EMBEDDEDOBJECT'],
+                'EMBEDDEDOBJECT', 'xml:lang'],
                ['QUALIFIER', 'VALUE'])
+
+    # The 'xml:lang' attribute is tolerated but ignored.
 
     attrl = attrs(tup_tree)
     try:
@@ -1273,14 +1282,17 @@ def parse_property_array(tup_tree):
             %ArraySize;
             %ClassOrigin;
             %Propagated;
-            %EmbeddedObject;>
+            %EmbeddedObject;
+            xml:lang NMTOKEN #IMPLIED>
     """
 
     check_node(tup_tree, 'PROPERTY.ARRAY', ['NAME', 'TYPE'],
                ['REFERENCECLASS', 'CLASSORIGIN', 'PROPAGATED',
-                'ARRAYSIZE', 'EmbeddedObject', 'EMBEDDEDOBJECT'],
+                'ARRAYSIZE', 'EmbeddedObject', 'EMBEDDEDOBJECT', 'xml:lang'],
                ['QUALIFIER', 'VALUE.ARRAY'])
     # TODO: Remove 'REFERENCECLASS' from attrs list, above.
+
+    # The 'xml:lang' attribute is tolerated but ignored.
 
     values = unpack_value(tup_tree)
     attrl = attrs(tup_tree)

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -4767,7 +4767,7 @@ testcases_tupleparse_xml = [
             '<INSTANCE CLASSNAME="CIM_Foo" xml:lang="en_us"/>',
             exp_result=CIMInstance('CIM_Foo'),
         ),
-        None, None, False  # TODO 1/18 AM #1033: Enable once xml:lang supported
+        None, None, True
     ),
     (
         "INSTANCE with properties",
@@ -5143,6 +5143,16 @@ testcases_tupleparse_xml = [
             xml_str=b''
             b'<PROPERTY NAME="Foo\xF0\x90\x85\x82" TYPE="string"/>',
             exp_result=CIMProperty(u'Foo\U00010142', value=None, type='string',
+                                   propagated=False),
+        ),
+        None, None, True
+    ),
+    (
+        "PROPERTY with xml:lang attribute",
+        dict(
+            xml_str=''
+            '<PROPERTY NAME="Foo" TYPE="string" xml:lang="en_us"/>',
+            exp_result=CIMProperty('Foo', value=None, type='string',
                                    propagated=False),
         ),
         None, None, True
@@ -6001,6 +6011,18 @@ testcases_tupleparse_xml = [
             b'<PROPERTY.ARRAY NAME="Foo\xF0\x90\x85\x82" TYPE="string"/>',
             exp_result=CIMProperty(
                 u'Foo\U00010142', value=None, type='string', is_array=True,
+                propagated=False,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "PROPERTY.ARRAY with xml:lang attribute",
+        dict(
+            xml_str=''
+            '<PROPERTY.ARRAY NAME="Foo" TYPE="string" xml:lang="en_us"/>',
+            exp_result=CIMProperty(
+                'Foo', value=None, type='string', is_array=True,
                 propagated=False,
             ),
         ),
@@ -7738,6 +7760,15 @@ testcases_tupleparse_xml = [
             exp_result=CIMQualifier(
                 u'Qual\U00010142', value=None, type='string',
             ),
+        ),
+        None, None, True
+    ),
+    (
+        "QUALIFIER with xml:lang attribute",
+        dict(
+            xml_str=''
+            '<QUALIFIER NAME="Qual" TYPE="string" xml:lang="en_us"/>',
+            exp_result=CIMQualifier('Qual', value=None, type='string'),
         ),
         None, None, True
     ),


### PR DESCRIPTION
**Note:** This PR is on top of PR #1045.
For details, see the commit message (of only the last commit).
Ready for review and merge.