### PR TITLE
Fixed Travis issue on py26 with format of empty field error.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,8 @@ pytest>=3.0.7,<3.3.0; python_version == '2.6'
 pytest>=3.0.7; python_version > '2.6'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
 testfixtures>=4.3.3,<6.0.0
-httpretty>=0.8.14
+httpretty>=0.8.14,<0.9.1; python_version == '2.6'
+httpretty>=0.8.14; python_version > '2.6'
 lxml>=4.0.0
 requests>=2.12.4
 decorator>=4.0.11

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,13 @@ Released: not yet
   representation of integer key values in binary, octal or hex format
   (part of Issue #904).
 
+* Fixed an issue with running the tests on Travis CI that occurred on
+  Python 2.6 with the latest package level and that was caused by the fact
+  that a new version of the "httpretty" Python package was released that
+  had dropped support for Python 2.6. This was fixed by limiting the
+  version of httpretty to <0.9 when running on Python 2.6. Note that
+  this only affects the development environment.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.