### PR TITLE
Fixes #1145: Fixed that get_central_instances() continues on CIM_ERR_METHOD_NOT_FOUND

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -648,6 +648,12 @@ Bug fixes
   significant digits required by DSP0201: 11 for real32, and 17 for real64.
   (Issue #1136).
 
+* In the `WBEMServer.get_central_instances()` method, fixed the error that a
+  CIM status code of CIM_ERR_METHOD_NOT_FOUND returned when attempting to
+  invoke the GetCentralInstances CIM method lead to failing the
+  `get_central_instances()` method. Now, execution continues with attempting
+  the next approach for determining the central instances (Issue #1145).
+
 Cleanup
 ^^^^^^^
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -97,7 +97,8 @@ Example output:
 import re
 
 from .cim_constants import CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_CLASS, \
-    CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_NOT_SUPPORTED, CIM_ERR_NOT_FOUND
+    CIM_ERR_METHOD_NOT_FOUND, CIM_ERR_METHOD_NOT_AVAILABLE, \
+    CIM_ERR_NOT_SUPPORTED, CIM_ERR_NOT_FOUND
 from .exceptions import CIMError
 from .cim_obj import CIMInstanceName, NocaseDict
 from .cim_operations import WBEMConnection
@@ -449,7 +450,8 @@ class WBEMServer(object):
                 MethodName="GetCentralInstances",
                 ObjectName=profile_path)
         except CIMError as exc:
-            if exc.status_code in (CIM_ERR_METHOD_NOT_AVAILABLE,
+            if exc.status_code in (CIM_ERR_METHOD_NOT_FOUND,
+                                   CIM_ERR_METHOD_NOT_AVAILABLE,
                                    CIM_ERR_NOT_SUPPORTED):
                 # Method is not implemented.
                 # CIM_ERR_NOT_SUPPORTED is not an official status code for this


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.