### PR TITLE
Code errors in run_operations.py and run_operationtimeouts.py

### DIFF
--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -6094,8 +6094,9 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
         sm = "test_create_delete_subscription"
+
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             with WBEMSubscriptionManager(subscription_manager_id=sm) \
                     as sub_mgr:
@@ -6165,8 +6166,9 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
         server = WBEMServer(self.conn)
 
         sm = 'test_create_indications'
+
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             with WBEMSubscriptionManager(subscription_manager_id=sm) \
                     as sub_mgr:
@@ -6191,10 +6193,10 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
                 self.confirm_created(sub_mgr, server_id, filter_.path,
                                      subscription_paths)
 
-                self.assertTrue(
-                    self.pegasus_send_indications(self.test_classname,
-                                                  requested_count),
-                    'Send indications test failed')
+                if not self.pegasus_send_indications(self.test_classname,
+                                                     requested_count):
+                    print('Test "test_create_indications" rcvd unexpected '
+                          'indications')
 
                 sub_mgr.remove_subscriptions(server_id, subscription_paths)
                 sub_mgr.remove_filter(server_id, filter_.path)
@@ -6252,8 +6254,8 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
 
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             sm = 'test_id_attributes'
             with WBEMSubscriptionManager(subscription_manager_id=sm) as sub_mgr:
@@ -6357,8 +6359,8 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
 
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             sm = 'test_id_attributes2'
             with WBEMSubscriptionManager(subscription_manager_id=sm) as sub_mgr:
@@ -6425,8 +6427,9 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
         sm = 'test_not_owned_indications'
+
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
             # TODO should we context this sub_mgr
             sub_mgr = WBEMSubscriptionManager(subscription_manager_id=sm)
             server_id = sub_mgr.add_server(server)
@@ -6495,8 +6498,8 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
         sm = 'test_not_owned_indications2'
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             with WBEMSubscriptionManager(subscription_manager_id=sm) as sub_mgr:
                 server_id = sub_mgr.add_server(server)
@@ -6549,6 +6552,7 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
             # self.assertTrue(self.pegasus_send_indications(self.test_classname,
             #                                              requested_count),
             #                'send Indications test failed')
+            self.pegasus_send_indications(self.test_classname, requested_count)
 
             sub_mgr2.remove_subscriptions(server_id, subscription_paths)
             sub_mgr2.remove_filter(server_id, filter_.path)
@@ -6589,8 +6593,8 @@ class TestSubscriptionsClass(PyWBEMServerClass, RegexpMixin):
 
         server = WBEMServer(self.conn)
 
+        my_listener = self.create_listener()
         try:
-            my_listener = self.create_listener()
 
             try:
                 sub_mgr = WBEMSubscriptionManager(

--- a/testsuite/run_operationtimeouts.py
+++ b/testsuite/run_operationtimeouts.py
@@ -131,12 +131,12 @@ class ServerTimeoutTest(ClientTest):
             print('execute url_type=%s timeout=%s delay=%s' % (url_type,
                                                                timeout, delay))
 
+        err_flag = ""
+        opttimer = ElapsedTimer()
         try:
             # Confirm server working with a simple request.
             conn.GetClass('CIM_ManagedElement')
             request_result = 0     # good response
-            err_flag = ""
-            opttimer = ElapsedTimer()
             conn.InvokeMethod(TESTMETHOD, TESTCLASS,
                               [('delayInSeconds', Uint32(delay))])
 
@@ -153,12 +153,16 @@ class ServerTimeoutTest(ClientTest):
         # This exception terminates the test
         except ConnectionError as ce:
             request_result = 2    # Connection error received
+            err_flag = "ConnectionError"
+            execution_time = opttimer.elapsed_sec()
 
             self.fail('%s exception %s' % ('Failed ConnectionError)', ce))
 
         # this exception tests against expected result. It terminates the
         # test only if the timeout is not expected
         except TimeoutError as ce:
+            execution_time = opttimer.elapsed_sec()
+            err_flag = "TimeoutError"
             execution_time = opttimer.elapsed_sec()
             request_result = 1    # timeout error received
             # error if the operation delay is lt timeout value and we get
@@ -174,6 +178,7 @@ class ServerTimeoutTest(ClientTest):
         # This exception terminates the test if stop_on_err set.
         except Exception as ec:      # pylint: disable=broad-except
             err_flag = "Test Failed.General Exception"
+            execution_time = opttimer.elapsed_sec()
             request_result = 2
             if self.stop_on_err:
                 self.fail('%s exception %s' % ('Failed(Exception)', ec))


### PR DESCRIPTION
In testing I found some code ordering issues that cause exceptions in
particular conditions.  Mostly putting to much code in try block so that
a variable was not set when exception was executed.