### PR TITLE
Fixes #1347 Fixed missing VALUE.OBJETWTHLOCALPATH in IRETURNVALUE

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -135,6 +135,11 @@ This version contains all fixes up to pywbem 0.12.4.
 * Fix issue in IterQueryInstances where the QueryLanguage and Query parameters
   were reveresed in the fallback call to ExecQuery method. See issue # 1334.
 
+* Fixed the issue that the VALUE.OBJECTWITHLOCALPATH element was not allowed
+  as a child element under IRETURNVALUE. This element is used as one
+  possibility for the result of the ExecQuery operation.
+  See issue #1347.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -1943,6 +1943,7 @@ class TupleParser(object):
         values = self.list_of_same(tup_tree,
                                    ['CLASSNAME', 'INSTANCENAME', 'VALUE',
                                     'VALUE.OBJECTWITHPATH',
+                                    'VALUE.OBJECTWITHLOCALPATH',
                                     'VALUE.OBJECT', 'OBJECTPATH',
                                     'QUALIFIER.DECLARATION', 'VALUE.ARRAY',
                                     'VALUE.REFERENCE', 'CLASS', 'INSTANCE',


### PR DESCRIPTION
Testcases have not been added at this point, there was an existing TODO to add testcases for IRETURNVALUE.

For details, see the commit message.
Ready for review and merge.