### PR TITLE
Cleaned up the TODO entries in pywbem package

### DIFF
--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -473,7 +473,7 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
             if self.debuglevel > 0:  # pylint: disable=no-member
                 print("send: %r" % strng)
             blocksize = 8192
-            # TODO 5/16 AM #418 Better approach needed than conv. to Bytes
+            # TODO #418: Better approach needed than converting to Bytes
             if hasattr(strng, 'read') and not isinstance(strng, list):
                 if self.debuglevel > 0:  # pylint: disable=no-member
                     print("sendIng a read()able")
@@ -603,7 +603,7 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                 # Within the defined set of protocol versions, SSLv23 selects
                 # the highest protocol version that both client and server
                 # support.
-                # TODO 4/16 KS #893: Consider the use of default_context()
+                # TODO #893: Consider the use of default_context()
                 ctx = SSL.SSLContext(SSL.PROTOCOL_SSLv23)
 
                 if self.cert_file:

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -703,6 +703,7 @@ class NocaseDict(object):
         The comparison is based on matching key/value pairs.
         The keys are looked up case-insensitively.
         """
+        # TODO #1062: Could compare hash values for better performance
         for key, self_value in self.iteritems():
             if key not in other:
                 return False
@@ -851,8 +852,6 @@ def cmpdict(dict1, dict2):
         return 0
     if dict1 is None or dict2 is None:
         return 1
-    # TODO 01/18 AM Could compare hash(dict) for better perf
-    #      That requires more unicode cleanliness (test_clienti.py fails)
     if dict1 == dict2:
         return 0
     return 1
@@ -7329,8 +7328,8 @@ def tocimxmlstr(value, indent=None):
 # internally in the CIM object classes, instead of tocimobj(). However,
 # tocimobj() is still used internally in the tupleparser, plus it is part of
 # the public API.
-# TODO 12/16 AM #904: Migr. remaining uses of tocimobj() to cimvalue() and depr.
-#
+# TODO #904: Migrate remaining uses of tocimobj() to cimvalue() and deprecate
+
 # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
 def tocimobj(type_, value):
     """

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1146,7 +1146,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # of end_of_sequence/enumeration_context
         # (IRETURNVALUE*, PARAMVALUE?)
         else:
-            # TODO KS #919: Further tests on this IRETURN or PARAMVALUE
+            # TODO #919: Further tests on this IRETURN or PARAMVALUE
             # Could be IRETURNVALUE or a PARAMVALUE
             return tup_tree
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -245,7 +245,7 @@ def t_binaryValue(t):
     # zeros not allowed for decimal) would match 'decimalValue' and only
     # the zero would be taken out.
     if re.search(r'[2-9]', t.value) is not None:
-        # TODO 01/18 AM Replace skipping with raising an error
+        # TODO #1063: Raise an error for invalid binary digits
         msg = "Skipping invalid binary number '%s' in line %d" % \
             (t.value, t.lineno)
         try:
@@ -267,7 +267,7 @@ def t_octalValue(t):
     # zeros not allowed for decimal) would match 'decimalValue' and only
     # the zero would be taken out, and the 8 would be another decimalValue.
     if re.search(r'[8-9]', t.value) is not None:
-        # TODO 01/18 AM Replace skipping with raising an error
+        # TODO #1063: Raise an error for invalid octal digits
         msg = "Skipping invalid octal number '%s' in line %d" % \
             (t.value, t.lineno)
         try:
@@ -334,7 +334,7 @@ t_ignore = ' \r\t'
 def t_error(t):
     """ Lexer error callback from PLY Lexer with token in error.
     """
-    # TODO 01/18 AM Replace skipping with raising an error
+    # TODO #1063: Raise an error for invalid tokens
     msg = "Skipping first character of invalid token '%s' in line %d" % \
         (t.value, t.lineno)
     try:
@@ -2131,7 +2131,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
             self.classes[self.default_namespace] = \
                 NocaseDict({cc.classname: cc})
 
-        # TODO KS #991: CreateClass should reject if the class already exists
+        # TODO #991: CreateClass should reject if the class already exists
         try:
             self.class_names[self.default_namespace].append(cc.classname)
         except KeyError:

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1123,7 +1123,7 @@ def parse_qualifier_declaration(tup_tree):
 
     array_size = attrl.get('ARRAYSIZE', None)
     if array_size is not None:
-        # TODO 2/18 AM #1044: Clarify if hex support is needed.
+        # TODO #1044: Clarify if hex support is needed.
         array_size = int(array_size)
 
     flavors = {}
