### PR TITLE
Added connection information to exceptions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -215,6 +215,11 @@ This version contains all fixes up to pywbem 0.12.4.
 
 **Cleanup:**
 
+* Added connection information to all pywbem exceptions. This is done via a
+  new optional `conn` keyword argument that was added to all pywbem exception
+  classes. The exception message now has a connection information string at
+  its end. See issue #1155.
+
 * Moved class `NocaseDict` into its own module (Issue #848).
 
 * Resolved several Pylint issues, including several fixes (Issue #1206).

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -605,9 +605,11 @@ class WBEMServer(object):
                 break
         if interop_ns is None:
             # Exhausted the possible namespaces
-            raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Interop namespace could not be determined "
-                           "(tried %s)" % self.INTEROP_NAMESPACES)
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                "Interop namespace could not be determined (tried %s)" %
+                self.INTEROP_NAMESPACES,
+                conn_id=self.conn.conn_id)
         self._interop_ns = interop_ns
 
     def _validate_interop_ns(self, interop_ns):
@@ -685,9 +687,11 @@ class WBEMServer(object):
                 break
         if ns_insts is None:
             # Exhausted the possible class names
-            raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Namespace class could not be determined "
-                           "(tried %s)" % self.NAMESPACE_CLASSNAMES)
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                "Namespace class could not be determined (tried %s)" %
+                self.NAMESPACE_CLASSNAMES,
+                conn_id=self.conn.conn_id)
         self._namespace_classname = ns_classname
         self._namespaces = [inst['Name'] for inst in ns_insts]
 
@@ -712,10 +716,11 @@ class WBEMServer(object):
         cimom_insts = self._conn.EnumerateInstances(
             "CIM_ObjectManager", namespace=self.interop_ns)
         if len(cimom_insts) != 1:
-            raise CIMError(CIM_ERR_NOT_FOUND,
-                           "Unexpected number of CIM_ObjectManager "
-                           "instances: %s " %
-                           [i['ElementName'] for i in cimom_insts])
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                "Unexpected number of CIM_ObjectManager instances: %s " %
+                [i['ElementName'] for i in cimom_insts],
+                conn_id=self.conn.conn_id)
         cimom_inst = cimom_insts[0]
         element_name = cimom_inst['ElementName']
         if element_name is not None:

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -624,6 +624,7 @@ class WBEMSubscriptionManager(object):
 
         # Validate server_id
         server = self._get_server(server_id)
+        conn_id = server.conn.conn_id if server.conn is not None else None
 
         # If list, recursively call this function with each list item.
         if isinstance(destination_paths, list):
@@ -640,9 +641,10 @@ class WBEMSubscriptionManager(object):
         if ref_paths:
             # DSP1054 1.2 defines that this CIM error is raised by the server
             # in that case, so we simulate that behavior on the client side.
-            raise CIMError(CIM_ERR_FAILED,
-                           "The listener destination is referenced by "
-                           "subscriptions.")
+            raise CIMError(
+                CIM_ERR_FAILED,
+                "The listener destination is referenced by subscriptions.",
+                conn_id=conn_id)
 
         server.conn.DeleteInstance(dest_path)
 
@@ -867,6 +869,7 @@ class WBEMSubscriptionManager(object):
 
         # Validate server_id
         server = self._get_server(server_id)
