### PR TITLE
Fixes #1292 Added type check to MOFCompiler init for search_args

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -157,6 +157,9 @@ Released: not yet
   pbr importing when running certain make targets in a freshly created
   Python environment. Issue #1288.
 
+* In `MOFCompiler.__init__()`, added a type check for the search_paths parameter
+  to avoid accidential passing of a single string. Issue #1292.
+
 **Cleanup**
 
 * Moved class `NocaseDict` into its own module (Issue #848).

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2406,7 +2406,12 @@ class MOFCompiler(object):
         """
 
         self.parser = _yacc(verbose)
-        self.parser.search_paths = search_paths if search_paths else []
+        if search_paths is None:
+            search_paths = []
+        if not isinstance(search_paths, (list, tuple)):
+            raise TypeError("search_paths parameter must be list or tuple, "
+                            "but is: %s" % type(search_paths))
+        self.parser.search_paths = search_paths
         self.handle = handle
         self.parser.handle = handle
         self.lexer = _lex(verbose)


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.