### PR TITLE
Excluded .DS_Store files from git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ setuptools-*.zip
 /tmp_*/
 /dist/pywbem*.tar.gz
 /dist/pywbem*.whl
+.DS_Store


### PR DESCRIPTION
On OS-X, the file finder creates hidden metafiles named .DS_Store for the
directories it opens. This change excludes them from the git repo.