### PR TITLE
Added a README file for Pypi

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -86,11 +86,26 @@ Their upstream repos are assumed to have the remote name `origin`.
 
     To make the following changes:
 
-    * Update the constants near the top of the file:
+    * Update the constants near the top of the file::
 
-      `.. |pywbem-version| replace:: M.N.U`
-      `.. |pywbem-next-version| replace:: M.N.U+1`
-      `.. |pywbem-next-issue| replace:: <issue-number>`
+        .. |pywbem-version| replace:: {M.N.U}
+        .. |pywbem-next-version| replace:: {M.N.U+1}
+        .. |pywbem-next-issue| replace:: {issue-number}
+
+      Where the items in curly braces are replaced with their actual values.
+
+5.  Edit the README_PYPI file:
+
+    - `vi README_PYPI.rst`
+
+    To make the following changes:
+
+    * Update the pywbem version in the two links near the bottom of the file::
+
+        .. _README file: https://github.com/pywbem/pywbem/blob/stable_{M.N}/README.rst
+        .. _Documentation: http://pywbem.readthedocs.io/en/stable_{M.N}/
+
+      Where the items in curly braces are replaced with their actual values.
 
 6.  Perform a complete build (in your favorite Python virtual environment):
 

--- a/README_PYPI.rst
+++ b/README_PYPI.rst
@@ -1,0 +1,14 @@
+Pywbem is a WBEM client, written in pure Python. It supports Python 2 and
+Python 3.
+        
+A WBEM client allows issuing operations to a WBEM server, using the CIM
+operations over HTTP (CIM-XML) protocol defined in the DMTF standards
+DSP0200 and DSP0201. The CIM/WBEM infrastructure is used for a wide variety of
+systems management tasks supported by systems running WBEM servers.
+See http://www.dmtf.org/standards/wbem for more information about WBEM.
+
+For more information, see the `README file`_, or the `Documentation`_.
+
+.. _README file: https://github.com/pywbem/pywbem/blob/stable_0.12/README.rst
+.. _Documentation: http://pywbem.readthedocs.io/en/stable_0.12/
+

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,28 @@ Change log
       :revisions: 1
 
 
+Version 0.12.1
+^^^^^^^^^^^^^^
+
+This version is currently in development and is shown as |version|.
+
+Released: not yet
+
+**Incompatible changes:**
+
+**Deprecations:**
+
+**Bug fixes:**
+
+**Enhancements:**
+
+**Known issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/pywbem/pywbem/issues
+
+
 pywbem v0.12.0
 --------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@
 [metadata]
 name = pywbem
 summary = pywbem - A WBEM client
-description-file = README.rst
+description-file = README_PYPI.rst
 license = LGPL version 2.1, or (at your option) any later version
 author = Tim Potter
 author-email = tpot@hp.com


### PR DESCRIPTION
This fixes the package information on Pypi that currently shows the README.rst file but does not format it right: https://pypi.python.org/pypi/pywbem/0.12.0.

Please review this PR, and particularly its README_PYPI.rst file as rendered by GitHub.