### PR TITLE
Added .pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .project
 /.settings/
 .pydevproject
+/.pytest_cache
 /.cache/
 /.tox/
 .ipynb_checkpoints/


### PR DESCRIPTION
Not clear which component creates the `.pytest_cache` directory (presumably pytest), but in any case, it should be excluded for Git.
Ready for review and merge.