### PR TITLE
Add comment on docstring of CIMInstanceName from_string method

### DIFF
--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2570,9 +2570,9 @@ class CIMInstanceName(_CIMComparisonMixin):
                 are required to create the :class:`~pywbem.CIMInstanceName`
                 object. Thus, for example, if the class were retrieved from a
                 server, generally, the `LocalOnly` parameter in the request
-                should be `False` to assure that all superclass properties are
-                retrieved and the IncludeQualifiers should be set to `True`
-                to assure that qualifiers are retrieved.
+                should be `False` to assure that superclass properties are
+                retrieved and `IncludeQualifiers` parameter should be set to
+                `True` to assure that qualifiers are retrieved.
 
                 In non-strict mode, that class may have missing key properties.
                 Any missing key properties will result in missing key bindings

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -2571,7 +2571,8 @@ class CIMInstanceName(_CIMComparisonMixin):
                 object. Thus, for example, if the class were retrieved from a
                 server, generally, the `LocalOnly` parameter in the request
                 should be `False` to assure that all superclass properties are
-                retrieved.
+                retrieved and the IncludeQualifiers should be set to `True`
+                to assure that qualifiers are retrieved.
 
                 In non-strict mode, that class may have missing key properties.
                 Any missing key properties will result in missing key bindings


### PR DESCRIPTION
Add to documentation that IncludeQualifiers should be True.

This is just a cautionary note since the setting in a server is implementation dependent if you do not set this and that could mean creating path with no keybindings.