### PR TITLE
Fixes #1253 Fix issue with deepcopy of objects in _wbemconnection_mock

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -66,6 +66,16 @@ Released: not yet
   (CIM_ERR_NOT_FOUND rather than CIM_ERR_METHOD_NOT_FOUND) when the
   class for a method is not defined in the methods repository. issue #1256
 
+* Fixed issue in pywbem_mock where we were not creating deepcopy (we were using
+  the pywbem .copy that is part of each object (see issue #1251) of objects
+  returned from the repository so that if the objects were modified some of the
+  changes bled back into the repository. Code modified to do deepcopy of
+  everything inserted into the repository through add_cimobjects and the
+  Create... methods and returned from the repository with any of the
+  get/enumerate/etc. methods.  We also modified code so that if there is a
+  class repository there is also an instance repository even if it
+  is empty. See issue #1253
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:


### PR DESCRIPTION
See commit for documentation.

This pr cherrypicks pr #1260 where we had a CIMError defined wrong in the Fake_InvokeMethod and with the deepcopy changes we hit that issue which caused the WBEMServer tests to fail.

NOTE: I think we want to put this in 0.12.3 also.