### PR TITLE
Modify test process that builds repo for test_wbemserverclass.py

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -66,6 +66,16 @@ Released: not yet
   (CIM_ERR_NOT_FOUND rather than CIM_ERR_METHOD_NOT_FOUND) when the
   class for a method is not defined in the methods repository. issue #1256
 
+* Fixed issue in pywbem_mock where we were not creating deepcopy (we were using
+  the pywbem .copy that is part of each object (see issue #1251) of objects
+  returned from the repository so that if the objects were modified some of the
+  changes bled back into the repository. Code modified to do deepcopy of
+  everything inserted into the repository through add_cimobjects and the
+  Create... methods and returned from the repository with any of the
+  get/enumerate/etc. methods.  We also modified code so that if there is a
+  class repository there is also an instance repository even if it
+  is empty. See issue #1253
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:


### PR DESCRIPTION

NOTE: This also cherry-picks the pr that fixes the issue with DEFAULT_NAMESPACE #1260  so that the
test runs.


This is a simple change that modifies the method that builds the repo from using a string with pragmas to using the FakedWbemconneciton method compile_dmtf_schema. I would not even worry about t his normally but I want to commonize the process for testing the subscription manager and the wbemserver class since the subscription manager requires the wbemserver.  I am trying to get some small pieces pushed so they can be committed and merged this week.

