### PR TITLE
fixes #1153 Added support to ValueMapping for translating to binary and iterating

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,8 +26,8 @@ Released: not yet
 
 **Bug fixes:**
 
-* fix issue where wbemcli-help-txt was not being updated when wbemcli.py
-  changed.  (Issue #1205)
+* Fixed the issue where wbemcli-help-txt was not being updated when wbemcli.py
+  changed. (Issue #1205)
 
 * Test: Fixed access to incorrect tuple members in run_cim_operations.py.
   that were used only in long version of the test. Found by Pylint.
@@ -54,6 +54,15 @@ Released: not yet
   repository builds without having to  specifically declare all dependent
   classes for the classes the user needs in a repository if the mof for the
   dependent classes in in the search path. (Issue #1160).
+
+* Added a `tobinary()` method to the `ValueMapping` class, which translates the
+  value mapping from a `Values` string to binary integer values, or a range
+  thereof. This is the opposite direction of the existing `tovalues()` method.
+  (Issue #1153)
+
+* Added an `items()` generator method to the `ValueMapping` class for iterating
+  through the items of the value mapping, returning tuples of the binary value
+  (or a range thereof), and the `Values` string. (Issue #1153)
 
 **Cleanup**
 

--- a/pywbem/_valuemapping.py
+++ b/pywbem/_valuemapping.py
@@ -15,10 +15,10 @@
 #
 
 """
-The :class:`~pywbem.ValueMapping` class supports translating the values of an
-integer-typed CIM element (e.g. property, method, or parameter) that is
-qualified with the `ValueMap` and `Values` qualifiers, to the corresponding
-value of the `Values` qualifier.
+The :class:`~pywbem.ValueMapping` class supports translating between the values
+of an integer-typed CIM element (e.g. property, method, or parameter) that is
+qualified with the `ValueMap` and `Values` qualifiers, and the corresponding
+values of the `Values` qualifier, in both directions.
 
 This class supports value ranges (e.g. ``"4..6"``) and the unclaimed marker
 (``".."``).
@@ -26,6 +26,10 @@ This class supports value ranges (e.g. ``"4..6"``) and the unclaimed marker
 
 import re
 import six
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 from .cim_types import CIMInt, type_from_name
 
@@ -36,17 +40,18 @@ class ValueMapping(object):
     """
     *New in pywbem 0.9 as experimental and finalized in 0.10.*
 
-    A utility class that supports translating the values of an integer-typed
-    CIM element (property, method, parameter) that is qualified with the
-    `ValueMap` and `Values` qualifiers, to the corresponding value of the
-    `Values` qualifier.
+    A utility class that supports translating between the values of an
+    integer-typed CIM element (property, method, parameter) that is qualified
+    with the `ValueMap` and `Values` qualifiers, and the corresponding values
+    of the `Values` qualifier, in both directions.
 
     This is done by retrieving the CIM class definition defining the CIM
     element in question, and by inspecting its `ValueMap` and `Values`
     qualifiers.
 
-    The translation of the values is performed by the
-    :meth:`~pywbem.ValueMapping.tovalues` method.
+    The translation is performed by the
+    :meth:`~pywbem.ValueMapping.tovalues` and
+    :meth:`~pywbem.ValueMapping.tobinary` methods.
 
     Instances of this class must be created through one of the factory class
     methods: :meth:`~pywbem.ValueMapping.for_property`,
@@ -72,8 +77,10 @@ class ValueMapping(object):
           };
 
       Assuming this class exists in a WBEM server, the following code will
-      create a value mapping for this property and will print a few property
-      values and their corresponding `Values` strings::
+      get the class from the server, create a value mapping for this property,
+      and look up the `Values` strings that correspond to binary property
+      values. This is useful when preparing binary property values for human
+      consumption::
 
           namespace = 'root/cimv2'
           conn = pywbem.WBEMConnection(...)  # WBEM server
@@ -81,27 +88,92 @@ class ValueMapping(object):
           myprop_vm = pywbem.ValueMapping.for_property(
               conn, namespace, 'CIM_Foo', 'MyProp')
 
-          print("value: Values")
-          for value in range(0, 12):
-              print("%5s: %r" % (value, myprop_vm.tovalues(value))
+          print("Binary value: Values string")
+          for bin_value in range(0, 12):
+              values_str = myprop_vm.tovalues(bin_value)
+              print("%12s: %r" % (bin_value, values_str))
 
       Resulting output:
 
       .. code-block:: text
 
-          value: Values
-              0: 'zero'
-              1: 'unclaimed'
-              2: 'two-four'
-              3: 'two-four'
-              4: 'two-four'
-              5: 'five-six'
-              6: 'five-six'
-              7: 'seven-eight'
-              8: 'seven-eight'
-              9: 'nine'
-             10: 'unclaimed'
-             11: 'unclaimed'
+          Binary value: Values string
+                     0: 'zero'
+                     1: 'unclaimed'
+                     2: 'two-four'
+                     3: 'two-four'
+                     4: 'two-four'
+                     5: 'five-six'
+                     6: 'five-six'
+                     7: 'seven-eight'
+                     8: 'seven-eight'
+                     9: 'nine'
+                    10: 'unclaimed'
+                    11: 'unclaimed'
+
+      Translating in the other direction is also of interest, for example when
+      processing values that are provided by humans in terms of the `Values`
+      strings, or when using the pywbem mock support and the test cases specify
+      property values for CIM instances in terms of the more human-readable
+      `Values` strings.
+
+      Again, assuming the class shown above exists in a WBEM server, the
+      following code will get the class from the server, create a value
+      mapping for this property, and look up the binary property values from
+      the `Values` strings::
+
+          namespace = 'root/cimv2'
+          conn = pywbem.WBEMConnection(...)  # WBEM server
+
+          myprop_vm = pywbem.ValueMapping.for_property(
+              conn, namespace, 'CIM_Foo', 'MyProp')
+
+          values_strs = ["zero", "two-four", "five-six", "seven-eight", "nine",
+                         "unclaimed"]
+
+          print("Values string: Binary value")
+          for values_str in values_strs:
+              bin_value = myprop_vm.tobinary(values_str)
+              print("%12s: %r" % (values_str, bin_value))
+
+      Resulting output:
+
+      .. code-block:: text
+
+          Values string: Binary value
+                 'zero': 0
+             'two-four': (2, 4)
+             'five-six': (5, 6)
+          'seven-eight': (7, 8)
+                 'nine': 9
+            'unclaimed': None
+
+      Iterating through the pairs of `ValueMap` and `Values` entries is
+      also possible. Assuming the class shown above exists in a WBEM server, the
+      following code will get the class from the server, and iterate through the
+      value mapping::
+
+          namespace = 'root/cimv2'
+          conn = pywbem.WBEMConnection(...)  # WBEM server
+
+          myprop_vm = pywbem.ValueMapping.for_property(
+              conn, namespace, 'CIM_Foo', 'MyProp')
+
+          print("Values string: Binary value")
+          for bin_value, values_str in myprop_vm.items():
+              print("%12s: %r" % (values_str, bin_value))
+
+      Resulting output:
+
+      .. code-block:: text
+
+          Values string: Binary value
+                 'zero': 0
+             'two-four': (2, 4)
+             'five-six': (5, 6)
+          'seven-eight': (7, 8)
+                 'nine': 9
+            'unclaimed': None
     """
 
     def __init__(self):
@@ -115,9 +187,13 @@ class ValueMapping(object):
 
         self._element_obj = None
 
-        self._single_dict = {}  # for single values; elem_val: values_str)
-        self._range_tuple_list = []  # for value ranges; tuple(lo,hi,values_str)
-        self._unclaimed = None  # value of the unclaimed indicator '..'
+        # Attributes for converting binary values to Values strings:
+        self._b2v_single_dict = {}  # for single values; bin: values
+        self._b2v_range_tuple_list = []  # for value ranges; tuple(lo,hi,values)
+        self._b2v_unclaimed = None  # value of the unclaimed indicator '..'
+
+        # Attributes for converting Values strings to binary values:
+        self._v2b_dict = {}  # values: bin (int or tuple)
 
     @classmethod
     def for_property(cls, server, namespace, classname, propname):
@@ -304,7 +380,8 @@ class ValueMapping(object):
     @classmethod
     def _values_tuple(cls, i, valuemap_list, values_list, cimtype):
         """
-        Return a tuple for the value range at position i, with these items:
+        Return a tuple for the value range or unclaimed marker at position i,
+        with these items:
 
         * lo - low value of the range
         * hi - high value of the range (can be equal to lo)
@@ -436,27 +513,34 @@ class ValueMapping(object):
         valuemap_qual = element_obj.qualifiers.get('ValueMap', None)
         if valuemap_qual is None:
             # DSP0004 defines a default of consecutive index numbers
-            vm._single_dict = dict(zip(range(0, len(values_list)), values_list))
-            vm._range_tuple_list = []
-            vm._unclaimed = None
+            vm._b2v_single_dict = dict(zip(range(0, len(values_list)),
+                                           values_list))
+            vm._b2v_range_tuple_list = []
+            vm._b2v_unclaimed = None
+            vm._v2b_dict = OrderedDict(zip(values_list,
+                                           range(0, len(values_list))))
         else:
-            vm._single_dict = {}
-            vm._range_tuple_list = []
-            vm._unclaimed = None
+            vm._b2v_single_dict = {}
+            vm._b2v_range_tuple_list = []
+            vm._b2v_unclaimed = None
+            vm._v2b_dict = OrderedDict()
             valuemap_list = valuemap_qual.value
             for i, valuemap_str in enumerate(valuemap_list):
                 values_str = values_list[i]
                 if valuemap_str == '..':
-                    vm._unclaimed = values_str
+                    vm._b2v_unclaimed = values_str
+                    vm._v2b_dict[values_str] = None
                 else:
                     lo, hi, values_str = cls._values_tuple(
                         i, valuemap_list, values_list, cimtype)
                     if lo == hi:
                         # single value
-                        vm._single_dict[lo] = values_str
+                        vm._b2v_single_dict[lo] = values_str
+                        vm._v2b_dict[values_str] = lo
                     else:
                         # value range
-                        vm._range_tuple_list.append((lo, hi, values_str))
+                        vm._b2v_range_tuple_list.append((lo, hi, values_str))
+                        vm._v2b_dict[values_str] = (lo, hi)
 
         # pylint: enable=protected-access
         return vm
@@ -469,11 +553,13 @@ class ValueMapping(object):
         return "%s(_conn=%r, _namespace=%r, " \
                "_classname=%r, _propname=%r, _methodname=%r, " \
                "_parametername=%r, _element_obj=%r, " \
-               "_single_dict=%r, _range_tuple_list=%r, _unclaimed=%r)" % \
+               "_b2v_single_dict=%r, _b2v_range_tuple_list=%r, " \
+               "_b2v_unclaimed=%r, _v2b_dict=%r)" % \
                (self.__class__.__name__, self._conn, self._namespace,
                 self._classname, self._propname, self._methodname,
                 self._parametername, self._element_obj,
-                self._single_dict, self._range_tuple_list, self._unclaimed)
+                self._b2v_single_dict, self._b2v_range_tuple_list,
+                self._b2v_unclaimed, self._v2b_dict)
 
     @property
     def conn(self):
@@ -560,19 +646,99 @@ class ValueMapping(object):
 
         # try single value
         try:
-            return self._single_dict[element_value]
+            return self._b2v_single_dict[element_value]
         except KeyError:
             pass
 
         # try value ranges
-        for range_tuple in self._range_tuple_list:
+        for range_tuple in self._b2v_range_tuple_list:
             lo, hi, values_str = range_tuple
             if lo <= element_value <= hi:
                 return values_str
 
         # try catch-all '..'
-        if self._unclaimed is not None:
-            return self._unclaimed
+        if self._b2v_unclaimed is not None:
+            return self._b2v_unclaimed
 
         raise ValueError("Element value outside of the set defined by "
                          "ValueMap: %r" % element_value)
+
+    def tobinary(self, values_str):
+        """
+        Return the integer value or values for a `Values` string, based upon
+        this value mapping.
+
+        Any returned integer value is represented as the CIM type of the
+        element (e.g. :class:`~pywbem.Uint16`).
+
+        If the `Values` string corresponds to a single value, that single value
+        is returned as an integer.
+
+        If the `Values` string corresponds to a value range (e.g. "1.." or
+        "..2" or "3..4"), that value range is returned as a tuple with two items
+        that are the lowest and the highest value of the range. That is the
+        case also when the value range is open on the left side or right side.
+
+        If the `Values` string corresponds to the `unclaimed` indicator "..",
+        `None` is returned.
+
+        Parameters:
+
+          values_str (:term:`string`):
+            The `Values` string for the element value.
+
+        Returns:
+
+          :class:`~pywbem.CIMInt` or tuple of :class:`~pywbem.CIMInt` or `None`:
+            The element value or value range corresponding to the `Values`
+            string, or `None` for unclaimed.
+
+        Raises:
+
+          ValueError: `Values` string outside of the set defined by `Values`.
+          TypeError: `Values` string is not a string type.
+        """
+
+        if not isinstance(values_str, six.string_types):
+            raise TypeError("Values string is not a string type: %s" %
+                            type(values_str))
+
+        try:
+            return self._v2b_dict[values_str]
+        except KeyError:
+            raise ValueError("Values string outside of the set defined by "
+                             "Values: %r" % values_str)
+
+    def items(self):
+        """
+        Generator that iterates through the items of the value mapping. The
+        items are the array entries of the `Values` and `ValueMap` qualifiers,
+        and they are iterated in the order specified in the arrays.
+        If the `ValueMap` qualifier is not specified, the default of consecutive
+        integers starting at 0 is used as a default, consistent with
+        :term:`DSP0004`.
+
+        Each iterated item is a tuple of integer value(s) representing the
+        `ValueMap` array entry, and the corresponding `Values` string.
+        Any integer value in the iterated items is represented as the CIM type
+        of the element (e.g. :class:`~pywbem.Uint16`).
+
+        If the `Values` string corresponds to a single element value, the
+        first tuple item is that single integer value.
+
+        If the `Values` string corresponds to a value range (e.g. "1.." or
+        "..2" or "3..4"), that value range is returned as a tuple with two items
+        that are the lowest and the highest value of the range. That is the
+        case also when the value range is open on the left side or right side.
+
+        If the `Values` string corresponds to the `unclaimed` indicator "..",
+        the first tuple item is `None`.
+
+        Returns:
+
+          :term:`iterator` for tuple of integer value(s) and `Values` string.
+        """
+
+        for values_str in self._v2b_dict:
+            element_value = self._v2b_dict[values_str]
+            yield element_value, values_str

--- a/testsuite/test_valuemapping.py
+++ b/testsuite/test_valuemapping.py
@@ -145,7 +145,7 @@ class Test_ValueMapping(object):
     @staticmethod
     def assertOutsideValueMap(vm, value):
         """
-        Test vm.tovalues Exception
+        Test vm.tovalues() Exception
         """
         with pytest.raises(ValueError) as exc_info:
             vm.tovalues(value)
@@ -153,6 +153,17 @@ class Test_ValueMapping(object):
         exc_msg = str(exc)
         assert re.match("Element value outside of the set defined by "
                         "ValueMap.*", exc_msg) is not None
+
+    def assertOutsideValues(self, vm, value):
+        """
+        Test vm.tobinary() Exception
+        """
+        with pytest.raises(ValueError) as exc_info:
+            vm.tobinary(value)
+        exc = exc_info.value
+        exc_msg = str(exc)
+        assert re.match("Values string outside of the set defined by "
+                        "Values.*", exc_msg) is not None
 
     def test_empty(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
@@ -164,6 +175,7 @@ class Test_ValueMapping(object):
                                     valuemap, values)
 
         self.assertOutsideValueMap(vm, 0)
+        self.assertOutsideValues(vm, 'x')
 
     def test_attrs_property(self, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
@@ -310,6 +322,22 @@ class Test_ValueMapping(object):
         assert isinstance(exc, TypeError)
         assert exc.args[0].startswith('Element value is not an integer type')
 
+    def test_invalid_tobinary_type(self, element_kind, server_arg,
+                                   integer_type):
+        # pylint: disable=redefined-outer-name
+        """Test tobinary() with invalid type"""
+        valuemap = ['0']
+        values = ['zero']
+
+        vm = self.setup_for_element(element_kind, server_arg, integer_type,
+                                    valuemap, values)
+
+        with pytest.raises(Exception) as exc_info:
+            vm.tobinary(0)
+        exc = exc_info.value
+        assert isinstance(exc, TypeError)
+        assert exc.args[0].startswith('Values string is not a string type')
+
     def test_no_values_qualifier(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test element without Values qualifier"""
@@ -327,6 +355,7 @@ class Test_ValueMapping(object):
         # pylint: disable=redefined-outer-name
         """Test default if no ValueMap qualifier is defined"""
         valuemap = None
+        exp_valuemap = [0, 1, 2]
         values = ['zero', 'one', 'two']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -338,10 +367,22 @@ class Test_ValueMapping(object):
         assert vm.tovalues(2) == 'two'
         self.assertOutsideValueMap(vm, 3)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary('zero') == 0
+        assert vm.tobinary('one') == 1
+        assert vm.tobinary('two') == 2
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_zero(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 0"""
         valuemap = ['0']
+        exp_valuemap = [0]
         values = ['zero']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -350,10 +391,20 @@ class Test_ValueMapping(object):
         assert vm.tovalues(0) == 'zero'
         self.assertOutsideValueMap(vm, 1)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary('zero') == 0
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_one(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 1"""
         valuemap = ['1']
+        exp_valuemap = [1]
         values = ['one']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -363,9 +414,19 @@ class Test_ValueMapping(object):
         assert vm.tovalues(1) == 'one'
         self.assertOutsideValueMap(vm, 2)
 
-    def test_one_cimtype(self, element_kind, server_arg, integer_type):
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary('one') == 1
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
+    def test_tovalues_with_cimtype(self, element_kind, server_arg,
+                                   integer_type):
         # pylint: disable=redefined-outer-name
-        """Test valuemap with value cimtype(1)"""
+        """Test tovalues() with argument of CIM type"""
         valuemap = ['1']
         values = ['one']
 
@@ -375,10 +436,23 @@ class Test_ValueMapping(object):
         cimtype = type_from_name(integer_type)
         assert vm.tovalues(cimtype(1)) == 'one'
 
+    def test_tobinary_with_unicode(self, element_kind, server_arg,
+                                   integer_type):
+        # pylint: disable=redefined-outer-name
+        """Test tobinary() with argument unicode string"""
+        valuemap = ['1']
+        values = ['one']
+
+        vm = self.setup_for_element(element_kind, server_arg, integer_type,
+                                    valuemap, values)
+
+        assert vm.tobinary(u'one') == 1
+
     def test_singles(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with multiple non-range values"""
         valuemap = ['0', '1', '9']
+        exp_valuemap = [0, 1, 9]
         values = ['zero', 'one', 'nine']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -391,10 +465,22 @@ class Test_ValueMapping(object):
         assert vm.tovalues(9) == 'nine'
         self.assertOutsideValueMap(vm, 10)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary('zero') == 0
+        assert vm.tobinary('one') == 1
+        assert vm.tobinary('nine') == 9
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_singles_ranges(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with ranges"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9']
+        exp_valuemap = [0, 1, (2, 4), (5, 6), (7, 8), 9]
         values = ['zero', 'one', 'two-four', 'five-six', 'seven-eight', 'nine']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -412,10 +498,25 @@ class Test_ValueMapping(object):
         assert vm.tovalues(9) == 'nine'
         self.assertOutsideValueMap(vm, 10)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary('zero') == 0
+        assert vm.tobinary('one') == 1
+        assert vm.tobinary('two-four') == (2, 4)
+        assert vm.tobinary('five-six') == (5, 6)
+        assert vm.tobinary('seven-eight') == (7, 8)
+        assert vm.tobinary('nine') == 9
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_unclaimed(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with unclaimed marker '..'"""
         valuemap = ['..']
+        exp_valuemap = [None]
         values = ['unclaimed']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
@@ -425,11 +526,20 @@ class Test_ValueMapping(object):
         assert vm.tovalues(1) == 'unclaimed'
         assert vm.tovalues(2) == 'unclaimed'
 
+        assert vm.tobinary('unclaimed') is None
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_singles_ranges_unclaimed(self, element_kind, server_arg,
                                       integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with combination of singles, ranges, unclaimed"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9', '..']
+        exp_valuemap = [0, 1, (2, 4), (5, 6), (7, 8), 9, None]
         values = ['zero', 'one', 'two-four', 'five-six', 'seven-eight', 'nine',
                   'unclaimed']
 
@@ -449,11 +559,26 @@ class Test_ValueMapping(object):
         assert vm.tovalues(10) == 'unclaimed'
         assert vm.tovalues(11) == 'unclaimed'
 
+        assert vm.tobinary('zero') == 0
+        assert vm.tobinary('one') == 1
+        assert vm.tobinary('two-four') == (2, 4)
+        assert vm.tobinary('five-six') == (5, 6)
+        assert vm.tobinary('seven-eight') == (7, 8)
+        assert vm.tobinary('nine') == 9
+        assert vm.tobinary('unclaimed') is None
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_singles_ranges_unclaimed2(self, element_kind, server_arg,
                                        integer_type):
         # pylint: disable=redefined-outer-name
         """Test singles, ranges, unclaimed"""
         valuemap = ['0', '2..4', '..6', '7..', '9', '..']
+        exp_valuemap = [0, (2, 4), (5, 6), (7, 8), 9, None]
         values = ['zero', 'two-four', 'five-six', 'seven-eight', 'nine',
                   'unclaimed']
 
@@ -473,6 +598,19 @@ class Test_ValueMapping(object):
         assert vm.tovalues(10) == 'unclaimed'
         assert vm.tovalues(11) == 'unclaimed'
 
+        assert vm.tobinary('zero') == 0
+        assert vm.tobinary('two-four') == (2, 4)
+        assert vm.tobinary('five-six') == (5, 6)
+        assert vm.tobinary('seven-eight') == (7, 8)
+        assert vm.tobinary('nine') == 9
+        assert vm.tobinary('unclaimed') is None
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_min_max_single(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with single min and max values of integer type"""
@@ -483,6 +621,8 @@ class Test_ValueMapping(object):
         valuemap = []
         valuemap.append(str(minvalue))
         valuemap.append(str(maxvalue))
+
+        exp_valuemap = [minvalue, maxvalue]
 
         values = []
         for v in valuemap:
@@ -499,9 +639,20 @@ class Test_ValueMapping(object):
         assert vm.tovalues(maxvalue) == values[1]
         self.assertOutsideValueMap(vm, maxvalue + 1)
 
-    def test_min_max_closed_range(self, element_kind, server_arg, integer_type):
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary(values[0]) == minvalue
+        assert vm.tobinary(values[1]) == maxvalue
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
+    def test_min_max_closed_ranges(self, element_kind, server_arg,
+                                   integer_type):
         # pylint: disable=redefined-outer-name
-        """Test valuemap with closed range of min and max of integer type"""
+        """Test valuemap with two closed ranges at min and max of int type"""
 
         minvalue = type_from_name(integer_type).minvalue
         maxvalue = type_from_name(integer_type).maxvalue
@@ -509,6 +660,8 @@ class Test_ValueMapping(object):
         valuemap = []
         valuemap.append('%s..%s' % (minvalue, minvalue + 2))
         valuemap.append('%s..%s' % (maxvalue - 2, maxvalue))
+
+        exp_valuemap = [(minvalue, minvalue + 2), (maxvalue - 2, maxvalue)]
 
         values = []
         for v in valuemap:
@@ -529,6 +682,16 @@ class Test_ValueMapping(object):
         assert vm.tovalues(maxvalue) == values[1]
         self.assertOutsideValueMap(vm, maxvalue + 1)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary(values[0]) == (minvalue, minvalue + 2)
+        assert vm.tobinary(values[1]) == (maxvalue - 2, maxvalue)
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_min_max_open_range1(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with open range 1 of min and max of integer type"""
@@ -541,6 +704,9 @@ class Test_ValueMapping(object):
         valuemap.append('..%s' % (minvalue + 2))
         valuemap.append('%s..' % (maxvalue - 2))
         valuemap.append('%s' % maxvalue)
+
+        exp_valuemap = [minvalue, (minvalue + 1, minvalue + 2),
+                        (maxvalue - 2, maxvalue - 1), maxvalue]
 
         values = []
         for v in valuemap:
@@ -561,6 +727,18 @@ class Test_ValueMapping(object):
         assert vm.tovalues(maxvalue) == values[3]
         self.assertOutsideValueMap(vm, maxvalue + 1)
 
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary(values[0]) == minvalue
+        assert vm.tobinary(values[1]) == (minvalue + 1, minvalue + 2)
+        assert vm.tobinary(values[2]) == (maxvalue - 2, maxvalue - 1)
+        assert vm.tobinary(values[3]) == maxvalue
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items
+
     def test_min_max_open_range2(self, element_kind, server_arg, integer_type):
         # pylint: disable=redefined-outer-name
         """Test valuemap with open range 2 of min and max of integer type"""
@@ -571,6 +749,9 @@ class Test_ValueMapping(object):
         valuemap = []
         valuemap.append('..%s' % (minvalue + 2))
         valuemap.append('%s..' % (maxvalue - 2))
+
+        exp_valuemap = [(minvalue, minvalue + 2),
+                        (maxvalue - 2, maxvalue)]
 
         values = []
         for v in valuemap:
@@ -590,3 +771,13 @@ class Test_ValueMapping(object):
         assert vm.tovalues(maxvalue - 1) == values[1]
         assert vm.tovalues(maxvalue) == values[1]
         self.assertOutsideValueMap(vm, maxvalue + 1)
+
+        self.assertOutsideValues(vm, 'x')
+        assert vm.tobinary(values[0]) == (minvalue, minvalue + 2)
+        assert vm.tobinary(values[1]) == (maxvalue - 2, maxvalue)
+
+        exp_items = list(zip(exp_valuemap, values))
+        items = []
+        for item in vm.items():
+            items.append(item)
+        assert items == exp_items


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

I'd like to point out some possible review points:

* What should be the datatype of the integer values returned by `tobinary()` (e.g. `Uint16` as in the current PR or simply `int`)?
  **COMMENT:** Karl will go back to the test we created. Since we do not lose anything by returning the exact cim type of the element, we agree that this is the best solution.

* What should `tobinary()` return for the Values string of the unclaimed marker? (e.g. `None` as in the current PR, or some representation of all unclaimed integer values)?
  CONCLUSION: Returning the None is much simpler and seems to be the most logical.

NEW QUESTION; What about an enumeration option.   Andy will look at the possibility. DONE.