### PR TITLE
fixes #1160 Enhance MOF compiler and missing dependent classes resolution logic

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,9 +27,20 @@ Released: not yet
 **Bug fixes:**
 
 * fix issue where wbemcli-help-txt was not being updated when wbemcli.py
-  changed.  Issue # 1205
+  changed.  (Issue #1205)
 
 **Enhancements:**
+
+* Extend MOFWBEMConnection to generate an exception if the compile of a
+  class with reference parameters or properties reference class is not in the
+  repository or if the class defined for an EmbeddedInstance qualifier is
+  not in the repository or. This makes use of the capability with the
+  mof compiler (extended slightly) to search the search path defined for the
+  compile for the corresponding missing classes if they are not in the
+  repository.  This means that the mof_compiler can be used to create complete
+  class repository builds without having to define specifically all dependent
+  classes for the classes defined for the build if those classes are in the
+  search path. (Issue #1160)
 
 **Cleanup**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,16 +31,25 @@ Released: not yet
 
 **Enhancements:**
 
-* Extend MOFWBEMConnection to generate an exception if the compile of a
+* Extend pywbem MOF compiler to search for dependent classes including:
+  a) reference classes (classes defined in reference properties or parameters)
+  b)EmbeddedInstance qualifier classes if they are not compiled before the
+  classes that reference them is compiled. Previously the lack of these
+  dependent classes was ignored.  The compiler already searches for superclasses
+  if they are not compiled before their subclasses.
+
+  Extends MOFWBEMConnection to generate an exception if the compile of a
   class with reference parameters or properties reference class is not in the
   repository or if the class defined for an EmbeddedInstance qualifier is
-  not in the repository or. This makes use of the capability with the
-  mof compiler (extended slightly) to search the search path defined for the
-  compile for the corresponding missing classes if they are not in the
-  repository.  This means that the mof_compiler can be used to create complete
-  class repository builds without having to define specifically all dependent
-  classes for the classes defined for the build if those classes are in the
-  search path. (Issue #1160)
+  not in the repository.
+
+  This uses the capability in the MOF compiler to search the defined
+  search path for the missing classes if they are not in the repository.
+
+  This means that the mof_compiler can be used to create a complete class
+  repository builds without having to  specifically declare all dependent
+  classes for the classes the user needs in a repository if the mof for the
+  dependent classes in in the search path. (Issue #1160).
 
 **Cleanup**
 

--- a/testsuite/testmofs/test_refs.mof
+++ b/testsuite/testmofs/test_refs.mof
@@ -1,17 +1,17 @@
-Class ex_sampleClass 
-{ 
-	[key] uint32 label1; 
-	[key] string label2; 	
-	uint32 size; 
-	uint32 weight; 
+Class ex_sampleClass
+{
+	[key] uint32 label1;
+	[key] string label2;
+	uint32 size;
+	uint32 weight;
 	string comment;
 };
 
-instance of ex_sampleClass 
-{ 
-	label1 = 9921; 
-	label2 = "SampleLabel"; 
-	comment = "Some text with \"quotes\""; 
+instance of ex_sampleClass
+{
+	label1 = 9921;
+	label2 = "SampleLabel";
+	comment = "Some text with \"quotes\"";
 	size = 80; weight = 45;
 };
 
@@ -20,19 +20,19 @@ instance of ex_sampleClass
 	//label1 = 0121;
 	label1 = 1121;
 	label2 = "Component";
-	comment = "Some text with a \\backslash\\ and a \\\"quote\\\""; 
+	comment = "Some text with a \\backslash\\ and a \\\"quote\\\"";
 	size = 80;
 	weight = 45;
 };
 
-Class ex_composedof 
-{ 
-	[key] ex_sampleClass REF composer; 
-	[key] ex_sampleClass REF component; 
+Class ex_composedof
+{
+	[key] ex_sampleClass REF composer;
+	[key] ex_sampleClass REF component;
 };
 
-instance of ex_composedof 
-{ 
+instance of ex_composedof
+{
 	composer = "ex_sampleClass.label1=9921,label2=\"SampleLabel\"";
 	component = "ex_sampleClass.label1=0121,label2=\"Component\"";
 };
@@ -42,8 +42,8 @@ instance of ex_composedof
 [Association ]
 Class ex_moreComposed
 {
-	[key] composedof REF ex_composedof1;
-	[key] composedof REF ex_composedof2;
+	[key] ex_composedof REF ex_composedof1;
+	[key] ex_composedof REF ex_composedof2;
 };
 
 /*


### PR DESCRIPTION
Review needed based on update with comments fixed.


Adds capability to find missing class dependencies(cases where a class is defined as a requirement in another class declaration to try to find the depend classes in the compile search path and compile them.
This includes finding reference classnames defined in reference properties and parameters (i.e CIM_ManagedElement REF parent) and the classes for embedded instances in the compile  search path
if they are not already in the repository.  This works with any WBEM server repository implementation that returns CIM_ERR_INVALID_PARAMETER or CIM_ERR_FAILED if the class defined in the dependency is not in the repository.

This pr extends MOFWBEMConnection to generate a CIM_ERR_INVALID_PARAMETER exception if
the class for a REF defined in a class being compiled does not exist in the MOFWBEMConnection repository or if the class defined for an EmbeddedInstance qualifier does not exist.

The mof_compiler catches these exceptions and tries to compile in the class by searching the compile search path for the class and compiling it.

Adds tests for cases of these conditions both correct and error (the REF or EmbeddedInstance class exists or does not exist) for the conditons in both properties and method parameters.

Fixes error in one of the test_mofs where the error actually existed (REF for nonexistent class) but was not being caught by the compiler before this pr.

Adds entry to changes.rst

DISCUSSION; This pr today DOES not add the requested test for circular search for missing class. I am still workin on that one