### PR TITLE
0.12: Added support for asterisks to CIMDateTime (rollback from 0.13.0)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,13 @@ Released: not yet
   This is only a workaround; An issue against python-coveralls has been
   opened: https://github.com/z4r/python-coveralls/issues/66
 
+* Added support for asterisks in CIM datetime values to the `pywbem.CIMDateTime`
+  class, as defined in DSP0004 for representing insignificant digits. Changed
+  the format returned by its `__repr()__` method so that it now shows its
+  internal attributes and no longer the string representation of the value.
+  Added a `__repr__()` method to the `pywbem.MinutesFromUTC` class that shows
+  its internal attributes. See issue #1379.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/testsuite/test_cim_types.py
+++ b/testsuite/test_cim_types.py
@@ -232,6 +232,7 @@ def test_real_init_str(real_tuple):
     #             exception type if initialization failed.
     #   exp_datetime: Expected value for datetime property.
     #   exp_timedelta: Expected value for timedelta property.
+    #   exp_precision: Expected value for precision property.
     #   exp_minutesfromutc: Expected value for minutes_from_utc property.
     #   exp_str: Expected string value of the CIMDateTime object.
     # )
@@ -242,6 +243,7 @@ def test_real_init_str(real_tuple):
         None,
         timedelta(days=12345678, hours=22, minutes=44, seconds=55,
                   microseconds=654321),
+        None,
         0,
         '12345678224455.654321:000'
     ),
@@ -251,6 +253,7 @@ def test_real_init_str(real_tuple):
         None,
         timedelta(days=12345678, hours=22, minutes=44, seconds=55,
                   microseconds=654321),
+        None,
         0,
         '12345678224455.654321:000'
     ),
@@ -260,16 +263,157 @@ def test_real_init_str(real_tuple):
         None,
         timedelta(days=12345678, hours=22, minutes=44, seconds=55,
                   microseconds=654321),
+        None,
         0,
         '12345678224455.654321:000'
     ),
     (
+        '12345678224455.65432*:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=654320),
+        20,
+        0,
+        '12345678224455.65432*:000'
+    ),
+    (
+        '12345678224455.6543**:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=654300),
+        19,
+        0,
+        '12345678224455.6543**:000'
+    ),
+    (
+        '12345678224455.654***:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=654000),
+        18,
+        0,
+        '12345678224455.654***:000'
+    ),
+    (
+        '12345678224455.65****:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=650000),
+        17,
+        0,
+        '12345678224455.65****:000'
+    ),
+    (
+        '12345678224455.6*****:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=600000),
+        16,
+        0,
+        '12345678224455.6*****:000'
+    ),
+    (
+        '12345678224455.******:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=55,
+                  microseconds=0),
+        15,
+        0,
+        '12345678224455.******:000'
+    ),
+    (
+        '1234567822445*.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '123456782244**.******:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=44, seconds=0,
+                  microseconds=0),
+        12,
+        0,
+        '123456782244**.******:000'
+    ),
+    (
+        '12345678224***.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '1234567822****.******:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=22, minutes=0, seconds=0,
+                  microseconds=0),
+        10,
+        0,
+        '1234567822****.******:000'
+    ),
+    (
+        '123456782*****.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '12345678******.******:000',
+        'interval',
+        None,
+        timedelta(days=12345678, hours=0, minutes=0, seconds=0,
+                  microseconds=0),
+        8,
+        0,
+        '12345678******.******:000'
+    ),
+    (
+        '1234567*******.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '123456********.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '12345*********.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '1234**********.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '123***********.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '12************.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '1*************.******:000',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '**************.******:000',
+        'interval',
+        None,
+        timedelta(days=0, hours=0, minutes=0, seconds=0,
+                  microseconds=0),
+        0,
+        0,
+        '**************.******:000'
+    ),
+    (
         '12345678224455.654321:777',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '12345678224455,654321:000',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
@@ -277,6 +421,7 @@ def test_real_init_str(real_tuple):
         'timestamp',
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
                  microsecond=654321, tzinfo=MinutesFromUTC(120)),
