### PR TITLE
Fixes #1337 Added support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,16 @@ matrix:
       python: "2.7"
       env:
         - PACKAGE_LEVEL=latest
-    - os: linux
-      language: python
-      python: "3.4"
-      env:
-        - PACKAGE_LEVEL=minimum
 #    - os: linux
 #      language: python
 #      python: "3.4"
 #      env:
-#        - PACKAGE_LEVEL=latest
+#        - PACKAGE_LEVEL=minimum
+    - os: linux
+      language: python
+      python: "3.4"
+      env:
+        - PACKAGE_LEVEL=latest
 #    - os: linux
 #      language: python
 #      python: "3.5"
@@ -75,11 +75,23 @@ matrix:
 #      python: "3.6"
 #      env:
 #        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "3.6"
+#      env:
+#        - PACKAGE_LEVEL=latest
     - os: linux
       language: python
-      python: "3.6"
+      python: "3.7"
+      dist: xenial
       env:
-        - PACKAGE_LEVEL=latest
+        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "3.7"
+#      dist: xenial
+#      env:
+#        - PACKAGE_LEVEL=latest
 # Note: pywbem does not install on pypy, because M2Crypto does not install.
 #    - os: linux
 #      language: python

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pywbem
-Version: 0.12.1.dev59
+Version: 0.12.1.dev70
 Summary: pywbem - A WBEM client
 Home-page: http://pywbem.github.io/pywbem/
 Author: Tim Potter
@@ -44,5 +44,6 @@ Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3.4
 Classifier: Programming Language :: Python :: 3.5
 Classifier: Programming Language :: Python :: 3.6
+Classifier: Programming Language :: Python :: 3.7
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Classifier: Topic :: System :: Systems Administration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,15 @@ environment:
 #    - PYTHON_VERSION: 3.6
 #      PYTHON_ARCH: 32
 #      PYTHON_HOME: C:\Python36
-    - PYTHON_VERSION: 3.6
+#    - PYTHON_VERSION: 3.6
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python36-x64
+#    - PYTHON_VERSION: 3.7
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python37
+    - PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
-      PYTHON_HOME: C:\Python36-x64
+      PYTHON_HOME: C:\Python37-x64
 
 configuration:
 # These values will become the values of the PACKAGE_LEVEL env.var.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,8 +16,8 @@ pytest>=3.3.0; python_version > '2.6'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.8.14,<0.9.1; python_version == '2.6'
-httpretty>=0.8.14; python_version > '2.6'
-lxml>=4.0.0
+httpretty>=0.9.5; python_version > '2.6'
+lxml>=4.2.4
 requests>=2.12.4
 decorator>=4.0.11
 yamlordereddictloader>=0.4.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -238,6 +238,8 @@ This version contains all fixes up to pywbem 0.12.4.
   according to DSP0004, return equal WBEM URI strings.
   See issue #1323.
 
+* Added support for Python 3.7, which was released 2018-06-27.
+
 **Cleanup:**
 
 * Added connection information to all pywbem exceptions. This is done via a
@@ -265,6 +267,10 @@ This version contains all fixes up to pywbem 0.12.4.
   that creates the pywbem_mock for any tests that depend on classes like
   CIM_Namespace, CIM_ObjectManager existing in the mocked server. See issue
   #1250
+
+* Needed to upgrade PyYAML version from >=3.12 to >=3.13 due to an issue
+  in PyYAML on Python 3.7, that was fixed in PyYAML 3.13.
+  See issue #1337.
 
 **Known issues:**
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -98,7 +98,7 @@ Pywbem is supported in these environments:
 * Operating Systems: Linux, Windows (native, and with UNIX-like environments),
   OS-X
 
-* Python: 2.6, 2.7, 3.4, 3.5, 3.6 and higher
+* Python: 2.6, 2.7, 3.4, and higher
 
 * WBEM servers: Any WBEM server that conforms to the DMTF specifications listed
   in :ref:`Standards conformance`. WBEM servers supporting older versions of

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -47,7 +47,7 @@ wheel===0.29.0
 pbr===1.10.0
 six===1.10.0
 ply===3.10
