### PR TITLE
issue #1334 - Fix issue where IterQueryInstances params reversed

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -132,6 +132,9 @@ This version contains all fixes up to pywbem 0.12.4.
   Added according testcases.
   See issue #1312.
 
+* Fix issue in IterQueryInstances where the QueryLanguage and Query parameters
+  were reveresed in the fallback call to ExecQuery method. See issue # 1334.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -5915,8 +5915,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 raise ValueError('ExecQuery does not support '
                                  'ContinueOnError.')
 
-            _instances = self.ExecQuery(FilterQuery,
-                                        FilterQueryLanguage,
+            # The parameters are QueryLanguage and Query for ExecQuery
+            _instances = self.ExecQuery(FilterQueryLanguage,
+                                        FilterQuery,
                                         namespace=namespace, **extra)
 
             rtn = IterQueryInstancesReturn(_instances)

--- a/testsuite/test_itermethods.py
+++ b/testsuite/test_itermethods.py
@@ -1447,20 +1447,13 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
         "ns", [None, 'test/testnamespace']
     )
     @pytest.mark.parametrize(
-        "ql,query", [(None, None), ('CQL', 'SELECT from *')]
+        "ql, query", [(None, None), ('CQL', 'SELECT from *')]
     )
     def test_orig_operation_success(self, use_pull_param, tst_insts, ns,
                                     ql, query):
         # pylint: disable=no-self-use
         """
-            Test Use of IterAssociatorInstances from IterAssociatorInstances.
-            This forces the enumerate by mocking NOT_Supported on the
-            OpenAssociatorInstancess.
-            It is parameterized to test variations on all parameters. Note
-            that it only tests legal parameters.
-
-            It confirms that AssociatorInstances receives the correct parameter
-            for all parameters.
+            Test Use IterQueryInstances using the original ExecQuery op
         """
         conn = WBEMConnection('dummy', use_pull_operations=use_pull_param)
 
@@ -1476,7 +1469,7 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
         q_result = conn.IterQueryInstances(ql, query, namespace=ns)
         result_insts = [inst for inst in q_result.generator]
 
-        conn.ExecQuery.assert_called_with(query, ql, namespace=ns)
+        conn.ExecQuery.assert_called_with(ql, query, namespace=ns)
 
         assert(q_result.query_result_class is None)
         assert(conn._use_query_pull_operations is False)


### PR DESCRIPTION
Fixes issue #1334 where the parameters for QueryLanguage and Query were
reversed in the ExecQuery call that is the fallback if the
OpenQueryInstances fails or use_pull_operations is False.

Also fixes test results for this test (also reversed) and adds comment
to changes.rst