### PR TITLE
Fixes #1038: Rejecting void method return types in tupleparser

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -386,7 +386,7 @@ Bug fixes
 
 * Docs: Clarified in the description of the `return_type` init parameter of
   `CIMMethod` that array return types, void return types, and reference
-  return types are all not supported in pywbem.
+  return types are all not supported in pywbem. See issue #1038, for void.
 
 * Fixed the bug that an (unsupported!) reference type could be specified for
   the return value of CIM methods, by raising `ValueError` if

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -4971,27 +4971,21 @@ class CIMMethod(_CIMComparisonMixin):
 
             Must not be `None` or ``"reference"``.
 
-            Support for void return types: Pywbem also does not support void
+            Support for void return types: Pywbem does not support void method
             return types, consistent with the CIM architecture and MOF syntax
-            (see :term:`DSP0004`).
-            As a side note, the CIM-XML protocol (see :term:`DSP0200` and
-            :term:`DSP0201`) is able to represent method declarations and
-            method invocations with void return types.
+            (see :term:`DSP0004`). Note that void return types could be
+            represented in CIM-XML (see :term:`DSP0201`).
 
             Support for reference return types: Pywbem does not support
-            reference return types of methods.
-            The CIM architecture and MOF syntax support reference return types.
-            The CIM-XML protocol supports the invocation of methods with
-            reference return types, but it does not support the representation
-            of class declarations with methods that have reference return
-            types. As a result, it is not possible to create such classes in a
-            WBEM server using the CIM-XML protocol. For consistency, pywbem
-            does not support reference return types, not even for method
-            invocations.
+            reference return types of methods. The CIM architecture and MOF
+            syntax support reference return types, and the CIM-XML protocol
+            supports the invocation of methods with reference return types.
+            However, CIM-XML does not support the representation of class
+            declarations with methods that have reference return types.
 
             Support for array return types: Pywbem does not support array
             return types of methods, consistent with the CIM architecture,
-            MOF syntax and the CIM-XML protocol.
+            MOF syntax and CIM-XML.
 
           parameters (:term:`parameters input object`):
             Parameter declarations for the method.

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1388,9 +1388,14 @@ def parse_method(tup_tree):
 
     qualifiers = list_of_matching(tup_tree, ['QUALIFIER'])
 
-    # TODO #1038: Clarify how to deal with omitted TYPE of METHOD
+    return_type = attrl.get('TYPE', None)
+    if not return_type:
+        raise ParseError("Element %r missing attribute 'TYPE' (a void method "
+                         "return type is not supported in CIM)" %
+                         name(tup_tree))
+
     return CIMMethod(attrl['NAME'],
-                     return_type=attrl.get('TYPE', None),
+                     return_type=return_type,
                      parameters=parameters,
                      qualifiers=qualifiers,
                      class_origin=attrl.get('CLASSORIGIN', None),

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -7446,22 +7446,13 @@ testcases_tupleparse_xml = [
         None, None, True
     ),
     (
-        # TODO 2/18 AM #1038: Clarify how to deal with METHOD without TYPE
-        # In DSP0201, TYPE is optional and omitting it means a void return
-        # type. That is not supported in DSP0004.
-        # In pywbem, the tupleparser defines TYPE as optional, but then fails
-        # when creating the CIMMethod object because that rejects
-        # return_type=None.
-        # So we cannot even define a testcase for this situation (we cannot
-        # expect a ParseError due to a missing TYPE, and we cannot test the
-        # handling of an omitted TYPE).
-        "METHOD without optional attribute TYPE",
+        "METHOD without attribute TYPE (void return type)",
         dict(
             xml_str=''
             '<METHOD NAME="Foo"/>',
             exp_result=None,
         ),
-        ParseError, None, False  # Disabled for now, see comment above
+        ParseError, None, True
     ),
     (
         "METHOD with two qualifiers",


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.