### PR TITLE
Fixes #1055: Removed toleration of invalid REFERENCECLASS attr on PROPERTY.ARRAY

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -460,8 +460,8 @@ Bug fixes
 
 * Fixed the issue that the parser for CIM-XML received from the WBEM server
   tolerated invalid child elements under INSTANCE, ERROR and
-  PROPERTY.REFERENCE elements.
-  This now results in a ParseError being raised.
+  PROPERTY.REFERENCE elements, and invalid attributes on the PROPERTY.ARRAY
+  element. This now results in a ParseError being raised.
 
 * Fixed the issue that the parser for CIM-XML received from the WBEM server
   did not set the `propagated` attribute to False in `CIMProperty` objects

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -877,7 +877,6 @@ def parse_instancename(tup_tree):
                              "(KEYBINDING* | KEYVALUE? | VALUE.REFERENCE?))" %
                              (name(tup_tree), k0_name))
 
-        # TODO 1/18 AM: Clarify how to represent unnamed keys - not supp. now
         val = parse_any(kid0)
         return CIMInstanceName(classname, {None: val})
     elif k0_name == 'KEYBINDING':
@@ -1286,10 +1285,9 @@ def parse_property_array(tup_tree):
     """
 
     check_node(tup_tree, 'PROPERTY.ARRAY', ['NAME', 'TYPE'],
-               ['REFERENCECLASS', 'CLASSORIGIN', 'PROPAGATED',
-                'ARRAYSIZE', 'EmbeddedObject', 'EMBEDDEDOBJECT', 'xml:lang'],
+               ['CLASSORIGIN', 'PROPAGATED', 'ARRAYSIZE', 'EmbeddedObject',
+                'EMBEDDEDOBJECT', 'xml:lang'],
                ['QUALIFIER', 'VALUE.ARRAY'])
-    # TODO: Remove 'REFERENCECLASS' from attrs list, above.
 
     # The 'xml:lang' attribute is tolerated but ignored.
 


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.