### PR TITLE
Refactor test_wbemserverclass.py

### DIFF
--- a/testsuite/instance_from_class_method.py
+++ b/testsuite/instance_from_class_method.py
@@ -1,0 +1,112 @@
+"""
+    Define instance in class method to be integrated into CIMInstance.
+    This temporarily adds the method to the CIMInstance class until we
+    agree on PR to incorporate the method into the class
+"""
+from pywbem import CIMInstance, CIMInstanceName
+from pywbem._nocasedict import NocaseDict
+
+
+@staticmethod
+def instance_from_class(klass, namespace=None,
+                        property_values=None,
+                        include_null_properties=True,
+                        include_path=True, strict=False,
+                        include_class_origin=False):
+    """
+    Build a new CIMInstance from the input CIMClass using the
+    property_values dictionary to complete properties and the other
+    parameters to filter properties, validate the properties, and
+    optionally set the path component of the CIMInstance.  If any of the
+    properties in the class have default values, those values are passed
+    to the instance unless overridden by the property_values dictionary.
+    No CIMProperty qualifiers are included in the created instance and the
+    `class_origin` attribute is transfered from the class only if the
+    `include_class_origin` parameter is True
+
+    Parameters:
+      klass (:class:`pywbem:CIMClass`)
+        CIMClass from which the instance will be constructed.  This
+        class must include qualifiers and should include properties
+        from any superclasses to be sure it includes all properties
+        that are to be built into the instance. Properties may be
+        excluded from the instance by not including them in the `klass`
+        parameter.
+
+      namespace (:term:`string`):
+        Namespace in the WBEMConnection used to retrieve the class or
+        `None` if the default_namespace is to be used.
+
+      property_values (dictionary):
+        Dictionary containing name/value pairs where the names are the
+        names of properties in the class and the properties are the
+        property values to be set into the instance. If a property is in
+        the property_values dictionary but not in the class an ValueError
+        exception is raised.
+
+      include_null_properties (:class:`py:bool`):
+        Determines if properties with Null values are included in the
+        instance.
+
+        If `True` they are included in the instance returned.
+
+        If `False` they are not included in the instance returned
+
+     inclued_class_origin  (:class:`py:bool`):
+        Determines if ClassOrigin information is included in the returned
+        instance.
+
+        If None or False, class origin information is not included.
+
+        If True, class origin information is included.
+
+      include_path (:class:`py:bool`:):
+        If `True` the CIMInstanceName path is build and inserted into
+        the new instance.  If `strict` all key properties must be in the
+        instance.
+
+      strict (:class:`py:bool`:):
+        If `True` and `include_path` is set, all key properties must be in
+        the instance so that
+
+        If not `True` The path component is created even if not all
+        key properties are in the created instance.
+
+    Returns:
+        Returns an instance with the defined properties and optionally
+        the path set.  No qualifiers are included in the returned instance
+        and the existence of ClassOrigin depends on the
+        `include_class_origin` parameter. The value of each property is
+        either the value from the `property_values` dictionary, the
+        default_value from the class or Null(unless
+        `include_null_properties` is False). All other attributes of each
+        property are the same as the corresponding class property.
+
+    Raises:
+       ValueError if there are conflicts between the class and
+       property_values dictionary or strict is set and the class is not
+       complete.
+    """
+    class_name = klass.classname
+    inst = CIMInstance(class_name)
+    for p in property_values:
+        if p not in klass.properties:
+            raise ValueError('Property Name %s in property_values but '
+                             'not in class %s' % (p, class_name))
+    for cp in klass.properties:
+        ip = klass.properties[cp].copy()
+        ip.qualifiers = NocaseDict()
+        if not include_class_origin:
+            ip.class_origin = None
+        if ip.name in property_values:
+            ip.value = property_values[ip.name]
+        if include_null_properties:
+            inst[ip.name] = ip
+        else:
+            if ip.value:
+                inst[ip.name] = ip
+
+    if include_path:
+        inst.path = CIMInstanceName.from_instance(klass, inst, namespace,
+                                                  strict=strict)
+    return inst

