### PR TITLE
Ks/run cimoperations add createnstest

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -476,6 +476,9 @@ References
    DSP1054
       `DMTF DSP1054, Indications Profile, Version 1.2 <http://www.dmtf.org/standards/published_documents/DSP1054_1.2.pdf>`_
 
+   DSP1092
+      `DMTF DSP1092, WBEM Server Profile, Version 1.0 <http://www.dmtf.org/standards/published_documents/DSP1092_1.0.pdf>`_
+
    X.509
       `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <http://www.itu.int/rec/T-REC-X.509/en>`_
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -265,6 +265,9 @@ This version contains all fixes up to pywbem 0.12.4.
   Extended the testcases for CreateInstance accordingly.
   See issue #1319.
 
+* Added support for CIM namespace creation via a new
+  `WBEMServer.create_namespace()` method. See issue #29.
+
 **Cleanup:**
 
 * Added connection information to all pywbem exceptions. This is done via a

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1496,8 +1496,8 @@ class FakedWBEMConnection(WBEMConnection):
                                'The class %r defined by "ClassName" parameter '
                                'does not exist in namespace %r' %
                                (classname, namespace))
-        cns = self._get_subclass_names(classname, namespace,
-                                       params['DeepInheritance'])
+        clns = self._get_subclass_names(classname, namespace,
+                                        params['DeepInheritance'])
 
         # Note: _get_class will return NOT_FOUND if the class not in the
         # repo but it was just found by _get_subclass_names so that would
@@ -1507,7 +1507,7 @@ class FakedWBEMConnection(WBEMConnection):
                             local_only=params['LocalOnly'],
                             include_qualifiers=params['IncludeQualifiers'],
                             include_classorigin=params['IncludeClassOrigin'])
-            for cn in cns]
+            for cn in clns]
 
         return self._make_tuple(classes)
 
@@ -1948,6 +1948,17 @@ class FakedWBEMConnection(WBEMConnection):
             else:
                 raise
 
+        # Handle special classes, currently hard coded.
+        # TODO AM 8/18 Generalize the hard coded handling into provider concept
+        if new_instance.classname.lower() == 'pg_namespace':
+            # These values must match those in testsuite/wbemserver_mock.py
+            new_instance['CreationClassName'] = 'PG_Namespace'
+            new_instance['ObjectManagerName'] = 'MyFakeObjectManager'
+            new_instance['ObjectManagerCreationClassName'] = \
+                'CIM_ObjectManager'
+            new_instance['SystemName'] = 'Mock_Test_WBEMServerTest'
+            new_instance['SystemCreationClassName'] = 'CIM_ComputerSystem'
+
         # Test all key properties in instance. This is our repository limit
         # since the repository cannot add values for key properties. We do
         # no allow creating key properties from class defaults.
