### PR TITLE
Clarified and improved copy() methods of NocaseDict and CIM objects (for 0.12.3)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,11 +21,39 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Changed the `path` argument of `CIMInstance` to be deep copied, because it 
+  may be modified by setting properties. It was previously shallow copied
+  (and incorrectly documented as not being copied). This is only incompatible
+  if user code relies on the init method modifying the keybindings of its
+  `path` input argument. If user code relies on that, it is highly recommended
+  that you decouple such dependencies (Issue #1251).
+
+* Changed the `path` argument of `CIMClass` to be shallow copied, in order
+  to decouple the created object from its input arguments. It was previously
+  not copied but referenced. This is only incompatible if user code relies on
+  the init method modifying the provided `path` input argument. If user code
+  relies on that, it is highly recommended that you decouple such
+  dependencies (Issue #1251).
+
 **Deprecations:**
 
 **Bug fixes:**
 
 **Enhancements:**
+
+* Docs: Clarified that the `copy()` methods of `NocaseDict` and of the CIM object
+  classes produce middle-deep copies, whereby mutable leaf attributes are not
+  copied and thus are shared between original and copy (Issue #1251).
+
+* Docs: Added a note to the description of the `copy()` methods of the CIM
+  objects that states that `copy.copy()` and `copy.deepcopy()` can be used
+  to create completely shallow or completely deep copies (Issue #1251).
+
+** Cleanup:**
+
+* Removed one level of superflous copies of dictionaries in the `copy()`
+  methods of the CIM object classes. These dictionaries are already copied
+  in the setter methods for the respective attributes (Issue #1251).
 
 **Known issues:**
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1971,7 +1971,7 @@ class FakedWBEMConnection(WBEMConnection):
             if p in modified_instance:
                 raise CIMError(CIM_ERR_INVALID_PARAMETER,
                                'ModifyInstance cannot modify key property %s' %
-                               (p.name))
+                               p)
 
         # remove any properties from modified instance not in the property_list
         if property_list:


### PR DESCRIPTION
This pr rolls back PR #1255 into 0.12.3.