+        None,
         None,
         120,
         '20140924193040.654321+120'
@@ -287,6 +432,7 @@ def test_real_init_str(real_tuple):
         'timestamp',
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
                  microsecond=654321, tzinfo=MinutesFromUTC(0)),
+        None,
         None,
         0,
         '20140924193040.654321+000'
@@ -298,6 +444,7 @@ def test_real_init_str(real_tuple):
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
                  microsecond=654321, tzinfo=MinutesFromUTC(0)),
         None,
+        None,
         0,
         '20140924193040.654321+000'
     ),
@@ -307,49 +454,197 @@ def test_real_init_str(real_tuple):
         datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
                  microsecond=654321, tzinfo=MinutesFromUTC(120)),
         None,
-        120,
-        '20140924193040.654321+120'
-    ),
-    (
-        CIMDateTime('20140924193040.654321+120'),
-        'timestamp',
-        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
-                 microsecond=654321, tzinfo=MinutesFromUTC(120)),
         None,
         120,
         '20140924193040.654321+120'
     ),
     (
+        '20140924193040.654321+120',
+        'timestamp',
+        datetime(year=2014, month=9, day=24, hour=19, minute=30, second=40,
+                 microsecond=654321, tzinfo=MinutesFromUTC(120)),
+        None,
+        None,
+        120,
+        '20140924193040.654321+120'
+    ),
+    (
+        '20180912123040.65432*+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=654320, tzinfo=MinutesFromUTC(120)),
+        None,
+        20,
+        120,
+        '20180912123040.65432*+120'
+    ),
+    (
+        '20180912123040.6543**+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=654300, tzinfo=MinutesFromUTC(120)),
+        None,
+        19,
+        120,
+        '20180912123040.6543**+120'
+    ),
+    (
+        '20180912123040.654***+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=654000, tzinfo=MinutesFromUTC(120)),
+        None,
+        18,
+        120,
+        '20180912123040.654***+120'
+    ),
+    (
+        '20180912123040.65****+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=650000, tzinfo=MinutesFromUTC(120)),
+        None,
+        17,
+        120,
+        '20180912123040.65****+120'
+    ),
+    (
+        '20180912123040.6*****+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=600000, tzinfo=MinutesFromUTC(120)),
+        None,
+        16,
+        120,
+        '20180912123040.6*****+120'
+    ),
+    (
+        '20180912123040.******+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=40,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        15,
+        120,
+        '20180912123040.******+120'
+    ),
+    (
+        '2018091212304*.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '201809121230**.******+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=30, second=0,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        12,
+        120,
+        '201809121230**.******+120'
+    ),
+    (
+        '20180912123***.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '2018091212****.******+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=12, minute=0, second=0,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        10,
+        120,
+        '2018091212****.******+120'
+    ),
+    (
+        '201809121*****.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '20180912******.******+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=12, hour=0, minute=0, second=0,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        8,
+        120,
+        '20180912******.******+120'
+    ),
+    (
+        '2018091*******.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '201809********.******+120',
+        'timestamp',
+        datetime(year=2018, month=9, day=1, hour=0, minute=0, second=0,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        6,
+        120,
+        '201809********.******+120'
+    ),
+    (
+        '20180*********.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '2018**********.******+120',
+        'timestamp',
+        datetime(year=2018, month=1, day=1, hour=0, minute=0, second=0,
+                 microsecond=0, tzinfo=MinutesFromUTC(120)),
+        None,
+        4,
+        120,
+        '2018**********.******+120'
+    ),
+    (
+        '201***********.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '20************.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
+        '2*************.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (    # year out of range for timestamp()
+        '**************.******+120',
+        ValueError, None, None, None, None, None
+    ),
+    (
         '20140924193040.654321*120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20140924193040,654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20141324193040.654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20140932193040.654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20140924253040.654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20140924196140.654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         '20140924193061.654321+120',
-        ValueError, None, None, None, None
+        ValueError, None, None, None, None, None
     ),
     (
         42,
-        TypeError, None, None, None, None
+        TypeError, None, None, None, None, None
     ),
 ], scope='module')
 def datetime_init_tuple(request):