@@ -1190,17 +1190,7 @@ def parse_qualifier(tup_tree):
         if rtn_val is not None:
             rtn_val = rtn_val.lower()
 
-        # TODO 2/18 AM #1039: Clarify whether to set defaults for omitted attrs.
-        # DSP0201 defines these defaults:
-        # * OVERRIDABLE: true
-        # * TOSUBCLASS: true
-        # * TOINSTANCE: false
-        # * TRANSLATABLE: false
-        # * PROPAGATED: false
-        # If we do this, then I suggest changing the for-loop into a series
-        # of unpack_boolean() for each possible attribute, specifying the
-        # desired default.
-
+        # TODO #1039: Clarify whether to default omitted qualifier flavors
         if rtn_val == 'true':
             rtn_val = True
         elif rtn_val == 'false':
@@ -1300,7 +1290,7 @@ def parse_property_array(tup_tree):
 
     array_size = attrl.get('ARRAYSIZE', None)
     if array_size is not None:
-        # TODO 2/18 AM #1044: Clarify if hex support is needed.
+        # TODO #1044: Clarify if hex support is needed.
         array_size = int(array_size)
 
     embedded_object = None
@@ -1394,12 +1384,7 @@ def parse_method(tup_tree):
 
     qualifiers = list_of_matching(tup_tree, ['QUALIFIER'])
 
-    # TODO 2/18 AM #1038: Clarify how to deal with omitted TYPE of METHOD
-    # In DSP0201, TYPE is optional and omitting it means a void return
-    # type. That is not supported in DSP0004.
-    # This code here fails when creating the CIMMethod object with an omitted
-    # TYPE attribute.
-
+    # TODO #1038: Clarify how to deal with omitted TYPE of METHOD
     return CIMMethod(attrl['NAME'],
                      return_type=attrl.get('TYPE', None),
                      parameters=parameters,
@@ -1470,7 +1455,7 @@ def parse_parameter_array(tup_tree):
 
     array_size = attrl.get('ARRAYSIZE', None)
     if array_size is not None:
-        # TODO 2/18 AM #1044: Clarify if hex support is needed.
+        # TODO #1044: Clarify if hex support is needed
         array_size = int(array_size)
 
     qualifiers = list_of_matching(tup_tree, ['QUALIFIER'])
@@ -1500,7 +1485,7 @@ def parse_parameter_refarray(tup_tree):
 
     array_size = attrl.get('ARRAYSIZE', None)
     if array_size is not None:
-        # TODO 2/18 AM #1044: Clarify if hex support is needed.
+        # TODO #1044: Clarify if hex support is needed
         array_size = int(array_size)
 
     qualifiers = list_of_matching(tup_tree, ['QUALIFIER'])
@@ -1662,12 +1647,12 @@ def parse_paramvalue(tup_tree):
             %ParamType;  #IMPLIED
             %EmbeddedObject;>
     """
-    # TODO: 6/16 KS: Extended per DSP0201 v 1.4 to include CLASSNAME,
-    # INSTANCENAME, CLASS, INSTANCE, VALUE.NAMEDINSTANCE but not sure
-    # we have tests for all of these.
-    # Version 2.1.1 of the DTD lacks the %ParamType attribute but it
-    # is present in version 2.2.  Make it optional to be backwards
-    # compatible.
+
+    # Version 2.4 of DSP0201 added CLASSNAME, INSTANCENAME, CLASS, INSTANCE, and
+    # VALUE.NAMEDINSTANCE.
+
+    # Version 2.1.1 of DSP0201 lacks the %ParamType entity but it is present as
+    # optional (for backwards compatibility) in version 2.2.
 
     check_node(tup_tree, 'PARAMVALUE', ['NAME'],
                ['PARAMTYPE', 'EmbeddedObject', 'EMBEDDEDOBJECT'])

--- a/testsuite/test_tupletree.py
+++ b/testsuite/test_tupletree.py
@@ -163,7 +163,7 @@ def dom_to_tupletree(node):
         attr_node = node.attributes.item(i)
         attrs[attr_node.nodeName] = attr_node.nodeValue
 
-    # XXX: Cannot handle comments, cdata, processing instructions, etc.
+    # TODO: Cannot handle comments, cdata, processing instructions, etc.
 
     # it's so easy in retrospect!
     return (name, attrs, contents, None)


### PR DESCRIPTION
If a TODO has an associated issue number, the date and initials are removed to save space in the line; any history etc. can then be seen in the issue. TODOs that are removed by pending PRs have not been touched to avoid merge conflicts.
Ready for review and merge.