### PR TITLE
Fixes #1032: Empty boolean values in returned CIM-XML now issue UserWarning

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -486,6 +486,11 @@ Bug fixes
   attributes of the QUALIFIER element in CIM-XML was not supported and resulted
   in `ParseError` to be raised (Issue #1042).
 
+* Fixed the issue that an empty boolean value in a CIM-XML response returned
+  from a WBEM server was accepted and treated as a NULL value. This treatment
+  does not conform to DSP0201. Empty boolean values now cause a `UserWarning`
+  to be issued, but otherwise continue to work as before. (Issue #1032).
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -79,11 +79,12 @@ representation of CIM in XML by having the following properties:
 
 from __future__ import absolute_import
 import re
+import warnings
 import six
 
 from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
-    CIMQualifierDeclaration
+    CIMQualifierDeclaration, _stacklevel_above_module
 from .cim_types import CIMDateTime, type_from_name
 from .tupletree import xml_to_tupletree_sax
 from .exceptions import ParseError
@@ -2092,13 +2093,16 @@ def unpack_boolean(data):
     # CIM-XML says "These values MUST be treated as case-insensitive"
     # (even though the XML definition requires them to be lowercase.)
 
-    data = data.strip().lower()                   # ignore space
-    if data == 'true':
+    data_ = data.strip().lower()                   # ignore space
+    if data_ == 'true':
         return True
-    elif data == 'false':
+    elif data_ == 'false':
         return False
-    elif data == '':
-        # TODO 1/18 AM #1032: Clarify whether an empty string should be supp.
+    elif data_ == '':
+        warnings.warn("WBEM server sent invalid empty boolean value in a "
+                      "CIM-XML response.",
+                      UserWarning,
+                      stacklevel=_stacklevel_above_module(__name__))
         return None
     else:
         raise ParseError("Invalid boolean value %r" % data)

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -1140,7 +1140,7 @@ testcases_tupleparse_xml = [
             '<KEYVALUE VALUETYPE="boolean"></KEYVALUE>',
             exp_result=None,
         ),
-        None, None, True
+        None, UserWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean without TYPE (WS string)",
@@ -1149,7 +1149,7 @@ testcases_tupleparse_xml = [
             '<KEYVALUE VALUETYPE="boolean">  </KEYVALUE>',
             exp_result=None,
         ),
-        None, None, True
+        None, UserWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean without TYPE (ASCII string)",
@@ -1241,7 +1241,7 @@ testcases_tupleparse_xml = [
             '<KEYVALUE VALUETYPE="boolean" TYPE="boolean"></KEYVALUE>',
             exp_result=None,
         ),
-        None, None, True
+        None, UserWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean with TYPE boolean (WS string)",
@@ -1250,7 +1250,7 @@ testcases_tupleparse_xml = [
             '<KEYVALUE VALUETYPE="boolean" TYPE="boolean">  </KEYVALUE>',
             exp_result=None,
         ),
-        None, None, True
+        None, UserWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean with TYPE boolean (ASCII string)",


### PR DESCRIPTION
For details, see commit message.
Ready for review and merge.