@@ -382,8 +677,8 @@ def test_datetime_init(datetime_init_tuple):
        datetime_init_tuple pytest.fixture.
     """
     # pylint: disable=redefined-outer-name
-    (dtarg, exp_kind, exp_datetime, exp_timedelta, exp_minutesfromutc,
-     exp_str) = datetime_init_tuple
+    (dtarg, exp_kind, exp_datetime, exp_timedelta, exp_precision,
+     exp_minutesfromutc, exp_str) = datetime_init_tuple
     try:
         obj = CIMDateTime(dtarg)
     except Exception as exc:  # pylint: disable=broad-except
@@ -398,6 +693,7 @@ def test_datetime_init(datetime_init_tuple):
         assert obj.timedelta == exp_timedelta
         if obj.timedelta is not None:
             assert isinstance(obj.timedelta, timedelta)
+        assert obj.precision == exp_precision
         assert obj.minutes_from_utc == exp_minutesfromutc
         assert str(obj) == exp_str
 

--- a/testsuite/test_recorder.py
+++ b/testsuite/test_recorder.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, print_function
 # Allows use of lots of single character variable names.
 # pylint: disable=invalid-name,missing-docstring,too-many-statements
 # pylint: disable=too-many-lines,no-self-use
-from datetime import timedelta, datetime, tzinfo
 import os
 import os.path
 import logging
@@ -28,7 +27,7 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
-from pywbem import CIMInstanceName, CIMInstance, MinutesFromUTC, \
+from pywbem import CIMInstanceName, CIMInstance, \
     Uint8, Uint16, Uint32, Uint64, Sint8, Sint16, \
     Sint32, Sint64, Real32, Real64, CIMProperty, CIMDateTime, CIMError, \
     HTTPError
@@ -64,15 +63,7 @@ class BaseRecorderTests(unittest.TestCase):
         Create a sample instance with multiple properties and
         property types.
         """
-        class TZ(tzinfo):
-            """'Simplistic tsinfo subclass for this test"""
-            def utcoffset(self, dt):  # pylint: disable=unused-argument
-                return timedelta(minutes=-399)
 
-        dt = datetime(year=2016, month=3, day=31, hour=19, minute=30,
-                      second=40, microsecond=654321,
-                      tzinfo=MinutesFromUTC(120))
-        cim_dt = CIMDateTime(dt)
         props_input = OrderedDict([
             ('S1', b'Ham'),
             ('Bool', True),
@@ -86,10 +77,10 @@ class BaseRecorderTests(unittest.TestCase):
             ('SI64', Sint64(-4264)),
             ('R32', Real32(42.0)),
             ('R64', Real64(42.64)),
-            ('DTI', CIMDateTime(timedelta(10, 49, 20))),
-            ('DTF', cim_dt),
-            ('DTP', CIMDateTime(datetime(2014, 9, 22, 10, 49, 20, 524789,
-                                         tzinfo=TZ()))),
+            # CIMDateTime.__repr__() output changes between Python versions,
+            # so we omit that from these properties. After all, this is not a
+            # test for a correct repr() of all CIM datatypes, but a test of
+            # the recorder with a long string.
         ])
         # TODO python 2.7 will not write the following unicode character
         # For the moment, only add this property in python 3 test
@@ -125,13 +116,7 @@ class BaseRecorderTests(unittest.TestCase):
 
     def create_method_params(self):
         """Create a set of method params to be used in InvokeMethodTests."""
-        dt_now = CIMDateTime.now()
         obj_name = self.create_ciminstancename()
-
-        dt = datetime(year=2016, month=3, day=31, hour=19, minute=30,
-                      second=40, microsecond=654321,
-                      tzinfo=MinutesFromUTC(120))
-        cim_dt = CIMDateTime(dt)
 
         params = [('StringParam', 'Spotty'),
                   ('Uint8', Uint8(1)),
@@ -145,10 +130,11 @@ class BaseRecorderTests(unittest.TestCase):
                   ('Real32', Real32(8)),
                   ('Real64', Real64(9)),
                   ('Bool', True),
-                  ('DTN', dt_now),
-                  ('DTF', cim_dt),
-                  ('DTI', CIMDateTime(timedelta(60))),
                   ('Ref', obj_name)]