--- a/testsuite/test_wbemserverclass.py
+++ b/testsuite/test_wbemserverclass.py
@@ -28,10 +28,9 @@ from __future__ import absolute_import, print_function
 import os
 import pytest
 
-from pywbem import WBEMServer, ValueMapping, CIMInstance, CIMInstanceName
+from pywbem import ValueMapping, CIMInstanceName
 from pywbem._nocasedict import NocaseDict
-from dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
-from pywbem_mock import FakedWBEMConnection
+from wbemserver_mock import WbemServerMock
 
 VERBOSE = True
 
@@ -47,261 +46,11 @@ class BaseMethodsForTests(object):
     build the DMTF schema and to build individual instances.
     """
 
-    def build_class_repo(self, default_namespace):
-        """
-        Build the schema qualifier and class objects in the repository.
-        This requires only that the leaf objects be defined in a mof
-        include file since the compiler finds the files for qualifiers
-        and dependent classes.
-        """
-        FakedWBEMConnection._reset_logging_config()
-        conn = FakedWBEMConnection(default_namespace=default_namespace)
-        classnames = ['CIM_Namespace',
-                      'CIM_ObjectManager',
-                      'CIM_RegisteredProfile',
-                      'CIM_ElementConformsToProfile']
-
-        conn.compile_dmtf_schema(DMTF_TEST_SCHEMA_VER,
-                                 TESTSUITE_SCHEMA_DIR,
-                                 class_names=classnames, verbose=False)
-
-        return conn
-
-    @staticmethod
-    def inst_from_class(klass, namespace=None,
-                        property_values=None,
-                        include_null_properties=True,
-                        include_path=True, strict=False,
-                        include_class_origin=False):
-        """
-        Build a new CIMInstance from the input CIMClass using the
-        property_values dictionary to complete properties and the other
-        parameters to filter properties, validate the properties, and
-        optionally set the path component of the CIMInstance.  If any of the
-        properties in the class have default values, those values are passed
-        to the instance unless overridden by the property_values dictionary.
-        No CIMProperty qualifiers are included in the created instance and the
-        `class_origin` attribute is transfered from the class only if the
-        `include_class_origin` parameter is True
-
-        Parameters:
-          klass (:class:`pywbem:CIMClass`)
-            CIMClass from which the instance will be constructed.  This
-            class must include qualifiers and should include properties
-            from any superclasses to be sure it includes all properties
-            that are to be built into the instance. Properties may be
-            excluded from the instance by not including them in the `klass`
-            parameter.
-
-          namespace (:term:`string`):
-            Namespace in the WBEMConnection used to retrieve the class or
-            `None` if the default_namespace is to be used.
-
-          property_values (dictionary):
-            Dictionary containing name/value pairs where the names are the
-            names of properties in the class and the properties are the
-            property values to be set into the instance. If a property is in
-            the property_values dictionary but not in the class an ValueError
-            exception is raised.
-
-          include_null_properties (:class:`py:bool`):
-            Determines if properties with Null values are included in the
-            instance.
-
-            If `True` they are included in the instance returned.
-
-            If `False` they are not included in the instance returned
-
-         inclued_class_origin  (:class:`py:bool`):
-            Determines if ClassOrigin information is included in the returned
-            instance.
-
-            If None or False, class origin information is not included.
-
-            If True, class origin information is included.
-
-          include_path (:class:`py:bool`:):
-            If `True` the CIMInstanceName path is build and inserted into
-            the new instance.  If `strict` all key properties must be in the
-            instance.
-
-          strict (:class:`py:bool`:):
-            If `True` and `include_path` is set, all key properties must be in
-            the instance so that
-
-            If not `True` The path component is created even if not all
-            key properties are in the created instance.
-
-        Returns:
-            Returns an instance with the defined properties and optionally
-            the path set.  No qualifiers are included in the returned instance
-            and the existence of ClassOrigin depends on the
-            `include_class_origin` parameter. The value of each property is
-            either the value from the `property_values` dictionary, the
-            default_value from the class or Null(unless
-            `include_null_properties` is False). All other attributes of each
-            property are the same as the corresponding class property.
-
-        Raises:
-           ValueError if there are conflicts between the class and
-           property_values dictionary or strict is set and the class is not
-           complete.
-        """
-        class_name = klass.classname
-        inst = CIMInstance(class_name)
-        for p in property_values:
-            if p not in klass.properties:
-                raise ValueError('Property Name %s in property_values but '
-                                 'not in class %s' % (p, class_name))
-        for cp in klass.properties:
-            ip = klass.properties[cp].copy()
-            ip.qualifiers = NocaseDict()
-            if not include_class_origin:
-                ip.class_origin = None
-            if ip.name in property_values:
-                ip.value = property_values[ip.name]
-            if include_null_properties:
-                inst[ip.name] = ip
-            else:
-                if ip.value:
-                    inst[ip.name] = ip
-
-        if include_path:
-            inst.path = CIMInstanceName.from_instance(klass, inst, namespace,
-                                                      strict=strict)
-        return inst
-
-    def inst_from_classname(self, conn, class_name, namespace=None,
-                            property_list=None,
-                            property_values=None,
-                            include_null_properties=True,
-                            strict=False, include_path=True):
-        """
-        Build instance from class using class_name property to get class
-        from a repository.
-        """
-        cls = conn.GetClass(class_name, namespace=namespace, LocalOnly=False,
-                            IncludeQualifiers=True, include_class_origin=True,
-                            property_list=property_list)
-
-        return self.inst_from_class(
-            cls, namespace=namespace, property_values=property_values,
-            include_null_properties=include_null_properties,
-            strict=strict, include_path=include_path)
-
 
 class TestServerClass(BaseMethodsForTests):
     """
     Conduct tests on the server class
     """
-    def build_obj_mgr_inst(self, conn, namespace, system_name,
-                           object_manager_name):
-        """
-        Build the Faked Class Repository and build the core instances for
-        this test.
-        """
-        omdict = {"SystemCreationClassName": "CIM_ComputerSystem",
-                  "CreationClassName": "CIM_ObjectManager",
-                  "SystemName": system_name,
-                  "Name": object_manager_name,
-                  "ElementName": "Pegasus",
-                  "Description": "Pegasus CIM Server Version 2.15.0 Released"}
-
-        ominst = self.inst_from_classname(conn, "CIM_ObjectManager",
-                                          namespace=namespace,
-                                          property_values=omdict, strict=True,
-                                          include_null_properties=False,
-                                          include_path=True)
-
-        conn.add_cimobjects(ominst, namespace=namespace)
-
-        assert(len(conn.EnumerateInstances("CIM_ObjectManager",
-                                           namespace=namespace)) == 1)
-        return ominst
-
-    def build_cimnamespace_insts(self, conn, namespace, system_name,
-                                 object_manager_name, test_namespaces):
-        """
-        Build instances of CIM_Namespace defined by test_namespaces list
-        """
-
-        for ns in test_namespaces:
-            nsdict = {"SystemName": system_name,
-                      "ObjectManagerName": object_manager_name,
-                      'Name': ns,
-                      'CreationClassName': 'CIM_Namespace',
-                      'ObjectManagerCreationClassName': 'CIM_ObjectManager',
-                      'SystemCreationClassName': 'CIM_ComputerSystem'}
-
-            ominst = self.inst_from_classname(conn, "CIM_Namespace",
-                                              namespace=namespace,
-                                              property_values=nsdict,
-                                              strict=True,
-                                              include_null_properties=False,
-                                              include_path=True)
-            conn.add_cimobjects(ominst, namespace=namespace)
-
-        namespaces = conn.EnumerateInstances("CIM_Namespace",
-                                             namespace=namespace)
-        assert len(namespaces) == len(test_namespaces)
-
-        # Build test CIM_RegisteredProfile instances
-    def build_reg_profile_insts(self, conn, namespace, profiles):
-        """
-        Build and install in repository the registered profiles define by
-        the profiles dictionary. The profiles to be build are defined by
-        the profiles parameter, A dictionary of tuples where each tuple
-        contains RegisteredOrganization, RegisteredName, RegisteredVersion
-        """
-        # Map ValueMap to Value
-        org_vm = ValueMapping.for_property(conn, namespace,
-                                           'CIM_RegisteredProfile',
-                                           'RegisteredOrganization')
-
-        # This is a workaround hack to get ValueMap from Value
-        org_vm_dict = {}   # reverse mapping dictionary (valueMap from Value)
-        for value in range(0, 22):
-            org_vm_dict[org_vm.tovalues(value)] = value
-
-        for p in profiles:
-            instance_id = '%s+%s+%s' % (p[0], p[1], p[2])
-            reg_prof_dict = {'RegisteredOrganization': org_vm_dict[p[0]],
-                             'RegisteredName': p[1],
-                             'RegisteredVersion': p[2],
-                             'InstanceID': instance_id}
-            rpinst = self.inst_from_classname(conn, "CIM_RegisteredProfile",
-                                              namespace=namespace,
-                                              property_values=reg_prof_dict,
-                                              strict=True,
-                                              include_null_properties=False,
-                                              include_path=True)
-
-            conn.add_cimobjects(rpinst, namespace=namespace)
-
-        assert(conn.EnumerateInstances("CIM_RegisteredProfile",
-                                       namespace=namespace))
-
-    def build_elementconformstoprofile_inst(self, conn, namespace,
-                                            profile_inst, element_inst):
-        """
-        Build an instance of CIM_ElementConformsToProfile and insert into
-        repository
-        """
-        class_name = 'CIM_ElementConformsToProfile'
-        element_conforms_dict = {'ConformantStandard': profile_inst,
-                                 'ManagedElement': element_inst}
-
-        inst = self.inst_from_classname(conn, class_name,
-                                        namespace=namespace,
-                                        property_values=element_conforms_dict,
-                                        strict=True,
-                                        include_null_properties=False,
-                                        include_path=True)
-        conn.add_cimobjects(inst, namespace=namespace)
-
-        assert conn.EnumerateInstances(class_name, namespace=namespace)
-        assert conn.GetInstance(inst.path)
-
     @pytest.mark.parametrize(
         "tst_namespace",
         ['interop', 'root/interop', 'root/PG_Interop'])
@@ -315,41 +64,13 @@ class TestServerClass(BaseMethodsForTests):
         for easily getting classes and instances into the repo and to provide
         a basic test of functionality.
         """
