### PR TITLE
Fixes #477: Poor test in run_cim_operations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -140,6 +140,10 @@ This version contains all fixes up to pywbem 0.12.4.
   possibility for the result of the ExecQuery operation.
   See issue #1347.
 
+* Fixed issue in run_cimoperations.py with test for deep inheritance on
+  EnumerateInstances. It was reporting confused result so we created a simpler
+  test. See issue #477.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:


### PR DESCRIPTION
Ready for review except for python 2.7 failure in getting plugin

Fix test for enumerateinstances deepinheritance option.

Original test could not really test enumerateinstances DeepInheritance.
Created simpler test that just does EnumerateInstances on
CIM_ManagedElement and determines the number of properties.  Without
DeepInheritance, there should be no more properties than in class. With
DeepInhertance, Pegasus at least has many instance that have more
properties than CIM_Managed element so finds some instances with
property count gt the number of properties in CIM_ManagedElement.