### PR TITLE
fixes #1205 docs/wbemcli)help-txt not uptodate

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -86,11 +86,26 @@ Their upstream repos are assumed to have the remote name `origin`.
 
     To make the following changes:
 
-    * Update the constants near the top of the file:
+    * Update the constants near the top of the file::
 
-      `.. |pywbem-version| replace:: M.N.U`
-      `.. |pywbem-next-version| replace:: M.N.U+1`
-      `.. |pywbem-next-issue| replace:: <issue-number>`
+        .. |pywbem-version| replace:: {M.N.U}
+        .. |pywbem-next-version| replace:: {M.N.U+1}
+        .. |pywbem-next-issue| replace:: {issue-number}
+
+      Where the items in curly braces are replaced with their actual values.
+
+5.  Edit the README_PYPI file:
+
+    - `vi README_PYPI.rst`
+
+    To make the following changes:
+
+    * Update the pywbem version in the two links near the bottom of the file::
+
+        .. _README file: https://github.com/pywbem/pywbem/blob/stable_{M.N}/README.rst
+        .. _Documentation: http://pywbem.readthedocs.io/en/stable_{M.N}/
+
+      Where the items in curly braces are replaced with their actual values.
 
 6.  Perform a complete build (in your favorite Python virtual environment):
 

--- a/README_PYPI.rst
+++ b/README_PYPI.rst
@@ -1,0 +1,21 @@
+.. # README file for Pypi
+
+Pywbem is a WBEM client, written in pure Python. It supports Python 2 and
+Python 3. Pywbem also contains a WBEM indication listener.
+
+A WBEM client allows issuing operations to a WBEM server, using the
+`CIM/WBEM standards`_ defined by the DMTF, for the purpose of performing
+systems management tasks. A WBEM indication listener is used to wait for
+and process notifications emitted by a WBEM server, also for the purpose
+of systems management.
+
+CIM/WBEM infrastructure is used for a wide variety of systems management
+tasks in the industry.
+
+For more information on pywbem, see the `pywbem readme`_, and the
+`pywbem documentation`_.
+
+.. _pywbem readme: https://github.com/pywbem/pywbem/blob/stable_0.12/README.rst
+.. _pywbem documentation: http://pywbem.readthedocs.io/en/stable_0.12/
+.. _CIM/WBEM standards: http://www.dmtf.org/standards/wbem/
+

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* fix issue where wbemcli-help-txt was not being updated when wbemcli.py
+  changed.  Issue # 1205
+
 **Enhancements:**
 
 **Known issues:**

--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -80,6 +80,20 @@ General options:
                         single use of the option. Scripts are executed after the
                         WBEMConnection call
   -v, --verbose         Print more messages while processing
+  -V, --version         Display pywbem version and exit.
+  --statistics          Enable gathering of statistics on operations.
+  -l log_spec[,logspec], --log log_spec[,logspec]
+                        Log_spec defines characteristics of the various named
+                        loggers. It is the form:
+                         COMP=[DEST[:DETAIL]] where:
+                           COMP:   Logger component name:[api|http|all].
+                                   (Default=all)
+                           DEST:   Destination for component:[file|stderr].
+                                   (Default=file)
+                           DETAIL: Detail Level to log: [all|paths|summary] or
+                                   an integer that defines the maximum length of
+                                   of each log record.
+                                   (Default=all)
   -h, --help            Show this help message and exit
 
 Examples:

--- a/makefile
+++ b/makefile
@@ -497,7 +497,7 @@ endif
 	mv -f $(test_tmp_file) $(test_log_file)
 	@echo "makefile: Done running tests; Log file: $@"
 
-$(doc_conf_dir)/wbemcli.help.txt: wbemcli
+$(doc_conf_dir)/wbemcli.help.txt: wbemcli wbemcli.py
 	@echo "makefile: Creating wbemcli script help message file"
 	./wbemcli --help >$@
 	@echo "makefile: Done creating wbemcli script help message file: $@"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@
 [metadata]
 name = pywbem
 summary = pywbem - A WBEM client
-description-file = README.rst
+description-file = README_PYPI.rst
 license = LGPL version 2.1, or (at your option) any later version
 author = Tim Potter
 author-email = tpot@hp.com


### PR DESCRIPTION
 Add wbemcli.py to makefile dependents list that makes docs/wbemcli_help_txt file in makefile

add comment to changes.rst

**TODO:** This one should probably be backed up to 0.12.2