### PR TITLE
Fixes #1337 Upgraded PyYAML from 3.12 to 3.13

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -252,6 +252,10 @@ This version contains all fixes up to pywbem 0.12.4.
   CIM_Namespace, CIM_ObjectManager existing in the mocked server. See issue
   #1250
 
+* Needed to upgrade PyYAML version from >=3.12 to >=3.13 due to an issue
+  in PyYAML on Python 3.7, that was fixed in PyYAML 3.13.
+  See issue #1337.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -47,7 +47,7 @@ wheel===0.29.0
 pbr===1.10.0
 six===1.10.0
 ply===3.10
-PyYAML===3.12
+PyYAML===3.13
 M2Crypto===0.30.1
 ordereddict===1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 pbr>=1.10.0
 six>=1.10.0
 ply>=3.10
-PyYAML>=3.12  # yaml package
+PyYAML>=3.13  # yaml package
 # On Windows, M2Crypto must be installed via pywbem_os_setup.bat
 M2Crypto>=0.30.1; python_version < '3.0' and sys_platform != 'win32'
 ordereddict>=1.1; python_version == '2.6'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -6,7 +6,7 @@
 pbr>=1.10.0
 six>=1.10.0
 ply>=3.8
-PyYAML>=3.12
+PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.4.9
 sphinx-git>=10.0.0


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

Note, the issue fixed by this only occurs on Python 3.7.
So in our CI runs it only occurs:
- In the manual-ci-run branch.
- In the master branch, once PR #1340 has been merged.
At that point, it becomes relevant for every PR.