### PR TITLE
Fixes #1268 Add input parameter to wbemcli to allow mocking a server

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -123,6 +123,11 @@ Released: not yet
   objects that states that `copy.copy()` and `copy.deepcopy()` can be used
   to create completely shallow or completely deep copies (Issue #1251).
 
+* Extend wbemcli to use pywbem_mock with a new command line parameter
+  (--mock_server <mock_info-filename>). Added a set of new tests for this
+  parameter and a mof file and pythong to testsuite to test the new option.
+  (Issue #1268)
+
 **Cleanup**
 
 * Moved class `NocaseDict` into its own module (Issue #848).

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1429,7 +1429,7 @@ class FakedWBEMConnection(WBEMConnection):
         Remove properties from an instance or class that aren't in the
         plist parameter
 
-        obj(:class:`~pywbem.CIMClass` or :class:`~pywbem.CIMClass):
+        obj(:class:`~pywbem.CIMClass` or :class:`~pywbem.CIMInstance):
             The class or instance from which properties are to be filtered
 
         property_list(list of :term:`string`):

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -227,7 +227,7 @@ class FakedWBEMConnection(WBEMConnection):
     """
     def __init__(self, default_namespace=DEFAULT_NAMESPACE,
                  use_pull_operations=False, stats_enabled=False,
-                 response_delay=None, repo_lite=False):
+                 timeout=None, response_delay=None, repo_lite=False):
         """
         Parameters:
 
@@ -239,6 +239,10 @@ class FakedWBEMConnection(WBEMConnection):
           use_pull_operations (:class:`py:bool`):
             Flag to control whether pull or traditional operaitons are
             used in the iter operations.
+            This parameter has the same characteristics as the same-named init
+            parameter of :class:`~pywbem.WBEMConnection`.
+
+          timeout (:term:`number`):
             This parameter has the same characteristics as the same-named init
             parameter of :class:`~pywbem.WBEMConnection`.
 
@@ -273,7 +277,7 @@ class FakedWBEMConnection(WBEMConnection):
             'http://FakedUrl',
             default_namespace=default_namespace,
             use_pull_operations=use_pull_operations,
-            stats_enabled=stats_enabled)
+            stats_enabled=stats_enabled, timeout=timeout)
 
         # The CIM classes in the mock repository.
         # This is a dictionary of dictionaries where the top level key is the
@@ -1425,7 +1429,7 @@ class FakedWBEMConnection(WBEMConnection):
         Remove properties from an instance or class that aren't in the
         plist parameter
 
-        obj(:class:`~pywbem.CIMClassName` or :class:`~pywbem.CIMClassName):
+        obj(:class:`~pywbem.CIMClass` or :class:`~pywbem.CIMClass):
             The class or instance from which properties are to be filtered
 
         property_list(list of :term:`string`):

--- a/testsuite/simple_mock_add_obj.py
+++ b/testsuite/simple_mock_add_obj.py
@@ -1,0 +1,19 @@
+"""
+Test file for use with wbemcli -mock-server parameter that adds an instance
+to the mock repository
+This file assumes that the file simple_mock_model.mof has already been loaded
+so the class CIM_Foo exists.
+"""
+from pywbem import CIMInstance, CIMInstanceName
+
+iname = 'CIM_Foo%s' % 'wbemcli_tst-1'
+inst_path = CIMInstanceName('CIM_Foo', {'InstanceID': iname})
+inst = CIMInstance('CIM_Foo',
+                   properties={'InstanceID': iname},
+                   path=inst_path)
+
+global CONN
+CONN.add_cimobjects(inst)  # noqa: F821
+
+# test that instance inserted
+assert(CONN.GetInstance(inst_path))  # noqa: F821

--- a/testsuite/simple_mock_model.mof
+++ b/testsuite/simple_mock_model.mof
@@ -1,0 +1,94 @@
+// This is a simple mof model that creates the qualifier declarations,
+// classes, and instances for a very simplistic model to be used in the
+// pywbemcli mock test environment.
+
+#pragma locale ("en_US")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string = null,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Override : string = null,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+     [Description ("Simple CIM Class")]
+class CIM_Foo {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+
+        [Description ("This is Uint32 property.")]
+    uint32 IntegerProp;
+
+        [Description ("Method with in and out parameters")]
+    uint32 Fuzzy(
+        [IN, Description("FuzzyMethod Param")]
+      string FuzzyParameter,
+
+        [IN, OUT, Description ( "Test of ref in/out parameter")]
+      CIM_Foo REF Foo,
+
+        [IN ( false ), OUT, Description("TestMethod Param")]
+      string OutputParam);
+
+        [ Description("Method with no Parameters") ]
+    uint32 DeleteNothing();
+};
+
+    [Description ("Subclass of CIM_Foo")]
+class CIM_Foo_sub : CIM_Foo {
+    string cimfoo_sub;
+};
+
+    [Description ("Subclass of CIM_Foo_sub")]
+class CIM_Foo_sub_sub : CIM_Foo_sub {
+    string cimfoo_sub_sub;
+        [Description("Sample method with input and output parameters")]
+    uint32 Method1(
+        [IN ( false), OUT, Description("Response param 2")]
+      string OutputParam2);
+};
+
+
+class CIM_Foo_sub2 : CIM_Foo {
+    string cimfoo_sub2;
+};
+
+instance of CIM_Foo as $foo1 {
+    InstanceID = "CIM_Foo1";
+    IntegerProp = 1;
+    };
+
+instance of CIM_Foo as $foo2 {
+    InstanceID = "CIM_Foo2";
+    IntegerProp = 2;
+    };
+
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo3"; };


### PR DESCRIPTION
This adds a parameter --mock_server to the command line parameters of
wbemcli to allow wbemcli to be used with the pywbem_mock environment.

This also adds one new constructor parameter to FakedWBEMConnection,
timeout that the WBEMConnection can use to return the timeout exception
if this value is set and is of a lower value than the response_delay
time which would indicate that the server delayed longer than the client
timeout setting

It also adds a test of the wbemcli new parameter to test_wbemcli.py and
a simple mof file to be used in that test.

Adds initial tests. Adds tests for the new parameters which means two new files in testsuite. This DOES NOT convert test_wbemcli.py to pytest.

Adds entry under enhancements to changes.rst