-        system_name = 'Mock_Test_subscription_mgr'
-        object_manager_name = 'MyFakeObjectManager'
-        conn = self.build_class_repo(tst_namespace)
-        server = WBEMServer(conn)
-
-        # Build CIM_ObjectManager instance
-        om_inst = self.build_obj_mgr_inst(conn, tst_namespace, system_name,
-                                          object_manager_name)
-
-        # build CIM_Namespace instances
-        test_namespaces = [tst_namespace, 'root/cimv2']
-
-        self.build_cimnamespace_insts(conn, tst_namespace, system_name,
-                                      object_manager_name, test_namespaces)
-
-        # Build RegisteredProfile instances
-        profiles = [('DMTF', 'Indications', '1.1.0'),
-                    ('DMTF', 'Profile Registration', '1.0.0'),
-                    ('SNIA', 'Server', '1.2.0'),
-                    ('SNIA', 'Server', '1.1.0'),
-                    ('SNIA', 'SMI-S', '1.2.0')]
-
-        self.build_reg_profile_insts(conn, tst_namespace, profiles)
+        # Build the wbem server mock using the  WbemServerMock default test
+        # data except that we define the interop namespace
+        mock_wbemserver = WbemServerMock(interop_ns=tst_namespace)
+        server = mock_wbemserver.wbem_server
 
         # Build instances for get_central instance
         # Using central methodology, i.e. ElementConformsToProfile
