### PR TITLE
Fixes #1040: Check for invalid values of boolean attributes of SCOPE in tupleparser

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -494,6 +494,10 @@ Bug fixes
   does not conform to DSP0201. Empty boolean values now cause a `UserWarning`
   to be issued, but otherwise continue to work as before. (Issue #1032).
 
+* Fixed the issue that invalid values were accepted for the boolean attributes
+  of the SCOPE element in CIM-XML received from a WBEM server. They now cause
+  `ParseError` to be raised (Issue #1040).
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1085,9 +1085,15 @@ def parse_scope(tup_tree):
                ['CLASS', 'ASSOCIATION', 'REFERENCE', 'PROPERTY', 'METHOD',
                 'PARAMETER', 'INDICATION'], [])
 
-    # TODO 2/18 AM #1040: Reject invalid boolean values of scope attributes
-    return dict([(k, v.lower() == 'true')
-                 for k, v in attrs(tup_tree).items()])
+    scopes = {}  # Attributes do not preserve order, so we use standard dict()
+    for k, v in attrs(tup_tree).items():
+        v_ = unpack_boolean(v)
+        if v_ is None:
+            raise ParseError("Element %r has an invalid value %r for its "
+                             "boolean attribute %r" %
+                             (name(tup_tree), v, k))
+        scopes[k] = v_
+    return scopes
 
 
 def parse_qualifier_declaration(tup_tree):

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -7639,24 +7639,22 @@ testcases_tupleparse_xml = [
         None, None, True
     ),
     (
-        # TODO 2/18 AM #1040: Enable once invalid attr values are rejected
         "SCOPE with invalid boolean attribute",
         dict(
             xml_str=''
             '<SCOPE CLASS="XXX"/>',
             exp_result=None,
         ),
-        ParseError, None, False
+        ParseError, None, True
     ),
     (
-        # TODO 2/18 AM #1040: Enable once invalid attr values are rejected
         "SCOPE with invalid empty boolean attribute",
         dict(
             xml_str=''
             '<SCOPE CLASS=""/>',
             exp_result=None,
         ),
-        ParseError, None, False
+        ParseError, None, True
     ),
     (
         "SCOPE with all supported scope attributes with different values",


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.