### PR TITLE
Fixes #1186 Added 'propagate' parameter to log config functions

### DIFF
--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -289,7 +289,7 @@ DEFAULT_LOG_DETAIL_LEVEL = 'all'
 def configure_logger(simple_name, log_dest=None,
                      detail_level=DEFAULT_LOG_DETAIL_LEVEL,
                      log_filename=DEFAULT_LOG_FILENAME,
-                     connection=None):
+                     connection=None, propagate=False):
     # pylint: disable=line-too-long
     """
     Configure the pywbem loggers and optionally activate WBEM connections
@@ -356,6 +356,10 @@ def configure_logger(simple_name, log_dest=None,
 
         If `None`, no WBEM connection will be activated for logging.
 
+      propagate (:class:`py:bool`): Flag controlling whether the
+        affected pywbem logger should propagate log events to its
+        parent loggers.
+
     Raises:
 
       ValueError: Invalid input parameters (loggers remain unchanged).
@@ -371,12 +375,13 @@ def configure_logger(simple_name, log_dest=None,
         log_dest=log_dest,
         detail_level=detail_level,
         log_filename=log_filename,
-        connection=connection)
+        connection=connection,
+        propagate=propagate)
 
 
 def configure_loggers_from_string(log_configuration_str,
                                   log_filename=DEFAULT_LOG_FILENAME,
-                                  connection=None):
+                                  connection=None, propagate=False):
     # pylint: disable=line-too-long
     """
     Configure the pywbem loggers and optionally activate WBEM connections for
@@ -427,6 +432,10 @@ def configure_loggers_from_string(log_configuration_str,
         will be set for the affected pywbem loggers on the connection.
 
         If `None`, no WBEM connection will be activated for logging.
+
+      propagate (:class:`py:bool`): Flag controlling whether the
+        affected pywbem logger should propagate log events to its
+        parent loggers.
 
     Raises:
 
@@ -488,4 +497,5 @@ def configure_loggers_from_string(log_configuration_str,
             log_dest=log_dest,
             detail_level=detail_level,
             log_filename=log_filename,
-            connection=connection)
+            connection=connection,
+            propagate=propagate)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1221,7 +1221,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def _configure_logger(cls, simple_name, log_dest, detail_level,
-                          log_filename, connection):
+                          log_filename, connection, propagate):
         # pylint: disable=line-too-long
         """
         Configure the pywbem loggers and optionally activate WBEM connections
@@ -1288,6 +1288,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             If `None`, no WBEM connection will be activated for logging.
 
+        propagate (:class:`py:bool`): Flag controlling whether the
+          affected pywbem logger should propagate log events to its
+          parent loggers.
+
         Raises:
 
           ValueError: Invalid input parameters (loggers remain unchanged).
@@ -1298,11 +1302,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             cls._configure_logger('api', log_dest=log_dest,
                                   detail_level=detail_level,
                                   log_filename=log_filename,
-                                  connection=connection)
+                                  connection=connection,
+                                  propagate=propagate)
             cls._configure_logger('http', log_dest=log_dest,
                                   detail_level=detail_level,
                                   log_filename=log_filename,
-                                  connection=connection)
+                                  connection=connection,
+                                  propagate=propagate)
             return
         elif simple_name == 'api':
             logger_name = LOGGER_API_CALLS_NAME
@@ -1317,7 +1323,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         detail_level = cls._configure_detail_level(detail_level)
 
         cls._activate_logger(logger_name, simple_name, detail_level, handler,
-                             connection)
+                             connection, propagate)
 
     @classmethod
     def _configure_detail_level(cls, detail_level):
@@ -1374,7 +1380,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def _activate_logger(cls, logger_name, simple_name, detail_level, handler,
-                         connection):
+                         connection, propagate):
         """
         Configure the specified logger, and activate logging and set detail
         level for connections.
@@ -1386,7 +1392,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         The 'handler' parameter controls logger configuration:
         * If None, nothing is done.
         * If a Handler object, the specified logger gets its handlers replaced
-          with the new handler, and logging level DEBUG is set.
+          with the new handler, and logging level DEBUG is set, and the
+          `propagate` attribute of the logger is set according to the
+          `propagate` parameter.
 
         The 'connection' paraneter controls activation and setting of the
         detail level:
@@ -1410,6 +1418,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             logger.addHandler(handler)
 
             logger.setLevel(logging.DEBUG)
+            logger.propagate = propagate
 
         if connection is not None:
             if isinstance(connection, bool):

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -536,11 +536,11 @@ class BaseLogOperationRecorderTests(BaseRecorderTests):
 
         configure_logger('api', log_dest='file',
                          detail_level=detail_level,
-                         log_filename=TEST_OUTPUT_LOG)
+                         log_filename=TEST_OUTPUT_LOG, propagate=True)
 
         configure_logger('http', log_dest='file',
                          detail_level=detail_level,
-                         log_filename=TEST_OUTPUT_LOG)
+                         log_filename=TEST_OUTPUT_LOG, propagate=True)
 
         # Define an attribute that is a single LogOperationRecorder to be used
         # in some of the tests.  Note that if detail_level is dict it is used