+        # CIMDateTime.__repr__() output changes between Python
+        # versions, so we omit any datetime parameters. After all,
+        # this is not a test for a correct repr() of all CIM
+        # datatypes, but a test of the recorder with a long string.
         return params
 
 
@@ -230,22 +216,12 @@ class ToYaml(ClientRecorderTests):
         self.assertEqual(si64['type'], 'sint64')
         self.assertEqual(si64['value'], -4264)
 
-        dtp = properties['DTP']
-        self.assertEqual(dtp['name'], 'DTP')
-        self.assertEqual(dtp['type'], 'datetime')
-        self.assertEqual(dtp['value'], '20140922104920.524789-399')
-        dti = properties['DTI']
-        self.assertEqual(dti['name'], 'DTI')
-        self.assertEqual(dti['type'], 'datetime')
-        self.assertEqual(dti['value'], '00000010000049.000020:000')
-
         # TODO add test for reference properties
         # TODO add test for embedded object property
 
     def test_inst_to_yaml_array_props(self):
         """Test  property with array toyaml"""
         str_data = "The pink fox jumped over the big blue dog"
-        dt = datetime(2014, 9, 22, 10, 49, 20, 524789)
         array_props = [
             ('MyString', str_data),
             ('MyUint8Array', [Uint8(1), Uint8(2)]),
@@ -254,7 +230,6 @@ class ToYaml(ClientRecorderTests):
                                Uint64(123456789),
                                Uint64(123456789)]),
             ('MyUint32Array', [Uint32(9999), Uint32(9999)]),
-            ('MyDateTimeArray', [dt, dt, dt]),
             ('MyStrLongArray', [str_data, str_data, str_data]),
         ]
         inst = CIMInstance('CIM_FooArray', array_props)
@@ -284,12 +259,6 @@ class ToYaml(ClientRecorderTests):
         self.assertEqual(my_sint64array['value'], [Uint64(123456789),
                                                    Uint64(123456789),
                                                    Uint64(123456789)])
-
-        my_datetimearray = properties['MyDateTimeArray']
-        self.assertEqual(my_datetimearray['name'], 'MyDateTimeArray')
-        self.assertEqual(my_datetimearray['type'], 'datetime')
-        cim_dt = str(CIMDateTime(dt))
-        self.assertEqual(my_datetimearray['value'], [cim_dt, cim_dt, cim_dt])
 
     def test_instname_to_yaml(self):
         """Test  instname toyaml"""
@@ -344,7 +313,6 @@ class ClientOperationStageTests(ClientRecorderTests):
         params = self.create_method_params()
         in_params_dict = OrderedDict(params)
         obj_name = in_params_dict['Ref']
