### PR TITLE
Fixes #1228 Fixes Error in mof_compiler CIMError Description text

### DIFF
--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2206,8 +2206,8 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                                        'Class %r referenced by element '
                                        '%r of class %r in namespace '
                                        '%r does not exist' %
-                                       (cc.classname, obj.name,
-                                        obj.reference_class, self.getns))
+                                       (obj.reference_class, obj.name,
+                                        cc.classname, self.getns()))
                     raise
 
             elif obj.type == 'string':
@@ -2224,7 +2224,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                                 'qualifier on element %r of class %r in '
                                 'namespace %r does not exist' %
                                 (eiqualifier.value, obj.name,
-                                 cc.classname, self.getns))
+                                 cc.classname, self.getns()))
                         raise
 
         # TODO #991: CreateClass should reject if the class already exists

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -1797,8 +1797,7 @@ class TestPartialSchema(MOFTest):
         except CIMError as ce:
             self.assertTrue(ce.status_code == CIM_ERR_INVALID_PARAMETER)
 
-    def test_compile_class_embInst(self):
-
+    def test_compile_class_embinst(self):
         """
         Test compile a single class with property and method param containing
         embedded instance.
@@ -1827,6 +1826,30 @@ class TestPartialSchema(MOFTest):
         self.assertEqual(len(exp_classes), len(clsrepo))
         for cln in exp_classes:
             self.assertTrue(cln in clsrepo)
+
+    def test_compile_class_embinst_err(self):
+        """
+        Test finding class for EmbeddedInstance qualifier where
+        class does not exist.
+        """
+        schema_mof = """
+            class My_ClassWithEmbeddedInst {
+                  [Key]
+                string InstanceID;
+
+                    [EmbeddedInstance ( "CIM_ClassDoesNotExist" )]
+                string FakeEmbeddedInstProp;
+
+                uint16 MyMethod(
+                        [EmbeddedInstance("CIM_SettingData")]
+                    string ParamWithEmbeddedInstance);
+            };
+            """
+        try:
+            self.mofcomp.compile_string(schema_mof, NAME_SPACE)
+            self.fail("Exception expected")
+        except CIMError as ce:
+            self.assertTrue(ce.status_code == CIM_ERR_INVALID_PARAMETER)
 
     def test_compile_class_circular(self):
 


### PR DESCRIPTION
Fixes error in mof_compiler CIMError description text where the classname and
reference classname were inverted in the message and the () not added to
call.

Corrected message is:

Parameter value(s) invalid: Class u'MY_ClassDoesNotexist' referenced by element u'Group' of class u'My_BadAssoc' in namespace 'root/test' does not exist

Did not include in the issues list since this is change to change in this version.