### PR TITLE
Added passing WBEMConnection as handle to MOFCompiler

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -268,12 +268,15 @@ This version contains all fixes up to pywbem 0.12.4.
 * Added support for CIM namespace creation via a new
   `WBEMServer.create_namespace()` method. See issue #29.
 
-**Cleanup:**
-
 * Added connection information to all pywbem exceptions. This is done via a
   new optional `conn_id` keyword argument that was added to all pywbem
   exception classes. The exception message now has a connection information
   string at its end. See issue #1155.
+
+* Added support for passing a `WBEMConnection` object for the handle
+  parameter of the `MOFCompiler` creation. This allows a user to pass
+  the WBEM connection directly as a CIM repository, without first having
+  to create a MOFWBEMConnection object.
 
 **Cleanup:**
 

--- a/testsuite/test_logging.py
+++ b/testsuite/test_logging.py
@@ -511,3 +511,6 @@ class TestLoggerPropagate(object):
             assert re.match(r'.*-pywbem.*-Connection:', pkg_line)
         else:
             assert pkg_line == ''
+
+        # Clean up the Python logging configuration
+        configure_logger(short_name, connection=False)

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -24,6 +24,7 @@ from pywbem.cim_obj import CIMClass, CIMProperty, CIMQualifier, \
     CIMQualifierDeclaration, CIMDateTime, CIMInstanceName
 from pywbem import mof_compiler
 from pywbem._nocasedict import NocaseDict
+from pywbem_mock import FakedWBEMConnection
 
 from unittest_extensions import CIMObjectMixin
 
@@ -82,6 +83,37 @@ class MOFTest(unittest.TestCase):
         if self.partial_schema_file:
             if os.path.exists(self.partial_schema_file):
                 os.remove(self.partial_schema_file)
+
+
+class Test_MOFCompiler_init(unittest.TestCase):
+    """Test the MOFCompiler initialization"""
+
+    def test_handle_repo_connection(self):
+        """Test init with a handle that is a MOFWBEMConnection"""
+
+        handle = MOFWBEMConnection()
+
+        mofcomp = MOFCompiler(handle)
+
+        self.assertIs(mofcomp.handle, handle)
+
+    def test_handle_wbem_connection(self):
+        """Test init with a handle that is a WBEMConnection"""
+
+        conn = FakedWBEMConnection()
+
+        mofcomp = MOFCompiler(conn)
+
+        self.assertIsInstance(mofcomp.handle, MOFWBEMConnection)
+        self.assertIs(mofcomp.handle.conn, conn)
+
+    def test_handle_invalid(self):
+        """Test init with a handle that is an invalid type"""
+
+        invalid = "boo"
+
+        with self.assertRaises(TypeError):
+            MOFCompiler(invalid)
 
 
 class TestInstancesUnicode(MOFTest):


### PR DESCRIPTION
This extension is necessary as a basis for using WBEMServer.create_namespace() in MOFCompiler (see PR #1339).

For details, see the commit message.
Ready for review and merge.