-
-        # Element conforms for SNIA server to object manager
-        prof_inst = server.get_selected_profiles(registered_org='SNIA',
-                                                 registered_name='Server',
-                                                 registered_version='1.1.0')
-
-        self.build_elementconformstoprofile_inst(conn, tst_namespace,
-                                                 prof_inst[0].path,
-                                                 om_inst.path)
 
         # Test basic brand, version, namespace methods
         assert server.namespace_classname == 'CIM_Namespace'
@@ -359,7 +80,7 @@ class TestServerClass(BaseMethodsForTests):
         assert server.brand == "OpenPegasus"
         assert server.version == "2.15.0"
         assert server.interop_ns == tst_namespace
-        assert set(server.namespaces) == set([tst_namespace, 'root/cimv2'])
+        assert set(server.namespaces) == set([tst_namespace])
 
         # Test basic profiles methods
         org_vm = ValueMapping.for_property(server, server.interop_ns,
@@ -373,7 +94,7 @@ class TestServerClass(BaseMethodsForTests):
 
             tst_tup = (org, name, vers)
             pass_tst = False
-            for tup in profiles:
+            for tup in mock_wbemserver.registered_profiles:
                 if tst_tup == tup:
                     pass_tst = True
                     break
@@ -402,11 +123,11 @@ class TestServerClass(BaseMethodsForTests):
         print('central inst %s' % insts[0])
         assert len(insts) == 1
         kb = NocaseDict([('SystemCreationClassName', 'CIM_ComputerSystem'),
-                         ('SystemName', system_name),
+                         ('SystemName', mock_wbemserver.system_name),
                          ('CreationClassName', 'CIM_ObjectManager')])
         assert insts[0] == CIMInstanceName('CIM_ObjectManager', keybindings=kb,
                                            namespace=tst_namespace,
-                                           host=conn.host)
+                                           host=server.conn.host)
 
 
 # TODO Break up tests to do individual tests for each group of methds so we can