@@ -2243,6 +2254,7 @@ class FakedWBEMConnection(WBEMConnection):
 
             CIMError: CIM_ERR_INVALID_NAMESPACE
         """
+
         inst_repo = self._get_instance_repo(namespace)
 
         cname = params['ClassName']

--- a/testsuite/run_cim_operations.py
+++ b/testsuite/run_cim_operations.py
@@ -34,7 +34,8 @@ from pywbem import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, \
     CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_INVALID_QUERY, \
     CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED, CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
-    CIM_ERR_METHOD_NOT_FOUND, DEFAULT_NAMESPACE, MinutesFromUTC
+    CIM_ERR_METHOD_NOT_FOUND, CIM_ERR_ALREADY_EXISTS, DEFAULT_NAMESPACE, \
+    MinutesFromUTC
 
 from pywbem import WBEMConnection, WBEMServer, CIMError, Error, WBEMListener, \
     WBEMSubscriptionManager, CIMInstance, CIMInstanceName, CIMClass, \
@@ -147,7 +148,7 @@ class ClientTest(unittest.TestCase):
         # if log set, enable the logger.
         if self.output_log:
             configure_logger(
-                'http', log_dest='file', log_filename='run_cimoperations.log',
+                'all', log_dest='file', log_filename='run_cimoperations.log',
                 connection=self.conn)
 
         # enable saving of xml for display
@@ -244,7 +245,7 @@ class ClientTest(unittest.TestCase):
             self.cimcall(self.conn.GetClass, PYWBEM_PERSON_CLASS)
             return True
         except CIMError as ce:
-            if ce.status_code == 'CIM_ERROR_NOT_FOUND':
+            if ce.status_code == CIM_ERR_NOT_FOUND:
                 mofcomp = MOFCompiler(handle=self.conn)
                 try:
                     mofcomp.compile_file(PYWBEM_TEST_MOF, self.namespace)
@@ -4502,6 +4503,81 @@ class PyWBEMServerClass(PegasusServerTestBase, RegexpMixin):
         # test getting nothing
         self.assertEqual(len(server.get_selected_profiles('blah', 'blah')), 0)
         self.assertEqual(len(server.get_selected_profiles('blah')), 0)
+
+    def test_create_namespace(self):
+        """Test the creat_namespace method."""
+
+        def delete_namespace(conn, ns_name, interop):
+            """Delete the namespace defined by ns_name"""
+            class_name = 'CIM_Namespace'
+            instances = self.cimcall(self.conn.EnumerateInstances,
+                                     class_name,
+                                     namespace=interop,
+                                     LocalOnly=True)
+            for instance in instances:
+                if test_ns == instance.properties['Name'].value:
+                    try:
+                        self.cimcall(self.conn.DeleteInstance, instance.path)
+                        return
+                    except Exception as ex:
+                        self.fail("Delete of created namespace failed %s " % ex)
+
+            self.fail("new ns %s not found in namespace instances %r" %
+                      (test_ns, instances))
+
+        server = WBEMServer(self.conn)
+        namespaces = server.namespaces
+        interop = server.interop_ns
+        for test_ns in ['root/runcimoperationstestns', 'runcimoperationns']:
+
+            if test_ns in namespaces:
+                self.fail("Test Create Namespace %s already in namespaces %s" %
+                          (test_ns, namespaces))
+
+            server.create_namespace(test_ns)
+
+            assert test_ns in server.namespaces
+            namespaces = server.namespaces
+            interop2 = server.interop_ns
+            assert interop2 == interop
+
+            # test adding a qualifier decl
+            qd = CIMQualifierDeclaration(u'FooQualDecl', 'string',
+                                         is_array=False,
+                                         value='Some string',
+                                         scopes={'CLASS': True},
+                                         overridable=False, tosubclass=False,
+                                         translatable=False, toinstance=False)
+
+            # Create the qualifier declaration in the server
+
+            try:
+                self.cimcall(self.conn.SetQualifier, qd, namespace=test_ns)
+            except CIMError as ce:
+                if ce.args[0] == CIM_ERR_NOT_SUPPORTED:
+                    print('NOTE: This server/namespace does not support '
+                          'SetQualifier since it returned NOT SUPPORTED')
+                    return
+
+            # get the qd and compare with original
+            rtn_qd = self.cimcall(self.conn.GetQualifier, qd.name,
+                                  namespace=test_ns)
+            self.assertEqual(qd, rtn_qd, 'Returned qualifier declaration '
+                             'did not match created')
+
+            self.cimcall(self.conn.DeleteQualifier, qd.name, namespace=test_ns)
+
+            delete_namespace(self.conn, test_ns, interop)
+
+    def test_create_namespace_er(self):
+        """Test error response, namespace exists"""
+        server = WBEMServer(self.conn)
+        interop = server.interop_ns
+        try:
+            server.create_namespace(interop)
+            self.fail("Exception expected")
+        except CIMError as ce:
+            self.assertEqual(ce.status_code, CIM_ERR_ALREADY_EXISTS)
 
 
 ##################################################################

--- a/testsuite/schema/OpenPegasus/PG_Namespace.mof
+++ b/testsuite/schema/OpenPegasus/PG_Namespace.mof
@@ -1,0 +1,7 @@
+// Minimalistic PG_Namespace class for mocking purposes
+
+class PG_Namespace : CIM_Namespace {
+   boolean SchemaUpdatesAllowed = TRUE;
+   boolean IsShareable = FALSE;
+   string ParentNamespace = NULL;
+};

--- a/testsuite/test_wbemserverclass.py
+++ b/testsuite/test_wbemserverclass.py
@@ -28,9 +28,10 @@ from __future__ import absolute_import, print_function
 import os
 import pytest
 
-from pywbem import ValueMapping, CIMInstanceName
+from pywbem import ValueMapping, CIMInstanceName, CIMError
 from pywbem._nocasedict import NocaseDict
 from wbemserver_mock import WbemServerMock
+import pytest_extensions
 
 VERBOSE = True
 
@@ -131,6 +132,85 @@ class TestServerClass(BaseMethodsForTests):
         assert insts[0] == CIMInstanceName('CIM_ObjectManager', keybindings=kb,
                                            namespace=tst_namespace,
                                            host=server.conn.host)
+
+
+TESTCASES_CREATE_NAMESPACE = [
+
+    # Testcases for WBEMServer.create_namespace()
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * new_namespace: Name of the namespace to be created.
+    #   * exp_namespace: Expected returned namespace name.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    (
+        "New top level namespace",
+        dict(
+            new_namespace='abc',
+            exp_namespace=u'abc',
+        ),
+        None, None, True
+    ),
+    (
+        "New top level namespace with leading and trailing slash",
+        dict(
+            new_namespace='/abc/',
+            exp_namespace=u'abc',
+        ),
+        None, None, True
+    ),
+    (
+        "New two-segment namespace with leading and trailing slash",
+        dict(
+            new_namespace='/abc/def/',
+            exp_namespace=u'abc/def',
+        ),
+        None, None, True
+    ),
+    (
+        "New two-segment namespace where first segment already exists",
+        dict(
+            new_namespace='interop/def',
+            exp_namespace=u'interop/def',
+        ),
+        None, None, True
+    ),
+    (
+        "Existing top level namespace",
+        dict(
+            new_namespace='interop',
+            exp_namespace=None,
+        ),
+        CIMError, None, True
+    ),
+
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_CREATE_NAMESPACE)
+@pytest_extensions.simplified_test_function
+def test_create_namespace_2(testcase,
+                            new_namespace, exp_namespace):
+    """
+    Test creation of a namespace using approach 2.
+    """
+
+    mock_wbemserver = WbemServerMock(interop_ns='interop')
+    server = mock_wbemserver.wbem_server
+
+    act_namespace = server.create_namespace(new_namespace)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    assert act_namespace == exp_namespace
 
 
 # TODO Break up tests to do individual tests for each group of methds so we can


### PR DESCRIPTION
This adds the create_namespace tests to run_cim_operations.py.

This replaces a previous pr that was getting too confusing for my brain.  Closed that one.

This is only changes to do the new tests but rebased on andy/#29-add-create-namespace pr # 1318