+        conn_id = server.conn.conn_id if server.conn is not None else None
 
         # Verify referencing subscriptions.
         ref_paths = server.conn.ReferenceNames(
@@ -874,9 +877,10 @@ class WBEMSubscriptionManager(object):
         if ref_paths:
             # DSP1054 1.2 defines that this CIM error is raised by the server
             # in that case, so we simulate that behavior on the client side.
-            raise CIMError(CIM_ERR_FAILED,
-                           "The indication filter is referenced by "
-                           "subscriptions.")
+            raise CIMError(
+                CIM_ERR_FAILED,
+                "The indication filter is referenced by subscriptions.",
+                conn_id=conn_id)
 
         server.conn.DeleteInstance(filter_path)
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -1634,25 +1634,33 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # Check the tuple tree
 
         if tup_tree[0] != 'CIM':
-            raise ParseError('Expecting CIM element, got %s' % tup_tree[0])
+            raise ParseError(
+                'Expecting CIM element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'MESSAGE':
-            raise ParseError('Expecting MESSAGE element, got %s' % tup_tree[0])
+            raise ParseError(
+                'Expecting MESSAGE element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'SIMPLERSP':
-            raise ParseError('Expecting SIMPLERSP element, got %s' %
-                             tup_tree[0])
+            raise ParseError(
+                'Expecting SIMPLERSP element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'IMETHODRESPONSE':
-            raise ParseError('Expecting IMETHODRESPONSE element, got %s' %
-                             tup_tree[0])
+            raise ParseError(
+                'Expecting IMETHODRESPONSE element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
 
         if tup_tree[1]['NAME'] != methodname:
-            raise ParseError('Expecting attribute NAME=%s, got %s' %
-                             (methodname, tup_tree[1]['NAME']))
+            raise ParseError(
+                'Expecting attribute NAME=%s, got %s' %
+                (methodname, tup_tree[1]['NAME']),
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         # At this point we either have a IRETURNVALUE, ERROR element
@@ -1667,14 +1675,19 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             err = tup_tree[0]
             code = int(err[1]['CODE'])
             if 'DESCRIPTION' in err[1]:
-                raise CIMError(code, err[1]['DESCRIPTION'])
-            raise CIMError(code, 'Error code %s' % err[1]['CODE'])
+                raise CIMError(
+                    code, err[1]['DESCRIPTION'],
+                    conn_id=self.conn_id)
+            raise CIMError(
+                code, 'Error code %s' % err[1]['CODE'],
+                conn_id=self.conn_id)
         if response_params_rqd is None:
             # expect either ERROR | IRETURNVALUE*
             err = tup_tree[0]
             if err[0] != 'IRETURNVALUE':
-                raise ParseError('Expecting IRETURNVALUE element, got %s'
-                                 % err[0])
+                raise ParseError(
+                    'Expecting IRETURNVALUE element, got %s' % err[0],
+                    conn_id=self.conn_id)
             return tup_tree
 
         # At this point should have optional RETURNVALUE and at maybe one
@@ -1872,25 +1885,33 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # Check the tuple tree
 
         if tup_tree[0] != 'CIM':
-            raise ParseError('Expecting CIM element, got %s' % tup_tree[0])
+            raise ParseError(
+                'Expecting CIM element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'MESSAGE':
-            raise ParseError('Expecting MESSAGE element, got %s' % tup_tree[0])
+            raise ParseError(
+                'Expecting MESSAGE element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'SIMPLERSP':
-            raise ParseError('Expecting SIMPLERSP element, got %s' %
-                             tup_tree[0])
+            raise ParseError(
+                'Expecting SIMPLERSP element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         if tup_tree[0] != 'METHODRESPONSE':
-            raise ParseError('Expecting METHODRESPONSE element, got %s' %
-                             tup_tree[0])
+            raise ParseError(
+                'Expecting METHODRESPONSE element, got %s' % tup_tree[0],
+                conn_id=self.conn_id)
 
         if tup_tree[1]['NAME'] != methodname:
-            raise ParseError('Expecting attribute NAME=%s, got %s' %
-                             (methodname, tup_tree[1]['NAME']))
+            raise ParseError(
+                'Expecting attribute NAME=%s, got %s' %
+                (methodname, tup_tree[1]['NAME']),
+                conn_id=self.conn_id)
         tup_tree = tup_tree[2]
 
         # At this point we have an optional RETURNVALUE and zero or
@@ -1899,8 +1920,12 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         if tup_tree and tup_tree[0][0] == 'ERROR':
             code = int(tup_tree[0][1]['CODE'])
             if 'DESCRIPTION' in tup_tree[0][1]:
-                raise CIMError(code, tup_tree[0][1]['DESCRIPTION'])
-            raise CIMError(code, 'Error code %s' % tup_tree[0][1]['CODE'])
+                raise CIMError(
+                    code, tup_tree[0][1]['DESCRIPTION'],
+                    conn_id=self.conn_id)
+            raise CIMError(
+                code, 'Error code %s' % tup_tree[0][1]['CODE'],
+                conn_id=self.conn_id)
 
         # #  Original code return tup_tree
 
@@ -2020,8 +2045,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                             'got: %s' % type(instancename))
         return instancename
 
-    @staticmethod
-    def _get_rslt_params(result, namespace):
+    def _get_rslt_params(self, result, namespace):
         """Common processing for pull results to separate
            end-of-sequence, enum-context, and entities in IRETURNVALUE.
            Returns tuple of entities in IRETURNVALUE, end_of_sequence,
@@ -2040,8 +2064,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                             else False
                         end_of_sequence_found = True
                     else:
-                        raise CIMError(CIM_ERR_INVALID_PARAMETER, 'Invalid '
-                                       'value %s on EndOfSequence' % p[2])
+                        raise CIMError(
+                            CIM_ERR_INVALID_PARAMETER,
+                            'Invalid value %s on EndOfSequence' % p[2],
+                            conn_id=self.conn_id)
 
             elif p[0] == 'EnumerationContext':
                 enumeration_context_found = True
@@ -2052,11 +2078,16 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 rtn_objects = p[2]
 
         if not end_of_sequence_found and not enumeration_context_found:
-            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence "
-                           "or EnumerationContext required in response.")
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                "EndOfSequence or EnumerationContext required in response.",
+                conn_id=self.conn_id)
         if not end_of_sequence and enumeration_context is None:
-            raise CIMError(CIM_ERR_INVALID_PARAMETER, "EndOfSequence False"
-                           "and EnumerationContext Null value or missing.")
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                "EndOfSequence False and EnumerationContext Null value or "
+                "missing.",
+                conn_id=self.conn_id)
 
         # Drop enumeration_context if eos True
         # Returns tuple of enumeration context and namespace
@@ -7600,8 +7631,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             for p in result:
                 if p[0] == 'QueryResultClass' and isinstance(p[2], CIMClass):
                     return p[2]
-            raise CIMError(CIM_ERR_INVALID_PARAMETER,
-                           "ReturnQueryResultClass invalid or missing.")
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                "ReturnQueryResultClass invalid or missing.",
+                conn_id=self.conn_id)
 
         exc = None
         result_tuple = None

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -34,30 +34,30 @@ class Error(Exception):
         """
         Parameters:
 
-          conn (:class:`~pywbem.WBEMConnection`): Must be a keyword argument.
-            Connection in whose context the error happened. Omitted or `None`
-            if the error did not happen in context of any connection, or if the
-            connection context was not known.
+          conn_id (:term:`connection id`): Must be a keyword argument.
+            Connection ID of the connection in whose context the error
+            happened. Omitted or `None` if the error did not happen in context
+            of any connection, or if the connection context was not known.
 
           Any other positional arguments or keyword arguments are passed to
           :exc:`py:Exception`.
         """
-        if 'conn' in kwargs:
-            conn = kwargs['conn']
-            del kwargs['conn']
+        if 'conn_id' in kwargs:
+            conn_id = kwargs['conn_id']
+            del kwargs['conn_id']
         else:
-            conn = None
+            conn_id = None
         super(Error, self).__init__(*args, **kwargs)
-        self._conn = conn
+        self._conn_id = conn_id
 
     @property
-    def conn(self):
+    def conn_id(self):
         """
-        :class:`~pywbem.WBEMConnection`: Connection in whose context
+        :term:`connection id`: Connection ID of the connection in whose context
         the error happened. `None` if the error did not happen in context
         of any connection, or if the connection context was not known.
         """
-        return self._conn
+        return self._conn_id
 
     @property
     def conn_str(self):
@@ -65,8 +65,7 @@ class Error(Exception):
         :term:`unicode string`: String that identifies the connection in
         exception messages.
         """
-        conn_id = self.conn.conn_id if self.conn else None
-        ret_str = "Connection id: %s" % conn_id
+        ret_str = "Connection id: %s" % self.conn_id
         return ret_str
 
     def __str__(self):
@@ -102,7 +101,7 @@ class HTTPError(Error):
 
     # pylint: disable=super-init-not-called
     def __init__(self, status, reason, cimerror=None, cimdetails=None,
-                 conn=None):
+                 conn_id=None):
         """
         Parameters:
 
@@ -123,9 +122,10 @@ class HTTPError(Error):
 
             Passing `None` will result in an empty dictionary.
 
-          conn (:class:`~pywbem.WBEMConnection`): Connection in whose context
-            the error happened. `None` if the error did not happen in context
-            of any connection, or if the connection context was not known.
+          conn_id (:term:`connection id`): Connection ID of the connection in
+            whose context the error happened. `None` if the error did not
+            happen in context of any connection, or if the connection context
+            was not known.
 
         :ivar args: A tuple (status, reason, cimerror, cimdetails) set from the
             corresponding init arguments.
@@ -133,7 +133,7 @@ class HTTPError(Error):
         if cimdetails is None:
             cimdetails = {}
         super(HTTPError, self).__init__(
-            status, reason, cimerror, cimdetails, conn=conn)
+            status, reason, cimerror, cimdetails, conn_id=conn_id)
 
     @property
     def status(self):
@@ -237,7 +237,7 @@ class CIMError(Error):
     """
 
     # pylint: disable=super-init-not-called
-    def __init__(self, status_code, status_description=None, conn=None):
+    def __init__(self, status_code, status_description=None, conn_id=None):
         """
         Parameters:
 
@@ -248,15 +248,16 @@ class CIMError(Error):
             describing the error. `None`, if the server did not return
             a description text.
 
-          conn (:class:`~pywbem.WBEMConnection`): Connection in whose context
-            the error happened. `None` if the error did not happen in context
-            of any connection, or if the connection context was not known.
+          conn_id (:term:`connection id`): Connection ID of the connection in
+            whose context the error happened. `None` if the error did not
+            happen in context of any connection, or if the connection context
+            was not known.
 
         :ivar args: A tuple (status_code, status_description) set from the
             corresponding init arguments.
         """
         super(CIMError, self).__init__(
-            status_code, status_description, conn=conn)
+            status_code, status_description, conn_id=conn_id)
 
     @property
     def status_code(self):

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -29,7 +29,50 @@ __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
 
 class Error(Exception):
     """Base class for pywbem specific exceptions."""
-    pass
+
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters:
+
+          conn (:class:`~pywbem.WBEMConnection`): Must be a keyword argument.
+            Connection in whose context the error happened. Omitted or `None`
+            if the error did not happen in context of any connection, or if the
+            connection context was not known.
+
+          Any other positional arguments or keyword arguments are passed to
+          :exc:`py:Exception`.
+        """
+        if 'conn' in kwargs:
+            conn = kwargs['conn']
+            del kwargs['conn']
+        else:
+            conn = None
+        super(Error, self).__init__(*args, **kwargs)
+        self._conn = conn
+
+    @property
+    def conn(self):
+        """
+        :class:`~pywbem.WBEMConnection`: Connection in whose context
+        the error happened. `None` if the error did not happen in context
+        of any connection, or if the connection context was not known.
+        """
+        return self._conn
+
+    @property
+    def conn_str(self):
+        """
+        :term:`unicode string`: String that identifies the connection in
+        exception messages.
+        """
+        conn_id = self.conn.conn_id if self.conn else None
+        ret_str = "Connection id: %s" % conn_id
+        return ret_str
+
+    def __str__(self):
+        error_str = super(Error, self).__str__()
+        ret_str = "%s, %s" % (error_str, self.conn_str)
+        return ret_str
 
 
 class ConnectionError(Error):
@@ -58,7 +101,8 @@ class HTTPError(Error):
     """
 
     # pylint: disable=super-init-not-called
-    def __init__(self, status, reason, cimerror=None, cimdetails=None):
+    def __init__(self, status, reason, cimerror=None, cimdetails=None,
+                 conn=None):
         """
         Parameters:
 
@@ -67,7 +111,7 @@ class HTTPError(Error):
           reason (:term:`string`): HTTP reason phrase (e.g.
             "Internal Server Error").
 
-          cimerror (:term:`string`): Value of the `CIMError` header field,
+          cimerror (:term:`string`): Value of the `CIMError` HTTP header field,
             if present. `None`, otherwise.
 
           cimdetails (dict): Dictionary with CIMOM-specific header
@@ -78,10 +122,18 @@ class HTTPError(Error):
             * Value: header field value (i.e. text message)
 
             Passing `None` will result in an empty dictionary.
+
+          conn (:class:`~pywbem.WBEMConnection`): Connection in whose context
+            the error happened. `None` if the error did not happen in context
+            of any connection, or if the connection context was not known.
+
+        :ivar args: A tuple (status, reason, cimerror, cimdetails) set from the
+            corresponding init arguments.
         """
         if cimdetails is None:
             cimdetails = {}
-        self.args = (status, reason, cimerror, cimdetails)
+        super(HTTPError, self).__init__(
+            status, reason, cimerror, cimdetails, conn=conn)
 
     @property
     def status(self):
@@ -104,7 +156,7 @@ class HTTPError(Error):
     @property
     def cimerror(self):
         """
-        :term:`string`: Value of `CIMError` header field in response, if
+        :term:`string`: Value of `CIMError` HTTP header field in response, if
         present. `None`, otherwise.
 
         See :term:`DSP0200` for a list of values.
@@ -128,6 +180,7 @@ class HTTPError(Error):
             ret_str += ", CIMError: %s" % self.cimerror
         for key in self.cimdetails:
             ret_str += ", %s: %s" % (key, self.cimdetails[key])
+        ret_str += ", %s" % self.conn_str
         return ret_str
 
 
@@ -184,7 +237,7 @@ class CIMError(Error):
     """
 
     # pylint: disable=super-init-not-called
-    def __init__(self, status_code, status_description=None):
+    def __init__(self, status_code, status_description=None, conn=None):
         """
         Parameters:
 
@@ -195,10 +248,15 @@ class CIMError(Error):
             describing the error. `None`, if the server did not return
             a description text.
 
+          conn (:class:`~pywbem.WBEMConnection`): Connection in whose context
+            the error happened. `None` if the error did not happen in context
+            of any connection, or if the connection context was not known.
+
         :ivar args: A tuple (status_code, status_description) set from the
-              corresponding init arguments.
+            corresponding init arguments.
         """
-        self.args = (status_code, status_description)
+        super(CIMError, self).__init__(
+            status_code, status_description, conn=conn)
 
     @property
     def status_code(self):
@@ -239,4 +297,6 @@ class CIMError(Error):
         return self.args[1] or _statuscode2string(self.status_code)
 
     def __str__(self):
-        return "%s: %s" % (self.status_code, self.status_description)
+        ret_str = "%s: %s, %s" % (self.status_code, self.status_description,
+                                  self.conn_str)
+        return ret_str

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2029,6 +2029,7 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         """
 
         self.conn = conn
+        self.conn_id = conn.conn_id if conn is not None else None
         self.class_names = {}
         self.qualifiers = {}
         self.instances = {}
@@ -2091,7 +2092,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         called, and is therefore not implemented.
         """
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def ModifyInstance(self, *args, **kwargs):
         """This method is used by the MOF compiler only in the course of
@@ -2100,7 +2103,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         method is never called, and is therefore not implemented.
         """
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def CreateInstance(self, *args, **kwargs):
         """Create a CIM instance in the local repository of this class.
@@ -2121,7 +2126,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         repository), and never by the MOF compiler, and is therefore not
         implemented."""
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def GetClass(self, *args, **kwargs):
         """Retrieve a CIM class from the local repository of this class.
@@ -2167,7 +2174,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         is never called, and is therefore not implemented.
         """
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def CreateClass(self, *args, **kwargs):
         """Create a CIM class in the local repository of this class.
@@ -2209,12 +2218,13 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                                   IncludeQualifiers=True)
                 except CIMError as ce:
                     if ce.status_code == CIM_ERR_NOT_FOUND:
-                        raise CIMError(CIM_ERR_INVALID_PARAMETER,
-                                       'Class %r referenced by element '
-                                       '%r of class %r in namespace '
-                                       '%r does not exist' %
-                                       (obj.reference_class, obj.name,
-                                        cc.classname, self.getns()))
+                        raise CIMError(
+                            CIM_ERR_INVALID_PARAMETER,
+                            "Class %r referenced by element %r of class %r in "
+                            "namespace %r does not exist" %
+                            (obj.reference_class, obj.name, cc.classname,
+                             self.getns()),
+                            conn_id=self.conn_id)
                     raise
 
             elif obj.type == 'string':
@@ -2231,7 +2241,8 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                                 'qualifier on element %r of class %r in '
                                 'namespace %r does not exist' %
                                 (eiqualifier.value, obj.name,
-                                 cc.classname, self.getns()))
+                                 cc.classname, self.getns()),
+                                conn_id=self.conn_id)
                         raise
 
         # TODO #991: CreateClass should reject if the class already exists
@@ -2245,7 +2256,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         repository), and never by the MOF compiler, and is therefore not
         implemented."""
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def EnumerateQualifiers(self, *args, **kwargs):
         """Enumerate the qualifier types in the local repository of this class.
@@ -2276,7 +2289,8 @@ class MOFWBEMConnection(BaseRepositoryConnection):
             qual = self.qualifiers[self.default_namespace][qualname]
         except KeyError:
             if self.conn is None:
-                raise CIMError(CIM_ERR_NOT_FOUND, qualname)
+                raise CIMError(
+                    CIM_ERR_NOT_FOUND, qualname, conn_id=self.conn_id)
             qual = self.conn.GetQualifier(*args, **kwargs)
         return qual
 
@@ -2300,7 +2314,9 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         repository), and never by the MOF compiler, and is therefore not
         implemented."""
 
-        raise CIMError(CIM_ERR_FAILED, 'This should not happen!')
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def rollback(self, verbose=False):
         """

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -174,6 +174,7 @@ class TestGetRsltParams(object):
         Test combminations of IRETURNVALUE, EOS and EnumerationContext for
         both good and fail responses.
         """
+        conn = WBEMConnection('http://localhost')
         result = [
             (u'IRETURNVALUE', {}, irval),
             (u'EnumerationContext', None, ec),
@@ -183,14 +184,14 @@ class TestGetRsltParams(object):
         if exc_exp:
             with pytest.raises(CIMError) as exec_info:
                 # pylint: disable=protected-access
-                result = WBEMConnection._get_rslt_params(result, 'root/blah')
+                result = conn._get_rslt_params(result, 'root/blah')
 
             exc = exec_info.value
             assert exc.status_code_name == 'CIM_ERR_INVALID_PARAMETER'
 
         else:
             # pylint: disable=protected-access
-            result = WBEMConnection._get_rslt_params(result, 'root/blah')
+            result = conn._get_rslt_params(result, 'root/blah')
             # the _get_rslt_params method sets context to None if eos True
             ecs = None if eos_exp is True else (ec, 'root/blah')
             assert result == (irval, eos_exp, ecs)
@@ -201,12 +202,13 @@ class TestGetRsltParams(object):
         Test both Enum context and EndOfSequence completely missing.
         Generates exception
         """
+        conn = WBEMConnection('http://localhost')
         result = [
             (u'IRETURNVALUE', {}, {})
         ]
         with pytest.raises(CIMError) as exec_info:
             # pylint: disable=protected-access
-            result = WBEMConnection._get_rslt_params(result, 'namespace')
+            result = conn._get_rslt_params(result, 'namespace')
 
         exc = exec_info.value
         assert exc.status_code_name == 'CIM_ERR_INVALID_PARAMETER'

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -12,9 +12,11 @@ import pytest
 from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError,\
     ParseError, VersionError, CIMError
 
-
 def _assert_subscription(exc):
-    """Test the exception defined by exc for required args"""
+    """
+    Test the exception defined by exc for required args.
+    """
+
     # Access by subscription is only supported in Python 2:
     if six.PY2:
         assert exc[:] == exc.args
@@ -38,35 +40,47 @@ def _assert_subscription(exc):
                 assert False, "Access by index did not fail in Python 3"
 
 
-# The exception classes for which the simple test should be done:
 @pytest.fixture(params=[
-    Error, ConnectionError, AuthError, TimeoutError, ParseError, VersionError
+    # The exception classes for which the simple test should be done:
+    Error,
+    ConnectionError,
+    AuthError,
+    TimeoutError,
+    ParseError,
+    VersionError,
 ], scope='module')
 def simple_class(request):
-    """Return request.param as defined by the fixture. Representing
-       the exception classes.
+    """
+    Fixture representing variations of the simple exception classes.
+
+    Returns the exception class.
     """
     return request.param
 
 
-# The init arguments for the simple exception classes:
 @pytest.fixture(params=[
+    # Tuple of positional init arguments for the simple exception classes
     (),
+    ('',),
     ('foo',),
     ('foo', 42),
 ], scope='module')
 def simple_args(request):
-    """Return request.param defined by the pytest.fixture
-       representing arguments for the exception class
+    """
+    Fixture representing variations of positional init arguments for the simple
+    exception classes.
+
+    Returns a tuple of positional arguments for initializing an exception
+    object.
     """
     return request.param
 
 
 def test_simple(simple_class, simple_args):
-    """Test exceptions classes and arguments using the
-      testfixtures.
-    """
     # pylint: disable=redefined-outer-name
+    """
+    Test the simple exception classes.
+    """
 
     exc = simple_class(*simple_args)
 
@@ -81,22 +95,31 @@ def test_simple(simple_class, simple_args):
     _assert_subscription(exc)
 
 
-# The init arguments for the HTTPError exception class:
 @pytest.fixture(params=[
+    # The init arguments for the HTTPError exception class:
     # (status, reason, cimerror=None, cimdetails={})
+    # Note: cimerror is the CIMError HTTP header field
     (200, 'OK'),
     (404, 'Not Found', 'instance xyz not found'),
-    (404, 'Not Found', 'instance xyz not found', 'foo'),
+    (404, 'Not Found', 'instance xyz not found', {'foo': 'bar'}),
 ], scope='module')
 def httperror_args(request):
-    """Returns init arguments for the HTTPError exception class as
-       pytest.fixture
+    """
+    Fixture representing variations of positional init arguments for the
+    HTTPError exception class.
+
+    Returns a tuple of positional arguments for initializing a HTTPError
+    exception object.
     """
     return request.param
 
 
-def test_httperror(httperror_args):  # pylint: disable=redefined-outer-name
-    """Test httperror arguments from test fixture"""
+def test_httperror(httperror_args):
+    # pylint: disable=redefined-outer-name
+    """
+    Test HTTPError exception class.
+    """
+
     exc = HTTPError(*httperror_args)
 
     assert exc.status == httperror_args[0]
@@ -119,8 +142,8 @@ def test_httperror(httperror_args):  # pylint: disable=redefined-outer-name
     _assert_subscription(exc)
 
 
-# The CIM status codes for the CIMError exception class:
 @pytest.fixture(params=[
+    # The CIM status codes for the CIMError exception class:
     # (code, name)
     # Note: We don't test the exact default description text.
     # Note: name = None means that the status code is invalid.
@@ -157,16 +180,23 @@ def test_httperror(httperror_args):  # pylint: disable=redefined-outer-name
     (30, None),
 ], scope='module')
 def status_tuple(request):
-    """pytest.fixture returns status codes for CIMError
-       exception
+    """
+    Fixture representing variations of CIM status codes for initializing a
+    CIMError exception class.
+
+    Returns a tuple of positional arguments for initializing a CIMError
+    exception object.
     """
     return request.param
 
 
-def test_cimerror_1(status_tuple):  # pylint: disable=redefined-outer-name
-    """Test cimerror"""
-    status_code = status_tuple[0]
-    status_code_name = status_tuple[1]
+def test_cimerror_1(status_tuple):
+    # pylint: disable=redefined-outer-name
+    """
+    Test CIMError exception class with just status_code as input.
+    """
+
+    status_code, status_code_name = status_tuple
 
     invalid_code_name = 'Invalid status code %s' % status_code
     invalid_code_desc = 'Invalid status code %s' % status_code
@@ -188,14 +218,15 @@ def test_cimerror_1(status_tuple):  # pylint: disable=redefined-outer-name
     _assert_subscription(exc)
 
 
-def test_cimerror_2(status_tuple):  # pylint: disable=redefined-outer-name
-    """Test cimerror status tuple from date in status-tuple fixture"""
+def test_cimerror_2(status_tuple):
+    # pylint: disable=redefined-outer-name
+    """
+    Test CIMError exception class with status_code and description as input.
+    """
 
-    status_code = status_tuple[0]
-    status_code_name = status_tuple[1]
+    status_code, status_code_name = status_tuple
 
     invalid_code_name = 'Invalid status code %s' % status_code
-
     input_desc = 'foo'
 
     exc = CIMError(status_code, input_desc)

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -828,8 +828,10 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
     def test_stage_result_exception(self, lc):
         """Test the ops result log None return, HTTPError exception."""
         self.recorder_setup(detail_level=10)
-        ce = CIMError(6, "Fake CIMError")
-        exc = HTTPError(500, "Fake Reason", cimerror='%s' % ce)
+
+        # Note: cimerror is the CIMError HTTP header field
+        exc = HTTPError(500, "Fake Reason", cimerror="Fake CIMError")
+
         self.test_recorder.stage_pywbem_result(None, exc)
 
         lc.check(
@@ -840,21 +842,15 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
     def test_stage_result_exception_all(self, lc):
         """Test the ops result log None return, HTTPError exception."""
         self.recorder_setup(detail_level='all')
-        ce = CIMError(6, "Fake CIMError")
-        exc = HTTPError(500, "Fake Reason", cimerror='%s' % ce)
+
+        # Note: cimerror is the CIMError HTTP header field
+        exc = HTTPError(500, "Fake Reason", cimerror="Fake CIMError")
+
         self.test_recorder.stage_pywbem_result(None, exc)
 
-        # TODO. V2 valid string has extra single quote after CIMError
-        if six.PY2:
-            lc.check(
-                ("pywbem.api.test_id", "DEBUG",
-                 "Exception:test_id None('HTTPError(500 (Fake Reason), "
-                 "CIMError: 6: Fake CIMError)')"),)
-        else:
-            lc.check(
-                ("pywbem.api.test_id", "DEBUG",
-                 "Exception:test_id None('HTTPError(500 (Fake Reason), "
-                 "CIMError: 6: Fake CIMError)')"),)
+        lc.check(
+            ("pywbem.api.test_id", "DEBUG",
+             "Exception:test_id None('HTTPError(%s)')" % exc),)
 
     @log_capture()
     def test_stage_getinstance_args(self, lc):
@@ -1418,8 +1414,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "classname=u'CIM_Foo', keybindings=NocaseDict([('Chicken', "
                  "u'Ham')]), namespace=u'root/cimv2', host=u'woot.com'))"),
                 ("pywbem.api.test_id", "DEBUG",
-                 "Exception:test_id GetInstance('CIMError(6: Fake "
-                 "CIMError)')"),)
+                 "Exception:test_id GetInstance('CIMError(%s)')" % exc),)
         else:
             lc.check(
                 ("pywbem.api.test_id", "DEBUG",
@@ -1427,8 +1422,7 @@ class LogOperationRecorderTests(BaseLogOperationRecorderTests):
                  "classname='CIM_Foo', keybindings=NocaseDict([('Chicken', "
                  "'Ham')]), namespace='root/cimv2', host='woot.com'))"),
                 ("pywbem.api.test_id", "DEBUG",
-                 "Exception:test_id GetInstance('CIMError(6: Fake "
-                 "CIMError)')"),)
+                 "Exception:test_id GetInstance('CIMError(%s)')" % exc),)
 
     @log_capture()
     def test_getinstance_result_all(self, lc):


### PR DESCRIPTION
Ready for review and merge.
What is needed for this PR, is a test on a life server.

The first three commits implement having the connection information in the pywbem exceptions, plus some preparatory changes. Each of these three commits is separate logical step and is best reviewed separately. They were part of the first review.

Compared to the first review, I had to change the connection information that is added to the pywbem exceptions, from adding the entire WBEMConnection object, to adding just the connection ID string. Reason was that in cim_http.py, the connection ID was available but not the connection object, and I did not want to change that there. This change in the exception classes (to take the connection ID string instead of the WBEMConnection object) is done in the fourth commit in this PR.

The fifth commit changes the places that raise pywbem exceptions to pass the connection ID to the exceptions, including some changes that were needed in support of that such as changing a static method to become an instance method.

The following pywbem exceptions that are raised do not get the connection ID passed as part of this PR:

* Parse errors in CIM-XML responses received from a WBEM server are raised as pywbem.ParseError exceptions and they do not have the connection ID. Reason is that adding the connection ID there is difficult to impossible, because in tupleparse we have flat functions whose interface is determined by our use of PLY.
* Pywbem exceptions raised in the pywbem listener do not have the connection ID. Reason is that for the listener, we don't have a concept of a connection ID.