### PR TITLE
Docs: Improved mock support chapter

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -434,6 +434,7 @@ Enhancements
   unique identifier for each WBEMConnection object and is part of each log
   record. This allows linking logs for each WBEMConnection in the log.
 
+* Improved the complete pywbem documentation (Issue #1115).
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -563,6 +563,10 @@ specified when following the links to the standards:
 
   - The ``EnumerationCount`` operation is not supported by pywbem.
 
+  - The mock support of pywbem (see :ref:`Mock support`) does not support the
+    ``ModifyClass`` operation. Note that in its implementation of the CIM-XML
+    protocol, pywbem does support the ``ModifyClass`` operation.
+
 * The CIM-XML representation of :ref:`CIM objects` as produced by their
   ``tocimxml()`` and ``tocimxmlstr()`` methods conforms to :term:`DSP0201`.
 

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -73,9 +73,9 @@ The operation mode of the mock repository is selected when creating
 a :class:`~pywbem_mock.FakedWBEMConnection` object, through its `repo_lite`
 init parameter. Full mode is the default.
 
-The following example demonstrates setting up a faked connection, adding some
-CIM objects defined in a MOF string to its mock repository, and executing
-WBEM operations on the faked connection:
+The following example demonstrates setting up a faked connection, adding
+several CIM objects defined in a MOF string to its mock repository, and
+executing WBEM operations on the faked connection:
 
 .. code-block:: python
 
@@ -486,49 +486,25 @@ The faked pull operations are:
 Faked iter operations
 ^^^^^^^^^^^^^^^^^^^^^
 
-The faked iter operations (like the real iter operations) do not directly
-issue requests and responses on the connection, but instead are simply a
-layer on top of underlying operations. For example, `IterEnumerateInstances`
+The iter operations on a faked connection are in fact the iter operations
+on :class:`~pywbem.WBEMConnection`, because they do not directly issue requests
+and responses on the connection, but instead are simply a layer on top of
+underlying operations. For example, `IterEnumerateInstances`
 invokes either pull operations (i.e. `OpenEnumerateInstances` followed by
 `PullInstancesWithPath`) or traditional operations (i.e. `EnumerateInstances`).
-The approach by which the use of pull vs. traditional operations is controlled
-is the same as for the iter operations of :class:`~pywbem.WBEMConnection`,
-through the `use_pull_operations` init parameter of
+The use of pull vs. traditional operations is controlled via the
+`use_pull_operations` init parameter of
 :class:`~pywbem_mock.FakedWBEMConnection`.
 
-Therefore, the faked iter operations behave like the iter operations of
-:class:`~pywbem.WBEMConnection`, and their limitations are those of the
-underlying faked traditional operations or faked pull operations.
+The iter operations are:
 
-The faked iter operations are:
-
-- **IterEnumerateInstances**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterEnumerateInstances`,
-  with the stated exceptions.
-
-- **IterEnumerateInstancePaths**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterEnumerateInstancePaths`,
-  with the stated exceptions.
-
-- **IterAssociatorInstances**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterAssociatorInstances`,
-  with the stated exceptions.
-
-- **IterAssociatorInstancePaths**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterAssociatorInstancePaths`,
-  with the stated exceptions.
-
-- **IterReferenceInstances**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterReferenceInstances`,
-  with the stated exceptions.
-
-- **IterReferenceInstancePaths**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterReferenceInstancePaths`,
-  with the stated exceptions.
-
-- **IterQueryInstances**: Behaves like
-  :meth:`~pywbem.WBEMConnection.IterQueryInstances`,
-  with the stated exceptions.
+- :meth:`~pywbem.WBEMConnection.IterEnumerateInstances`
+- :meth:`~pywbem.WBEMConnection.IterEnumerateInstancePaths`
+- :meth:`~pywbem.WBEMConnection.IterAssociatorInstances`
+- :meth:`~pywbem.WBEMConnection.IterAssociatorInstancePaths`
+- :meth:`~pywbem.WBEMConnection.IterReferenceInstances`
+- :meth:`~pywbem.WBEMConnection.IterReferenceInstancePaths`
+- :meth:`~pywbem.WBEMConnection.IterQueryInstances`
 
 
 .. _`Faked class operations`:

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -10,11 +10,10 @@ Mock support
 Overview
 --------
 
-The ``pywbem_mock`` module provides mock support that enables usage of the
-pywbem library without a WBEM server.
-
-This is used for testing the pywbem library itself and can also be used for
-the development and testing of Python programs using the pywbem library.
+The pywbem package contains the ``pywbem_mock`` module which provides mock
+support that enables usage of the pywbem library without a WBEM server.
+This module is used for testing the pywbem library itself and can also be used
+for the development and testing of Python programs using the pywbem library.
 
 The pywbem mock support consists of a :class:`pywbem_mock.FakedWBEMConnection`
 class that establishes a *faked connection*. That class is a subclass of
@@ -43,38 +42,40 @@ has a default CIM namespace that can be set upon object creation.
 
 :class:`~pywbem_mock.FakedWBEMConnection` has some additional methods that
 provide for adding CIM classes, instances and qualifier types to its mock
-repository:
-
-* :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects` adds
-  the specified :ref:`CIM objects`.
-
-* :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_str` compiles a MOF
-  string and adds the resulting CIM objects.
-
-* :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_file` compiles a MOF
-  file and adds the resulting CIM objects.
-
-In all cases, certain prerequisite CIM objects must already exist in the target
-namespace of the mock repository for a new CIM object to be successfully added:
-For a CIM class to be added, the superclass of that class as well as CIM
-qualifier types for the qualifiers used by that class must exist.
-For a CIM instance to be added, its CIM creation class must exist.
-
-Some CIM objects that are used by a CIM object to be added, do not need to
-exist and in fact allow forward references:
-CIM classes specified in reference properties or in reference parameters of
-methods of a class to be added do not need to exist.
-CIM classes specified in qualifiers (for example, in the EmbeddedInstance
-qualifier) of a class to be added do not need to exist.
+repository. See :ref:`Building the mock repository` for details.
 
 There are no setup methods to remove or modify CIM objects in the mock
 repository. However, if needed, that can be done by using operation methods
 such as :meth:`~pywbem.WBEMConnection.DeleteClass` or
 :meth:`~pywbem.WBEMConnection.ModifyInstance`.
 
+.. _`mock repository operation modes`:
+
+The mock repository supports two operation modes:
+
+* full mode: The repository must contain the classes and qualifier types that
+  are needed for the operations that are invoked. This results in a behavior of
+  the faked operations that is close to the behavior of the operations of a
+  real WBEM server.
+
+* lite mode: The repository does not need to contain any classes and qualifier
+  types, and can be used when it contains only instances. This simplifies the
+  setup of the mock repository for users, but it also affects the behavior of
+  the faked instance operations to be farther away from the behavior of the
+  operations of a real WBEM server. For example, the faked `EnumerateInstances`
+  operation will not return instances of subclasses when `DeepInheritance` is
+  set, because without looking at classes, there is no way it can find out what
+  the subclasses are. And of course, class operations and qualifier operations
+  that retrieve objects don't work at all if the mock repository does not
+  contain them.
+
+The operation mode of the mock repository is selected when creating
+a :class:`~pywbem_mock.FakedWBEMConnection` object, through its `repo_lite`
+init parameter. Full mode is the default.
+
 The following example demonstrates setting up a faked connection, adding some
-CIM objects defined in a MOF string to its mock repository, and performing a
-few operations:
+CIM objects defined in a MOF string to its mock repository, and executing
+WBEM operations on the faked connection:
 
 .. code-block:: python
 
@@ -109,7 +110,7 @@ few operations:
         instance of CIM_Foo as $I1 { InstanceID = "I1"; SomeData=3 };
         """
 
-    # Create a faked connection
+    # Create a faked connection (with a mock repository in full mode)
     conn = pywbem_mock.FakedWBEMConnection(default_namespace='root/cimv2')
 
     # Compile the MOF string and add its CIM objects to the default namespace
@@ -169,221 +170,192 @@ Pywbem mock does NOT support:
    HTTP requests or responses.
 7. Generating CIM indications.
 8. Some of the functionality that may be implemented in real WBEM servers such
-   as the ``__Namespace__`` class/provider or the ``CIM_Namespace``
+   as the `__Namespace__` class/provider or the `CIM_Namespace`
    class/provider, because these are WBEM server-specific implementations and
    not WBEM request level capabilities.  Note that such capabilities can be at
    least partly built on top of the existing capabilities by inserting
    corresponding CIM instances into the mock repository.
 
 
-.. _`FakedWBEMConnection methods`:
+.. _`Faked WBEM operations`:
 
-FakedWBEMConnection methods
----------------------------
+Faked WBEM operations
+---------------------
 
-:class:`pywbem_mock.FakedWBEMConnection` defines a set of WBEM Server methods
-corresponding to the WBEMConnection client methods and mocks the communication with
-the WBEMServer) and returns syntatically the same forms of data and
-exceptions as the :class:`pywbem.WBEMConnection` methods.  These methods adher to the
-behavior requirements defined in the DMTF specification :term:`DSP0200` for
-handling requests from the client and returning responses.
+The :class:`pywbem_mock.FakedWBEMConnection` class supports the same WBEM
+operations that are supported by the :class:`pywbem.WBEMConnection` class.
 
-Generally it attempts to get data required by the operation from the fake
-repository created by the user or to put the data from operations that modify
-the server objects (create, modify, and delete operations) into the fake
-repository.  However because this is a simulation of a WBEM server and
-intended to be used primarily for testing there are a number of limitations
-and differences between what these methods do and what a real server would do.
+These faked operations generally adhere to the behavior requirements defined in
+:term:`DSP0200` for handling input parameters and returning a result.
 
-The descriptions below describes differences between the mocker and access to
+The faked operations get the data to be returned from the mock repository of
+the faked connection, and put the data provided in operation parameters that
+modify objects (create, modify, and delete operations) into that mock
+repository.
+
+However, because the pywbem mock support is only a simulation of a WBEM server
+and intended to be used primarily for testing, there are a number of
+limitations and differences between the behavior of the faked operations and
 a real WBEM server.
 
-Generally these methods provide the same behavior as the corresponding
-methods in a real WBEM Server and the behavior definitions in
-:term:`DSP0200` except for specific limitations and variations.
+The descriptions below describe differences between the faked operations of
+the pywbem mock support and the operations of a real WBEM server, and the
+effects of the operation modes of the mock repository.
 
 
-.. _`Server class operation methods`:
+.. _`Faked instance operations`:
 
-Server class operation methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Faked instance operations
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The methods that get data require the target classes to be in the repository
-before the mock call.  The methods including limitations are:
+Instance operations work in both operation modes of the repository.
 
-- **GetClass:** Behaves like :meth:`~pywbem.WBEMConnection.GetClass`.
-
-- **EnumerateClasses:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateClasses`. Requires that there
-  be one or more top level classes (i.e. no superclass) in the repository
-  if the request does not include the classname parameter.
-
-- **EnumerateClassNames:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateClassNames`. Requires that there
-  be one or more top level classes (i.e. no subclass) in the mock repository
-  if the request does not include the classname parameter.
-
-- **CreateClass:** Behaves like
-  :meth:`~pywbem.WBEMConnection.CreateClass`. It requires that any superclass
-  defined in the new class be in the mock repository.
-
-- **DeleteClass:** Behaves like
-  :meth:`~pywbem.WBEMConnection.DeleteClass`. This includes deleting all
-  subclasses and instances.
-
-- **ModifyClass:** Currently not implemented. Returns CIMError, not supported
-
-
-.. _`Server CIMQualifierDeclaration operation methods`:
-
-Server CIMQualifierDeclaration operation methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **SetQualifier:** Behaves like :meth:`~pywbem.WBEMConnection.SetQualifier`.
-
-- **GetQualifier:** Behaves like :meth:`~pywbem.WBEMConnection.GetQualifier`.
-
-- **EnumerateQualifiers:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateQualifiers`.
-
-
-.. _`Server CIMInstance operation methods`:
-
-Server CIMInstance operation methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The methods that get data require instances in the
+The operations that retrieve objects require instances in the
 repository for the instances to be recovered.  We allow some of these methods to
 try to return data if the class repository is empty but they may react differently
 if there are classes in the repository.
 
-- **GetInstance:** Behaves like :meth:`~pywbem.WBEMConnection.GetInstance` except
-  that the LocalOnly option depends only on instance class_origin attribute
-  of each property if repo_lite is True
+- **GetInstance:** Behaves like :meth:`~pywbem.WBEMConnection.GetInstance`,
+  except that the behavior of property selection for the returned instance when
+  `LocalOnly` is set depends on the operation mode of the mock repository: In
+  lite mode, property selection is based upon the `class_origin` attribute of
+  the properties of the instance. In full mode, property selection is based
+  upon the classes in which they are defined.
 
 - **EnumerateInstances:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateInstances` except that what it
-  returns depends on  the repo_lite WBEMConnection flag.  If repo_lite == True
-  only instances of the defined classname are returned if they exist and the
-  existence of the target classname is not validated.
-  If repo_lite == None, it is assumed that there is no class repository
-  so the DeepInheritance, LocalOnly, parameters are ignored and it returns
-  only instances of the classname defined on input.
+  :meth:`~pywbem.WBEMConnection.EnumerateInstances`, except for these
+  differences when the mock repository is in lite mode: When `DeepInheritance`
+  is set, instances of subclasses of the specified class will not be returned,
+  and `LocalOnly` is ignored and treated as if it was set to `False`.
 
 - **EnumerateInstanceNames:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateInstances` except that what it
-  returns depends on if there are classes in the repository.
+  :meth:`~pywbem.WBEMConnection.EnumerateInstances`, except for this
+  difference when the mock repository is in lite mode: When `DeepInheritance`
+  is set, instances of subclasses of the specified class will not be returned.
 
 - **CreateInstance**: Behaves like
-  :meth:`~pywbem.WBEMConnection.CreateInstance`. This operation requires
-  that the corresponding class exist in the repository.  It returns
-  not supported if repo_lite is set. It adds the new
-  instance to the repository.  It also requires that all key properties be
-  in the new_instance parameter since the repository has no way to define
-  key property values.
+  :meth:`~pywbem.WBEMConnection.CreateInstance`, except for these
+  differences: This operation requires that all key properties are specified in
+  the new instance since the mock repository has no support for dynamically
+  setting key properties as a dynamic provider for the class in a real WBEM
+  server might have. This operation requires that the mock repository is in
+  full mode and that the class of the new instance exists in the mock
+  repository. It fails with not supported if the mock repository is in lite
+  mode.
 
-- **ModifyInstance**: Behaves like :meth:`~pywbem.WBEMConnection.ModifyInstance`.
-  This operation requires that the corresponding class exist in the
-  repository and that the repo_lite flag is False. It modifies an existing
-  instance in the repository.
+- **ModifyInstance**: Behaves like
+  :meth:`~pywbem.WBEMConnection.ModifyInstance`. This operation requires that
+  the mock repository is in full mode and that the class of the instance exists
+  in the mock repository. It fails with not supported if the mock repository is
+  in lite mode.
 
-- **DeleteInstance**: Behaves like :meth:`~pywbem.WBEMConnection.DeleteInstance`.
-  If the repo_lite flag is set, it does not check for corresponding class.
-  In the current implementation it does not attempt to delete references
-  to this instance. If the repo_lite flag is not set, it validates the
-  existence of the corresponding class before attempting to delete the
-  instance.
+- **DeleteInstance**: Behaves like
+  :meth:`~pywbem.WBEMConnection.DeleteInstance`, except for this difference
+  depending on the operation mode of the mock repository: In lite mode, the
+  operation does not check for existence of the class of the instance. In full
+  mode, the operation validates the existence of the class of the instance.
+  In the current implementation, this operation does not check for association
+  instances referencing the instance to be deleted, so any such instances
+  become dangling references.
 
-- **ExecQuery**: Behaves like :meth:`~pywbem.WBEMConnection.ExecQuery` except
-  that it returns instances based on a very limited parse of the
-  query string (generally the SELECT and FROM clauses. It ignores the WHERE clause).
-  It does not execute the select statement itself nor does it parse it completely.
-  An incorrect select statement will be ignored other than SELECT and FROM.
-  It does check to be sure that the language is one of those normally defined.
-  TODO: Not done. Clarify when we finish code.
+- **ExecQuery**: This operation is not currently implemented. Once implemented:
+  Behaves like :meth:`~pywbem.WBEMConnection.ExecQuery`, except
+  that it returns instances based on a very limited parsing of the query
+  string: Generally, the SELECT and FROM clauses are evaluated, and the WHERE
+  clause is ignored. The query string is not validated for correctness.
+  The query language is not validated.
 
 
-.. _`Server WBEM associators and reference operation methods`:
+.. _`Faked association operations`:
 
-Server associators and reference operation methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Faked association operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The fake versions of the esponders for these methods allow both class and
-instance requests.  At the same time, they allow mock repositories that
-would be used to test only instance methods to be built without the
-corresponding classes. They include the following methods:
+The faked association operations support both instance-level use and
+class-level use. Class-level use requires the mock repository to be in full
+mode, while instance-level use works in both operation modes of the mock
+repository.
 
 - **AssociatorNames**: Behaves like
-  :meth:`~pywbem.WBEMConnection.AssociatorNames`. If a classname is specified
-  the source, target, and association classes must be in the repository. If
-  an instance target is specified, correct results are returned if classes
-  are in the repository. More limited results are returned if repo_lite is
-  set (the classes in the repository are ignored so do not need to be
-  installed.)
+  :meth:`~pywbem.WBEMConnection.AssociatorNames`, with the following
+  exceptions and requirements:
+  For class-level use, the mock repository must be in full mode and the source,
+  target, and association classes and their subclasses must exist in the mock
+  repository.
+  For instance-level use, correct results are returned if the mock repository
+  is in full mode and the the source, target, and association classes and their
+  subclasses exist in the repository. More limited results are returned in lite
+  mode, because the class hierarchy is not considered when selecting the
+  instances to be returned.
 
 - **Associators**: Behaves like
-  :meth:`~pywbem.WBEMConnection.Associators` See AssociatorNames above for
-  limitations
+  :meth:`~pywbem.WBEMConnection.Associators`, with the exceptions and
+  requirements described for `AssociatorNames`, above.
 
 - **ReferenceNames**: Behaves like
-  :meth:`~pywbem.WBEMConnection.ReferenceNames` See AssociatorNames above
-  for limitations
+  :meth:`~pywbem.WBEMConnection.ReferenceNames`, with the exceptions and
+  requirements described for `AssociatorNames`, above.
 
 - **References**: Behaves like
-  :meth:`~pywbem.WBEMConnection.References` See AssociatorNames above for
-  limitations.
+  :meth:`~pywbem.WBEMConnection.References`, with the exceptions and
+  requirements described for `AssociatorNames`, above.
 
 
-.. _`Server InvokeMethod  operation methods`:
+.. _`Faked method invocation operation`:
 
-Server InvokeMethod operation method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Faked method invocation operation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The fake InvokeMethod behaves like :meth:`~pywbem.WBEMConnection.InvokeMethod`.
+The faked method invocation operation (`InvokeMethod`) behaves like
+:meth:`~pywbem.WBEMConnection.InvokeMethod`, but because of the nature of
+`InvokeMethod`, the user must provide a callback function that performs the
+actual task of the CIM method. The mock repository must be in full operation
+mode.
 
-Since this method is outside the normal intrinsic WBEM operations in that it
-generally implies a side effect and not just a get/put interface to a
-repository.  It could not be implemented simply to get objects from the
-repository or put them into the repository.
+The callback function must have the signature defined in the
+:func:`~pywbem_mock.method_callback_interface` function and must be registered
+with the mock repository through
+:meth:`~pywbem_mock.FakedWBEMConnection.add_method_callback` for a particular
+combination of namespace, class, and CIM method name.
 
-The fake InvokeMethod requires a callback to a user defined function
-based on the namespace, objectname, and method defined in the call.\
-Because the nature of InvokeMethod, there was no way to define a standard means
-to get information just from the mock repository for the responses.
+When the callback function is invoked on behalf of an `InvokeMethod` operation,
+the target object of the method invocation (class or instance) is provided to
+the callback function, in addition to the method input parameters.
 
-This user defined function acts as the WBEM server implementation of the
-InvokeMethod, processing input parameters and returning a return value and
-output parameters.
+The callback function can access the mock repository of the faked connection
+using the normal WBEM operation methods.
 
-The user must create a function that will be executed as a callback for each
-method that is to be tested. This method is attached to the mock repository
-through :meth:`~pywbem_mock.FakedWBEMConnection.add_method_callback` which
-defines the namespace, class, and methodname for the InvokeMethod and the
-callback method to be executed.
+The callback function is expected to return a tuple consisting of two items:
 
+* the CIM method return value, as a :term:`CIM data type` value.
+* a :ref:`NocaseDict` containing any output parameters as
+  :class:`~pywbem.CIMParameter` objects.
 
-This user defined callback method should have the signature defined in
-:meth:`~pywbem_mock.FakedWBEMConnection.add_method_callback`.
-
-The callback is expected to return a tuple consiting of ReturnValue and
-a `NocaseDict` containing any output parameters. The following is an example
-of the definition and execution of InvokeMethod.
+The following is an example for invoking the faked `InvokeMethod` operation
+with a simple callback function.
 
 .. code-block:: python
 
     import pywbem
     import pywbem_mock
 
-    def method1_callback(self, conn, methodname, local_object, params=None):
-        """ Callback for method1"""
+    def method1_callback(conn, objectname, methodname, params):
+        """
+        Callback function that demonstrates what can be done, without being
+        really useful.
+        """
 
-        # this method can access the repository through pywbem client calls
-        # in this case the CIMClassName in local_object
-        cl = conn.GetClass(local_object)
+        # Access input parameters
+        ip1 = params['IP1']
 
-        rtn_val = 0  # return 0 as a return code
-        rtn_params = NocaseDict('OP1' : 'Some return Data')
-        return (rtn_val, rtn_params)
+        # Access the mock repository through the faked connection object.
+        # In case of a static CIM method, objectname is a CIMClassName object.
+        cl = conn.GetClass(objectname)
+
+        # Set return value and output parameters
+        rtn_val = 0
+        op1 = CIMParameter('OP1', 'string', value='Some output data')
+        return rtn_val, [op1]
 
     mof = """
         Qualifier In : boolean = true,
@@ -397,13 +369,17 @@ of the definition and execution of InvokeMethod.
         Qualifier Out : boolean = false,
             Scope(parameter),
             Flavor(DisableOverride, ToSubclass);
+
         class TST_Class {
+
             string InstanceID;
-                [Description("Sample method with input and output parameters")]
+
+              [Static,
+               Description("Static method with input and output parameters")]
             uint32 Method1(
-                [IN, Description("Input Param1")]
+                [IN, Description("Input param 1")]
               string IP1,
-                [IN ( false), OUT, Description("Response param 1")]
+                [IN (false), OUT, Description("Output param 1")]
               string OP1);
     """
 
@@ -414,54 +390,197 @@ of the definition and execution of InvokeMethod.
     # of the mock repository
     conn.compile_mof_str(mof)
 
-    # Add the defined class and method to the defaault repository.
-    conn.add_method_callback('TST_Class', 'Method1',
-                          self.method1_callback)
+    # Register the method callback function to the mock repository, for the
+    # default namespace of the connection
+    conn.add_method_callback('TST_Class', 'Method1', method1_callback)
 
-    # execute the InvokeMethod as a static (class level) method.
+    # Invoke static method Method1
     params = [('IP1', 'someData')]
     result = conn.InvokeMethod('Method1', 'TST_Class', Params=params)
 
-    print('return value %s' result[0])
-    print('Return parameters %s' % (result[1],))
-
-.. _`Server pull operations methods`:
-
-Server pull operations methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The fake pull operations implement all of the Open and Pull WBEM server
-methods with the same behavior as the real operations except as follows.
-
-- Filter Query Language parameters are ignored and the full instance responses
-  generated. Since FQL only filters the set of instanced defined by
-  the corresponding request (i.e. Open/Pull EnumerateInstances simply
-  filters instances that would be acquired by EnumerateInstances. This means
-  that these methods can be used but may return more instances than would
-  be returned without the filters.
-
-- The ContinueOnError has no real meaning since we do not have a means to
-  introduce an error into a pull operation in process.
-
-- The timeout is ignored unless the faked response time on operations property
-  is set.
-
-- TODO Should we name the pull operations to be complete
+    print('Return value: %r' % result[0])
+    print('Output parameters: %r' % (result[1],))
 
 
-.. _`Pywbem ClientIter... Operations`:
+.. _`Callback functions for faked method invocation`:
 
-Pywbem ClientIter... Operations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Callback functions for faked method invocation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Because these opertions do not directly call the server but are simply a
-layer on top of the basic server communication methods like
-EnumerateInstances, OpenEnumerateInstances, etc. hese operations all execute
-with the same behavior as the real operations including use of the
-``use_pull_operations`` constructor attribute except:
+The callback functions for faked method invocation must have the following
+signature:
 
-- When the pull operations are used, the same limitations as the faked
-  pull operations themselves exist (see `Server pull operations methods`).
+.. autofunction:: pywbem_mock.method_callback_interface
+
+
+.. _`Faked pull operations`:
+
+Faked pull operations
+^^^^^^^^^^^^^^^^^^^^^
+
+The faked pull operations behave like the pull operations of
+:class:`~pywbem.WBEMConnection`, with the following exceptions:
+
+- The filter query related parameters `FilterQuery` and `FilterQueryLanguage`
+  are ignored and no such filtering takes place.
+
+- The `ContinueOnError` parameter is ignored because injecting an error into
+  the processing of the pull operations is not supported by the pywbem mock
+  support, so no failures can happen during the processing of the pull
+  operations.
+
+- The `OperationTimeout` parameter is currently ignored. As a result, there
+  will be no timeout if the
+  :attr:`~pywbem_mock.FakedWBEMConnection.response_delay` property is set to a
+  time larger than the `OperationTimeout` parameter.
+
+The faked pull operations are:
+
+- **OpenEnumerateInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenEnumerateInstances`,
+  with the stated exceptions.
+
+- **OpenEnumerateInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenEnumerateInstancePaths`,
+  with the stated exceptions.
+
+- **OpenAssociatorInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenAssociatorInstances`,
+  with the stated exceptions.
+
+- **OpenAssociatorInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenAssociatorInstancePaths`,
+  with the stated exceptions.
+
+- **OpenReferenceInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenReferenceInstances`,
+  with the stated exceptions.
+
+- **OpenReferenceInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenReferenceInstancePaths`,
+  with the stated exceptions.
+
+- **OpenQueryInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.OpenQueryInstances`,
+  with the stated exceptions.
+
+- **PullInstancesWithPath**: Behaves like
+  :meth:`~pywbem.WBEMConnection.PullInstancesWithPath`,
+  with the stated exceptions.
+
+- **PullInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.PullInstancePaths`,
+  with the stated exceptions.
+
+- **PullInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.PullInstances`,
+  with the stated exceptions.
+
+- **CloseEnumeration**: Behaves like
+  :meth:`~pywbem.WBEMConnection.CloseEnumeration`,
+  with the stated exceptions.
+
+
+.. _`Faked iter operations`:
+
+Faked iter operations
+^^^^^^^^^^^^^^^^^^^^^
+
+The faked iter operations (like the real iter operations) do not directly
+issue requests and responses on the connection, but instead are simply a
+layer on top of underlying operations. For example, `IterEnumerateInstances`
+invokes either pull operations (i.e. `OpenEnumerateInstances` followed by
+`PullInstancesWithPath`) or traditional operations (i.e. `EnumerateInstances`).
+The approach by which the use of pull vs. traditional operations is controlled
+is the same as for the iter operations of :class:`~pywbem.WBEMConnection`,
+through the `use_pull_operations` init parameter of
+:class:`~pywbem_mock.FakedWBEMConnection`.
+
+Therefore, the faked iter operations behave like the iter operations of
+:class:`~pywbem.WBEMConnection`, and their limitations are those of the
+underlying faked traditional operations or faked pull operations.
+
+The faked iter operations are:
+
+- **IterEnumerateInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterEnumerateInstances`,
+  with the stated exceptions.
+
+- **IterEnumerateInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterEnumerateInstancePaths`,
+  with the stated exceptions.
+
+- **IterAssociatorInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterAssociatorInstances`,
+  with the stated exceptions.
+
+- **IterAssociatorInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterAssociatorInstancePaths`,
+  with the stated exceptions.
+
+- **IterReferenceInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterReferenceInstances`,
+  with the stated exceptions.
+
+- **IterReferenceInstancePaths**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterReferenceInstancePaths`,
+  with the stated exceptions.
+
+- **IterQueryInstances**: Behaves like
+  :meth:`~pywbem.WBEMConnection.IterQueryInstances`,
+  with the stated exceptions.
+
+
+.. _`Faked class operations`:
+
+Faked class operations
+^^^^^^^^^^^^^^^^^^^^^^
+
+Class operations only work if the mock repository is in full operation mode.
+
+- **GetClass:** Behaves like :meth:`~pywbem.WBEMConnection.GetClass`. Requires
+  that the class to be returned is in the mock repository.
+
+- **EnumerateClasses:** Behaves like
+  :meth:`~pywbem.WBEMConnection.EnumerateClasses`. Requires that the class
+  specified in the `ClassName` parameter as well as the classes to be returned
+  are in the mock repository.
+
+- **EnumerateClassNames:** Behaves like
+  :meth:`~pywbem.WBEMConnection.EnumerateClassNames`. Requires that the class
+  specified in the `ClassName` parameter as well as the classes to be returned
+  are in the mock repository.
+
+- **CreateClass:** Behaves like
+  :meth:`~pywbem.WBEMConnection.CreateClass`. Requires that the superclass of
+  the new class (if it specifies one) is in the mock repository.
+
+- **DeleteClass:** Behaves like
+  :meth:`~pywbem.WBEMConnection.DeleteClass`, with the following difference:
+  This operation additionally deletes all direct and indirect subclasses of the
+  class to be deleted, and all instances of the classes that are being deleted.
+  Requires that the class to be deleted is in the mock repository.
+
+- **ModifyClass:** Not currently implemented.
+
+
+.. _`Faked qualifier operations`:
+
+Faked qualifier operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Qualifier operations only work if the mock repository is in full operation
+mode.
+
+- **SetQualifier:** Behaves like :meth:`~pywbem.WBEMConnection.SetQualifier`.
+  Requires that the specified qualifier type is in the mock repository.
+
+- **GetQualifier:** Behaves like :meth:`~pywbem.WBEMConnection.GetQualifier`.
+  Requires that the specified qualifier type is in the mock repository.
+
+- **EnumerateQualifiers:** Behaves like
+  :meth:`~pywbem.WBEMConnection.EnumerateQualifiers`.
+  Requires that the qualifier types to be returned are in the mock repository.
 
 
 .. _`Building the mock repository`:
@@ -469,49 +588,49 @@ with the same behavior as the real operations including use of the
 Building the mock repository
 ----------------------------
 
-Having data with which to respond to requests from a client is required for
-the faked connection to do useful work.  Therefore, in incorporates a
-repository which can be built as part of a test.
+The following methods can be used to add CIM instances, classes and
+qualifier types to the mock repository of a
+:meth:`~pywbem_mock.FakedWBEMConnection` object:
 
-There are three methods in the faked connection to add data to the
-mock repository
+* :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects` adds
+  the specified :ref:`CIM objects` to the mock repository.
 
-1. Add pywbem CIM Objects directly to the repository.
-   This is the method :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects`. The
-   goal of this operation is to be able to add objects independently of
-   the normal critera of what is required.  Thus you can add instances withou
-   having corresponding classes in the repository or add classes without
-   having the corresponding qualifier declarations.
+  The reason for having this method in addition to `CreateInstance` is that it
+  performs fewer checks.
 
-2. Compile pywbem objects from strings or file input with the pywbem MOF compiler
-   from strings.
-   These  methods allow the user to build correctly a  defined repository
-   easily simply by defing the MOF for the objects to be inserted in the
-   repository. In order to compile correctly each object type to be compiled
-   must be able to find any prerequisites in the repository. Thus to compile
-   MOF instances, the CIMClasses for those instances must be in the repository
-   and to compile MOF CIM classes the CIM qualifier declarations must be in
-   the repository already.
+* :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_str` and
+  :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_file` compile MOF in
+  a string or file, respectively, and add the resulting CIM objects to the
+  mock repository.
 
-   There are two different methods and the only difference is whether they
-   compile from a string input for the MOF or from MOF in a file.
+  These methods allow the user to easily build a consistent mock repository
+  by defing the MOF for the objects to be inserted into the repository.
 
-   - The method :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_file` compiles
-     MOF into the repository from a file.
+In all cases, the existing mock repository content is used for resolving any
+prerequisite objects:
 
-   - The method :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_str` compiles
-     MOF into the repository from python string.
+* For a CIM class to be added, the superclass of that class as well as CIM
+  qualifier types for the qualifiers used by that class must exist.
+
+* For a CIM instance to be added, its CIM creation class must exist.
+
+Some CIM objects that are used by a CIM object to be added do not need to
+exist in the mock repository, which in fact allows forward references:
+
+* CIM classes specified in reference properties or in reference parameters of
+  methods of a class to be added do not need to exist.
+
+* CIM classes specified in qualifiers (for example, in the `EmbeddedInstance`
+  qualifier) of a class to be added do not need to exist.
 
 
-.. _`Examples`:
+.. _`Example: Set up qualifier types and classes from MOF`:
 
-Examples
---------
+Example: Set up qualifier types and classes from MOF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _`Add object with add_cimobjects()`:
-
-Add object with add_cimobjects()
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This example creates a faked connection and sets up its mock repository with
+qualifier types and classes that are defined in a MOF string.
 
 .. code-block:: python
 
@@ -521,27 +640,176 @@ Add object with add_cimobjects()
     tst_namespace = 'root/blah'
     conn = pywbem_mock.FakedWBEMConnection()
 
-    # build the qualifier declarations
-    q1 = pywbem.CIMQualifierDeclaration('FooQualDecl1', 'uint32')
-    q2 = pywbem.CIMQualifierDeclaration('FooQualDecl2', 'string',
-                                        value='my string')
+    # Add some qualifier types and classes to the mock repo by compiling MOF
+    mof = """
+        Qualifier Key : boolean = false,
+            Scope(property, reference),
+            Flavor(DisableOverride, ToSubclass);
 
-    conn.add_cimobjects([q1, q2], tst_namespace)
+        Qualifier Association : boolean,
+            Scope(class),
+            Flavor(DisableOverride, ToSubclass);
 
-    # test the WBEMConnection GetQualifier and EnumerateQualifiers methods
-    rtn_q1 = conn.GetQualifier('FooQualDecl1', namespace=tst_namespace)
+        class TST_Class1 {
+              [Key]
+            string InstanceID;
+            string Prop1;
+        };
 
-    q_rtn = conn.EnumerateQualifiers(namespace=tst_namespace)
+        class TST_Class2 {
+              [Key]
+            string InstanceID;
+            string Prop2;
+        };
+
+          [Association]
+        class TST_Association12 {
+              [Key]
+            TST_Class1 REF Ref1;
+              [Key]
+            TST_Class2 REF Ref2;
+        };
+    """
+    conn.compile_mof_str(mof, tst_namespace)
+
+    conn.display_repository()
+
+This code displays the mock repository in MOF format after adding these objects:
+
+.. code-block:: text
+
+    # ========Mock Repo Display fmt=mof namespaces=all =========
 
 
-.. _`Define Association`:
+    # NAMESPACE root/blah
 
-Define Association
-^^^^^^^^^^^^^^^^^^
+    # Namespace root/blah: contains 2 Qualifier Declarations
 
-TODO add the define association example.
+    Qualifier Association : boolean,
+        Scope(class),
+        Flavor(DisableOverride, ToSubclass);
 
-TODO add more examples if necessary
+    Qualifier Key : boolean = false,
+        Scope(property, reference),
+        Flavor(DisableOverride, ToSubclass);
+
+    # Namespace root/blah: contains 3 Classes
+
+       [Association ( true )]
+    class TST_Association12 {
+
+          [Key ( true )]
+       TST_Class1 REF Ref1;
+
+          [Key ( true )]
+       TST_Class2 REF Ref2;
+
+    };
+
+    class TST_Class1 {
+
+          [Key ( true )]
+       string InstanceID;
+
+       string Prop1;
+
+    };
+
+    class TST_Class2 {
+
+          [Key ( true )]
+       string InstanceID;
+
+       string Prop2;
+
+    };
+
+    ============End Repository=================
+
+
+.. _`Example: Set up instances from single CIM objects`:
+
+Example: Set up instances from single CIM objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Based on the mock repository content of the previous example, this example
+adds two class instances and one association instance from their CIM objects.
+
+.. code-block:: python
+
+    c1_key = pywbem.CIMProperty('InstanceID', type='string', value='111')
+    c1_path = pywbem.CIMInstanceName(
+        'TST_Class1',
+        keybindings={c1_key.name: c1_key.value},
+    )
+    c1 = pywbem.CIMInstance(
+        'TST_Class1',
+        properties=[
+            c1_key,
+            pywbem.CIMProperty('Prop1', type='string', value='1'),
+        ],
+        path=c1_path,
+    )
+
+    c2_key = pywbem.CIMProperty('InstanceID', type='string', value='222')
+    c2_path = pywbem.CIMInstanceName(
+        'TST_Class2',
+        keybindings={c2_key.name: c2_key.value},
+    )
+    c2 = pywbem.CIMInstance(
+        'TST_Class2',
+        properties=[
+            c2_key,
+            pywbem.CIMProperty('Prop2', type='string', value='2'),
+        ],
+        path=c2_path,
+    )
+
+    a12_key1 = pywbem.CIMProperty('Ref1', type='reference', value=c1_path)
+    a12_key2 = pywbem.CIMProperty('Ref2', type='reference', value=c2_path)
+    a12_path = pywbem.CIMInstanceName(
+        'TST_Association12',
+        keybindings={
+            a12_key1.name: a12_key1.value,
+            a12_key2.name: a12_key2.value,
+        },
+    )
+    a12 = pywbem.CIMInstance(
+        'TST_Association12',
+        properties=[
+            a12_key1,
+            a12_key2,
+        ],
+        path=a12_path,
+    )
+
+    conn.add_cimobjects([c1, c2, a12], tst_namespace)
+
+    conn.display_repository()
+
+This adds the instances to the repository display of the previous example:
+
+.. code-block:: text
+
+    # Namespace root/blah: contains 3 Instances
+
+    #  Path=/root/blah:TST_Class1.InstanceID="111"
+    instance of TST_Class1 {
+       InstanceID = "111";
+       Prop1 = "1";
+    };
+
+    #  Path=/root/blah:TST_Class2.InstanceID="222"
+    instance of TST_Class2 {
+       InstanceID = "222";
+       Prop2 = "2";
+    };
+
+    #  Path=/root/blah:TST_Association12.Ref1="/:TST_Class1.InstanceID=\"111\"",Ref2="/:TST_Class2.InstanceID=\"222\""
+    instance of TST_Association12 {
+       Ref1 = "/:TST_Class1.InstanceID=\"111\"";
+       Ref2 = "/:TST_Class2.InstanceID=\"222\"";
+    };
 
 
 .. _`FakedWBEMConnection`:

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2313,16 +2313,29 @@ class MOFCompiler(object):
             not depend on existing CIM elements in the repository.
 
           search_paths (:term:`py:iterable` of :term:`string`):
-            An iterable of path names of directories where compiler will search
-            for mof files to complete a compile operation.  The compiler
-            searches these paths (including subdirectories) for
-            mof in a number of cases including: 1) find a superclass that
-            is not in repository while compiling a class 2) Find a
-            qualifier that is not in the repository (it looks for filenames
-            'qualifiers' and 'qualifiers_optional' in the search path, 3) find
-            a dependent class reference property and the
-            EmbeddedInstanceQualifier). Currently item 3 above is only partly
-            implemented. (See issue # 1138)
+            An iterable of directory path names where the MOF compiler will
+            search for MOF dependent files if the MOF element they define is
+            not in the target namespace of the CIM repository. The compiler
+            searches the specified directories and their subdirectories.
+
+            MOF dependent files are:
+
+            * The MOF file defining the superclass of a class that is compiled.
+              The MOF file searched for is '<classname>.mof'.
+
+            * The MOF file defining the qualifier type of a qualifier that
+              is specified on a MOF element that is compiled.
+              The MOF files searched for are 'qualifiers.mof' and
+              'qualifiers_optional.mof'.
+
+            * The MOF file of a class specified in a reference property or
+              in the `EmbeddedInstance` qualifier that is compiled.
+              The MOF file searched for is '<classname>.mof'.
+              This is only partly implemented, see issue #1138.
+
+            Note that MOF include files are not searched for; they are specified
+            in the ``pragma include`` directive as a file path relative to the
+            including file.
 
           verbose (:class:`py:bool`):
             Indicates whether to issue more detailed compiler messages.

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -355,11 +355,14 @@ class FakedWBEMConnection(WBEMConnection):
 
         If a CIM class or CIM qualifier type to be added already exists in the
         target namespace with the same name (comparing case insensitively),
-        this method fails, and the mock repository remains unchanged.
+        this method raises :exc:`~pywbem.CIMError`.
 
         If a CIM instance to be added already exists in the target namespace
-        with the same keybinding values, this method fails, and the mock
-        repository remains unchanged.
+        with the same keybinding values, this method raises
+        :exc:`~pywbem.CIMError`.
+
+        In all cases where this method raises an exception, the mock repository
+        remains unchanged.
 
         Parameters:
 
@@ -373,19 +376,23 @@ class FakedWBEMConnection(WBEMConnection):
             used.
 
           search_paths (:term:`py:iterable` of :term:`string`):
-            An iterable of path names of directories where MOF include files
-            will be looked up.
+            An iterable of directory path names where MOF dependent files will
+            be looked up.
+            See the description of the `search_path` init parameter of the
+            :class:`~pywbem.MOFCompiler` class for more information on MOF
+            dependent files.
 
           verbose (:class:`py:bool`):
             Controls whether to issue more detailed compiler messages.
 
         Raises:
 
+          IOError: MOF file not found.
+
           :exc:`~pywbem.MOFParseError`: Compile error in the MOF.
-            The mock repository remains unchanged.
 
           :exc:`~pywbem.CIMError`: Failure related to the CIM objects in the
-            mock repository. The mock repository remains unchanged.
+            mock repository.
         """
 
         if not namespace:
@@ -415,11 +422,14 @@ class FakedWBEMConnection(WBEMConnection):
 
         If a CIM class or CIM qualifier type to be added already exists in the
         target namespace with the same name (comparing case insensitively),
-        this method fails, and the mock repository remains unchanged.
+        this method  raises :exc:`~pywbem.CIMError`.
 
         If a CIM instance to be added already exists in the target namespace
-        with the same keybinding values, this method fails, and the mock
-        repository remains unchanged.
+        with the same keybinding values, this method raises
+        :exc:`~pywbem.CIMError`.
+
+        In all cases where this method raises an exception, the mock repository
+        remains unchanged.
 
         Parameters:
 
@@ -433,19 +443,23 @@ class FakedWBEMConnection(WBEMConnection):
             used.
 
           search_paths (:term:`py:iterable` of :term:`string`):
-            An iterable of path names of directories where MOF include files
-            will be looked up.
+            An iterable of directory path names where MOF dependent files will
+            be looked up.
+            See the description of the `search_path` init parameter of the
+            :class:`~pywbem.MOFCompiler` class for more information on MOF
+            dependent files.
 
           verbose (:class:`py:bool`):
             Controls whether to issue more detailed compiler messages.
 
         Raises:
 
+          IOError: MOF file not found.
+
           :exc:`~pywbem.MOFParseError`: Compile error in the MOF.
-            The mock repository remains unchanged.
 
           :exc:`~pywbem.CIMError`: Failure related to the CIM objects in the
-            mock repository. The mock repository remains unchanged.
+            mock repository.
         """
 
         if not namespace:
@@ -477,7 +491,8 @@ class FakedWBEMConnection(WBEMConnection):
         If the CIM namespace does not exist, it is created.
 
         The method imposes very few limits on the objects added. It does
-        require that the superclass exist for any class added.
+        require that the superclass exist for any class added and that
+        instances added include a path component.
 
         If a CIM class or CIM qualifier type to be added already exists in the
         target namespace with the same name (comparing case insensitively),


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

**Note:** When reviewing, please pay particular attention to the description of the behavior w.r.t. prerequisite CIM objects in the mock repository. That is different for:

* add_cimobjects()
* compile_...()
* the WBEM operation methods

and also different between lite mode and full mode of the mock repository.

I don't think that is correctly described yet for all those cases.

**COMMENTS:** I tried to review and compare with code.  A few new comments but we are getting close enough that it is probably time to close this out and approve.  This gets harder and harder to review and we do more comments on top of comments and try to review the doc/code/built doc.

I actually think the next step in documentation will be as we try to use it on pywbemcli.

Congratulations. Really good job cleaning up the doc.
