### PR TITLE
Fixes #1221 mof_compiler change use of args[0] etc.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,6 +82,8 @@ Released: not yet
 
 * Resolved several Pylint issues, including several fixes (Issue #1206).
 
+* Cleanup mof_compiler use of args[0] and args[1] with CIMError. (Issue #1221)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -307,7 +307,7 @@ class TestSchemaError(MOFTest):
                                                    'CIM_ComputerSystem.mof'),
                                       NAME_SPACE)
         except CIMError as ce:
-            self.assertEqual(ce.args[0], CIM_ERR_FAILED)
+            self.assertEqual(ce.status_code, CIM_ERR_FAILED)
             self.assertEqual(ce.file_line[0],
                              os.path.join(SCHEMA_MOF_DIR,
                                           'System',
@@ -325,7 +325,7 @@ class TestSchemaError(MOFTest):
                                                    'CIM_ComputerSystem.mof'),
                                       NAME_SPACE)
         except CIMError as ce:
-            self.assertEqual(ce.args[0], CIM_ERR_INVALID_SUPERCLASS)
+            self.assertEqual(ce.status_code, CIM_ERR_INVALID_SUPERCLASS)
             self.assertEqual(ce.file_line[0],
                              os.path.join(
                                  SCHEMA_MOF_DIR,
@@ -589,7 +589,7 @@ class TestInstCompile(MOFTest, CIMObjectMixin):
             self.mofcomp.compile_string(third_instance, NAME_SPACE)
             self.fail('Must fail compile with invalid property name')
         except CIMError as ce:
-            self.assertEqual(ce.args[0], CIM_ERR_INVALID_PARAMETER)
+            self.assertEqual(ce.status_code, CIM_ERR_INVALID_PARAMETER)
 
     def test_dup_property(self):
         """Test compile of instance with duplicated property fails"""
@@ -613,7 +613,8 @@ class TestInstCompile(MOFTest, CIMObjectMixin):
             self.mofcomp.compile_string(third_instance, NAME_SPACE)
             self.fail('Must fail compile with duplicate property name')
         except CIMError as ce:
-            self.assertEqual(ce.args[0], CIM_ERR_INVALID_PARAMETER)
+            self.assertEqual(ce.status_code,
+                             CIM_ERR_INVALID_PARAMETER)
 
     def test_mismatch_property(self):
         """Test compile of instance with duplicated property fails"""
@@ -637,7 +638,7 @@ class TestInstCompile(MOFTest, CIMObjectMixin):
             self.mofcomp.compile_string(third_instance, NAME_SPACE)
             self.fail('Must fail compile with mismatch property name')
         except CIMError as ce:
-            self.assertEqual(ce.args[0], CIM_ERR_INVALID_PARAMETER)
+            self.assertEqual(ce.status_code, CIM_ERR_INVALID_PARAMETER)
 
     # TODO add test for array value in inst, not scalar
 


### PR DESCRIPTION
WIP - I want to go back and sort out where it adds line_no, etc. to CIMError.

Changes use of args[0] in mof_compiler to status_code and args[1] to status_dscription.

The simple changes have all been made and it passes tests now.