--- a/testsuite/wbemserver_mock.py
+++ b/testsuite/wbemserver_mock.py
@@ -1,0 +1,322 @@
+"""
+    Define the classes and instances to mock a WEMServer as the basis for
+    other test mocks
+"""
+import os
+from pywbem import WBEMServer, ValueMapping, CIMInstance
+from pywbem_mock import FakedWBEMConnection
+from dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
+
+# Temporary until we agree on pr to incorporate instance_from_class method
+# into cim_obj.CIMInstance
+from instance_from_class_method import instance_from_class
+CIMInstance.instance_from_class = instance_from_class
+
+# location of testsuite/schema dir used by all tests as test DMTF CIM Schema
+# This directory is permanent and should not be removed.
+TEST_DIR = os.path.dirname(__file__)
+TESTSUITE_SCHEMA_DIR = os.path.join(TEST_DIR, 'schema')
+
+# The following dictionary represents the data required to build a
+# set of classes and instances for a mock WbemServer. This dictionary defines
+# the following elements of a wbem server:
+#
+#  dmtf_schema: The DMTF schema version (ex (2, 49, 0) of the schema that
+#  will be installed and the directory into which it will be installed
+#
+#  system_name: The name of the system (used by the CIM_ObjectManager)
+#
+#  object_manager: A dictionary that defines variable element for the
+#  CIM_ObjectManager class.
+#
+#  interop_namespace: The interop namespace. Note that that if the interop
+#  namespace is defined in the WbemServerMock constructor that overrides any
+#  value in this dictionary
+#
+#  other_namespaces: Any other namespaces that the users wants to be defined
+#  in the mock repository
+#
+#  registered_profiles: The Organization, profile name, profile version for any
+#  registered profiles
+#
+#  TODO
+DEFAULT_WBEM_SERVER_MOCK_DICT = {
+    'dmtf_schema': {'version': DMTF_TEST_SCHEMA_VER,
+                    'dir': TESTSUITE_SCHEMA_DIR},
+    'system_name': 'Mock_Test_WBEMServerTest',
+    'object_manager': {'Name': 'MyFakeObjectManager',
+                       'ElementName': 'Pegasus',
+                       'Description': 'Pegasus CIM Server Version 2.15.0'
+                                      ' Released', },
+    'interop_namspace': 'interop',
+    'other_namespaces': [],
+    'registered_profiles': [('DMTF', 'Indications', '1.1.0'),
+                            ('DMTF', 'Profile Registration', '1.0.0'),
+                            ('SNIA', 'Server', '1.2.0'),
+                            ('SNIA', 'Server', '1.1.0'),
+                            ('SNIA', 'SMI-S', '1.2.0'), ],
+    'element_conforms_to_profile': [['SNIA', 'Server', '1.1.0'], ]
+}
+
+
+class WbemServerMock(object):
+    """
+    Class that mocks the classes and methods used by the pywbem
+    WBEMServer class so that the WBEMServer class will produce valid data
+    for the server CIM_ObjectManager, CIM_Namespace, CIM_RegisteredProfile
+    instances.
+
+    This can be used to test the WbemServer class but is also required for
+    other tests such as the Subscription manager since that class is based
+    on getting data from the WbemServer class (ex. namespace)
+
+    It allows building a the instance data for a particular server either
+    from user defined input or from standard data predefined for pywbem
+    tests
+    """
+    def __init__(self, interop_ns=None, server_mock_data=None):
+        """
+        Build the class repository for with the classes defined for
+        the WBEMSERVER.  This is built either from a dictionary of data
+        that represents the mock wbem server with the elements defined in
+        DEFAULT_WBEM_SERVER_MOCK_DICT or if server_mock_data is None from
+        the DEFAULT_WBEM_SERVER_MOCK_DICT dictionary.
+        """
+        if server_mock_data is None:
+            self.server_mock_data = DEFAULT_WBEM_SERVER_MOCK_DICT
+        else:
+            self.server_mock_data = server_mock_data
+
+        self.system_name = self.server_mock_data['system_name']
+        self.object_manager_name = \
+            self.server_mock_data['object_manager']['Name']
+
+        # override dictionary interop namespace with constructor input
+        if interop_ns:
+            self.interop_ns = interop_ns
+        else:
+            self.interop_ns = self.server_mock_data['interop_ns']
+
+        self.dmtf_schema_ver = self.server_mock_data['dmtf_schema']['version']
+        self.schema_dir = self.server_mock_data['dmtf_schema']['dir']
+        self.registered_profiles = self.server_mock_data['registered_profiles']
+        self.wbem_server = self.build_mock()
+
+    def __str__(self):
+        print('object_manager_name=%r, interop_ns=%r, system_name=%r, '
+              'dmtf_schema_ver=%r, schema_dir=%r, wbem_server=%s' %
+              (self.object_manager_name,
+               self.interop_ns, self.system_name,
+               self.dmtf_schema_ver,
+               self.schema_dir, self.wbem_server))
+
+    def __repr__(self):
+        """
+        Return a representation of the class object
+        with all attributes, that is suitable for debugging.
+        """
+        print('WBEMServerMock: object_manager_name=%r, interop_ns=%r, '
+              'system_name=%r, dmtf_schema_ver=%r, schema_dir=%r, '
+              'wbem_server=%r, registered_profiles=%r' %
+              (self.object_manager_name,
+               self.interop_ns, self.system_name,
+               self.dmtf_schema_ver, self.schema_dir, self.wbem_server,
+               self.registered_profiles))
+
+    def build_class_repo(self, default_namespace):
+        """
+        Build the schema qualifier and class objects in the repository
+        from a DMTF schema.
+        This requires only that the leaf objects be defined in a mof
+        include file since the compiler finds the files for qualifiers
+        and dependent classes.
+
+        Returns:
+            Instance of FakedWBEMConnection object.
+        """
+        # pylint: disable=protected-access
+        FakedWBEMConnection._reset_logging_config()
+        conn = FakedWBEMConnection(default_namespace=default_namespace)
+        classnames = ['CIM_Namespace',
+                      'CIM_ObjectManager',
+                      'CIM_RegisteredProfile',
+                      'CIM_ElementConformsToProfile']
+
+        conn.compile_dmtf_schema(self.dmtf_schema_ver, self.schema_dir,
+                                 class_names=classnames, verbose=False)
+
+        return conn
+
+    @staticmethod
+    def inst_from_classname(conn, class_name, namespace=None,
+                            property_list=None,
+                            property_values=None,
+                            include_null_properties=True,
+                            strict=False, include_path=True):
+        """
+        Build instance from classname using class_name property to get class
+        from a repository.
+        """
+        cls = conn.GetClass(class_name, namespace=namespace, LocalOnly=False,
+                            IncludeQualifiers=True, include_class_origin=True,
+                            property_list=property_list)
+
+        return CIMInstance.instance_from_class(
+            cls, namespace=namespace, property_values=property_values,
+            include_null_properties=include_null_properties,
+            strict=strict, include_path=include_path)
+
+    def build_obj_mgr_inst(self, conn, system_name, object_manager_name,
+                           object_manager_element_name,
+                           object_manager_description):
+        """
+        Build a CIMObjectManager instance for the mock wbem server using
+        fixed data defined in this method and data from the constructor
+        mock data.
+        """
+        omdict = {"SystemCreationClassName": "CIM_ComputerSystem",
+                  "CreationClassName": "CIM_ObjectManager",
+                  "SystemName": system_name,
+                  "Name": object_manager_name,
+                  "ElementName": object_manager_element_name,
+                  "Description": object_manager_description}
+
+        ominst = self.inst_from_classname(conn, "CIM_ObjectManager",
+                                          namespace=self.interop_ns,
+                                          property_values=omdict, strict=True,
+                                          include_null_properties=False,
+                                          include_path=True)
+
+        conn.add_cimobjects(ominst, namespace=self.interop_ns)
+
+        assert(len(conn.EnumerateInstances(
+            "CIM_ObjectManager", namespace=self.interop_ns)) == 1)
+        return ominst
+
+    def build_cimnamespace_insts(self, conn, namespaces=None):
+        """
+        Build instances of CIM_Namespace defined by test_namespaces list. These
+        instances are built into the interop namespace
+        """
+        for ns in namespaces:
+            nsdict = {"SystemName": self.system_name,
+                      "ObjectManagerName": self.object_manager_name,
+                      'Name': ns,
+                      'CreationClassName': 'CIM_Namespace',
+                      'ObjectManagerCreationClassName': 'CIM_ObjectManager',
+                      'SystemCreationClassName': 'CIM_ComputerSystem'}
+
+            ominst = self.inst_from_classname(conn, "CIM_Namespace",
+                                              namespace=self.interop_ns,
+                                              property_values=nsdict,
+                                              strict=True,
+                                              include_null_properties=False,
+                                              include_path=True)
+            conn.add_cimobjects(ominst, namespace=self.interop_ns)
+
+        rtn_namespaces = conn.EnumerateInstances("CIM_Namespace",
+                                                 namespace=self.interop_ns)
+        assert len(rtn_namespaces) == len(namespaces)
+
+    def build_reg_profile_insts(self, conn, profiles):
+        """
+        Build and install in repository the registered profiles define by
+        the profiles parameter. A dictionary of tuples where each tuple
+        contains RegisteredOrganization, RegisteredName, RegisteredVersion
+
+        Parameters:
+          conn:
+          profiles (dict of lists where each list contains org, name, version
+             for a profiles)
+        """
+        # Map ValueMap to Value
+        org_vm = ValueMapping.for_property(conn, self.interop_ns,
+                                           'CIM_RegisteredProfile',
+                                           'RegisteredOrganization')
+
+        # This is a workaround hack to get ValueMap from Value
+        org_vm_dict = {}   # reverse mapping dictionary (valueMap from Value)
+        for value in range(0, 22):
+            org_vm_dict[org_vm.tovalues(value)] = value
+
+        for p in profiles:
+            instance_id = '%s+%s+%s' % (p[0], p[1], p[2])
+            reg_prof_dict = {'RegisteredOrganization': org_vm_dict[p[0]],
+                             'RegisteredName': p[1],
+                             'RegisteredVersion': p[2],
+                             'InstanceID': instance_id}
+            rpinst = self.inst_from_classname(conn, "CIM_RegisteredProfile",
+                                              namespace=self.interop_ns,
+                                              property_values=reg_prof_dict,
+                                              strict=True,
+                                              include_null_properties=False,
+                                              include_path=True)
+
+            conn.add_cimobjects(rpinst, namespace=self.interop_ns)
+
+        assert(conn.EnumerateInstances("CIM_RegisteredProfile",
+                                       namespace=self.interop_ns))
+
+    def build_elementconformstoprofile_inst(self, conn, profile_inst,
+                                            element_inst):
+        """
+        Build an instance of CIM_ElementConformsToProfile and insert into
+        repository
+        """
+        class_name = 'CIM_ElementConformsToProfile'
+        element_conforms_dict = {'ConformantStandard': profile_inst,
+                                 'ManagedElement': element_inst}
+
+        inst = self.inst_from_classname(conn, class_name,
+                                        namespace=self.interop_ns,
+                                        property_values=element_conforms_dict,
+                                        strict=True,
+                                        include_null_properties=False,
+                                        include_path=True)
+        conn.add_cimobjects(inst, namespace=self.interop_ns)
+
+        assert conn.EnumerateInstances(class_name, namespace=self.interop_ns)
+        assert conn.GetInstance(inst.path)
+
+    def build_mock(self):
+        """
+            Builds the classes and instances for a mock WBEMServer from data
+            in the constructor. This calls the builder for:
+              the object manager
+              the namespaces
+              the profiles
+        """
+        conn = self.build_class_repo(self.interop_ns)
+        server = WBEMServer(conn)
+        # NOTE: The wbemserver is not complete until the instances for at
+        # least object manager and namespaces have been inserted. Any attempt
+        # to display the instance object before that will fail because the
+        # enumerate namespaces will be inconsistent
+
+        # Build CIM_ObjectManager instance into the interop namespace since
+        # this is required to build namespace instances
+        om_inst = self.build_obj_mgr_inst(
+            conn,
+            self.system_name,
+            self.object_manager_name,
+            self.server_mock_data['object_manager']['ElementName'],
+            self.server_mock_data['object_manager']['Description'])
+
+        # build CIM_Namespace instances based on the constructor attributes
+        namespaces = [self.interop_ns]
+        if self.server_mock_data['other_namespaces']:
+            namespaces.extend(self.server_mock_data['other_namespaces'])
+
+        self.build_cimnamespace_insts(conn, namespaces)
+
+        self.build_reg_profile_insts(conn, self.registered_profiles)
+
+        # Element conforms for SNIA server to object manager
+        prof_inst = server.get_selected_profiles(registered_org='SNIA',
+                                                 registered_name='Server',
+                                                 registered_version='1.1.0')
+
+        self.build_elementconformstoprofile_inst(conn,
+                                                 prof_inst[0].path,
+                                                 om_inst.path)
+        return server


### PR DESCRIPTION
Will do more refactor as part of using this as driver for test_subscriptionmanager.py
Refactors the test so that a mock of wbemserver can be use for this and other tests and adds two new files:

1. instance_from_class_method.py - Temporary localization of the
instance_from_class method until we get it accepted.  This keeps the
tests running until we get this added method accepted as a new method in
ICMInstance.

2. teststuite/wbemserver_mock.py which isolates all the code to generate
the mock for the wbem server.  Since the wbem server mock is required to
run the WbemServer class in any mock this simplifies building this
component.

3. Modifications to test_wbemserverclass.py to work with the two new
files.

I want to refactor so we separate profile and central class creation into a common component and move the data definition out of the new WbemServerMock class. Then we can actually use this new
class to create the mock wbemserver for other tests. 

I apologize but I forgot that I had refactored a couple of tests in test_wbemconnection around testing of iq and ico.  I would rather just leave them in this pr rather than go through the process of moving them to a separate pr.  That included setting the description qualifier on some of the cim objects that get added to the repository to make tests more complete.