### PR TITLE
Fixes issue #1227. mof compiler search path extended to allow string

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -154,6 +154,10 @@ This version contains all fixes up to pywbem 0.12.4.
   to the user as a list of `CIMInstance` objects in a new `instances` property
   of the `CIMError` exception that is raised. See issue #1380.
 
+* Fixed issue in mof_compiler search_paths where doc defined iterable as
+  input but since string is an interable it was allowed but misused. Extended
+  code to specifically allow single string on input. See issue #1227.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2341,11 +2341,11 @@ class MOFCompiler(object):
             case, the MOF compiler can only process standalone MOF that does
             not depend on existing CIM elements in the repository.
 
-          search_paths (:term:`py:iterable` of :term:`string`):
-            An iterable of directory path names where the MOF compiler will
-            search for MOF dependent files if the MOF element they define is
-            not in the target namespace of the CIM repository. The compiler
-            searches the specified directories and their subdirectories.
+          search_paths (:term:`py:iterable` of :term:`string` or :term:`string`):
+            Directory path name(s) where the MOF compiler will search for MOF
+            dependent files if the MOF element they define is not in the target
+            namespace of the CIM repository. The compiler searches the
+            specified directories and their subdirectories.
 
             MOF dependent files are:
 
@@ -2373,7 +2373,7 @@ class MOFCompiler(object):
             A logger function that is invoked for each compiler message.
             The logger function must take one parameter of string type.
             The default logger function prints to stdout.
-        """
+        """  # noqa: E501
 
         if isinstance(handle, WBEMConnection):
             conn = handle
@@ -2393,18 +2393,18 @@ class MOFCompiler(object):
                             "BaseRepositoryConnection) or a WBEM connection "
                             "(WBEMConnection), but is: %s" % type(handle))
 
-        if conn:
-            server = WBEMServer(conn)
-        else:
-            server = None
+        server = WBEMServer(conn) if conn else None
 
         if search_paths is None:
             search_paths = []
-        if not isinstance(search_paths, (list, tuple)):
+        elif isinstance(search_paths, six.string_types):
+            search_paths = [search_paths]
+        elif not isinstance(search_paths, (list, tuple)):
             raise TypeError("search_paths parameter must be list or tuple, "
                             "but is: %s" % type(search_paths))
 
         self.parser = _yacc(verbose)
+
         self.parser.search_paths = search_paths
         self.handle = handle
         self.parser.handle = handle

--- a/testsuite/test_mof_compiler.py
+++ b/testsuite/test_mof_compiler.py
@@ -502,8 +502,53 @@ class TestSchemaSearch(MOFTest):
             LocalOnly=False, IncludeQualifiers=True)
         self.assertEqual(cele.properties['RequestedState'].type, 'uint16')
 
-        # TODO ks 4/16 add error test for something not found
-        # in schema directory
+    def test_search_single_string(self):
+        """
+        Test search_paths with single string as path definition.  Compiles
+        a single file and tests that file compiled
+        """
+        def moflog(msg):
+            """Display message to moflog"""
+            print(msg, file=self.logfile)
+
+        moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
+        open(moflog_file, 'w')
+        mofcomp = MOFCompiler(
+            MOFWBEMConnection(),
+            search_paths=TEST_DMTF_CIMSCHEMA_MOF_DIR,
+            verbose=True,
+            log_func=moflog)
+        mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
+                                          'System',
+                                          'CIM_ComputerSystem.mof'),
+                             NAME_SPACE)
+        mofcomp.handle.GetClass(
+            'CIM_ComputerSystem',
+            LocalOnly=False, IncludeQualifiers=True)
+
+    def test_search_None(self):
+        """
+        Test search_paths with single string as path definition.  Compiles
+        a single file and tests that file compiled
+        """
+        def moflog(msg):
+            """Display message to moflog"""
+            print(msg, file=self.logfile)
+
+        moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
+        open(moflog_file, 'w')
+        mofcomp = MOFCompiler(
+            MOFWBEMConnection(),
+            verbose=True,
+            log_func=moflog)
+        try:
+            mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
+                                              'System',
+                                              'CIM_ComputerSystem.mof'),
+                                 NAME_SPACE)
+            self.fail("Exception expected")
+        except CIMError as ce:
+            self.assertTrue(ce.status_code == CIM_ERR_FAILED)
 
 
 class TestParseError(MOFTest):


### PR DESCRIPTION
See commit for details
Extended the seach_paths ctor parameter to allow single string as input
and cvt to iterable.  Also added test for this.

Removed one TODO because it had been incorporated into a test (see test
test_error_search).