### PR TITLE
0.12: Fixed IndexError in tomof() of some CIM objects on empty array value

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,13 @@ Released: 2018-05-18
   class repository there is also an instance repository even if it
   is empty. See issue #1253
 
+* Fixed issue where the `tomof()` methods of `CIMProperty`, `CIMQualifier`,
+  and `CIMQualifierDeclaration` raised `IndexError` when the value was
+  an empty array. This issue perculated up to higher level CIM objects
+  that are using these objects, i.e. `CIMInstance` or `CIMClass`.
+  Added according testcases.
+  See issue #1312.
+
 **Enhancements:**
 
 * Docs: Clarified that the `copy()` methods of `NocaseDict` and of the CIM object

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -5144,7 +5144,8 @@ class CIMProperty(_CIMComparisonMixin):
                 val_str, line_pos = _value_tomof(
                     self.value, self.type, indent + MOF_INDENT, maxline,
                     line_pos + 1, 1, True)
-                if val_str[0] != '\n':
+                # Empty arrays are represented as val_str=''
+                if val_str and val_str[0] != '\n':
                     # The extra space was actually needed
                     mof.append(u' ')
                 else:
@@ -5160,6 +5161,7 @@ class CIMProperty(_CIMComparisonMixin):
                 val_str, line_pos = _value_tomof(
                     self.value, self.type, indent + MOF_INDENT, maxline,
                     line_pos + 1, 1, True)
+                # Scalars cannot be represented as val_str=''
                 if val_str[0] != '\n':
                     # The extra space was actually needed
                     mof.append(u' ')
@@ -6962,7 +6964,8 @@ class CIMQualifier(_CIMComparisonMixin):
         # Assume in line_pos that the extra space would be needed
         val_str, line_pos = _value_tomof(
             self.value, self.type, indent, maxline, line_pos + 1, 3, True)
-        if val_str[0] != '\n':
+        # Empty arrays are represented as val_str=''
+        if val_str and val_str[0] != '\n':
             # The extra space was actually needed
             mof.append(u' ')
         else:

--- a/testsuite/test_cim_obj.py
+++ b/testsuite/test_cim_obj.py
@@ -11323,6 +11323,19 @@ class Test_CIMProperty_tomof(object):
             None, True
         ),
         (
+            "instance uint32 array property, empty array",
+            CIMProperty(
+                name='P1',
+                value=list(),
+                type='uint32',
+                is_array=True,
+            ),
+            True, 12,
+            u"""\
+            P1 = { };\n""",
+            None, CHECK_0_12_0
+        ),
+        (
             "instance uint32 array property, single-line",
             CIMProperty(
                 name='P1',
@@ -14737,6 +14750,17 @@ class Test_CIMQualifier_tomof(object):  # pylint: disable=too-few-public-methods
             if CHECK_0_12_0 else \
             u"""Q1 ("vt=\\f,cr=\\r")""",
             None, True
+        ),
+        (
+            "string array that is empty",
+            CIMQualifier(
+                name='Q1',
+                value=[],
+                type='string',
+            ),
+            12,
+            u"""Q1 { }""",
+            None, CHECK_0_12_0
         ),
         (
             "string array with a value of two items",
@@ -28504,6 +28528,21 @@ Qualifier Q1 : datetime = "20140924193040.654321+120",
 Qualifier Q1 : datetime = 20140924193040.654321+120,
     Scope();""",
             None, True
+        ),
+        (
+            "string array of variable size that has an empty array value",
+            CIMQualifierDeclaration(
+                name='Q1',
+                type='string',
+                is_array=True,
+                array_size=None,
+                value=[],
+            ),
+            u"""\
+Qualifier Q1 : string[] = {  },
+    Scope();
+""",
+            None, CHECK_0_12_0
         ),
         (
             "string array of variable size",


### PR DESCRIPTION
This PR rolls back PR #1313 into pywbem 0.12.