### PR TITLE
Upgraded Win32 OpenSSL from 1.1.0h to 1.1.0i

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -186,7 +186,8 @@ This version contains all fixes up to pywbem 0.12.4.
   `pywbem_os_setup.bat` script. As part of that, the latest `M2Crypto` version
   0.30.1 is now used on Windows, and no longer the somewhat aged versions in
   the `M2CryptoWin32/64` packages. For details, see the installation section
-  in the documentation.
+  in the documentation. That script also downloads and installs Win32 OpenSSL
+  from https://slproweb.com/products/Win32OpenSSL.html.
 
 * Made exception messages more explicit in the ValueMapping and WBEMServer
   classes. Issue #1281.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -293,6 +293,9 @@ environment (i.e. without using a UNIX-like environment; for that, see
   This script will also install the ``M2Crypto`` Python package into the active
   Python environment.
 
+  This script will also install Win32 OpenSSL from
+  https://slproweb.com/products/Win32OpenSSL.html.
+
 * Install pywbem (and its other prerequisite Python packages) into the active
   Python environment:
 

--- a/pywbem_os_setup.bat
+++ b/pywbem_os_setup.bat
@@ -64,10 +64,10 @@ echo Done installing Swig
 
 :: The bit size of Win32/64OpenSSL must match the bit size of the Python env.
 set _WINOPENSSL_BITSIZE=%PYTHON_ARCH%
-set _WINOPENSSL_BASENAME=Win%_WINOPENSSL_BITSIZE%OpenSSL-1_1_0h
-set _WINOPENSSL_INSTALL_DIR=C:\OpenSSL-1-1-0h-Win%_WINOPENSSL_BITSIZE%
+set _WINOPENSSL_BASENAME=Win%_WINOPENSSL_BITSIZE%OpenSSL-1_1_0i
+set _WINOPENSSL_INSTALL_DIR=C:\OpenSSL-1-1-0i-Win%_WINOPENSSL_BITSIZE%
 if exist %_WINOPENSSL_INSTALL_DIR% (
-    echo %_WINOPENSSL_BASENAME% is already installed ... skipping
+    echo %_WINOPENSSL_BASENAME% is already installed in %_WINOPENSSL_INSTALL_DIR% ... skipping
     goto done_winopenssl
 )
 
@@ -78,6 +78,19 @@ echo %_CMD%
 %_CMD%
 set _RC=%errorlevel%
 if not "%_RC%"=="0" goto error1
+
+:: If the web site does not know the file, it returns a HTML page showing an error, and curl succeeds downloading that
+set _CMD=grep "^<html>" %_WINOPENSSL_BASENAME%.exe
+echo %_CMD%
+%_CMD%
+set _RC=%errorlevel%
+if "%_RC%"=="0" (
+    echo Error: The %_WINOPENSSL_BASENAME%.exe file does not exist on https://slproweb.com:
+    cat %_WINOPENSSL_BASENAME%.exe
+    rm %_WINOPENSSL_BASENAME%.exe
+    set _RC=1
+    goto error1
+)
 
 :: Downloaded files may not have the execution right.
 set _CMD=chmod 755 %_WINOPENSSL_BASENAME%.exe


### PR DESCRIPTION
This fixes the recent Appveyor issue where it cannot execute Win32OpenSSL_....exe.
This is needed by all other PRs and therefore has been set to priority.