-        dt_now = str(in_params_dict['DTN'])
 
         self.test_recorder.stage_pywbem_args(method='InvokeMethod',
                                              MethodName='Blah',
@@ -382,9 +350,6 @@ class ClientOperationStageTests(ClientRecorderTests):
         self.assertEqual(out_params_dict['Real32'], 8)
         self.assertEqual(out_params_dict['Real64'], 9)
         self.assertEqual(out_params_dict['Bool'], True)
-        self.assertEqual(out_params_dict['DTN'], dt_now)
-        self.assertEqual(out_params_dict['DTI'],
-                         str(CIMDateTime(timedelta(60))))
         # TODO fix the following. Currently it fails with:
         # AssertionError: CIMIn[16 chars]name={'classname': 'CIM_Foo',
         # 'keybindings': {[132 chars]None) != CIMIn[16 chars]name=u'CIM_Foo',
@@ -626,18 +591,6 @@ get_inst_return_all_log = (
     u"type='real64', reference_class=None, embedded_object=None, "
     u"is_array=False, array_size=None, class_origin=None, propagated=None, "
     u"qualifiers=NocaseDict([]))), "
-    u"('DTI', CIMProperty(name='DTI', value=CIMDateTime(cimtype='datetime', "
-    u"'00000010000049.000020:000'), type='datetime', reference_class=None, "
-    u"embedded_object=None, is_array=False, array_size=None, "
-    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
-    u"('DTF', CIMProperty(name='DTF', value=CIMDateTime(cimtype='datetime', "
-    u"'20160331193040.654321+120'), type='datetime', reference_class=None, "
-    u"embedded_object=None, is_array=False, array_size=None, "
-    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
-    u"('DTP', CIMProperty(name='DTP', value=CIMDateTime(cimtype='datetime', "
-    u"'20140922104920.524789-399'), type='datetime', reference_class=None, "
-    u"embedded_object=None, is_array=False, array_size=None, "
-    u"class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
     u"('S2', CIMProperty(name='S2', value='H\u00E4m', type='string', "
     u"reference_class=None, embedded_object=None, is_array=False, "
     u"array_size=None, class_origin=None, propagated=None, "
@@ -700,19 +653,7 @@ get_inst_return_all_log_PY2 = (
     "('R64', CIMProperty(name=u'R64', value=Real64(cimtype='real64', 42.64), "
     "type=u'real64', reference_class=None, embedded_object=None, "
     "is_array=False, array_size=None, class_origin=None, propagated=None, "
-    "qualifiers=NocaseDict([]))), "
-    "('DTI', CIMProperty(name=u'DTI', value=CIMDateTime(cimtype='datetime', "
-    "'00000010000049.000020:000'), type=u'datetime', reference_class=None, "
-    "embedded_object=None, is_array=False, array_size=None, class_origin=None,"
-    " propagated=None, qualifiers=NocaseDict([]))), "
-    "('DTF', CIMProperty(name=u'DTF', value=CIMDateTime("
-    "cimtype='datetime', '20160331193040.654321+120'), type=u'datetime', "
-    "reference_class=None, embedded_object=None, is_array=False, array_size="
-    "None, class_origin=None, propagated=None, qualifiers=NocaseDict([]))), "
-    "('DTP', CIMProperty(name=u'DTP', value=CIMDateTime(cimtype='datetime', "
-    "'20140922104920.524789-399'), type=u'datetime', reference_class=None, "
-    "embedded_object=None, is_array=False, array_size=None, "
-    "class_origin=None, propagated=None, qualifiers=NocaseDict([])))"
+    "qualifiers=NocaseDict([])))"
     "]), property_list=None, qualifiers=NocaseDict([])))")
 
 
@@ -1041,25 +982,7 @@ class LogOperationRecorderStagingTests(BaseLogOperationRecorderTests):
                  "cimtype='real64', 42.64), type=u'real64', "
                  "reference_class=None, embedded_object=None, "
                  "is_array=False, array_size=None, class_origin=None, "
-                 "propagated=None, qualifiers=NocaseDict([]))), "
-                 "('DTI', CIMProperty(name=u'DTI', value=CIMDateTime("
-                 "cimtype='datetime', '00000010000049.000020:000'), "
-                 "type=u'datetime', reference_class=None, "
-                 "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict([]))), "
-                 "('DTF', CIMProperty(name=u'DTF', value=CIMDateTime("
-                 "cimtype='datetime', '20160331193040.654321+120'), "
-                 "type=u'datetime', reference_class=None, "
-                 "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict([]))), "
-                 "('DTP', CIMProperty(name=u'DTP', value=CIMDateTime("
-                 "cimtype='datetime', '20140922104920.524789-399'), "
-                 "type=u'datetime', reference_class=None, "
-                 "embedded_object=None, is_array=False, array_size=None, "
-                 "class_origin=None, propagated=None, "
-                 "qualifiers=NocaseDict([])))"
+                 "propagated=None, qualifiers=NocaseDict([])))"
                  "]), property_list=None, qualifiers=NocaseDict([])))"),)
         else:
             none_result_all = get_inst_return_all_log.replace('GetInstance',


### PR DESCRIPTION
This PR rolls back PR #1381 into 0.12.6.
No review needed.