### PR TITLE
Changes to docs for _logging.py and mock

### DIFF
--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -10,12 +10,12 @@ Mock support
 Overview
 --------
 
-The pywbem package contains the ``pywbem_mock`` module which provides mock
+The pywbem package contains the ``pywbem_mock`` subpackage which provides mock
 support that enables usage of the pywbem library without a WBEM server.
-This module is used for testing the pywbem library itself and can also be used
-for the development and testing of Python programs using the pywbem library.
+This subpackage is used for testing the pywbem library itself and can be used
+for the development and testing of Python programs that use the pywbem library.
 
-The pywbem mock support consists of a :class:`pywbem_mock.FakedWBEMConnection`
+The pywbem mock support consists of the :class:`pywbem_mock.FakedWBEMConnection`
 class that establishes a *faked connection*. That class is a subclass of
 :class:`pywbem.WBEMConnection` and replaces its internal methods that use
 HTTP/HTTPS to communicate with a WBEM server with methods that instead operate
@@ -24,14 +24,14 @@ on a local in-memory repository of CIM objects (the *mock repository*).
 As a result, the operation methods of :class:`~pywbem_mock.FakedWBEMConnection`
 are those inherited from :class:`~pywbem.WBEMConnection`, so they have the
 exact same input parameters, output parameters, return values, and even most of
-the raised exceptions, as when they would be invoked on a
+the raised exceptions, as when being invoked on a
 :class:`~pywbem.WBEMConnection` object against a WBEM server.
 
 Each :class:`~pywbem_mock.FakedWBEMConnection` object has its own mock
 repository.
 The mock repository contains the same kinds of CIM objects a WBEM server
-contains: CIM classes, CIM instances, and CIM qualifier types (declarations),
-all contained in CIM namespaces.
+repository contains: CIM classes, CIM instances, and CIM qualifier types
+(declarations), all contained in CIM namespaces.
 
 Because :class:`~pywbem_mock.FakedWBEMConnection` operates only on the mock
 repository, the class does not have any connection- or security-related

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -135,7 +135,7 @@ for activating WBEM connections for logging:
     configure_logger('api', log_dest='stderr', detail_level='summary',
                      connection=True)
 
-    # All of the following connections will log:
+    # All of the following connections will log to stderr with summary output:
     conn1 = WBEMConnection(...)
     conn2 = WBEMConnection(...)
 
@@ -145,29 +145,12 @@ for activating WBEM connections for logging:
 
     conn = WBEMConnection(...)
 
-    configure_logger('all', log_dest='file', log_filname='xxx.log',
+    configure_logger('all', log_dest='file', log_filname='my_logfile.log',
                      connection=conn)
 
 Examples for configuring the pywbem loggers using Python logging methods,
 and using the pywbem logging configuration functions only for setting the
 detail level and for activating WBEM connections for logging:
-
-* Example: Configure the Python root logger for logging to a file, configure
-  both pywbem loggers for detail level `'all'`, and activate an existing WBEM
-  connection for logging::
-
-    import logging
-
-    # This configures the Python root logger
-    logging.basicConfig(filename='example.log', level=logging.DEBUG)
-
-    conn = WBEMConnection(...)
-
-    configure_logger('all', detail_level='all', connection=conn)
-
-  TODO: This configures the pywbem loggers with a null handler and thus
-  does not propagate up to the Python root logger. Clarify whether this
-  approach actually works.
 
 * Example: Configure the pywbem parent logger (named `'pywbem'`) for logging to
   a rotating file, configure both pywbem loggers for detail level `'summary'`,
@@ -183,17 +166,18 @@ detail level and for activating WBEM connections for logging:
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
+    # configure without setting log_dest
     configure_logger('api', detail_level='summary', connection=True)
 
-    # All of the following connections will log:
+    # All of the following connections will log using the rotating file handler:
     conn1 = WBEMConnection(...)
     conn2 = WBEMConnection(...)
 
 Examples for using :func:`configure_loggers_from_string` for configuring the
 pywbem loggers and for activating WBEM connections for logging:
 
-* Example: Configure the `'pywbem.api'` logger with detail level `'summary'`
-  and output to stderr, and activate all subsequently created WBEM connections
+* Example: Configure the `'pywbem.api'` logger with detail level `'summary'`,
+  output to stderr, and activate all subsequently created WBEM connections
   for logging::
 
     configure_loggers_from_string('api=stderr:summary', connection=True)
@@ -203,12 +187,12 @@ pywbem loggers and for activating WBEM connections for logging:
     conn2 = WBEMConnection(...)
 
 * Example: Configure both pywbem loggers with the default detail level
-  (`'all'`) and output to a file, and activate a single existing WBEM
-  connection for logging::
+  (`'all'`) and output to the file 'my_log.log', and activate a single existing
+  WBEM connection object (conn) for logging::
 
     conn = WBEMConnection(...)
 
-    configure_loggers_from_string('all=file', log_filname='xxx.log',
+    configure_loggers_from_string('all=file', log_filname='my_log.log',
                                   connection=conn)
 
 
@@ -274,7 +258,8 @@ LOGGER_SIMPLE_NAMES = ['api', 'http', 'all']
 #: List of log destinations that the logging configuration functions
 #: recognize, as follows:
 #:
-#: * `'file'` - Log to a file (requires filename to be specified)
+#: * `'file'` - Log to a file (requires filename to be specified). The file
+#:   logger appends to the logger file defined by filename.
 #: * `'stderr'` - Log to the standard error stream of the Python process
 LOG_DESTINATIONS = ['file', 'stderr']
 


### PR DESCRIPTION
In _logging removed example that uses basicconfig and expanded text on some of the
others

Minor changes to mock doc. Changed word module to
subpackage since pywbem_mock is not a module. From other
doc it appears that it can be called either a subfolder
or a subpackage.