### PR TITLE
fixes #1256 Correct issue in pywbem_mock with incorrect CIMError return

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,10 @@ Released: not yet
   version of httpretty to <0.9 when running on Python 2.6. Note that
   this only affects the development environment.
 
+* Correct issue in pywbem_mock where we return incorrect CIMError
+  (CIM_ERR_NOT_FOUND rather than CIM_ERR_METHOD_NOT_FOUND) when the
+  class for a method is not defined in the methods repository. issue #1256
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -3043,30 +3043,33 @@ class FakedWBEMConnection(WBEMConnection):
                              local_only=False, include_qualifiers=True,
                              include_classorigin=True)
 
+        # Determine if method defined in classname defined in
+        # the classorigin of the method
         try:
-            target_class = cc.methods[methodname].class_origin
+            target_cln = cc.methods[methodname].class_origin
         except KeyError:
             raise CIMError(CIM_ERR_METHOD_NOT_FOUND, 'Method %s not found '
-                           'in %s class hiearchy' % (methodname,
-                                                     localobject.classname))
+                           'in class %s class' % (methodname,
+                                                  localobject.classname))
+        if target_cln != cc.classname:
+            # TODO FUTURE: add method to repo that allows privileged users
+            # direct access so we don't have to go through _get_class and can
+            # test classes directly in repo
+            tcc = self._get_class(target_cln, namespace,
+                                  local_only=False, include_qualifiers=True,
+                                  include_classorigin=True)
+            if methodname not in tcc.methods:
+                raise CIMError(CIM_ERR_METHOD_NOT_FOUND, 'Method %s not found '
+                               'in class %s' % (methodname, target_cln))
 
-        # test for target class in methods repo
+        # Test for target class in methods repo
         try:
-            methods = methodsrepo[target_class]
+            methods = methodsrepo[target_cln]
         except KeyError:
-            raise CIMError(CIM_ERR_NOT_FOUND, 'Class %s for Method %s in '
-                                              'namespace %s not '
-                                              'registered in methods '
-                                              'repository' %
+            raise CIMError(CIM_ERR_METHOD_NOT_FOUND,
+                           'Class %s for method %s in namespace %s not '
+                           'registered in methods repository' %
                            (localobject.classname, methodname, namespace))
-
-        # test for method in local class.
-        try:
-            cc.methods[methodname]
-        except KeyError:
-            raise CIMError(CIM_ERR_METHOD_NOT_FOUND, 'Method %s not found '
-                           'in method repository for class %s' %
-                           (methodname, localobject.classname))
 
         try:
             bound_method = methods[methodname]

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -3049,8 +3049,8 @@ class FakedWBEMConnection(WBEMConnection):
             target_cln = cc.methods[methodname].class_origin
         except KeyError:
             raise CIMError(CIM_ERR_METHOD_NOT_FOUND, 'Method %s not found '
-                           'in class %s class' % (methodname,
-                                                  localobject.classname))
+                           'in class %s.' % (methodname,
+                                             localobject.classname))
         if target_cln != cc.classname:
             # TODO FUTURE: add method to repo that allows privileged users
             # direct access so we don't have to go through _get_class and can
@@ -3060,7 +3060,9 @@ class FakedWBEMConnection(WBEMConnection):
                                   include_classorigin=True)
             if methodname not in tcc.methods:
                 raise CIMError(CIM_ERR_METHOD_NOT_FOUND, 'Method %s not found '
-                               'in class %s' % (methodname, target_cln))
+                               'in origin class %s derived from '
+                               'objectname class %s' % (methodname, target_cln,
+                                                        localobject.classname))
 
         # Test for target class in methods repo
         try:


### PR DESCRIPTION
Fixes issue in Fake_invokemethod where we are returning
CIM_ERR_NOT_FOUND rather than CIM_ERR_METHOD_NOT_FOUND.  Also
reorganizes order of the tests to be more logical and adds one more test
to validate that the
class_origin is correct.  The problem occurs in WBEMServer where the
method that gets the central instances expects CIM_ERR_METHOD_NOT_FOUND.

This should also be in release 0.12.3