### PR TITLE
Fixes #1355: Issues with case insensitivity on classnames in pywbem_mock

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pywbem
-Version: 0.12.1.dev89
+Version: 0.12.1.dev94
 Summary: pywbem - A WBEM client
 Home-page: https://pywbem.github.io/pywbem/
 Author: Tim Potter
@@ -8,6 +8,9 @@ Author-email: tpot@hp.com
 Maintainer: Andreas Maier, Karl Schopmeyer
 Maintainer-email: maiera@de.ibm.com, k.schopmeyer@swbell.net
 License: LGPL version 2.1, or (at your option) any later version
+Project-URL: Bug Tracker, https://github.com/pywbem/pywbem/issues
+Project-URL: Documentation, https://pywbem.readthedocs.io/en/latest/
+Project-URL: Source Code, https://github.com/pywbem/pywbem
 Description: .. # README file for Pypi
         
         Pywbem is a WBEM client, written in pure Python. It supports Python 2 and

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -144,6 +144,11 @@ This version contains all fixes up to pywbem 0.12.4.
   EnumerateInstances. It was reporting confused result so we created a simpler
   test. See issue #477.
 
+* Fixed issues in pywbem_mock where classnames on the operation requests were
+  not treated as case insensitive for some operations, in particular the
+  enumerate operations, reference operations, and associator operations. This
+  also adds a number of tests to validate that classnames. See issue #1355.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:


### PR DESCRIPTION
Ready for review

See commit messages for details.  

Note: The changes to the mocker code are minor. The changes to the tests are more significant in that  this adds a significant number of tests and it was easier to rewrite some of the tests rather than to continue to extend them directly.

NOTE: We also cleaned up one issue where we had been using strings to define CIM_ERR... messages in the tests and changed all of that to use the status_code variables directly.
