### PR TITLE
Fixes #1035: Reference values in CIM objects can now be class paths

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -142,6 +142,11 @@ Incompatible changes
   specify consistent values for these attributes, this change should not affect
   users of pywbem.
 
+* Values of CIM type 'reference' in CIM objects (`CIMProperty`,
+  `CIMParameter`, `CIMQualifier`, and `CIMQualifierDeclaration`) may now be
+  `CIMClassName` objects (i.e. class paths). This has been changed for
+  consistency with DSP0201 (Issue #1035).
+
 Deprecations
 ^^^^^^^^^^^^
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -7603,6 +7603,8 @@ def cimvalue(value, type):
 
           - :term:`string`. The string must be an untyped WBEM URI representing
             an instance path (see :term:`DSP0207`).
+          - :class:`~pywbem.CIMInstanceName`. An instance path.
+          - :class:`~pywbem.CIMClassName`. A class path.
 
     Returns:
 
@@ -7638,7 +7640,7 @@ def cimvalue(value, type):
 
     # REF type
     if type == 'reference':
-        if isinstance(value, CIMInstanceName):
+        if isinstance(value, (CIMInstanceName, CIMClassName)):
             return value
         if isinstance(value, six.string_types):
             return CIMInstanceName.from_wbem_uri(value)

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -16566,6 +16566,7 @@ class Test_cimvalue(object):
     ref1_str = 'http://host/ns:CN.k1="abc"'
     ref1_obj = CIMInstanceName(classname='CN', keybindings=dict(k1="abc"),
                                namespace='ns', host='host')
+    ref2_obj = CIMClassName('CIM_Foo')
 
     testcases_succeeds = [
         # Testcases where cimvalue() succeeds.
@@ -16720,6 +16721,7 @@ class Test_cimvalue(object):
 
         (ref1_str, 'reference', ref1_obj, None, CHECK_0_12_0),
         (ref1_obj, 'reference', ref1_obj, None, CHECK_0_12_0),
+        (ref2_obj, 'reference', ref2_obj, None, CHECK_0_12_0),
     ]
 
     @pytest.mark.parametrize(
@@ -16765,7 +16767,6 @@ class Test_cimvalue(object):
         ('000000:000', 'datetime', ValueError),  # invalid dt value
 
         ('foo', 'reference', ValueError),  # invalid ref value
-        (CIMClassName('CIM_Foo'), 'reference', TypeError),  # invalid type
     ]
 
     @pytest.mark.parametrize(

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -6545,7 +6545,6 @@ testcases_tupleparse_xml = [
         None, None, True
     ),
     (
-        # TODO 1/18 AM #1035: Clarify class path support
         "PROPERTY.REFERENCE with ref value that is a CLASSNAME (not used)",
         dict(
             xml_str=''
@@ -6556,14 +6555,13 @@ testcases_tupleparse_xml = [
             '</PROPERTY.REFERENCE>',
             exp_result=CIMProperty(
                 'Foo', type='reference',
-                value=None,  # CIMClassName('CIM_Foo'),
+                value=CIMClassName('CIM_Foo'),
                 propagated=False,
             ),
         ),
-        None, None, False
+        None, None, True
     ),
     (
-        # TODO 1/18 AM #1035: Clarify class path support
         "PROPERTY.REFERENCE with ref value that is a LOCALCLASSPATH (not used)",
         dict(
             xml_str=''
@@ -6579,14 +6577,13 @@ testcases_tupleparse_xml = [
             '</PROPERTY.REFERENCE>',
             exp_result=CIMProperty(
                 'Foo', type='reference',
-                value=None,  # CIMClassName('CIM_Foo', namespace='foo'),
+                value=CIMClassName('CIM_Foo', namespace='foo'),
                 propagated=False,
             ),
         ),
-        None, None, False
+        None, None, True
     ),
     (
-        # TODO 1/18 AM #1035: Clarify class path support
         "PROPERTY.REFERENCE with ref value that is a CLASSPATH (not used)",
         dict(
             xml_str=''
@@ -6605,10 +6602,9 @@ testcases_tupleparse_xml = [
             '</PROPERTY.REFERENCE>',
             exp_result=CIMProperty(
                 'Foo', type='reference',
-                value=None,
-                # value=CIMClassName(
-                #     'CIM_Foo', namespace='foo', host='woot.com',
-                # ),
+                value=CIMClassName(
+                    'CIM_Foo', namespace='foo', host='woot.com',
+                ),
                 propagated=False,
             ),
         ),


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.