### PR TITLE
Fixes #1180 Changed default log_dest in config_logger() to None

### DIFF
--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -305,7 +305,7 @@ LOG_DETAIL_LEVELS = ['all', 'paths', 'summary']
 DEFAULT_LOG_DETAIL_LEVEL = 'all'
 
 
-def configure_logger(simple_name, log_dest=DEFAULT_LOG_DESTINATION,
+def configure_logger(simple_name, log_dest=None,
                      detail_level=DEFAULT_LOG_DETAIL_LEVEL,
                      log_filename=DEFAULT_LOG_FILENAME,
                      connection=None):


### PR DESCRIPTION
For details, see the commit message. Note particularly, that the log_dest default was only changed for configure_logger() (not for the string version) and that the default log filename of that function was not changed to None.
Ready for review and merge.