@@ -730,7 +730,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
         # Fake the connection to create a fixed data environment
         conn = WBEMConnection('http://blah')
         configure_logger('api', log_dest='stderr', detail_level='all',
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         # pywbem 2 and 3 differ in only the use of unicode for certain
         # string properties. (ex. classname)
@@ -765,7 +765,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
                               use_pull_operations=True,
                               stats_enabled=True)
         configure_logger('api', log_dest='stderr', detail_level='all',
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         # fake conn id by directly setting internal attribute
         # pywbem 2 and 3 differ in only the use of unicode for certain
@@ -803,7 +803,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
                               use_pull_operations=True,
                               stats_enabled=True)
         configure_logger('api', log_dest='stderr', detail_level='summary',
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         # fake conn id by directly setting internal attribute
         # pywbem 2 and 3 differ in only the use of unicode for certain
@@ -1778,7 +1778,8 @@ class TestExternLoggerDef(BaseLogOperationRecorderTests):
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-        configure_logger('api', detail_level='summary', connection=True)
+        configure_logger('api', detail_level='summary', connection=True,
+                         propagate=True)
         try:
             conn = WBEMConnection('http://blah', timeout=1)
 
@@ -1867,7 +1868,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         configure_logger('api', log_dest='file',
                          detail_level='summary',
                          log_filename=TEST_OUTPUT_LOG,
-                         connection=True)
+                         connection=True, propagate=True)
         conn = FakedWBEMConnection('http://blah')
         conn.compile_mof_string(partial_schema, namespace=namespace,
                                 search_paths=[SCHEMA_MOF_DIR])
@@ -1910,7 +1911,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         configure_logger('all', log_dest='file',
                          log_filename=TEST_OUTPUT_LOG,
                          detail_level=10,
-                         connection=conn)
+                         connection=conn, propagate=True)
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
 
         conn_id = conn.conn_id
@@ -1948,7 +1949,8 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         conn = self.build_repo(namespace)
 
         # Define the detail_level and WBEMConnection object to activate.
-        configure_logger('all', detail_level=10, connection=conn)
+        configure_logger('all', detail_level=10, connection=conn,
+                         propagate=True)
 
         # logging_tree_printout()
 
@@ -1987,7 +1989,8 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         conn = self.build_repo(namespace)
 
         # Define the detail_level and WBEMConnection object to activate.
-        configure_logger('api', detail_level=10, connection=conn)
+        configure_logger('api', detail_level=10, connection=conn,
+                         propagate=True)
 
         # logging_tree_printout()
 
@@ -2027,7 +2030,8 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         conn = self.build_repo(namespace)
 
         # Define the detail_level and WBEMConnection object to activate.
-        configure_logger('api', detail_level=10, connection=conn)
+        configure_logger('api', detail_level=10, connection=conn,
+                         propagate=True)
 
         # logging_tree_printout()
 
@@ -2070,7 +2074,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         # Define the detail_level and WBEMConnection object to activate.
         configure_logger('http', detail_level='all', log_dest='file',
                          log_filename=TEST_OUTPUT_LOG,
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
 
@@ -2111,7 +2115,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
 
         # Define the detail_level and WBEMConnection object to activate.
         configure_logger('http', detail_level='all', log_dest=None,
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
 
@@ -2158,7 +2162,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
 
         # Define the detail_level and WBEMConnection object to activate.
         configure_logger('http', detail_level='all', log_dest=None,
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
 
@@ -2199,7 +2203,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
 
         # Define the detail_level and WBEMConnection object to activate.
         configure_logger('http', detail_level='all', log_dest=None,
-                         connection=conn)
+                         connection=conn, propagate=True)
 
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
 
@@ -2240,7 +2244,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         namespace = 'interop'
         # Define the detail_level and WBEMConnection object to activate.
         configure_logger('http', detail_level='all',
-                         connection=True)
+                         connection=True, propagate=True)
         conn = self.build_repo(namespace)
 
         conn.GetClass('CIM_ObjectManager', namespace=namespace)
@@ -2278,7 +2282,8 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
 
         # Define the detail_level and WBEMConnection object to activate.
         try:
-            configure_logger('api', detail_level='blah', connection=conn)
+            configure_logger('api', detail_level='blah', connection=conn,
+                             propagate=True)
             self.fail("Exception expected")
         except ValueError:
             pass


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

A particular review point might be the default of propagate=False, which is probably right, but incompatible to before w.r.t. log propagation. That's why the testcases needed to be adjusted.