### PR TITLE
Issue #1332 Add ExecQuery Operation to wbemcli as shortcut eqy.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -224,6 +224,8 @@ This version contains all fixes up to pywbem 0.12.4.
   disabled with a new pywbem config variable `AUTO_GENERATE_SFCB_UEP_HEADER`.
   See issue #1326.
 
+* Add support for ExecQuery (shortcut eqy) to wbemcli. See issue # 1332.
+
 **Cleanup:**
 
 * Added connection information to all pywbem exceptions. This is done via a

--- a/testsuite/test_wbemcli.py
+++ b/testsuite/test_wbemcli.py
@@ -25,6 +25,9 @@
     where each test is a call to execute wbemcli with a particular set of
     arguments and options. It then tests the stdout, stderr, and exitcode
     against the TEST_MAP.
+
+    This test does not test the individual operations that can be executed,
+    just the initialization components for wbemcli
 """
 
 from __future__ import print_function, absolute_import

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -38,6 +38,7 @@ Function               WBEM operation
 :func:`~wbemcli.r`     References
 :func:`~wbemcli.rn`    ReferenceNames
 :func:`~wbemcli.im`    InvokeMethod
+:func:`~wbemcli.eqy`   ExecQuery
 ---------------------  --------------------------------------------------------
 :func:`~wbemcli.iei`   IterEnumerateInstances (pywbem only)
 :func:`~wbemcli.ieip`  IterEnumerateInstancePaths (pywbem only)
@@ -934,6 +935,45 @@ def im(mn, op, params, **kwparams):
     return CONN.InvokeMethod(mn, op, params, **kwparams)
 
 
+def eqy(ql, qs, ns=None,):
+    """
+    *New in pywbem 0.12*
+
+    This function is a wrapper for :meth:`~pywbem.WBEMConnection.ExecQuery`.
+
+    Execute a query in a namespace.
+
+    Parameters:
+
+      ql (:term:`string`):
+          Name of the query language used in the `qs` parameter, e.g.
+          "DMTF:CQL" for CIM Query Language, and "WQL" for WBEM Query
+          Language. Because this is not a filter query, "DMTF:FQL" is not a
+          valid query language for this request.
+
+      qs (:term:`string`):
+          Query string in the query language specified in the `ql` parameter.
+
+      ns (:term:`string`):
+          Name of the CIM namespace to be used (case independent).
+
+          If `None`, defaults to the default namespace of the connection.
+
+    Returns:
+
+        A list of :class:`~pywbem.CIMInstance` objects that represents
+        the query result.
+
+        These instances have their `path` attribute set to identify
+        their creation class and the target namespace of the query, but
+        they are not addressable instances.
+    """  # noqa: E501
+
+    return CONN.ExecQuery(QueryLanguage=ql,
+                          Query=qs,
+                          namespace=ns)
+
+
 def iei(cn, ns=None, lo=None, di=None, iq=None, ico=None, pl=None, fl=None,
         fs=None, ot=None, coe=None, moc=DEFAULT_ITER_MAXOBJECTCOUNT,):
     # pylint: disable=too-many-arguments, redefined-outer-name
@@ -1603,7 +1643,7 @@ def iqi(ql, qs, ns=None, rc=None, ot=None, coe=None,
     Parameters:
 
       ql (:term:`string`):
-          Name of the query language used in the `q` parameter, e.g.
+          Name of the query language used in the `qs` parameter, e.g.
           "DMTF:CQL" for CIM Query Language, and "WQL" for WBEM Query
           Language. Because this is not a filter query, "DMTF:FQL" is not a
           valid query language for this request.
@@ -2948,6 +2988,7 @@ Global functions for WBEM operations:
   r                References
   rn               ReferenceNames
   im               InvokeMethod
+  eqy              ExecQuery
 
   iei              IterEnumerateInstances
   ieip             IterEnumerateInstancePaths


### PR DESCRIPTION
Somewhere we completely forgot this operation.  I only added it because
I needed to test it since we are getting some strange results from
run_cimoperations.py in another pr and I wanted to confirm or discard
that some conclusions.

Note: There is no test since the test_wbemcli.py tests only initialization, etc. not the individual operations.

Add new entry to changes.doc