-PyYAML===3.12
+PyYAML===3.13
 M2Crypto===0.30.1
 ordereddict===1.1
 
@@ -63,8 +63,9 @@ pytest===3.0.7; python_version == '2.6'
 pytest===3.3.0; python_version > '2.6'
 testfixtures===4.3.3
 mock===2.0.0
-httpretty===0.8.14
-lxml===4.0.0
+httpretty===0.8.14; python_version == '2.6'
+httpretty===0.9.5; python_version > '2.6'
+lxml===4.2.4
 requests===2.12.4
 decorator===4.0.11
 yamlordereddictloader===0.4.0
@@ -148,7 +149,7 @@ py===1.4.32; python_version == '2.6'
 py===1.5.1; python_version > '2.6'
 Pygments===2.1.3
 pytz===2016.10
-pyzmq===16.0.2
+pyzmq===16.0.4
 qtconsole===4.2.1
 requests===2.12.4
 requests-toolbelt===0.7.0

--- a/pywbem/_nocasedict.py
+++ b/pywbem/_nocasedict.py
@@ -186,9 +186,9 @@ class NocaseDict(object):
                 "%s (1 allowed)" % len(args))
 
         # Step 2: Add any keyword arguments
-        if len(kwargs) > 1 and sys.version_info[0:2] <= (3, 6):
+        if len(kwargs) > 1 and sys.version_info[0:2] < (3, 7):
             warnings.warn("Initializing a pywbem.NocaseDict object from "
-                          "keyword arguments before Python 3.6 will not "
+                          "keyword arguments before Python 3.7 will not "
                           "preserve order of items",
                           UserWarning,
                           stacklevel=_stacklevel_above_module(__name__))

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -626,6 +626,16 @@ class CIMInt(CIMType, _Longint):
     maxvalue = None
 
     def __new__(cls, *args, **kwargs):
+
+        # Python 3.7 removed support for passing the value for int() as a
+        # keyword argument named 'x'. It now needs to be passed as a positional
+        # argument. The testclient test case definitions rely on a keyword
+        # argument, so we now transform the keyword arg into a positional
+        # arg.
+        if 'x' in kwargs:
+            args = list(*args)  # args is passed as a tuple
+            args.append(kwargs.pop('x'))
+
         value = _Longint(*args, **kwargs)
         if ENFORCE_INTEGER_RANGE:
             if value > cls.maxvalue or value < cls.minvalue:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 pbr>=1.10.0
 six>=1.10.0
 ply>=3.10
-PyYAML>=3.12  # yaml package
+PyYAML>=3.13  # yaml package
 # On Windows, M2Crypto must be installed via pywbem_os_setup.bat
 M2Crypto>=0.30.1; python_version < '3.0' and sys_platform != 'win32'
 ordereddict>=1.1; python_version == '2.6'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -6,7 +6,7 @@
 pbr>=1.10.0
 six>=1.10.0
 ply>=3.8
-PyYAML>=3.12
+PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.4.9
 sphinx-git>=10.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ classifier =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: System :: Systems Administration
 

--- a/testsuite/test_nocasedict.py
+++ b/testsuite/test_nocasedict.py
@@ -4,6 +4,7 @@ Test the _nocasedict module.
 
 from __future__ import absolute_import
 
+import sys
 import re
 import six
 try:
@@ -149,7 +150,7 @@ TESTCASES_NOCASEDICT_INIT = [
             exp_dict=OrderedDict([('Dog', 'Cat'), ('Budgie', 'Fish')]),
             verify_order=False,
         ),
-        None, UserWarning, True
+        None, UserWarning if sys.version_info[0:2] < (3, 7) else None, True
     ),
     (
         "Dict from list as positional arg and keyword args",


### PR DESCRIPTION
Python 3.7 has been released on 2018-06-28. This PR adds Python 3.7 support to pywbem, and also fixes #1337 as part of that.
Ready for review and merge.