### PR TITLE
0.12: Various logistical rollbacks into 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ mofparsetab.py
 moflextab.py
 testsuite/runtests.log
 /testsuite/testtmp/
-/testsuite/schema/mof/
+/testsuite/schema/mof*/
 /epydoc-3.0.1-patches/
 swig-2.0*.tar.gz
 /swig-2.0*/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ setuptools-*.zip
 /tmp_*/
 /dist/pywbem*.tar.gz
 /dist/pywbem*.whl
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,8 @@ install:
 
 # commands to run builds & tests
 script:
-  - if [[ -n $_MANUAL_CI_RUN ]]; then make build; fi
+# make build is always run in order to verify the package version determination
+  - make build
   - if [[ -n $_MANUAL_CI_RUN ]]; then make builddoc; fi
   - make check
   - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,15 @@ decorator>=4.0.11
 yamlordereddictloader>=0.4.0
 
 # Unit test (no imports, invoked via py.test script):
-pytest-cov>=2.4.0
+
+# TODO: Remove the pinning of the pytest-cov version again once issue
+#       https://github.com/z4r/python-coveralls/issues/66
+#       is resolved.
+#       Background: pytest-cov 2.6.0 has increased the version
+#       requirement for the coverage package from >=3.7.1 to
+#       >=4.4, which is in conflict with the version requirement
+#       defined by the python-coveralls package for coverage==4.0.3.
+pytest-cov>=2.4.0,<2.6
 
 # Coverage reporting (no imports, invoked via coveralls script, only used on py27):
 python-coveralls>=2.8.0; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,10 @@ Released: not yet
 
 **Enhancements:**
 
+* Make: Eliminated the confusing but unproblematic error message about
+  pbr importing when running certain make targets in a freshly created
+  Python environment. Issue #1288.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,13 @@ Released: not yet
   pbr importing when running certain make targets in a freshly created
   Python environment. Issue #1288.
 
+* Pinned the version of the pytest-cov package to <2.6 due to the fact that
+  pytest-cov 2.6.0 has increased its version requirement for the coverage
+  package from coverage>=3.7.1 to coverage>=4.4. That is in conflict with
+  the version requirement of python-coveralls for coverage==4.0.3.
+  This is only a workaround; An issue against python-coveralls has been
+  opened: https://github.com/z4r/python-coveralls/issues/66
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/makefile
+++ b/makefile
@@ -74,7 +74,7 @@ coverage_html_dir := coverage_html
 # e.g. because the pywbem.egg-info directory or the PKG-INFO file are deleted,
 # when a new version tag has been assigned. Therefore, this variable is assigned with
 # "=" so that it is evaluated every time it is used.
-package_version := $(shell $(PYTHON_CMD) -c $$'try:\n from pbr.version import VersionInfo\nexcept ImportError:\n pass\nelse:\n print(VersionInfo("$(package_name)").release_string())\n')
+package_version = $(shell $(PYTHON_CMD) -c "$$(printf 'try:\n from pbr.version import VersionInfo\nexcept ImportError:\n pass\nelse:\n print(VersionInfo(\042$(package_name)\042).release_string())\n')")
 
 # Python versions
 python_version := $(shell $(PYTHON_CMD) -c "import sys; sys.stdout.write('%s.%s.%s'%sys.version_info[0:3])")
@@ -84,10 +84,11 @@ python_mn_version := $(shell $(PYTHON_CMD) -c "import sys; sys.stdout.write('%s%
 dist_dir := dist
 
 # Distribution archives
-bdist_file := $(dist_dir)/$(package_name)-$(package_version)-py2.py3-none-any.whl
-sdist_file := $(dist_dir)/$(package_name)-$(package_version).tar.gz
+# These variables are set with "=" for the same reason as package_version.
+bdist_file = $(dist_dir)/$(package_name)-$(package_version)-py2.py3-none-any.whl
+sdist_file = $(dist_dir)/$(package_name)-$(package_version).tar.gz
 
-dist_files := $(bdist_file) $(sdist_file)
+dist_files = $(bdist_file) $(sdist_file)
 
 # Source files in the packages
 package_py_files := \


### PR DESCRIPTION
This PR rolls back some logistical changes into 0.12:
* Adjusted exclusion of CIM schema to new names (part of PR #1220)
* Excluded .DS_Store files from git. (PR #1233)
* Fixes #1288 Eliminated confusing pbr import error message in make (PR #1289, just one commit)
* Fixed determination of package version for Linux. (PR #1294)
* Fixes #1371: Pinned version of pytest-cov to <2.6 (PR #1370)
* Change log for pinning pytest-cov version to <2.6 (PR #1375)