### PR TITLE
Fixes #1090: Improvements for port in use handling and other cleanup in listener

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -359,6 +359,14 @@ Enhancements
 * The `url` property of `WBEMConnection` now transforms its input value
   to unicode. (Issue #1068).
 
+* In the `WBEMListener` class, added support for using it as a context
+  manager in order to ensure that the listener is stopped automatically
+  upon leaving the context manager scope.
+
+* In the `WBEMListener` class, added properties `http_started` and
+  `https_started` indicating whether the listener is started for the
+  respective port.
+
 Bug fixes
 ^^^^^^^^^
 


### PR DESCRIPTION
For details, see commit message.
Ready for review and merge.

Note that on Windows, starting a second listener on the same port does not raise an exception (as shown by the `test_port_in_use()` test case). There is no test case that verifies whether this actually works on Windows.