### PR TITLE
fixes #1271 - Issue with mock EnumerateClassNames and EnumerateClasses

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pywbem
-Version: 0.12.1.dev23
+Version: 0.12.1.dev32
 Summary: pywbem - A WBEM client
 Home-page: http://pywbem.github.io/pywbem/
 Author: Tim Potter

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,7 +22,7 @@ Released: not yet
 
 **Incompatible changes:**
 
-* Changed the `path` argument of `CIMInstance` to be deep copied, because it 
+* Changed the `path` argument of `CIMInstance` to be deep copied, because it
   may be modified by setting properties. It was previously shallow copied
   (and incorrectly documented as not being copied). This is only incompatible
   if user code relies on the init method modifying the keybindings of its
@@ -75,6 +75,10 @@ Released: not yet
   get/enumerate/etc. methods.  We also modified code so that if there is a
   class repository there is also an instance repository even if it
   is empty. See issue #1253
+
+* Fixed issue where pywbem_mock EnumerateClass and EnumerateClassNames
+  parameter losing the ClassName parameter and no test for the ClassName
+  parameter not existing in the repository. (See issue #1271)
 
 **Enhancements:**
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1465,11 +1465,12 @@ class FakedWBEMConnection(WBEMConnection):
 
         Raises:
 
-            CIMError: CIM_ERR_INVALID_NAMESPACE if invalid namespace,
-            CIMError: CIM_ERR_NOT_FOUND if Classname not found
-            CIMError: CIM_ERR_INVALID_CLASS if class that is basis for tes
-                      does not exist
-
+            CIMError: CIM_ERR_INVALID_NAMESPACE: invalid namespace,
+            CIMError: CIM_ERR_NOT_FOUND: A class that should be a subclass
+            of either the root or "ClassName" parameter was not found in the
+            repository. This is probably a repository build error.
+            CIMError: CIM_ERR_INVALID_CLASS: class defined by the classname
+            parameter does not exist.
         """
         self._get_class_repo(namespace)
 
@@ -1478,11 +1479,15 @@ class FakedWBEMConnection(WBEMConnection):
             assert(isinstance(classname, CIMClassName))
             if not self._class_exists(classname.classname, namespace):
                 raise CIMError(CIM_ERR_INVALID_CLASS,
-                               'The class %s does not exist in namespace %s' %
+                               'The class %s  defined by "ClassName" parameter '
+                               'does not exist in namespace %s' %
                                (classname, namespace))
         cns = self._get_subclass_names(classname, namespace,
                                        params['DeepInheritance'])
 
+        # Note: _get_class will return NOT_FOUND if the class not in the
+        # repo but it was just found by _get_subclass_names so that would
+        # probably be some form of repo corruption.
         classes = [
             self._get_class(cn, namespace,
                             local_only=params['LocalOnly'],
@@ -1506,10 +1511,9 @@ class FakedWBEMConnection(WBEMConnection):
 
         Raises:
 
-            CIMError: CIM_ERR_INVALID_NAMESPACE if invalid namespace,
-            CIMError: CIM_ERR_NOT_FOUND if Classname not found
-            CIMError: CIM_ERR_INVALID_CLASS if class that is basis for tes
-                      does not exist
+            CIMError: CIM_ERR_INVALID_NAMESPACE: invalid namespace,
+            CIMError: CIM_ERR_INVALID_CLASS: class defined by the classname
+            parameter does not exist
         """
         self._get_class_repo(namespace)
 
@@ -1518,7 +1522,8 @@ class FakedWBEMConnection(WBEMConnection):
             assert(isinstance(classname, CIMClassName))
             if not self._class_exists(classname.classname, namespace):
                 raise CIMError(CIM_ERR_INVALID_CLASS,
-                               'The class %s does not exist in namespace %s' %
+                               'The class %s  defined by "ClassName" parameter '
+                               'does not exist in namespace %s' %
                                (classname, namespace))
         clns = self._get_subclass_names(classname, namespace,
                                         params['DeepInheritance'])


### PR DESCRIPTION
This fixes the issues documented in issue #1271 where there was a param
acquisition name that lower case instead of mixed case (Should have been
ClassName) and a test for invalid classname on EnumerateClassNames and
EnumerateClasses was mising.

This also removes two print statements that should not have been in the
code (printed out the error for the two methods that are not
implemented)
and fixed one pylint issue.

We added tests to cover the new code for ClassName not in repo.

Added note to changes.rst