### PR TITLE
Fixes #1138: Compile mof based on pragma include file from compile_string

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -177,7 +177,7 @@ Incompatible changes
   defined through a mof file containing  #pragma include statements.
   This precluded using a string to define the classes to include in
   a mof compile in a string and required that the include be a file.
-  See issue 1138
+  See issue #1138
 
 Deprecations
 ^^^^^^^^^^^^

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -173,6 +173,12 @@ Incompatible changes
   - The "fq" parameter of the filtering functions was renamed to "fs",
     for consistency with the query functions.
 
+* Fix issue where mof. compile_str could not compile mof that was
+  defined through a mof file containing  #pragma include statements.
+  This precluded using a string to define the classes to include in
+  a mof compile in a string and required that the include be a file.
+  See issue 1138
+
 Deprecations
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
Fix issue where compile_string that starts with include filefails the compile, cannot find the classes in the include file.

See commit message for details.

I fixed the issue and added tests for compiling partial pragma include files both as a file and as a string.

However, as we noted in issue #1160, the dependency finder mechanism in the compiler is still broken as it will not figure out that EmbeddedInstance classes or references are not compiled and, will in fact successfully complete a pragma or class compile while with these dependent classes completly missing.

This pr does not test for those dependency but sets up tests we can extend easily with the pr for issue #1138.  

Shakespeare in our world(From MacBeth.   'Out dammed bugs! Out I say!'.