### PR TITLE
Docs: Improvements for method and attribute lists and other imprs.

### DIFF
--- a/pywbem/_nocasedict.py
+++ b/pywbem/_nocasedict.py
@@ -131,7 +131,7 @@ class NocaseDict(object):
         * Passing an OrderedDict or NocaseDict object as a single positional
           argument.
 
-        A UserWarning will be issued if the provided constructor arguments will
+        A UserWarning will be issued if the provided init parameters will
         cause the order of provided items not to be preserved when adding them
         to the new dictionary.
         """

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -142,11 +142,10 @@ yaml.SafeDumper.represent_undefined = _represent_undefined
 
 class OpArgs(OpArgsTuple):
     """
-    **Experimental:** *New in pywbem 0.9 as experimental.*
-
     A named tuple representing the name and input arguments of the invocation
-    of a :class:`~pywbem.WBEMConnection` method, with the following named fields
-    and attributes:
+    of a :class:`~pywbem.WBEMConnection` method.
+
+    **Experimental:** *New in pywbem 0.9 as experimental.*
 
     Attributes:
 
@@ -171,11 +170,10 @@ OpResultTuple = namedtuple("OpResultTuple", ["ret", "exc"])
 
 class OpResult(OpResultTuple):
     """
-    **Experimental:** *New in pywbem 0.9 as experimental.*
-
     A named tuple representing the result of the invocation of a
-    :class:`~pywbem.WBEMConnection` method, with the following named fields
-    and attributes:
+    :class:`~pywbem.WBEMConnection` method.
+
+    **Experimental:** *New in pywbem 0.9 as experimental.*
 
     Attributes:
 
@@ -207,10 +205,9 @@ HttpRequestTuple = namedtuple("HttpRequestTuple",
 
 class HttpRequest(HttpRequestTuple):
     """
-    **Experimental:** *New in pywbem 0.9 as experimental.*
+    A named tuple representing the HTTP request sent by the WBEM client.
 
-    A named tuple representing the HTTP request sent by the WBEM client, with
-    the following named fields and attributes:
+    **Experimental:** *New in pywbem 0.9 as experimental.*
 
     Attributes:
 
@@ -234,7 +231,6 @@ class HttpRequest(HttpRequestTuple):
 
       ~HttpRequest.payload (:term:`unicode string`):
         HTTP payload, i.e. the CIM-XML string.
-
     """
     __slots__ = ()
 
@@ -257,10 +253,9 @@ HttpResponseTuple = namedtuple("HttpResponseTuple",
 
 class HttpResponse(HttpResponseTuple):
     """
-    **Experimental:** *New in pywbem 0.9 as experimental.*
+    A named tuple representing the HTTP response received by the WBEM client.
 
-    A named tuple representing the HTTP response received by the WBEM client,
-    with the following named fields and attributes:
+    **Experimental:** *New in pywbem 0.9 as experimental.*
 
     Attributes:
 
@@ -298,11 +293,11 @@ class HttpResponse(HttpResponseTuple):
 class BaseOperationRecorder(object):
     # pylint: disable=too-many-instance-attributes
     """
-    **Experimental:** *New in pywbem 0.9 as experimental.*
-
     Abstract base class defining the interface to an operation recorder,
     that records the WBEM operations executed in a connection to a WBEM
     server.
+
+    **Experimental:** *New in pywbem 0.9 as experimental.*
 
     An operation recorder can be added to a connection via the
     :meth:`~pywbem.WBEMConnection.add_operation_recorder` method. The operation
@@ -327,38 +322,39 @@ class BaseOperationRecorder(object):
 
     def enable(self):
         """
-        *New in pywbem 0.10.*
-
         Enable the recorder.
+
+        *New in pywbem 0.10.*
         """
         self._enabled = True
 
     def disable(self):
         """
-        *New in pywbem 0.10.*
-
         Disable the recorder.
+
+        *New in pywbem 0.10.*
         """
         self._enabled = False
 
     @property
     def enabled(self):
         """
-        *New in pywbem 0.10.*
-
         Indicate whether the recorder is enabled.
+
+        *New in pywbem 0.10.*
         """
         return self._enabled
 
     @staticmethod
     def open_file(filename, file_mode='w'):
         """
+        A static convenience function that performs the open of the recorder
+        file correctly for different versions of Python.
+
         *New in pywbem 0.10.*
 
-        A static convenience function that performs the open of the recorder
-        file correctly for different versions of Python.  This covers the
-        issue where the file should be opened in text mode but that is
-        done differently in Python 2 and Python 3.
+        This covers the issue where the file should be opened in text mode but
+        that is done differently in Python 2 and Python 3.
 
         The returned file-like object must be closed by the caller.
 
@@ -529,11 +525,11 @@ class BaseOperationRecorder(object):
 
 class LogOperationRecorder(BaseOperationRecorder):
     """
-    **Experimental:** *New in pywbem 0.11 and redesigned in pywbem 0.12 as
-    experimental.*
-
     A recorder that logs certain aspects of the WBEM operations driven by
     pywbem users to Python loggers.
+
+    **Experimental:** *New in pywbem 0.11 and redesigned in pywbem 0.12 as
+    experimental.*
 
     This recorder supports two Python loggers:
 
@@ -865,10 +861,12 @@ class LogOperationRecorder(BaseOperationRecorder):
 
 class TestClientRecorder(BaseOperationRecorder):
     """
+    An operation recorder that generates test cases for each recorded
+    operation.
+
     **Experimental:** *New in pywbem 0.9 as experimental.*
 
-    An operation recorder that generates test cases for each recorded
-    operation. The test cases are in the YAML format suitable for the
+    The test cases are in the YAML format suitable for the
     `test_client` unit test module of the pywbem project.
     """
 

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -491,13 +491,13 @@ class OperationStatistic(object):
             "max_reply_len={s.max_reply_len!A})",
             s=self)
 
-    formatted_header_w_svr = \
+    _formatted_header_w_svr = \
         'Count Excep         ClientTime              ServerTime        ' \
         '     RequestLen                ReplyLen       Operation\n' \
         '        Cnt     Avg     Min     Max     Avg     Min     Max   ' \
         ' Avg    Min    Max      Avg      Min      Max\n'
 
-    formatted_header = \
+    _formatted_header = \
         'Count Excep         ClientTime        ' \
         '     RequestLen              ReplyLen       Operation\n' \
         '        Cnt     Avg     Min     Max   ' \
@@ -707,9 +707,9 @@ class Statistics(object):
                 if stats._server_time_stored:
                     include_svr = True
             if include_svr:
-                ret += OperationStatistic.formatted_header_w_svr
+                ret += OperationStatistic._formatted_header_w_svr
             else:
-                ret += OperationStatistic.formatted_header
+                ret += OperationStatistic._formatted_header
 
             for name, stats in snapshot:  # pylint: disable=unused-variable
                 ret += stats.formatted(include_svr)

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -441,7 +441,7 @@ def cmpdict(dict1, dict2):
 
 def _qualifiers_tomof(qualifiers, indent, maxline=MAX_MOF_LINE):
     """
-    Return a MOF fragment with the qualifier values, including the surrounding
+    Return a MOF string with the qualifier values, including the surrounding
     square brackets. The qualifiers are ordered by their name.
 
     Return empty string if no qualifiers.
@@ -459,7 +459,7 @@ def _qualifiers_tomof(qualifiers, indent, maxline=MAX_MOF_LINE):
 
     Returns:
 
-      :term:`unicode string`: MOF fragment.
+      :term:`unicode string`: MOF string.
     """
 
     if not qualifiers:
@@ -659,7 +659,7 @@ def mofstr(value, indent=MOF_INDENT, maxline=MAX_MOF_LINE, line_pos=0,
     Returns:
 
       tuple of
-        * :term:`unicode string`: MOF fragment.
+        * :term:`unicode string`: MOF string.
         * new line_pos
     """
 
@@ -759,7 +759,7 @@ def mofval(value, indent=MOF_INDENT, maxline=MAX_MOF_LINE, line_pos=0,
     Returns:
 
       tuple of
-        * :term:`unicode string`: MOF fragment.
+        * :term:`unicode string`: MOF string.
         * new line_pos
 
     Raises:
@@ -800,7 +800,7 @@ def _scalar_value_tomof(
         avoid_splits=False):
     # pylint: disable=line-too-long,redefined-builtin
     """
-    Return a MOF fragment representing a scalar CIM-typed value.
+    Return a MOF string representing a scalar CIM-typed value.
 
     `None` is returned as 'NULL'.
 
@@ -831,7 +831,7 @@ def _scalar_value_tomof(
     Returns:
 
       tuple of
-        * :term:`unicode string`: MOF fragment.
+        * :term:`unicode string`: MOF string.
         * new line_pos
     """  # noqa: E501
 
@@ -879,7 +879,7 @@ def _value_tomof(
         avoid_splits=False):
     # pylint: disable=redefined-builtin
     """
-    Return a MOF fragment representing a CIM-typed value (scalar or array).
+    Return a MOF string representing a CIM-typed value (scalar or array).
 
     In case of an array, the array items are separated by comma, but the
     surrounding curly braces are not added.
@@ -905,7 +905,7 @@ def _value_tomof(
     Returns:
 
       tuple of
-        * :term:`unicode string`: MOF fragment.
+        * :term:`unicode string`: MOF string.
         * new line_pos
     """
 
@@ -1189,8 +1189,8 @@ class CIMInstanceName(_CIMComparisonMixin):
     @property
     def classname(self):
         """
-        :term:`unicode string`: Name of the creation class of the referenced
-        instance.
+        :term:`unicode string`: Class name of this CIM instance path,
+        identifying the creation class of the referenced instance.
 
         Will not be `None`.
 
@@ -1214,8 +1214,8 @@ class CIMInstanceName(_CIMComparisonMixin):
     @property
     def keybindings(self):
         """
-        `NocaseDict`_: Keybindings of the instance path (that is, the key
-        property values of the referenced instance).
+        `NocaseDict`_: Keybindings of this CIM instance path,
+        identifying the key properties of the referenced instance.
 
         Will not be `None`.
 
@@ -1303,8 +1303,8 @@ class CIMInstanceName(_CIMComparisonMixin):
     @property
     def namespace(self):
         """
-        :term:`unicode string`: Name of the CIM namespace containing the
-        referenced instance.
+        :term:`unicode string`: Namespace name of this CIM instance path,
+        identifying the namespace of the referenced instance.
 
         `None` means that the namespace is unspecified.
 
@@ -1327,8 +1327,9 @@ class CIMInstanceName(_CIMComparisonMixin):
     @property
     def host(self):
         """
-        :term:`unicode string`: Host and optionally port of the WBEM server
-        containing the CIM namespace of the referenced instance.
+        :term:`unicode string`: Host and optionally port
+        of this CIM instance path,
+        identifying the WBEM server of the referenced instance.
 
         For details about the string format, see the same-named constructor
         parameter.
@@ -1391,8 +1392,7 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a WBEM URI string of the CIM instance path represented by the
-        :class:`~pywbem.CIMInstanceName` object.
+        Return the WBEM URI string of this CIM instance path.
 
         The returned WBEM URI string is in the historical format returned by
         :meth:`~pywbem.CIMInstanceName.to_wbem_uri`.
@@ -1419,9 +1419,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the
-        :class:`~pywbem.CIMInstanceName` object that is suitable for
-        debugging.
+        Return a string representation of this CIM instance path,
+        that is suitable for debugging.
 
         The key bindings will be ordered by their names in the result.
         """
@@ -1454,7 +1453,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMInstanceName` object.
+        Return a new :class:`~pywbem.CIMInstanceName` object that is a copy
+        of this CIM instance path.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -1478,31 +1478,69 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def update(self, *args, **kwargs):
         """
-        Add the positional arguments and keyword arguments to the keybindings,
-        updating the values of those that already exist.
+        Update the keybindings of this CIM instance path.
+
+        Existing keybindings will be updated, and new keybindings will be
+        added.
+
+        Parameters:
+
+           *args (list):
+             Keybindings for updating the keybindings of the instance path,
+             specified as positional arguments. Each positional argument must
+             be a tuple (key, value), where key and value are described for
+             setting the :attr:`~pywbem.CIMInstanceName.keybindings` property.
+
+           **kwargs (dict):
+             Keybindings for updating the keybindings of the instance path,
+             specified as keyword arguments. The name and value of the keyword
+             arguments are described as key and value for setting the
+             :attr:`~pywbem.CIMInstanceName.keybindings` property.
         """
         self.keybindings.update(*args, **kwargs)
 
     def has_key(self, key):
         """
-        Return a boolean indicating whether the instance path has a
-        keybinding with name `key`.
+        Return a boolean indicating whether this CIM instance path has a
+        particular keybinding.
+
+        Parameters:
+
+          key (:term:`string`):
+            Name of the keybinding (in any lexical case).
+
+        Returns:
+          :class:`py:bool`: Boolean indicating whether this CIM instance path
+          has the keybinding.
         """
         return key in self.keybindings
 
     def get(self, key, default=None):
         """
+        Return the value of a particular keybinding of this CIM instance path,
+        or a default value.
+
         *New in pywbem 0.8.*
 
-        Return the value of the keybinding with name `key`, or a default
-        value if a keybinding with that name does not exist.
+        Parameters:
+
+          key (:term:`string`):
+            Name of the keybinding (in any lexical case).
+
+          default (:term:`CIM data type`):
+            Default value that is returned if a keybinding with the specified
+            name does not exist in the instance path.
+
+        Returns:
+          :term:`CIM data type`: Value of the keybinding, or the default value.
         """
         return self.keybindings.get(key, default)
 
     def keys(self):
         """
-        Return a copied list of the keybinding names (in their original
-        lexical case).
+        Return a copied list of the keybinding names of this CIM instance path.
+
+        The keybinding names have their original lexical case.
 
         The order of keybindings is preserved.
         """
@@ -1510,7 +1548,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def values(self):
         """
-        Return a copied list of the keybinding values.
+        Return a copied list of the keybinding values
+        of this CIM instance path.
 
         The order of keybindings is preserved.
         """
@@ -1518,8 +1557,11 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def items(self):
         """
-        Return a copied list of the keybindings, where each item is a tuple
-        of its keybinding name (in the original lexical case) and its value.
+        Return a copied list of the keybinding names and values
+        of this CIM instance path.
+
+        Each item in the returned list is a tuple of keybinding name (in the
+        original lexical case) and keybinding value.
 
         The order of keybindings is preserved.
         """
@@ -1527,7 +1569,9 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def iterkeys(self):
         """
-        Iterate through the keybinding names (in their original lexical case).
+        Iterate through the keybinding names of this CIM instance path.
+
+        The keybinding names have their original lexical case.
 
         The order of keybindings is preserved.
         """
@@ -1535,7 +1579,7 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def itervalues(self):
         """
-        Iterate through the keybinding values.
+        Iterate through the keybinding values of this CIM instance path.
 
         The order of keybindings is preserved.
         """
@@ -1543,9 +1587,11 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def iteritems(self):
         """
-        Iterate through the keybindings, where each item is a tuple of the
-        keybinding name (in the original lexical case) and the keybinding
-        value.
+        Iterate through the keybinding names and values
+        of this CIM instance path.
+
+        Each iteration item is a tuple of the keybinding name (in the original
+        lexical case) and the keybinding value.
 
         The order of keybindings is preserved.
         """
@@ -1554,17 +1600,8 @@ class CIMInstanceName(_CIMComparisonMixin):
     # pylint: disable=too-many-branches
     def tocimxml(self, ignore_host=False, ignore_namespace=False):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMInstanceName` object,
-        as an instance of an appropriate subclass of :term:`Element`.
-
-        Parameters:
-
-          ignore_host (:class:`py:bool`): Ignore the host of the
-            instance path, even if a host is specified.
-
-          ignore_namespace (:class:`py:bool`): Ignore the namespace and host of
-            the instance path, even if a namespace and/or host is specified.
+        Return the CIM-XML representation of this CIM instance path,
+        as an object of an appropriate subclass of :term:`Element`.
 
         If the instance path has no namespace specified or if
         `ignore_namespace` is `True`, the returned CIM-XML representation is an
@@ -1579,6 +1616,19 @@ class CIMInstanceName(_CIMComparisonMixin):
 
         The order of keybindings in the returned CIM-XML representation is
         preserved from the :class:`~pywbem.CIMInstanceName` object.
+
+        Parameters:
+
+          ignore_host (:class:`py:bool`): Ignore the host of the
+            instance path, even if a host is specified.
+
+          ignore_namespace (:class:`py:bool`): Ignore the namespace and host of
+            the instance path, even if a namespace and/or host is specified.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         kbs = []
@@ -1640,10 +1690,10 @@ class CIMInstanceName(_CIMComparisonMixin):
     def tocimxmlstr(self, indent=None, ignore_host=False,
                     ignore_namespace=False):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM instance path,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMInstanceName` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMInstanceName.tocimxml`.
@@ -1815,10 +1865,10 @@ class CIMInstanceName(_CIMComparisonMixin):
     def from_wbem_uri(wbem_uri):
         # pylint: disable=line-too-long
         """
-        *New in pywbem 0.12.*
-
         Return a new :class:`~pywbem.CIMInstanceName` object from the specified
         WBEM URI string.
+
+        *New in pywbem 0.12.*
 
         The WBEM URI string must be a CIM instance path in untyped WBEM URI
         format, as defined in :term:`DSP0207`, with these extensions:
@@ -1950,8 +2000,7 @@ class CIMInstanceName(_CIMComparisonMixin):
     def to_wbem_uri(self, format='standard'):
         # pylint: disable=redefined-builtin
         """
-        Return the untyped WBEM URI of the CIM instance path represented
-        by the :class:`~pywbem.CIMInstanceName` object.
+        Return the (untyped) WBEM URI string of this CIM instance path.
 
         The returned WBEM URI contains its components as follows:
 
@@ -2157,9 +2206,9 @@ class CIMInstanceName(_CIMComparisonMixin):
     def from_instance(class_, instance, namespace=None, host=None,
                       strict=False):
         """
-        Given a class and corresponding instance, create and return a
-        :class:`~pywbem.CIMInstanceName` from the class key properties and
-        instance key property values.
+        Return a new :class:`~pywbem.CIMInstanceName` object from the key
+        property values in a CIM instance and the key property definitions in a
+        CIM class.
 
         If the `strict` parameter is `False`, and a property value does not
         exist in the `instance` that entry is not included in the constructed
@@ -2291,8 +2340,14 @@ class CIMInstance(_CIMComparisonMixin):
             will also be `None`.
 
           property_list (:term:`py:iterable` of :term:`string`):
-            List of property names for use as a filter by some operations on
-            the instance. The property names may have any lexical case.
+            **Deprecated:** List of property names for use as a filter by some
+            operations on the instance.
+
+            This parameter has been deprecated in pywbem 0.12.
+            Set only the desired properties on the object, instead of
+            working with this property filter.
+
+            The property names may have any lexical case.
 
             A copy of the provided iterable will be stored in the
             :class:`~pywbem.CIMInstance` object, and the property names will be
@@ -2301,10 +2356,6 @@ class CIMInstance(_CIMComparisonMixin):
             `None` means that the properties are not filtered, and the
             same-named attribute in the :class:`~pywbem.CIMInstance` object
             will also be `None`.
-
-            **Deprecated:** This parameter has been deprecated in pywbem 0.12.
-            Set only the desired properties on the object, instead of
-            working with this property filter.
 
         Raises:
 
@@ -2325,7 +2376,8 @@ class CIMInstance(_CIMComparisonMixin):
     @property
     def classname(self):
         """
-        :term:`unicode string`: Name of the creation class of the instance.
+        :term:`unicode string`: Name of the creation class
+        of this CIM instance.
 
         Will not be `None`.
 
@@ -2349,7 +2401,7 @@ class CIMInstance(_CIMComparisonMixin):
     @property
     def properties(self):
         """
-        `NocaseDict`_: Properties of the CIM instance.
+        `NocaseDict`_: Properties of this CIM instance.
 
         Will not be `None`.
 
@@ -2427,7 +2479,7 @@ class CIMInstance(_CIMComparisonMixin):
     @property
     def qualifiers(self):
         """
-        `NocaseDict`_: Qualifiers of the CIM instance.
+        `NocaseDict`_: Qualifiers (qualifier values) of this CIM instance.
 
         Will not be `None`.
 
@@ -2481,7 +2533,7 @@ class CIMInstance(_CIMComparisonMixin):
     @property
     def path(self):
         """
-        :class:`~pywbem.CIMInstanceName`: Instance path of the instance.
+        :class:`~pywbem.CIMInstanceName`: Instance path of this CIM instance.
 
         `None` means that the instance path is unspecified.
 
@@ -2507,18 +2559,20 @@ class CIMInstance(_CIMComparisonMixin):
     @property
     def property_list(self):
         """
-        :term:`py:list` of :term:`unicode string`: List of property names for
-        use as a filter by some operations on the instance. The property names
-        are in lower case.
+        :term:`py:list` of :term:`unicode string`: **Deprecated:** List of
+        property names for use as a filter by some operations on
+        this CIM instance.
+
+        This attribute has been deprecated in pywbem 0.12.
+        Set only the desired properties on the object, instead of working with
+        this property filter.
+
+        The property names are specified in lower case.
 
         `None` means that the properties are not filtered.
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
-
-        **Deprecated:** This attribute has been deprecated in pywbem 0.12.
-        Set only the desired properties on the object, instead of working with
-        this property filter.
         """
         return self._property_list
 
@@ -2586,8 +2640,8 @@ class CIMInstance(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMInstance` object for human consumption.
+        Return a short string representation of this CIM instance,
+        for human consumption.
         """
         return _format(
             "CIMInstance("
@@ -2597,8 +2651,8 @@ class CIMInstance(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMInstance`
-        object that is suitable for debugging.
+        Return a string representation of this CIM instance,
+        that is suitable for debugging.
 
         The properties and qualifiers will be ordered by their names in the
         result.
@@ -2650,7 +2704,8 @@ class CIMInstance(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMInstance` object.
+        Return a new :class:`~pywbem.CIMInstance` object that is a copy
+        of this CIM instance.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -2685,8 +2740,23 @@ class CIMInstance(_CIMComparisonMixin):
 
     def update(self, *args, **kwargs):
         """
-        Add the positional arguments and keyword arguments to the properties,
-        updating the values of those that already exist.
+        Update the properties of this CIM instance.
+
+        Existing properties will be updated, and new properties will be added.
+
+        Parameters:
+
+           *args (list):
+             Properties for updating the properties of the instance, specified
+             as positional arguments. Each positional argument must be a tuple
+             (key, value), where key and value are described for setting the
+             :attr:`~pywbem.CIMInstance.properties` property.
+
+           **kwargs (dict):
+             Properties for updating the properties of the instance, specified
+             as keyword arguments. The name and value of the keyword arguments
+             are described as key and value for setting the
+             :attr:`~pywbem.CIMInstance.properties` property.
         """
 
         for mapping in args:
@@ -2701,8 +2771,24 @@ class CIMInstance(_CIMComparisonMixin):
 
     def update_existing(self, *args, **kwargs):
         """
-        Update the values of already existing properties from the positional
-        arguments and keyword arguments.
+        Update already existing properties of this CIM instance.
+
+        Existing properties will be updated, and new properties will be
+        ignored without further notice.
+
+        Parameters:
+
+           *args (list):
+             Properties for updating the properties of the instance, specified
+             as positional arguments. Each positional argument must be a tuple
+             (key, value), where key and value are described for setting the
+             :attr:`~pywbem.CIMInstance.properties` property.
+
+           **kwargs (dict):
+             Properties for updating the properties of the instance, specified
+             as keyword arguments. The name and value of the keyword arguments
+             are described as key and value for setting the
+             :attr:`~pywbem.CIMInstance.properties` property.
         """
 
         for mapping in args:
@@ -2729,25 +2815,47 @@ class CIMInstance(_CIMComparisonMixin):
 
     def has_key(self, key):
         """
-        Return a boolean indicating whether the instance has a property with
-        name `key`.
+        Return a boolean indicating whether this CIM instance has a particular
+        property.
+
+        Parameters:
+
+          key (:term:`string`):
+            Name of the property (in any lexical case).
+
+        Returns:
+          :class:`py:bool`: Boolean indicating whether the instance has the
+          property.
         """
         return key in self.properties
 
     def get(self, key, default=None):
         """
+        Return the value of a particular property of this CIM instance,
+        or a default value.
+
         *New in pywbem 0.8.*
 
-        Return the value of the property with name `key`, or a default value if
-        a property with that name does not exist.
+        Parameters:
+
+          key (:term:`string`):
+            Name of the property (in any lexical case).
+
+          default (:term:`CIM data type`):
+            Default value that is returned if a property with the specified
+            name does not exist in the instance.
+
+        Returns:
+          :term:`CIM data type`: Value of the property, or the default value.
         """
         prop = self.properties.get(key, None)
         return default if prop is None else prop.value
 
     def keys(self):
         """
-        Return a copied list of the property names (in their original lexical
-        case).
+        Return a copied list of the property names of this CIM instance.
+
+        The property names have their original lexical case.
 
         The order of properties is preserved.
         """
@@ -2755,7 +2863,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     def values(self):
         """
-        Return a copied list of the property values.
+        Return a copied list of the property values of this CIM instance.
 
         The order of properties is preserved.
         """
@@ -2763,9 +2871,11 @@ class CIMInstance(_CIMComparisonMixin):
 
     def items(self):
         """
-        Return a copied list of the properties, where each item is a tuple
-        of the property name (in the original lexical case) and the property
-        value.
+        Return a copied list of the property names and values
+        of this CIM instance.
+
+        Each item in the returned list is a tuple of property name (in the
+        original lexical case) and property value.
 
         The order of properties is preserved.
         """
@@ -2773,8 +2883,9 @@ class CIMInstance(_CIMComparisonMixin):
 
     def iterkeys(self):
         """
-        Iterate through the property names (in their original lexical
-        case).
+        Iterate through the property names of this CIM instance.
+
+        The property names have their original lexical case.
 
         The order of properties is preserved.
         """
@@ -2782,7 +2893,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     def itervalues(self):
         """
-        Iterate through the property values.
+        Iterate through the property values of this CIM instance.
 
         The order of properties is preserved.
         """
@@ -2791,7 +2902,10 @@ class CIMInstance(_CIMComparisonMixin):
 
     def iteritems(self):
         """
-        Iterate through the property names (in their original lexical case).
+        Iterate through the property names and values of this CIM instance.
+
+        Each iteration item is a tuple of the property name (in the original
+        lexical case) and the property value.
 
         The order of properties is preserved.
         """
@@ -2800,14 +2914,8 @@ class CIMInstance(_CIMComparisonMixin):
 
     def tocimxml(self, ignore_path=False):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMInstance` object,
-        as an instance of an appropriate subclass of :term:`Element`.
-
-        Parameters:
-
-          ignore_path (:class:`py:bool`): Ignore the path of the instance, even
-            if a path is specified.
+        Return the CIM-XML representation of this CIM instance,
+        as an object of an appropriate subclass of :term:`Element`.
 
         If the instance has no instance path specified or if `ignore_path` is
         `True`, the returned CIM-XML representation is an `INSTANCE` element
@@ -2828,6 +2936,16 @@ class CIMInstance(_CIMComparisonMixin):
         The order of properties and qualifiers in the returned CIM-XML
         representation is preserved from the :class:`~pywbem.CIMInstance`
         object.
+
+        Parameters:
+
+          ignore_path (:class:`py:bool`): Ignore the path of the instance, even
+            if a path is specified.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         # The items in the self.properties dictionary are required to be
@@ -2872,10 +2990,10 @@ class CIMInstance(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None, ignore_path=False):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM instance,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMInstance` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMInstance.tocimxml`.
@@ -2904,8 +3022,7 @@ class CIMInstance(_CIMComparisonMixin):
 
     def tomof(self, indent=0, maxline=MAX_MOF_LINE):
         """
-        Return a MOF string with the instance specification represented by
-        the :class:`~pywbem.CIMInstance` object.
+        Return a MOF string with the specification of this CIM instance.
 
         The returned MOF string conforms to the ``instanceDeclaration``
         ABNF rule defined in :term:`DSP0004`, with the following limitations:
@@ -2961,16 +3078,14 @@ class CIMInstance(_CIMComparisonMixin):
                    include_missing_properties=True,
                    include_path=True, include_class_origin=False):
         """
-        Create a new CIMInstance from the input CIMClass using the
-        property_values parameter to complete properties and the other
-        parameters to filter properties, validate the properties, and
-        optionally set the path component of the CIMInstance.
-        No CIMProperty qualifiers are included in the created instance and the
-        `class_origin` attribute is transfered from the class only if the
-        `include_class_origin` parameter is `True`.
+        Return a new :class:`~pywbem.CIMInstance` object from specified key
+        property values and from the key property definitions in a class.
+
+        The properties in the returned instance do not have any qualifiers.
 
         Parameters:
-          klass (:class:`pywbem:CIMClass`)
+
+          klass (:class:`~pywbem.CIMClass`):
             CIMClass from which the instance will be constructed.  This class
             must include qualifiers and should include properties from any
             superclasses in the model insure it includes all properties that
@@ -3004,7 +3119,7 @@ class CIMInstance(_CIMComparisonMixin):
             If `False` only properties in the `property_values` parameter are
             included in the new instance.
 
-         include_class_origin  (:class:`py:bool`):
+         include_class_origin (:class:`py:bool`):
             Determines if class origin information from the class is included
             in the returned instance.
 
@@ -3174,7 +3289,8 @@ class CIMClassName(_CIMComparisonMixin):
     @property
     def classname(self):
         """
-        :term:`unicode string`: Class name of the referenced class.
+        :term:`unicode string`: Class name of this CIM class path,
+        identifying the referenced class.
 
         Will not be `None`.
 
@@ -3203,8 +3319,8 @@ class CIMClassName(_CIMComparisonMixin):
     @property
     def namespace(self):
         """
-        :term:`unicode string`: Name of the CIM namespace containing the
-        referenced class.
+        :term:`unicode string`: Namespace name of this CIM class path,
+        identifying the namespace of the referenced class.
 
         `None` means that the namespace is unspecified.
 
@@ -3227,8 +3343,9 @@ class CIMClassName(_CIMComparisonMixin):
     @property
     def host(self):
         """
-        :term:`unicode string`: Host and optionally port of the WBEM server
-        containing the CIM namespace of the referenced class.
+        :term:`unicode string`: Host and optionally port
+        of this CIM class path,
+        identifying the WBEM server of the referenced class.
 
         For details about the string format, see the same-named constructor
         parameter.
@@ -3248,7 +3365,8 @@ class CIMClassName(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy the :class:`~pywbem.CIMClassName` object.
+        Return a new :class:`~pywbem.CIMClassName` object that is a copy
+        of this CIM class path.
 
         Objects of this class have no mutable types in any attributes, so
         modifications of the original object will not affect the returned copy,
@@ -3302,8 +3420,7 @@ class CIMClassName(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a WBEM URI string of the CIM class path represented by the
-        :class:`~pywbem.CIMClassName` object.
+        Return a WBEM URI string of this CIM class path.
 
         The returned WBEM URI string is in the historical format returned by
         :meth:`~pywbem.CIMClassName.to_wbem_uri`.
@@ -3335,8 +3452,8 @@ class CIMClassName(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMClassName`
-        object that is suitable for debugging.
+        Return a string representation of this CIM class path,
+        that is suitable for debugging.
         """
         return _format(
             "CIMClassName("
@@ -3347,17 +3464,8 @@ class CIMClassName(_CIMComparisonMixin):
 
     def tocimxml(self, ignore_host=False, ignore_namespace=False):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMClassName` object,
-        as an instance of an appropriate subclass of :term:`Element`.
-
-        Parameters:
-
-          ignore_host (:class:`py:bool`): Ignore the host of the
-            class path, even if a host is specified.
-
-          ignore_namespace (:class:`py:bool`): Ignore the namespace and host of
-            the class path, even if a namespace and/or host is specified.
+        Return the CIM-XML representation of this CIM class path,
+        as an object of an appropriate subclass of :term:`Element`.
 
         If the class path has no namespace specified or if
         `ignore_namespace` is `True`, the returned CIM-XML representation is a
@@ -3369,6 +3477,19 @@ class CIMClassName(_CIMComparisonMixin):
 
         Otherwise, the returned CIM-XML representation is a
         `CLASSPATH` element consistent with :term:`DSP0201`.
+
+        Parameters:
+
+          ignore_host (:class:`py:bool`): Ignore the host of the
+            class path, even if a host is specified.
+
+          ignore_namespace (:class:`py:bool`): Ignore the namespace and host of
+            the class path, even if a namespace and/or host is specified.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         classname_xml = cim_xml.CLASSNAME(self.classname)
@@ -3390,10 +3511,10 @@ class CIMClassName(_CIMComparisonMixin):
     def tocimxmlstr(self, indent=None, ignore_host=False,
                     ignore_namespace=False):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM class path,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMClassName` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMClassName.tocimxml`.
@@ -3426,10 +3547,10 @@ class CIMClassName(_CIMComparisonMixin):
     @staticmethod
     def from_wbem_uri(wbem_uri):
         """
-        *New in pywbem 0.12.*
-
         Return a new :class:`~pywbem.CIMClassName` object from the specified
         WBEM URI string.
+
+        *New in pywbem 0.12.*
 
         The WBEM URI string must be a CIM class path in untyped WBEM URI
         format, as defined in :term:`DSP0207`, with these extensions:
@@ -3509,8 +3630,7 @@ class CIMClassName(_CIMComparisonMixin):
     def to_wbem_uri(self, format='standard'):
         # pylint: disable=redefined-builtin
         """
-        Return the untyped WBEM URI of the CIM class path represented by the
-        :class:`~pywbem.CIMClassName` object.
+        Return the (untyped) WBEM URI string of this CIM class path.
 
         The returned WBEM URI contains its components as follows:
 
@@ -3687,9 +3807,9 @@ class CIMClass(_CIMComparisonMixin):
             The qualifiers for the class.
 
           path (:class:`~pywbem.CIMClassName`):
-            *New in pywbem 0.11.*
-
             Class path for the class.
+
+            *New in pywbem 0.11.*
 
             The provided object will be copied before being stored in the
             :class:`~pywbem.CIMClass` object.
@@ -3721,7 +3841,7 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def classname(self):
         """
-        :term:`unicode string`: Class name of the CIM class.
+        :term:`unicode string`: Class name of this CIM class.
 
         Will not be `None`.
 
@@ -3750,7 +3870,7 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def superclass(self):
         """
-        :term:`unicode string`: Class name of the superclass of the CIM class.
+        :term:`unicode string`: Class name of the superclass of this CIM class.
 
         `None` means that the class is a top-level class.
 
@@ -3768,7 +3888,7 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def properties(self):
         """
-        `NocaseDict`_: Properties (declarations) of the CIM class.
+        `NocaseDict`_: Properties (declarations) of this CIM class.
 
         Will not be `None`.
 
@@ -3827,7 +3947,7 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def methods(self):
         """
-        `NocaseDict`_: Methods (declarations) of the CIM class.
+        `NocaseDict`_: Methods (declarations) of this CIM class.
 
         Will not be `None`.
 
@@ -3886,7 +4006,7 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def qualifiers(self):
         """
-        `NocaseDict`_: Qualifiers (qualifier values) of the CIM class.
+        `NocaseDict`_: Qualifiers (qualifier values) of this CIM class.
 
         Will not be `None`.
 
@@ -3946,9 +4066,9 @@ class CIMClass(_CIMComparisonMixin):
     @property
     def path(self):
         """
-        *New in pywbem 0.11.*
+        :class:`~pywbem.CIMClassName`: Class path of this CIM class.
 
-        :class:`~pywbem.CIMClassName`: Class path of the CIM class.
+        *New in pywbem 0.11.*
 
         `None` means that the class path is unspecified.
 
@@ -4026,8 +4146,8 @@ class CIMClass(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMClass` object for human consumption.
+        Return a short string representation of this CIM class,
+        for human consumption.
         """
         return _format(
             "CIMClass("
@@ -4036,8 +4156,8 @@ class CIMClass(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMClass`
-        object that is suitable for debugging.
+        Return a string representation of this CIM class,
+        that is suitable for debugging.
 
         The order of properties, method and qualifiers will be preserved in
         the result.
@@ -4054,7 +4174,8 @@ class CIMClass(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMClass` object.
+        Return a new :class:`~pywbem.CIMClass` object that is a copy
+        of this CIM class.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -4086,9 +4207,8 @@ class CIMClass(_CIMComparisonMixin):
 
     def tocimxml(self):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMClass` object,
-        as an instance of an appropriate subclass of :term:`Element`.
+        Return the CIM-XML representation of this CIM class,
+        as an object of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is a `CLASS` element
         consistent with :term:`DSP0201`. This is the required element for
@@ -4099,6 +4219,11 @@ class CIMClass(_CIMComparisonMixin):
         The order of properties, methods, parameters, and qualifiers in the
         returned CIM-XML representation is preserved from the
         :class:`~pywbem.CIMClass` object.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
         return cim_xml.CLASS(
             self.classname,
@@ -4109,10 +4234,10 @@ class CIMClass(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM class,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMClass` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMClass.tocimxml`.
@@ -4138,8 +4263,7 @@ class CIMClass(_CIMComparisonMixin):
 
     def tomof(self, maxline=MAX_MOF_LINE):
         """
-        Return a MOF string with the class definition represented by the
-        :class:`~pywbem.CIMClass` object.
+        Return a MOF string with the declaration of this CIM class.
 
         The returned MOF string conforms to the ``classDeclaration``
         ABNF rule defined in :term:`DSP0004`.
@@ -4247,9 +4371,11 @@ class CIMProperty(_CIMComparisonMixin):
             hash value calculation are performed case-insensitively.
 
           value (:term:`CIM data type` or other suitable types):
-            Value of the property (interpreted as actual value when
-            representing a property value, and as default value for property
-            declarations).
+            Value of the property.
+
+            The property value is interpreted as an actual property value when
+            the CIM property is used in a CIM instance, and as default value
+            when the CIM property is used in a CIM class.
 
             `None` means that the property is Null, and the same-named
             attribute in the :class:`~pywbem.CIMProperty` object will also be
@@ -4289,10 +4415,9 @@ class CIMProperty(_CIMComparisonMixin):
             will also be `None`.
 
           propagated (:class:`py:bool`):
-            If not `None`, indicates whether the property declaration has been
-            propagated from a superclass to this class, or the property value
-            has been propagated from the creation class to this instance (the
-            latter is not really used).
+            If not `None`, specifies whether the property declaration has been
+            propagated from a superclass, or the property value has been
+            propagated from the creation class.
 
             `None` means that propagation information is not available, and
             the same-named attribute in the :class:`~pywbem.CIMProperty` object
@@ -4302,21 +4427,16 @@ class CIMProperty(_CIMComparisonMixin):
             A boolean indicating whether the property is an array (`True`) or a
             scalar (`False`).
 
-            `None` means that it is unspecified whether the property is an
-            array, and the same-named attribute in the
-            :class:`~pywbem.CIMProperty` object will be inferred from the
-            `value` parameter. If the `value` parameter is `None`, a scalar is
-            assumed.
+            If `None`, the same-named attribute in this object will be inferred
+            from the `value` parameter. If the `value` parameter is `None`, a
+            scalar is assumed.
 
           reference_class (:term:`string`):
             For reference properties, the name of the class referenced by the
-            property, as declared in the class defining the property (for both,
-            property declarations in CIM classes, and property values in CIM
-            instances).
+            property, or `None` indicating that the referenced class is
+            unspecified.
 
-            `None` means that the referenced class is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMProperty` object
-            will also be `None`.
+            For non-reference properties, must be `None`.
 
             The lexical case of the string is preserved. Object comparison and
             hash value calculation are performed case-insensitively.
@@ -4428,7 +4548,7 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def name(self):
         """
-        :term:`unicode string`: Name of the property.
+        :term:`unicode string`: Name of this CIM property.
 
         Will not be `None`.
 
@@ -4452,9 +4572,11 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def value(self):
         """
-        :term:`CIM data type`: Value of the property (interpreted as actual
-        value when representing a property value, and as default value for
-        property declarations).
+        :term:`CIM data type`: Value of this CIM property.
+
+        The property value is interpreted as an actual property value when this
+        CIM property is used in a CIM instance, and as default value when this
+        CIM property is used in a CIM class.
 
         `None` means that the value is Null.
 
@@ -4472,8 +4594,9 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def type(self):
         """
-        :term:`unicode string`: Name of the CIM data type of the property
-        (e.g. ``"uint8"``).
+        :term:`unicode string`: Name of the CIM data type of this CIM property.
+
+        Example: ``"uint8"``
 
         Will not be `None`.
 
@@ -4501,15 +4624,11 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def reference_class(self):
         """
-        :term:`unicode string`:
+        :term:`unicode string`: The name of the class referenced by this CIM
+        reference property.
 
-        For reference properties, the name of the class referenced by the
-        property, as declared in the class defining the property (for both,
-        property declarations in CIM classes, and property values in CIM
-        instances).
-        `None` means that the referenced class is unspecified.
-
-        For non-reference properties, will be `None`.
+        Will be `None` for non-reference properties or if the referenced class
+        is unspecified in reference properties.
 
         Note that in CIM instances returned from a WBEM server, :term:`DSP0201`
         recommends this attribute not to be set. For CIM classes returned from
@@ -4530,7 +4649,9 @@ class CIMProperty(_CIMComparisonMixin):
     def embedded_object(self):
         """
         :term:`unicode string`: A string value indicating the kind of embedded
-        object represented by the property value.
+        object represented by this CIM property value.
+
+        Has no meaning for CIM property declarations.
 
         The following values are defined for this parameter:
 
@@ -4562,8 +4683,8 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def is_array(self):
         """
-        :class:`py:bool`: A boolean indicating whether the property is an array
-        (`True`) or a scalar (`False`).
+        :class:`py:bool`: Boolean indicating that this CIM property
+        is an array (as opposed to a scalar).
 
         Will not be `None`.
 
@@ -4581,10 +4702,10 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def array_size(self):
         """
-        :term:`integer`: The size of the array property, for fixed-size arrays.
+        :term:`integer`: The size of the fixed-size array of this CIM property.
 
-        `None` means that the array property has variable size, or that it is
-        not an array.
+        `None` means that the array has variable size, or that the
+        property is a scalar.
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
@@ -4600,9 +4721,9 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def class_origin(self):
         """
-        :term:`unicode string`: The CIM class origin of the property (the name
-        of the most derived class that defines or overrides the property in
-        the class hierarchy of the class owning the property).
+        :term:`unicode string`: The class origin of this CIM property,
+        identifying the most derived class that defines or overrides the
+        property in the class hierarchy of the class owning the property.
 
         `None` means that class origin information is not available.
 
@@ -4620,10 +4741,9 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def propagated(self):
         """
-        :class:`py:bool`: If not `None`, indicates whether the property
-        declaration has been propagated from a superclass to this class, or the
-        property value has been propagated from the creation class to this
-        instance (the latter is not really used).
+        :class:`py:bool`: Boolean indicating that the property declaration
+        has been propagated from a superclass, or that the property value has
+        been propagated from the creation class.
 
         `None` means that propagation information is not available.
 
@@ -4641,7 +4761,7 @@ class CIMProperty(_CIMComparisonMixin):
     @property
     def qualifiers(self):
         """
-        `NocaseDict`_: Qualifiers (qualifier values) of the property
+        `NocaseDict`_: Qualifiers (qualifier values) of this CIM property
         declaration.
 
         Will not be `None`.
@@ -4701,7 +4821,8 @@ class CIMProperty(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMProperty` object.
+        Return a new :class:`~pywbem.CIMProperty` object that is a copy
+        of this CIM property.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -4730,8 +4851,8 @@ class CIMProperty(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMProperty` object for human consumption.
+        Return a short string representation of this CIM property,
+        for human consumption.
         """
         return _format(
             "CIMProperty("
@@ -4745,8 +4866,8 @@ class CIMProperty(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMProperty`
-        object that is suitable for debugging.
+        Return a string representation of this CIM property,
+        that is suitable for debugging.
 
         The order of qualifiers will be preserved in the result.
         """
@@ -4766,9 +4887,8 @@ class CIMProperty(_CIMComparisonMixin):
 
     def tocimxml(self):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMProperty` object,
-        as an instance of an appropriate subclass of :term:`Element`.
+        Return the CIM-XML representation of this CIM property,
+        as an object of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is a `PROPERTY`,
         `PROPERTY.REFERENCE`, or `PROPERTY.ARRAY` element dependent on the
@@ -4777,6 +4897,11 @@ class CIMProperty(_CIMComparisonMixin):
 
         The order of qualifiers in the returned CIM-XML representation is
         preserved from the :class:`~pywbem.CIMProperty` object.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         qualifiers = [q.tocimxml() for q in self.qualifiers.values()]
@@ -4848,10 +4973,10 @@ class CIMProperty(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM property,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMProperty` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMProperty.tocimxml`.
@@ -4878,11 +5003,11 @@ class CIMProperty(_CIMComparisonMixin):
     def tomof(
             self, is_instance=True, indent=0, maxline=MAX_MOF_LINE, line_pos=0):
         """
-        *New in pywbem 0.9.*
+        Return a MOF string with the declaration of this CIM property for use
+        in a CIM class, or the specification of this CIM property for use in a
+        CIM instance.
 
-        Return a MOF fragment with the property definition (for use in a CIM
-        class) or property value (for use in a CIM instance) represented by the
-        :class:`~pywbem.CIMProperty` object.
+        *New in pywbem 0.9.*
 
         Even though pywbem supports qualifiers on :class:`~pywbem.CIMProperty`
         objects that are used as property values within an instance, the
@@ -4902,7 +5027,7 @@ class CIMProperty(_CIMComparisonMixin):
 
         Returns:
 
-          :term:`unicode string`: MOF fragment.
+          :term:`unicode string`: MOF string.
         """
 
         mof = []
@@ -5059,17 +5184,17 @@ class CIMMethod(_CIMComparisonMixin):
         Parameters:
 
           name (:term:`string`):
-            Name of the method (just the method name, without class name
-            or parenthesis).
+            **Deprecated:** Name of this CIM method (just the method name,
+            without class name or parenthesis).
+
+            This argument has been named `methodname` before pywbem 0.9.
+            Using `methodname` as a named argument still works, but has been
+            deprecated in pywbem 0.9.
 
             Must not be `None`.
 
             The lexical case of the string is preserved. Object comparison and
             hash value calculation are performed case-insensitively.
-
-            Deprecated: This argument has been named `methodname` before
-            pywbem 0.9. Using `methodname` as a named argument still works,
-            but has been deprecated in pywbem 0.9.
 
           return_type (:term:`string`):
             Name of the CIM data type of the method return type
@@ -5113,8 +5238,8 @@ class CIMMethod(_CIMComparisonMixin):
             hash value calculation are performed case-insensitively.
 
           propagated (:class:`py:bool`):
-            If not `None`, indicates whether the method has been propagated
-            from a superclass to this class.
+            If not `None`, specifies whether the method has been
+            propagated from a superclass.
 
             `None` means that propagation information is not available, and the
             same-named attribute in the :class:`~pywbem.CIMMethod` object will
@@ -5148,7 +5273,7 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def name(self):
         """
-        :term:`unicode string`: Name of the method.
+        :term:`unicode string`: Name of this CIM method.
 
         Will not be `None`.
 
@@ -5172,8 +5297,10 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def return_type(self):
         """
-        :term:`unicode string`: Name of the CIM data type of the method return
-        type (e.g. ``"uint32"``).
+        :term:`unicode string`: Name of the CIM data type of the return type of
+        this CIM method.
+
+        Example: ``"uint32"``
 
         Will not be `None` or ``"reference"``.
 
@@ -5202,9 +5329,9 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def class_origin(self):
         """
-        :term:`unicode string`: The CIM class origin of the method (the name
-        of the most derived class that defines or overrides the method in
-        the class hierarchy of the class owning the method).
+        :term:`unicode string`: The class origin of this CIM method,
+        identifying the most derived class that defines or overrides the
+        method in the class hierarchy of the class owning the method.
 
         `None` means that class origin information is not available.
 
@@ -5222,8 +5349,8 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def propagated(self):
         """
-        :class:`py:bool`: If not `None`, indicates whether the method has been
-        propagated from a superclass to this class.
+        :class:`py:bool`: Boolean indicating that this CIM method has been
+        propagated from a superclass.
 
         `None` means that propagation information is not available.
 
@@ -5241,7 +5368,7 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def parameters(self):
         """
-        `NocaseDict`_: Parameters of the method.
+        `NocaseDict`_: Parameters of this CIM method.
 
         Will not be `None`.
 
@@ -5298,7 +5425,7 @@ class CIMMethod(_CIMComparisonMixin):
     @property
     def qualifiers(self):
         """
-        `NocaseDict`_: Qualifiers (qualifier values) of the method.
+        `NocaseDict`_: Qualifiers (qualifier values) of this CIM method.
 
         Will not be `None`.
 
@@ -5402,8 +5529,8 @@ class CIMMethod(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMMethod` object for human consumption.
+        Return a short string representation of this CIM method,
+        for human consumption.
         """
         return _format(
             "CIMMethod("
@@ -5413,8 +5540,8 @@ class CIMMethod(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMMethod`
-        object that is suitable for debugging.
+        Return a string representation of this CIM method,
+        that is suitable for debugging.
 
         The order of parameters and qualifiers will be preserved in the
         result.
@@ -5431,7 +5558,8 @@ class CIMMethod(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMMethod` object.
+        Return a new :class:`~pywbem.CIMMethod` object that is a copy
+        of this CIM method.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -5460,15 +5588,19 @@ class CIMMethod(_CIMComparisonMixin):
 
     def tocimxml(self):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMMethod` object,
-        as an instance of an appropriate subclass of :term:`Element`.
+        Return the CIM-XML representation of this CIM method,
+        as an object of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is a `METHOD` element consistent
         with :term:`DSP0201`.
 
         The order of parameters and qualifiers in the returned CIM-XML
         representation is preserved from the :class:`~pywbem.CIMMethod` object.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
         return cim_xml.METHOD(
             self.name,
@@ -5480,10 +5612,10 @@ class CIMMethod(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM method,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMMethod` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMMethod.tocimxml`.
@@ -5509,8 +5641,8 @@ class CIMMethod(_CIMComparisonMixin):
 
     def tomof(self, indent=0, maxline=MAX_MOF_LINE):
         """
-        Return a MOF fragment with the method definition represented by the
-        :class:`~pywbem.CIMMethod` object.
+        Return a MOF string with the declaration of this CIM method for use in
+        a CIM class declaration.
 
         The order of parameters and qualifiers is preserved.
 
@@ -5521,7 +5653,7 @@ class CIMMethod(_CIMComparisonMixin):
 
         Returns:
 
-          :term:`unicode string`: MOF fragment.
+          :term:`unicode string`: MOF string.
         """
 
         mof = []
@@ -5593,7 +5725,7 @@ class CIMParameter(_CIMComparisonMixin):
         Parameters:
 
           name (:term:`string`):
-            Name of the parameter.
+            Name of this CIM parameter.
 
             Must not be `None`.
 
@@ -5601,7 +5733,9 @@ class CIMParameter(_CIMComparisonMixin):
             hash value calculation are performed case-insensitively.
 
           type (:term:`string`):
-            Name of the CIM data type of the parameter (e.g. ``"uint8"``).
+            Name of the CIM data type of this CIM parameter.
+
+            Example: ``"uint8"``
 
             Must not be `None`.
 
@@ -5610,11 +5744,10 @@ class CIMParameter(_CIMComparisonMixin):
 
           reference_class (:term:`string`):
             For reference parameters, the name of the class referenced by the
-            parameter, as declared in the class defining the method.
+            parameter, or `None` indicating that the referenced class is
+            unspecified.
 
-            `None` means that the referenced class is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMParameter` object
-            will also be `None`.
+            For non-reference parameters, must be `None`.
 
             The lexical case of the string is preserved. Object comparison and
             hash value calculation are performed case-insensitively.
@@ -5623,11 +5756,9 @@ class CIMParameter(_CIMComparisonMixin):
             A boolean indicating whether the parameter is an array (`True`) or a
             scalar (`False`).
 
-            `None` means that it is unspecified whether the parameter is an
-            array, and the same-named attribute in the
-            :class:`~pywbem.CIMParameter` object will be inferred from the
-            `value` parameter. If the `value` parameter is `None`, a scalar is
-            assumed.
+            If `None`, the same-named attribute in this object will be inferred
+            from the `value` parameter. If the `value` parameter is `None`, a
+            scalar is assumed.
 
           array_size (:term:`integer`):
             The size of the array parameter, for fixed-size arrays.
@@ -5688,7 +5819,7 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def name(self):
         """
-        :term:`unicode string`: Name of the parameter.
+        :term:`unicode string`: Name of this CIM parameter.
 
         Will not be `None`.
 
@@ -5712,8 +5843,10 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def type(self):
         """
-        :term:`unicode string`: Name of the CIM data type of the parameter
-        (e.g. ``"uint8"``).
+        :term:`unicode string`: Name of the CIM data type of this CIM
+        parameter.
+
+        Example: ``"uint8"``
 
         Will not be `None`.
 
@@ -5741,13 +5874,11 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def reference_class(self):
         """
-        :term:`unicode string`:
+        :term:`unicode string`: The name of the class referenced by this CIM
+        reference parameter.
 
-        For reference parameters, the name of the class referenced by the
-        parameter, as declared in the class defining the parameter.
-        `None` means that the referenced class is unspecified.
-
-        For non-reference parameters, will be `None`.
+        Will be `None` for non-reference parameters or if the referenced class
+        is unspecified in reference parameters.
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
@@ -5763,10 +5894,10 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def is_array(self):
         """
-        :class:`py:bool`: A boolean indicating whether the parameter is an array
-        (`True`) or a scalar (`False`).
+        :class:`py:bool`: Boolean indicating that this CIM parameter
+        is an array (as opposed to a scalar).
 
-        `None` means that it is unspecified whether the parameter is an array.
+        Will not be `None`.
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
@@ -5782,11 +5913,11 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def array_size(self):
         """
-        :term:`integer`: The size of the array parameter, for fixed-size
-        arrays.
+        :term:`integer`: The size of the fixed-size array of this CIM
+        parameter.
 
-        `None` means that the array parameter has variable size, or that it is
-        not an array.
+        `None` means that the array has variable size, or that the
+        parameter is a scalar.
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
@@ -5802,7 +5933,7 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def qualifiers(self):
         """
-        `NocaseDict`_: Qualifiers (qualifier values) of the parameter.
+        `NocaseDict`_: Qualifiers (qualifier values) of this CIM parameter.
 
         Will not be `None`.
 
@@ -5862,7 +5993,8 @@ class CIMParameter(_CIMComparisonMixin):
     @property
     def value(self):
         """
-        The value of the CIM method parameter for the method invocation.
+        The value of this CIM parameter for the method invocation.
+
         Has no meaning for parameter declarations.
 
         This attribute is settable. For details, see the description of the
@@ -5880,8 +6012,9 @@ class CIMParameter(_CIMComparisonMixin):
     def embedded_object(self):
         """
         :term:`unicode string`: A string value indicating the kind of embedded
-        object represented by the parameter value.
-        Has no meaning for parameter declarations.
+        object represented by this CIM parameter value.
+
+        Has no meaning for CIM parameter declarations.
 
         The following values are defined for this parameter:
 
@@ -5968,8 +6101,8 @@ class CIMParameter(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMParameter` object for human consumption.
+        Return a short string representation of this CIM parameter,
+        for human consumption.
         """
         return _format(
             "CIMParameter("
@@ -5981,8 +6114,8 @@ class CIMParameter(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMParameter`
-        object that is suitable for debugging.
+        Return a string representation of this CIM parameter,
+        that is suitable for debugging.
 
         The order of qualifiers will be preserved in the result.
         """
@@ -6000,7 +6133,8 @@ class CIMParameter(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMParameter` object.
+        Return a new :class:`~pywbem.CIMParameter` object that is a copy
+        of this CIM parameter.
 
         This is a middle-deep copy; any mutable types in attributes except the
         following are copied, so besides these exceptions, modifications of the
@@ -6028,9 +6162,12 @@ class CIMParameter(_CIMComparisonMixin):
 
     def tocimxml(self, as_value=False):
         """
-        Return the CIM-XML representation of the :class:`~pywbem.CIMParameter`
-        object, either as a parameter declaration for use in a method
-        declaration, or as a parameter value for use in a method invocation.
+        Return the CIM-XML representation of this CIM parameter,
+        as an object of an appropriate subclass of :term:`Element`.
+
+        The returned CIM-XML representation can be created
+        either as a parameter declaration for use in a method declaration,
+        or as a parameter value for use in a method invocation.
 
         If a parameter value is to be returned, the returned CIM-XML
         representation is a `PARAMVALUE` element with child elements dependent
@@ -6052,8 +6189,8 @@ class CIMParameter(_CIMComparisonMixin):
 
         Returns:
 
-            The CIM-XML representation of the object, as an appropriate
-            subclass of :term:`Element`.
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         if as_value:
@@ -6149,11 +6286,14 @@ class CIMParameter(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None, as_value=False):
         """
+        Return the CIM-XML representation of this CIM parameter,
+        as a :term:`unicode string`.
+
         *New in pywbem 0.9.*
 
-        Return the CIM-XML representation of the :class:`~pywbem.CIMParameter`
-        object, either as a parameter declaration for use in a method
-        declaration, or as a parameter value for use in a method invocation.
+        The returned CIM-XML representation can be created
+        either as a parameter declaration for use in a method declaration,
+        or as a parameter value for use in a method invocation.
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMParameter.tocimxml`.
@@ -6182,8 +6322,8 @@ class CIMParameter(_CIMComparisonMixin):
 
     def tomof(self, indent=0, maxline=MAX_MOF_LINE):
         """
-        Return a MOF fragment with the parameter definition represented by the
-        :class:`~pywbem.CIMParameter` object.
+        Return a MOF string with the declaration of this CIM parameter for use
+        in a CIM method declaration.
 
         The object is always interpreted as a parameter declaration; so the
         :attr:`~pywbem.CIMParameter.value` and
@@ -6198,7 +6338,7 @@ class CIMParameter(_CIMComparisonMixin):
 
         Returns:
 
-          :term:`unicode string`: MOF fragment.
+          :term:`unicode string`: MOF string.
         """
 
         mof = []
@@ -6313,7 +6453,7 @@ class CIMQualifier(_CIMComparisonMixin):
 
           propagated (:class:`py:bool`):
             If not `None`, specifies whether the qualifier value has been
-            propagated from a superclass to this class.
+            propagated from a superclass.
 
             `None` means that this information is not available, and the
             same-named attribute in the :class:`~pywbem.CIMQualifier` object
@@ -6396,7 +6536,7 @@ class CIMQualifier(_CIMComparisonMixin):
     @property
     def name(self):
         """
-        :term:`unicode string`: Name of the qualifier.
+        :term:`unicode string`: Name of this CIM qualifier.
 
         Will not be `None`.
 
@@ -6420,8 +6560,10 @@ class CIMQualifier(_CIMComparisonMixin):
     @property
     def type(self):
         """
-        :term:`unicode string`: Name of the CIM data type of the qualifier
-        (e.g. ``"uint8"``).
+        :term:`unicode string`: Name of the CIM data type of this CIM
+        qualifier.
+
+        Example: ``"uint8"``
 
         Will not be `None`.
 
@@ -6449,7 +6591,7 @@ class CIMQualifier(_CIMComparisonMixin):
     @property
     def value(self):
         """
-        :term:`CIM data type`: Value of the qualifier.
+        :term:`CIM data type`: Value of this CIM qualifier.
 
         `None` means that the value is Null.
 
@@ -6471,8 +6613,8 @@ class CIMQualifier(_CIMComparisonMixin):
     @property
     def propagated(self):
         """
-        :class:`py:bool`: Indicates whether the qualifier value has been
-        propagated from a superclass to this class.
+        :class:`py:bool`: Boolean indicating that the qualifier value has been
+        propagated from a superclass.
 
         `None` means that propagation information is not available.
 
@@ -6638,8 +6780,8 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMQualifier` object for human consumption.
+        Return a short string representation of this CIM qualifier,
+        for human consumption.
         """
         return _format(
             "CIMQualifier("
@@ -6650,8 +6792,8 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the :class:`~pywbem.CIMQualifier`
-        object that is suitable for debugging.
+        Return a string representation of this CIM qualifier,
+        that is suitable for debugging.
         """
         return _format(
             "CIMQualifier("
@@ -6667,7 +6809,8 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy of the :class:`~pywbem.CIMQualifier` object.
+        Return a new :class:`~pywbem.CIMQualifier` object that is a copy
+        of this CIM qualifier.
 
         Objects of this class have no mutable types in any attributes, so
         modifications of the original object will not affect the returned copy,
@@ -6689,12 +6832,16 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def tocimxml(self):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMQualifier` object,
-        as an instance of an appropriate subclass of :term:`Element`.
+        Return the CIM-XML representation of this CIM qualifier,
+        as an object of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is a `QUALIFIER` element consistent
         with :term:`DSP0201`.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         if self.value is None:
@@ -6726,10 +6873,10 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM qualifier,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMQualifier` object, as a :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMQualifier.tocimxml`.
@@ -6755,8 +6902,8 @@ class CIMQualifier(_CIMComparisonMixin):
 
     def tomof(self, indent=MOF_INDENT, maxline=MAX_MOF_LINE, line_pos=0):
         """
-        Return a MOF fragment with the qualifier value represented by the
-        :class:`~pywbem.CIMQualifier` object.
+        Return a MOF string with the specification of this CIM qualifier
+        as a qualifier value.
 
         The items of array values are tried to keep on the same line. If the
         generated line would exceed the maximum MOF line length, the value is
@@ -6775,7 +6922,7 @@ class CIMQualifier(_CIMComparisonMixin):
 
         Returns:
 
-          :term:`unicode string`: MOF fragment.
+          :term:`unicode string`: MOF string.
         """
 
         mof = []
@@ -6858,9 +7005,9 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     """
 
     # Order of scopes when externalizing the qualifier declaration
-    ordered_scopes = ["CLASS", "ASSOCIATION", "INDICATION",
-                      "PROPERTY", "REFERENCE", "METHOD", "PARAMETER",
-                      "ANY"]
+    _ordered_scopes = ["CLASS", "ASSOCIATION", "INDICATION",
+                       "PROPERTY", "REFERENCE", "METHOD", "PARAMETER",
+                       "ANY"]
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, type, value=None, is_array=False,
@@ -6902,9 +7049,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
             A boolean indicating whether the qualifier is an array (`True`) or
             a scalar (`False`).
 
-            `None` means that it is unspecified whether the qualifier is an
-            array, and the same-named attribute in the
-            :class:`~pywbem.CIMQualifierDeclaration` object will be inferred
+            If `None`, the same-named attribute in this object will be inferred
             from the `value` parameter. If the `value` parameter is `None`, a
             scalar is assumed.
 
@@ -7000,7 +7145,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def name(self):
         """
-        :term:`unicode string`: Name of the qualifier.
+        :term:`unicode string`: Name of this CIM qualifier type.
 
         Will not be `None`.
 
@@ -7025,8 +7170,10 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def type(self):
         """
-        :term:`unicode string`: Name of the CIM data type of the qualifier
-        (e.g. ``"uint8"``).
+        :term:`unicode string`: Name of the CIM data type of this CIM
+        qualifier type.
+
+        Example: ``"uint8"``.
 
         Will not be `None`.
 
@@ -7054,7 +7201,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def value(self):
         """
-        :term:`CIM data type`: Default value of the qualifier.
+        :term:`CIM data type`: Default value of this CIM qualifier type.
 
         `None` means that the value is Null.
 
@@ -7076,8 +7223,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def is_array(self):
         """
-        :class:`py:bool`: A boolean indicating whether the qualifier is an
-        array (`True`) or a scalar (`False`).
+        :class:`py:bool`: Boolean indicating that this CIM qualifier type
+        is an array (as opposed to a scalar).
 
         Will not be `None`.
 
@@ -7095,11 +7242,11 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def array_size(self):
         """
-        :term:`integer`: The size of the array qualifier, for fixed-size
-        arrays.
+        :term:`integer`: The size of the fixed-size array of this CIM qualifier
+        type.
 
-        `None` means that the array qualifier has variable size, or that it is
-        not an array.
+        `None` means that the array has variable size (or that the
+        qualifier type is not an array).
 
         This attribute is settable. For details, see the description of the
         same-named constructor parameter.
@@ -7115,7 +7262,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     @property
     def scopes(self):
         """
-        `NocaseDict`_: Scopes of the qualifier.
+        `NocaseDict`_: Scopes of this CIM qualifier type.
 
         Each dictionary item specifies one scope value, with:
 
@@ -7289,9 +7436,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def __str__(self):
         """
-        Return a short string representation of the
-        :class:`~pywbem.CIMQualifierDeclaration` object for human
-        consumption.
+        Return a short string representation of this CIM qualifier type,
+        for human consumption.
         """
         return _format(
             "CIMQualifierDeclaration("
@@ -7303,9 +7449,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def __repr__(self):
         """
-        Return a string representation of the
-        :class:`~pywbem.CIMQualifierDeclaration` object that is suitable for
-        debugging.
+        Return a string representation of this CIM qualifier type,
+        that is suitable for debugging.
 
         The scopes will be ordered by their names in the result.
         """
@@ -7325,7 +7470,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def copy(self):
         """
-        Return a copy the :class:`~pywbem.CIMQualifierDeclaration` object.
+        Return a new :class:`~pywbem.CIMQualifierDeclaration` object
+        that is a copy of this CIM qualifier type.
 
         Objects of this class have no mutable types in any attributes, so
         modifications of the original object will not affect the returned copy,
@@ -7349,12 +7495,16 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def tocimxml(self):
         """
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMQualifierDeclaration` object,
-        as an instance of an appropriate subclass of :term:`Element`.
+        Return the CIM-XML representation of this CIM qualifier type,
+        as an object of an appropriate subclass of :term:`Element`.
 
         The returned CIM-XML representation is a `QUALIFIER.DECLARATION`
         element consistent with :term:`DSP0201`.
+
+        Returns:
+
+          The CIM-XML representation, as an object of an appropriate subclass
+          of :term:`Element`.
         """
 
         if self.value is None:
@@ -7388,11 +7538,10 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def tocimxmlstr(self, indent=None):
         """
-        *New in pywbem 0.9.*
+        Return the CIM-XML representation of this CIM qualifier type,
+        as a :term:`unicode string`.
 
-        Return the CIM-XML representation of the
-        :class:`~pywbem.CIMQualifierDeclaration` object, as a
-        :term:`unicode string`.
+        *New in pywbem 0.9.*
 
         For the returned CIM-XML representation, see
         :meth:`~pywbem.CIMQualifierDeclaration.tocimxml`.
@@ -7418,8 +7567,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     def tomof(self, maxline=MAX_MOF_LINE):
         """
-        Return a MOF string with the qualifier type declaration represented by
-        the :class:`~pywbem.CIMQualifierDeclaration` object.
+        Return a MOF string with the declaration of this CIM qualifier type.
 
         The returned MOF string conforms to the ``qualifierDeclaration``
         ABNF rule defined in :term:`DSP0004`.
@@ -7471,7 +7619,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         mof.append(_indent_str(MOF_INDENT + 1))
         mof.append(u'Scope(')
         mof_scopes = []
-        for scope in self.ordered_scopes:
+        for scope in self._ordered_scopes:
             if self.scopes.get(scope, False):
                 mof_scopes.append(scope.lower())
         mof.append(u', '.join(mof_scopes))
@@ -7508,22 +7656,22 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 def tocimxml(value):
     # pylint: disable=line-too-long
     """
-    Return the CIM-XML representation of the input value, as an
-    :term:`Element` object.
+    Return the CIM-XML representation of the input object,
+    as an object of an appropriate subclass of :term:`Element`.
 
     The returned CIM-XML representation is consistent with :term:`DSP0201`.
 
     Parameters:
 
       value (:term:`CIM object`, :term:`CIM data type`, :term:`number`, :class:`py:datetime.datetime`, or tuple/list thereof):
-        The input value.
+        The input object.
 
         Specifying `None` has been deprecated in pywbem 0.12.
 
     Returns:
 
-      The CIM-XML representation of the specified value, as an object of an
-      appropriate subclass of :term:`Element`.
+      The CIM-XML representation, as an object of an appropriate subclass of
+      :term:`Element`.
     """  # noqa: E501
 
     if isinstance(value, (tuple, list)):
@@ -7552,10 +7700,10 @@ def tocimxml(value):
 
 def tocimxmlstr(value, indent=None):
     """
-    *New in pywbem 0.9.*
-
     Return the CIM-XML representation of the CIM object or CIM data type,
     as a :term:`unicode string`.
+
+    *New in pywbem 0.9.*
 
     The returned CIM-XML representation is consistent with :term:`DSP0201`.
 
@@ -7603,9 +7751,10 @@ def tocimxmlstr(value, indent=None):
 # pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
 def tocimobj(type_, value):
     """
-    Return a CIM object representing the specified value and type.
+    **Deprecated:** Return a CIM object representing the specified value and
+    type.
 
-    **Deprecated:** This function has been deprecated in pywbem 0.13. Use
+    This function has been deprecated in pywbem 0.13. Use
     :func:`~pywbem.cimvalue` instead.
 
     Parameters:
@@ -7807,10 +7956,10 @@ def tocimobj(type_, value):
 def cimvalue(value, type):
     # pylint: disable=redefined-builtin
     """
-    *New in pywbem 0.12.*
-
     Return a :term:`CIM data type` representing the specified value in the
     specified CIM type.
+
+    *New in pywbem 0.12.*
 
     This function guarantees that the returned object is a valid
     :term:`CIM data type`. If the input parameters are not sufficient to
@@ -8077,10 +8226,10 @@ def _check_embedded_object(embedded_object, type, value, element_txt):
 
 def byname(nlist):
     """
-    Convert a list of named objects into an ordered dictionary indexed by name.
+    **Deprecated:** Convert a list of named objects into an ordered dictionary
+    indexed by name.
 
-    Deprecated: This function is internal and has been deprecated in pywbem
-    0.12.
+    This function is internal and has been deprecated in pywbem 0.12.
     """
     warnings.warn("The internal byname() function has been deprecated, with "
                   "no replacement.", DeprecationWarning,

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1155,8 +1155,8 @@ class CIMInstanceName(_CIMComparisonMixin):
               before the zone ID string, as an additional choice to ``%25``.
 
             `None` means that the WBEM server is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMInstanceName` object will also be
-            `None`.
+            :attr:`~pywbem.CIMInstanceName.host` attribute
+            will also be `None`.
 
             The lexical case of the string is preserved. Object comparison and
             hash value calculation are performed case-insensitively.
@@ -1165,8 +1165,8 @@ class CIMInstanceName(_CIMComparisonMixin):
             Name of the CIM namespace containing the referenced instance.
 
             `None` means that the namespace is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMInstanceName` object will also be
-            `None`.
+            :attr:`~pywbem.CIMInstanceName.namespace` attribute
+            will also be `None`.
 
             Leading and trailing slash characters will be stripped.
             The lexical case of the string is preserved. Object comparison and
@@ -1195,7 +1195,8 @@ class CIMInstanceName(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMInstanceName>`.
         """
         return self._classname
 
@@ -1240,7 +1241,8 @@ class CIMInstanceName(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         keybindings to be replaced with the new keybindings. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMInstanceName>`.
 
         The keybindings can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -1309,7 +1311,8 @@ class CIMInstanceName(_CIMComparisonMixin):
         `None` means that the namespace is unspecified.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMInstanceName>`.
         """
         return self._namespace
 
@@ -1331,13 +1334,13 @@ class CIMInstanceName(_CIMComparisonMixin):
         of this CIM instance path,
         identifying the WBEM server of the referenced instance.
 
-        For details about the string format, see the same-named constructor
-        parameter.
+        For details about the string format, see the same-named init parameter
+        of :class:`this class <pywbem.CIMInstanceName>`.
 
         `None` means that the host and port are unspecified.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter.
         """
         return self._host
 
@@ -2336,7 +2339,7 @@ class CIMInstance(_CIMComparisonMixin):
             path will be updated to match the property values.
 
             `None` means that the instance path is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMInstance` object
+            :attr:`~pywbem.CIMInstance.path` attribute
             will also be `None`.
 
           property_list (:term:`py:iterable` of :term:`string`):
@@ -2354,7 +2357,7 @@ class CIMInstance(_CIMComparisonMixin):
             converted to lower case.
 
             `None` means that the properties are not filtered, and the
-            same-named attribute in the :class:`~pywbem.CIMInstance` object
+            :attr:`~pywbem.CIMInstance.property_list` attribute
             will also be `None`.
 
         Raises:
@@ -2382,7 +2385,8 @@ class CIMInstance(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMInstance>`.
         """
         return self._classname
 
@@ -2494,7 +2498,8 @@ class CIMInstance(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         qualifiers to be replaced with the new qualifiers. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMInstance>`.
 
         The qualifier values can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary.
@@ -2538,7 +2543,8 @@ class CIMInstance(_CIMComparisonMixin):
         `None` means that the instance path is unspecified.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMInstance>`.
         """
         return self._path
 
@@ -2572,7 +2578,8 @@ class CIMInstance(_CIMComparisonMixin):
         `None` means that the properties are not filtered.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMInstance>`.
         """
         return self._property_list
 
@@ -3259,7 +3266,7 @@ class CIMClassName(_CIMComparisonMixin):
               before the zone ID string, as an additional choice to ``%25``.
 
             `None` means that the WBEM server is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMClassName` object
+            :attr:`~pywbem.CIMClassName.host` attribute
             will also be `None`.
 
             The lexical case of the string is preserved. Object comparison and
@@ -3269,7 +3276,7 @@ class CIMClassName(_CIMComparisonMixin):
             Name of the CIM namespace containing the referenced class.
 
             `None` means that the namespace is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMClassName` object
+            :attr:`~pywbem.CIMClassName.namespace` attribute
             will also be `None`.
 
             Leading and trailing slash characters will be stripped.
@@ -3295,7 +3302,8 @@ class CIMClassName(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMClassName>`.
         """
         return self._classname
 
@@ -3325,7 +3333,8 @@ class CIMClassName(_CIMComparisonMixin):
         `None` means that the namespace is unspecified.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMClassName>`.
         """
         return self._namespace
 
@@ -3347,13 +3356,13 @@ class CIMClassName(_CIMComparisonMixin):
         of this CIM class path,
         identifying the WBEM server of the referenced class.
 
-        For details about the string format, see the same-named constructor
-        parameter.
+        For details about the string format, see the same-named init parameter
+        of :class:`this class <pywbem.CIMClassName>`.
 
         `None` means that the host and port are unspecified.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter.
         """
         return self._host
 
@@ -3797,8 +3806,8 @@ class CIMClass(_CIMComparisonMixin):
             Name of the superclass for the class.
 
             `None` means that the class is a top-level class, and the
-            same-named attribute in the :class:`~pywbem.CIMClass` object will
-            also be `None`.
+            :attr:`~pywbem.CIMClassName.superclass` attribute
+            will also be `None`.
 
             The lexical case of the string is preserved. Object comparison and
             hash value calculation are performed case-insensitively.
@@ -3815,8 +3824,8 @@ class CIMClass(_CIMComparisonMixin):
             :class:`~pywbem.CIMClass` object.
 
             `None` means that the instance path is unspecified, and the
-            same-named attribute in the :class:`~pywbem.CIMClass` object will
-            also be `None`.
+            :attr:`~pywbem.CIMClass.path` attribute
+            will also be `None`.
 
             This parameter has been added in pywbem 0.11 as a convenience
             for the user in order so that :class:`~pywbem.CIMClass` objects can
@@ -3846,7 +3855,8 @@ class CIMClass(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
         """
         return self._classname
 
@@ -3875,7 +3885,8 @@ class CIMClass(_CIMComparisonMixin):
         `None` means that the class is a top-level class.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
         """
         return self._superclass
 
@@ -3903,7 +3914,8 @@ class CIMClass(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current CIM
         properties to be replaced with the new properties. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
 
         The CIM properties can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -3962,7 +3974,8 @@ class CIMClass(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current CIM
         methods to be replaced with the new methods. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
 
         The CIM methods can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -4021,7 +4034,8 @@ class CIMClass(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         qualifiers to be replaced with the new qualifiers. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
 
         The qualifier values can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -4081,7 +4095,8 @@ class CIMClass(_CIMComparisonMixin):
         on information in the response from the WBEM server.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMClass>`.
         """
         return self._path
 
@@ -4401,7 +4416,7 @@ class CIMProperty(_CIMComparisonMixin):
             the class hierarchy of the class owning the property).
 
             `None` means that class origin information is not available, and
-            the same-named attribute in the :class:`~pywbem.CIMProperty` object
+            :attr:`~pywbem.CIMProperty.class_origin` attribute
             will also be `None`.
 
             The lexical case of the string is preserved. Object comparison and
@@ -4411,7 +4426,7 @@ class CIMProperty(_CIMComparisonMixin):
             The size of the array property, for fixed-size arrays.
 
             `None` means that the array property has variable size, and
-            the same-named attribute in the :class:`~pywbem.CIMProperty` object
+            :attr:`~pywbem.CIMProperty.array_size` attribute
             will also be `None`.
 
           propagated (:class:`py:bool`):
@@ -4420,16 +4435,16 @@ class CIMProperty(_CIMComparisonMixin):
             propagated from the creation class.
 
             `None` means that propagation information is not available, and
-            the same-named attribute in the :class:`~pywbem.CIMProperty` object
+            :attr:`~pywbem.CIMProperty.propagated` attribute
             will also be `None`.
 
           is_array (:class:`py:bool`):
             A boolean indicating whether the property is an array (`True`) or a
             scalar (`False`).
 
-            If `None`, the same-named attribute in this object will be inferred
-            from the `value` parameter. If the `value` parameter is `None`, a
-            scalar is assumed.
+            If `None`, the :attr:`~pywbem.CIMProperty.is_array` attribute
+            will be inferred from the `value` parameter.
+            If the `value` parameter is `None`, a scalar is assumed.
 
           reference_class (:term:`string`):
             For reference properties, the name of the class referenced by the
@@ -4553,7 +4568,8 @@ class CIMProperty(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._name
 
@@ -4581,7 +4597,8 @@ class CIMProperty(_CIMComparisonMixin):
         `None` means that the value is Null.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._value
 
@@ -4601,7 +4618,8 @@ class CIMProperty(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._type
 
@@ -4635,7 +4653,8 @@ class CIMProperty(_CIMComparisonMixin):
         a WBEM server, :term:`DSP0201` requires this attribute to be set.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._reference_class
 
@@ -4670,7 +4689,8 @@ class CIMProperty(_CIMComparisonMixin):
         * `None`, for properties not representing embedded objects.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._embedded_object
 
@@ -4689,7 +4709,8 @@ class CIMProperty(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._is_array
 
@@ -4708,7 +4729,8 @@ class CIMProperty(_CIMComparisonMixin):
         property is a scalar.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._array_size
 
@@ -4728,7 +4750,8 @@ class CIMProperty(_CIMComparisonMixin):
         `None` means that class origin information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._class_origin
 
@@ -4748,7 +4771,8 @@ class CIMProperty(_CIMComparisonMixin):
         `None` means that propagation information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
         """
         return self._propagated
 
@@ -4777,7 +4801,8 @@ class CIMProperty(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         qualifiers to be replaced with the new qualifiers. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMProperty>`.
 
         The qualifier values can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -5231,7 +5256,7 @@ class CIMMethod(_CIMComparisonMixin):
             the class hierarchy of the class owning the method).
 
             `None` means that class origin information is not available, and
-            the same-named attribute in the :class:`~pywbem.CIMMethod` object
+            the :attr:`~pywbem.CIMMethod.class_origin` attribute
             will also be `None`.
 
             The lexical case of the string is preserved. Object comparison and
@@ -5242,8 +5267,8 @@ class CIMMethod(_CIMComparisonMixin):
             propagated from a superclass.
 
             `None` means that propagation information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMMethod` object will
-            also be `None`.
+            the :attr:`~pywbem.CIMMethod.propagated` attribute
+            will also be `None`.
 
           qualifiers (:term:`qualifiers input object`):
             The qualifiers for the method.
@@ -5278,7 +5303,8 @@ class CIMMethod(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
         """
         return self._name
 
@@ -5305,7 +5331,8 @@ class CIMMethod(_CIMComparisonMixin):
         Will not be `None` or ``"reference"``.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
         """
         return self._return_type
 
@@ -5336,7 +5363,8 @@ class CIMMethod(_CIMComparisonMixin):
         `None` means that class origin information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
         """
         return self._class_origin
 
@@ -5355,7 +5383,8 @@ class CIMMethod(_CIMComparisonMixin):
         `None` means that propagation information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
         """
         return self._propagated
 
@@ -5383,7 +5412,8 @@ class CIMMethod(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         parameters to be replaced with the new parameters. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
 
         The parameters can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -5440,7 +5470,8 @@ class CIMMethod(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         qualifiers to be replaced with the new qualifiers. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMMethod>`.
 
         The qualifier values can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -5756,15 +5787,16 @@ class CIMParameter(_CIMComparisonMixin):
             A boolean indicating whether the parameter is an array (`True`) or a
             scalar (`False`).
 
-            If `None`, the same-named attribute in this object will be inferred
-            from the `value` parameter. If the `value` parameter is `None`, a
-            scalar is assumed.
+            If `None`, the
+            :attr:`~pywbem.CIMParameter.is_array` attribute
+            will be inferred from the `value` parameter.
+            If the `value` parameter is `None`, a scalar is assumed.
 
           array_size (:term:`integer`):
             The size of the array parameter, for fixed-size arrays.
 
             `None` means that the array parameter has variable size, and the
-            same-named attribute in the :class:`~pywbem.CIMParameter` object
+            :attr:`~pywbem.CIMParameter.array_size` attribute
             will also be `None`.
 
           qualifiers (:term:`qualifiers input object`):
@@ -5824,7 +5856,8 @@ class CIMParameter(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._name
 
@@ -5851,7 +5884,8 @@ class CIMParameter(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._type
 
@@ -5881,7 +5915,8 @@ class CIMParameter(_CIMComparisonMixin):
         is unspecified in reference parameters.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._reference_class
 
@@ -5900,7 +5935,8 @@ class CIMParameter(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._is_array
 
@@ -5920,7 +5956,8 @@ class CIMParameter(_CIMComparisonMixin):
         parameter is a scalar.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._array_size
 
@@ -5948,7 +5985,8 @@ class CIMParameter(_CIMComparisonMixin):
 
         This attribute is settable; setting it will cause the current
         qualifiers to be replaced with the new qualifiers. For details, see
-        the description of the same-named constructor parameter.
+        the description of the same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
 
         The qualifier values can also be accessed and manipulated one by one
         because the attribute value is a modifiable dictionary. The provided
@@ -5998,7 +6036,8 @@ class CIMParameter(_CIMComparisonMixin):
         Has no meaning for parameter declarations.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._value
 
@@ -6033,7 +6072,8 @@ class CIMParameter(_CIMComparisonMixin):
         * `None`, for parameters not representing embedded objects.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMParameter>`.
         """
         return self._embedded_object
 
@@ -6456,7 +6496,7 @@ class CIMQualifier(_CIMComparisonMixin):
             propagated from a superclass.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifier` object
+            :attr:`~pywbem.CIMQualifier.propagated` attribute
             will also be `None`.
 
           overridable (:class:`py:bool`):
@@ -6464,7 +6504,7 @@ class CIMQualifier(_CIMComparisonMixin):
             in subclasses.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifier` object
+            :attr:`~pywbem.CIMQualifier.overridable` attribute
             will also be `None`.
 
           tosubclass (:class:`py:bool`):
@@ -6472,7 +6512,7 @@ class CIMQualifier(_CIMComparisonMixin):
             to subclasses.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifier` object
+            :attr:`~pywbem.CIMQualifier.tosubclass` attribute
             will also be `None`.
 
           toinstance (:class:`py:bool`):
@@ -6480,7 +6520,7 @@ class CIMQualifier(_CIMComparisonMixin):
             to instances.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifier` object
+            :attr:`~pywbem.CIMQualifier.toinstance` attribute
             will also be `None`.
 
             Note that :term:`DSP0200` has deprecated the presence of qualifier
@@ -6490,7 +6530,7 @@ class CIMQualifier(_CIMComparisonMixin):
             If not `None`, specifies whether the qualifier is translatable.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifier` object
+            :attr:`~pywbem.CIMQualifier.translatable` attribute
             will also be `None`.
 
         Examples:
@@ -6541,7 +6581,8 @@ class CIMQualifier(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._name
 
@@ -6568,7 +6609,8 @@ class CIMQualifier(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._type
 
@@ -6600,7 +6642,8 @@ class CIMQualifier(_CIMComparisonMixin):
         in the constructor.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._value
 
@@ -6619,7 +6662,8 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that propagation information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._propagated
 
@@ -6642,7 +6686,8 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._tosubclass
 
@@ -6669,7 +6714,8 @@ class CIMQualifier(_CIMComparisonMixin):
         values on CIM instances.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._toinstance
 
@@ -6692,7 +6738,8 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._overridable
 
@@ -6716,7 +6763,8 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifier>`.
         """
         return self._translatable
 
@@ -7037,9 +7085,9 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
           value (:term:`CIM data type` or other suitable types):
             Default value of the qualifier.
 
-            `None` means a default value of Null, and the same-named attribute
-            in the :class:`~pywbem.CIMQualifierDeclaration` object will also be
-            `None`.
+            `None` means a default value of Null, and the
+            :attr:`~pywbem.CIMQualifierDeclaration.value` attribute
+            will also be `None`.
 
             The specified value will be converted to a :term:`CIM data type`
             using the rules documented in the description of
@@ -7049,16 +7097,17 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
             A boolean indicating whether the qualifier is an array (`True`) or
             a scalar (`False`).
 
-            If `None`, the same-named attribute in this object will be inferred
-            from the `value` parameter. If the `value` parameter is `None`, a
-            scalar is assumed.
+            If `None`, the
+            :attr:`~pywbem.CIMQualifierDeclaration.is_array` attribute
+            will be inferred from the `value` parameter.
+            If the `value` parameter is `None`, a scalar is assumed.
 
           array_size (:term:`integer`):
             The size of the array qualifier, for fixed-size arrays.
 
             `None` means that the array qualifier has variable size, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifierDeclaration`
-            object will also be `None`.
+            :attr:`~pywbem.CIMQualifierDeclaration.array_size` attribute
+            will also be `None`.
 
           scopes (:class:`py:dict` or `NocaseDict`_):
             Scopes of the qualifier.
@@ -7089,24 +7138,24 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
             qualifier value is overridable in subclasses.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifierDeclaration`
-            object will also be `None`.
+            :attr:`~pywbem.CIMQualifierDeclaration.overridable` attribute
+            will also be `None`.
 
           tosubclass (:class:`py:bool`):
             If not `None`, specifies the flavor that defines whether the
             qualifier value propagates to subclasses.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifierDeclaration`
-            object will also be `None`.
+            :attr:`~pywbem.CIMQualifierDeclaration.tosubclass` attribute
+            will also be `None`.
 
           toinstance (:class:`py:bool`):
             If not `None`, specifies the flavor that defines whether the
             qualifier value propagates to instances.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifierDeclaration`
-            object will also be `None`.
+            :attr:`~pywbem.CIMQualifierDeclaration.toinstance` attribute
+            will also be `None`.
 
             Note that :term:`DSP0200` has deprecated the presence of qualifier
             values on CIM instances and this flavor is not defined in
@@ -7117,8 +7166,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
             qualifier is translatable.
 
             `None` means that this information is not available, and the
-            same-named attribute in the :class:`~pywbem.CIMQualifierDeclaration`
-            object will also be `None`.
+            :attr:`~pywbem.CIMQualifierDeclaration.translatable` attribute
+            will also be `None`.
         """
 
         # We use the respective setter methods:
@@ -7150,7 +7199,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._name
 
@@ -7178,7 +7228,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._type
 
@@ -7210,7 +7261,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         in the constructor.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._value
 
@@ -7229,7 +7281,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._is_array
 
@@ -7249,7 +7302,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         qualifier type is not an array).
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._array_size
 
@@ -7278,7 +7332,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         Will not be `None`.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._scopes
 
@@ -7299,7 +7354,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._tosubclass
 
@@ -7323,7 +7379,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         values on CIM instances.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._toinstance
 
@@ -7344,7 +7401,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._overridable
 
@@ -7365,7 +7423,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         `None` means that this information is not available.
 
         This attribute is settable. For details, see the description of the
-        same-named constructor parameter.
+        same-named init parameter of
+        :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
         return self._translatable
 

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -123,24 +123,24 @@ class (the parent object) has a list of CIM properties, CIM methods and CIM
 qualifiers (the child objects).
 
 In pywbem, the parent CIM object allows initializing each list of child objects
-via an argument of its constructor. For example, the :class:`~pywbem.CIMClass`
-constructor has an argument named ``properties`` that allows specifying the
-properties of the class.
+via an init parameter. For example, the :class:`~pywbem.CIMClass` init method
+has a parameter named ``properties`` that allows specifying the CIM properties
+of the CIM class.
 
-Once the parent CIM object exists, each list of child elements can be modified
+Once the parent CIM object exists, each list of child objects can be modified
 via a settable attribute. For example, the :class:`~pywbem.CIMClass` class has
-a :attr:`~pywbem.CIMClass.properties` attribute for its list of properties.
+a :attr:`~pywbem.CIMClass.properties` attribute for its list of CIM properties.
 
-For such attributes and constructor arguments that specify lists of child
+For such attributes and init parameters that specify lists of child
 objects, pywbem supports a number of different ways the child objects can be
 specified.
 
 Some of these ways preserve the order of child objects and some don't.
 
-This section uses properties in classes as an example, but it applies to all
-kinds of child objects in CIM objects.
+This section uses CIM properties in CIM classes as an example, but it applies
+to all kinds of child objects in CIM objects.
 
-The possible input objects for the ``properties`` constructor argument
+The possible input objects for the ``properties`` init parameter
 and for the :attr:`~pywbem.CIMClass.properties` attribute of
 :class:`~pywbem.CIMClass` is described in the type
 :term:`properties input object`, and must be one of these objects:
@@ -1023,7 +1023,7 @@ def _cim_property_value(key, value):
     else:
         # We no longer check for the common error to set CIM numeric values as
         # Python number types, because that is done in the CIMProperty
-        # constructor.
+        # init method.
         prop = CIMProperty(key, value)
 
     return prop
@@ -1100,7 +1100,7 @@ def _cim_qualifier(key, value):
     else:
         # We no longer check for the common error to set CIM numeric values as
         # Python number types, because that is done in the CIMQualifier
-        # constructor.
+        # init method.
         qual = CIMQualifier(key, value)
 
     return qual
@@ -2422,7 +2422,7 @@ class CIMInstance(_CIMComparisonMixin):
         properties to be replaced with the new properties, and will also cause
         the values of corresponding keybindings in the instance path (if set)
         to be updated. For details, see the description of the same-named
-        constructor parameter. Note that the property value may be specified as
+        init parameter. Note that the property value may be specified as
         a :term:`CIM data type` or as a :class:`~pywbem.CIMProperty` object.
 
         The CIM property values can also be accessed and manipulated one by one
@@ -4369,7 +4369,7 @@ class CIMProperty(_CIMComparisonMixin):
         # pylint: disable=redefined-builtin,too-many-arguments,too-many-branches
         # pylint: disable=too-many-statements,too-many-instance-attributes
         """
-        The constructor infers optional parameters that are not specified (for
+        The init method infers optional parameters that are not specified (for
         example, it infers `type` from the Python type of `value` and other
         information). If the specified parameters are inconsistent, an
         exception is raised. If an optional parameter is needed for some
@@ -5202,7 +5202,7 @@ class CIMMethod(_CIMComparisonMixin):
                  class_origin=None, propagated=None, qualifiers=None,
                  methodname=None):
         """
-        The constructor stores the input parameters as-is and does not infer
+        The init method stores the input parameters as-is and does not infer
         unspecified parameters from the others (like
         :class:`~pywbem.CIMProperty` does).
 
@@ -5749,7 +5749,7 @@ class CIMParameter(_CIMComparisonMixin):
                  embedded_object=None):
         # pylint: disable=redefined-builtin
         """
-        The constructor stores the input parameters as-is and does
+        The init method stores the input parameters as-is and does
         not infer unspecified parameters from the others
         (like :class:`~pywbem.CIMProperty` does).
 
@@ -6454,7 +6454,7 @@ class CIMQualifier(_CIMComparisonMixin):
                  translatable=None):
         # pylint: disable=redefined-builtin
         """
-        The constructor infers optional parameters that are not specified (for
+        The init method infers optional parameters that are not specified (for
         example, it infers `type` from the Python type of `value` and other
         information). If the specified parameters are inconsistent, an
         exception is raised. If an optional parameter is needed for some reason,
@@ -6638,8 +6638,7 @@ class CIMQualifier(_CIMComparisonMixin):
         `None` means that the value is Null.
 
         For CIM data types string and char16, this attribute will be a
-        :term:`unicode string`, even when specified as a :term:`byte string`
-        in the constructor.
+        :term:`unicode string`, even when specified as a :term:`byte string`.
 
         This attribute is settable. For details, see the description of the
         same-named init parameter of
@@ -7257,8 +7256,7 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
         `None` means that the value is Null.
 
         For CIM data types string and char16, this attribute will be a
-        :term:`unicode string`, even when specified as a :term:`byte string`
-        in the constructor.
+        :term:`unicode string`, even when specified as a :term:`byte string`.
 
         This attribute is settable. For details, see the description of the
         same-named init parameter of

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -674,8 +674,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
         :term:`unicode string`: URL of the WBEM server.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -699,8 +699,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         :func:`py:tuple`: Credentials for HTTP authentication with the WBEM
         server.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -724,8 +724,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         :term:`unicode string`: Name of the CIM namespace to be used by default
         (if no namespace is specified for an operation).
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -754,8 +754,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         :class:`py:dict`: :term:`X.509` client certificate and key file to be
         presented to the WBEM server during the TLS/SSL handshake.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -781,8 +781,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         TLS/SSL handshake, in addition to the validation already performed
         by the TLS/SSL support.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -806,8 +806,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         :term:`string`: Location of CA certificates (trusted certificates) for
         verifying the X.509 server certificate returned by the WBEM server.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -831,8 +831,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         :class:`py:bool`: Boolean indicating that verifications are disabled
         for this connection.
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -857,8 +857,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         *New in pywbem 0.8.*
 
-        For details, see the description of the same-named constructor
-        parameter of :class:`~pywbem.WBEMConnection`.
+        For details, see the description of the same-named init
+        parameter of :class:`this class <pywbem.WBEMConnection>`.
 
         This attribute is settable, but setting it has been deprecated.
         """
@@ -1049,10 +1049,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         *New in pywbem 0.11 as experimental and finalized in 0.13.*
 
         This property reflects the intent of the user as specified in the
-        same-named constructor parameter. This property is not updated with
-        the status of actually using pull operations. That status is
-        maintained internally for each pull operation separately to accomodate
-        WBEM servers that support only some of the pull operations.
+        same-named init parameter of
+        :class:`this class <pywbem.WBEMConnection>`. This property is not
+        updated with the status of actually using pull operations. That status
+        is maintained internally for each pull operation separately to
+        accomodate WBEM servers that support only some of the pull operations.
         """
         return self._use_pull_operations
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -4145,7 +4145,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -4493,7 +4493,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -4766,7 +4766,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -5099,7 +5099,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -5376,7 +5376,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -5681,7 +5681,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).
@@ -5939,7 +5939,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         in the :class:`~pywbem.WBEMConnection` object (by operation type), and
         avoids unnecessary attempts to try these pull operations on that
         connection in the future.
-        The `use_pull_operations` constructor parameter of
+        The `use_pull_operations` init parameter of
         :class:`~pywbem.WBEMConnection` can be used to control the preference
         for always using pull operations, always using traditional operations,
         or using pull operations if supported by the WBEM server (the default).

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -564,12 +564,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             and should be avoided!
 
           timeout (:term:`number`):
+            Timeout in seconds, for requests sent to the server.
+
             *New in pywbem 0.8.*
 
-            Timeout in seconds, for requests sent to the server. If the server
-            did not respond within the timeout duration, the socket for the
-            connection will be closed, causing a :exc:`~pywbem.TimeoutError` to
-            be raised.
+            If the server did not respond within the timeout duration, the
+            socket for the connection will be closed, causing a
+            :exc:`~pywbem.TimeoutError` to be raised.
 
             A value of `None` means that the connection uses the standard
             timeout behavior of Python sockets, which can be between several
@@ -584,9 +585,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             exception.
 
           use_pull_operations (:class:`py:bool`):
-            *New in pywbem 0.11 as experimental and finalized in 0.13.*
-
             Controls the use of pull operations in any `Iter...()` methods.
+
+            *New in pywbem 0.11 as experimental and finalized in 0.13.*
 
             `None` means that the `Iter...()` methods will attempt a pull
             operation first, and if the WBEM server does not support it, will
@@ -605,13 +606,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             traditional operations.
 
           stats_enabled (:class:`py:bool`):
+            Initial enablement status for maintaining statistics about the
+            WBEM operations executed via this connection.
+
             *New in pywbem 0.11 as experimental, renamed from `enable_stats`
             and finalized in 0.12.*
 
-            Initial enablement status for maintaining statistics about the
-            WBEM operations executed via this connection. See the
-
-            :ref:`WBEM operation statistics` section for details.
+            See the :ref:`WBEM operation statistics` section for details.
         """  # noqa: E501
         # pylint: enable=line-too-long
 
@@ -775,7 +776,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def verify_callback(self):
         """
-        :term:`callable`: A callback function that will be called to verify the
+        :term:`callable`: Callback function that will be called to verify the
         X.509 server certificate returned by the WBEM server during the
         TLS/SSL handshake, in addition to the validation already performed
         by the TLS/SSL support.
@@ -827,8 +828,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def no_verification(self):
         """
-        :class:`py:bool`: Indicates that verifications are disabled for this
-        connection.
+        :class:`py:bool`: Boolean indicating that verifications are disabled
+        for this connection.
 
         For details, see the description of the same-named constructor
         parameter of :class:`~pywbem.WBEMConnection`.
@@ -852,9 +853,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def timeout(self):
         """
-        *New in pywbem 0.8.*
-
         :term:`number`: Timeout in seconds, for requests sent to the server.
+
+        *New in pywbem 0.8.*
 
         For details, see the description of the same-named constructor
         parameter of :class:`~pywbem.WBEMConnection`.
@@ -878,27 +879,27 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def operation_recorders(self):
         """
-        **Experimental** *New in pywbem 0.12 as experimental.*
-
         Tuple of :class:`BaseOperationRecorder` subclass objects:
-          The operation recorders of this connection.
+          **Experimental:** The operation recorders of this connection.
+
+        *New in pywbem 0.12 as experimental.*
         """
         return tuple(self._operation_recorders)
 
     @property
     def operation_recorder(self):
         """
-        **Experimental** *New in pywbem 0.9 as experimental.*
+        :class:`BaseOperationRecorder`: **Deprecated:** The operation recorder
+        that was last added to the connection, or `None` if the connection does
+        not currently have any recorders.
 
-        :class:`BaseOperationRecorder`: The operation recorder that was last
-        added to the connection, or `None` if the connection does not currently
-        have any recorders.
+        *New in pywbem 0.9 as experimental. Deprecated since pywbem 0.12.*
 
-        **Deprecated:** Deprecated since pywbem 0.12.
-        The method :meth:`~pywbem.WBEMConnection.add_operation_recorder` should
-        be used to add a recorder, and the
+        Instead of using this deprecated property, the
         :attr:`~pywbem.WBEMConnection.operation_recorders` property should be
-        used to retrieve the recorders of the connection.
+        used to retrieve the recorders of the connection, and the
+        :meth:`~pywbem.WBEMConnection.add_operation_recorder` method should be
+        used to add a recorder.
 
         This property is settable; setting this property will cause the
         specified operation recorder to be added to the connection as if
@@ -932,10 +933,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def host(self):
         """
-        *New in pywbem 0.11.*
-
         :term:`unicode string`: The ``{host}[:{port}]`` component of the
         WBEM server's URL, as specified in the ``url`` attribute.
+
+        *New in pywbem 0.11.*
         """
         host = self.url.split('://')[-1]
         return host
@@ -943,10 +944,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def operation_recorder_enabled(self):
         """
-        **Experimental** *New in pywbem 0.11 as experimental*
+        :class:`py:bool`: **Experimental:** Enablement status for all operation
+        recorders of the connection.
 
-        :class:`py:bool`: Enablement status for all operation recorders of the
-        connection.
+        *New in pywbem 0.11 as experimental*
 
         This is a writeable property; setting this property will change the
         operation recorder enablement status accordingly for all operation
@@ -973,9 +974,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def stats_enabled(self):
         """
-        *New in pywbem 0.11 as experimental and finalized in 0.12.*
-
         :class:`py:bool`: Statistics enablement status for this connection.
+
+        *New in pywbem 0.11 as experimental and finalized in 0.12.*
 
         This is a writeable property; setting this property will change the
         statistics enablement status accordingly.
@@ -997,9 +998,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def statistics(self):
         """
-        *New in pywbem 0.11 as experimental and finalized in 0.12.*
-
         :class:`~pywbem.Statistics`: Statistics for this connection.
+
+        *New in pywbem 0.11 as experimental and finalized in 0.12.*
 
         Statistics are disabled by default and can be enabled via the
         ``stats_enabled`` argument when creating a connection object, or
@@ -1012,10 +1013,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def last_operation_time(self):
         """
-        *New in pywbem 0.11 as experimental and finalized in 0.12.*
-
         :class:`py:float`: Elapsed time of the last operation that was executed
         via this connection in seconds or `None`.
+
+        *New in pywbem 0.11 as experimental and finalized in 0.12.*
 
         This time is available only subsequent to the execution of an operation
         on this connection, and if the statistics are enabled on this
@@ -1026,12 +1027,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def last_server_response_time(self):
         """
+        :class:`py:float`: Server-measured response time of the last request,
+        or `None`.
+
         *New in pywbem 0.11 as experimental and finalized in 0.12.*
 
-        :class:`py:float`: Server measured response time of the last
-        request. This is optionally returned from the server in HTTP
-        header
-
+        This time is optionally returned from the server in the HTTP header of
+        the response.
         This time is available only subsequent to the execution of an operation
         on this connection if the WBEMServerResponseTime is received from the
         WBEM server. Otherwise, the value is `None`.
@@ -1041,10 +1043,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def use_pull_operations(self):
         """
-        *New in pywbem 0.11 as experimental and finalized in 0.13.*
+        :class:`py:bool`: Boolean indicating that the client should attempt
+        the use of pull operations in any `Iter...()` methods.
 
-        :class:`py:bool`: Indicates whether the client should attempt the use
-        of pull operations in any `Iter...()` methods.
+        *New in pywbem 0.11 as experimental and finalized in 0.13.*
 
         This property reflects the intent of the user as specified in the
         same-named constructor parameter. This property is not updated with
@@ -1057,19 +1059,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @property
     def debug(self):
         """
-        :class:`py:bool`: A boolean indicating whether saving of the last
-        request and last reply to the WBEMConnection object is enabled (`True`)
-        or disabled (`False`).
+        :class:`py:bool`: Boolean indicating that saving the last request and
+        last response is enabled for this connection.
 
-        When enabled, the last request and last reply will be available in the
-        following properties of this class:
+        When enabled (value `True`), the last request and last reply will be
+        available in the following properties of this class:
 
         * :attr:`~pywbem.WBEMConnection.last_request`
         * :attr:`~pywbem.WBEMConnection.last_raw_request`
         * :attr:`~pywbem.WBEMConnection.last_reply`
         * :attr:`~pywbem.WBEMConnection.last_raw_reply`
 
-        When disabled, these properties will be `None`.
+        When disabled (value `False`), these properties will be `None`.
 
         This attribute is writeable. The initial value of this attribute is
         `False`.
@@ -1169,11 +1170,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def conn_id(self):
         """
         :term:`connection id`:
-        String that is unique for each :class:`~pywbem.WBEMConnection` object.
-        The `conn_id` is created when the :class:`~pywbem.WBEMConnection` object
-        is created and remains constant throughout the life of that connection.
+        Connection ID (a unique ID) of this connection.
 
-        `conn_id` is part of each log entry output to uniquely identify
+        The value for this property is created when the
+        :class:`~pywbem.WBEMConnection` object is created and remains constant
+        throughout the life of that object.
+
+        The connection ID is part of each log entry output to uniquely identify
         the :class:`~pywbem.WBEMConnection` object responsible for that log.
         It also part of the logger name for the "pywbem.api" and "pywbem.http"
         loggers that create log entries so that logging can be defined
@@ -1348,8 +1351,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @classmethod
     def _configure_detail_level(cls, detail_level):
         """
-        Validate the detail_level parameter and return it.  This accepts
-        a string or integer
+        Validate the `detail_level` parameter and return it.
+
+        This accepts a string or integer for `detail_level`.
         """
         # process detail_level
         if isinstance(detail_level, six.string_types):
@@ -1375,8 +1379,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     @classmethod
     def _configure_logger_handler(cls, log_dest, log_filename):
         """
-        Return a logging handler for the specified log_dest,
-        or None if log_dest is None.
+        Return a logging handler for the specified `log_dest`, or `None` if
+        `log_dest` is `None`.
         """
 
         if log_dest is None:
@@ -1489,9 +1493,12 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def add_operation_recorder(self, operation_recorder):
         # pylint: disable=line-too-long
         """
-        Add an operation recorder to this connection. If the connection already
-        has a recorder with the same class, the request to add the recorder is
-        ignored.
+        **Experimental:** Add an operation recorder to this connection.
+
+        *New in pywbem 0.12 as experimental.*
+
+        If the connection already has a recorder with the same class, the
+        request to add the recorder is ignored.
 
         Parameters:
 
@@ -1520,30 +1527,40 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     def operation_recorder_reset(self, pull_op=False):
         """
-        This is a low-level method that is used by the operation-specific
-        methods of this class to reset the operation processing state of all
-        recorders of this connection, to be ready for processing a new
-        operation call.
+        **Experimental:** Low-level method used by the operation-specific
+        methods of this class.
+
+        *New in pywbem 0.9 as experimental.*
+
+        It resets the operation processing state of all recorders of this
+        connection, to be ready for processing a new operation call.
         """
         for recorder in self._operation_recorders:
             recorder.reset(pull_op)
 
     def operation_recorder_stage_pywbem_args(self, method, **kwargs):
         """
-        This is a low-level method that is used by the operation-specific
-        methods of this class to forward the operation method name and
-        arguments to all recorders of this connection.
+        **Experimental:** Low-level method used by the operation-specific
+        methods of this class.
+
+        *New in pywbem 0.9 as experimental.*
+
+        It forwards the operation method name and arguments to all recorders of
+        this connection.
         """
         for recorder in self._operation_recorders:
             recorder.stage_pywbem_args(method, **kwargs)
 
     def operation_recorder_stage_result(self, ret, exc):
         """
-        This is a low-level method that is used by the operation-specific
-        methods of this class to forward the operation results including
-        exceptions that were raised, to all recorders of this connection,
-        and to cause the forwarded information to be recorded by all
-        recorders of this connection.
+        **Experimental:** Low-level method used by the operation-specific
+        methods of this class.
+
+        *New in pywbem 0.9 as experimental.*
+
+        It forwards the operation results including exceptions that were
+        raised, to all recorders of this connection, and causes the forwarded
+        information to be recorded by all recorders of this connection.
         """
         for recorder in self._operation_recorders:
             recorder.stage_pywbem_result(ret, exc)
@@ -1553,7 +1570,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def _reset_logging_config(cls):
         """
         Reset the activation of logging and the log detail levels for future
-        WBEM connections, by resetting the corresponding class variables
+        WBEM connections.
+
+        This method resets the corresponding class variables
         of :class:`~pywbem.WBEMConnection`.
         """
         cls._activate_logging = False
@@ -1562,12 +1581,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def imethodcall(self, methodname, namespace, response_params_rqd=False,
                     **params):
         """
-        This is a low-level method that is used by the operation-specific
-        methods of this class
-        (e.g. :meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`).
+        **Deprecated:** Low-level method used by the operation-specific methods
+        of this class.
 
-        Deprecated: Calling this function directly has been deprecated and
-        will issue a :term:`DeprecationWarning`.
+        *Deprecated since pywbem 0.12.*
+
+        Calling this function directly has been deprecated and will issue a
+        :term:`DeprecationWarning`.
         Users should call the operation-specific methods (e.g. GetInstance)
         instead of this method.
         This method will be removed in the next pywbem release after 0.12.
@@ -1794,11 +1814,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     def methodcall(self, methodname, localobject, Params=None, **params):
         """
-        This is a low-level method that is used by the
+        **Deprecated:** Low-level method used by the
         :meth:`~pywbem.WBEMConnection.InvokeMethod` method of this class.
 
-        Deprecated: Calling this function directly has been deprecated and
-        will issue a :term:`DeprecationWarning`.
+        *Deprecated since pywbem 0.12.*
+
+        Calling this function directly has been deprecated and will issue a
+        :term:`DeprecationWarning`.
         Users should call :meth:`~pywbem.WBEMConnection.InvokeMethod` instead
         of this method.
         This method will be removed in the next pywbem release after 0.12.
@@ -2060,11 +2082,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     def _iparam_namespace_from_namespace(self, obj):
         # pylint: disable=invalid-name,
-        """Determine the namespace from a namespace string, or `None`. The
+        """
+        Determine the namespace from a namespace string, or `None`. The
         default namespace of the connection object is used, if needed.
 
         Return the so determined namespace for use as an argument to
-        imethodcall()."""
+        imethodcall().
+        """
 
         if isinstance(obj, six.string_types):
             namespace = obj.strip('/')
@@ -2080,12 +2104,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     def _iparam_namespace_from_objectname(self, obj):
         # pylint: disable=invalid-name,
-        """Determine the namespace from an object name, that can be a class
+        """
+        Determine the namespace from an object name, that can be a class
         name string, a CIMClassName or CIMInstanceName object, or `None`.
         The default namespace of the connection object is used, if needed.
 
         Return the so determined namespace for use as an argument to
-        imethodcall()."""
+        imethodcall().
+        """
 
         if isinstance(obj, (CIMClassName, CIMInstanceName)):
             namespace = obj.namespace
@@ -2104,9 +2130,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _iparam_objectname(objectname):
-        """Convert an object name (= class or instance name) specified in an
+        """
+        Convert an object name (= class or instance name) specified in an
         operation method into a CIM object that can be passed to
-        imethodcall()."""
+        imethodcall().
+        """
 
         if isinstance(objectname, (CIMClassName, CIMInstanceName)):
             objectname = objectname.copy()
@@ -2125,8 +2153,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _iparam_classname(classname):
-        """Convert a class name specified in an operation method into a CIM
-        object that can be passed to imethodcall()."""
+        """
+        Convert a class name specified in an operation method into a CIM
+        object that can be passed to imethodcall().
+        """
 
         if isinstance(classname, CIMClassName):
             classname = classname.copy()
@@ -2144,8 +2174,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _iparam_instancename(instancename):
-        """Convert an instance name specified in an operation method into a CIM
-        object that can be passed to imethodcall()."""
+        """
+        Convert an instance name specified in an operation method into a CIM
+        object that can be passed to imethodcall().
+        """
 
         if isinstance(instancename, CIMInstanceName):
             instancename = instancename.copy()
@@ -2160,10 +2192,12 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         return instancename
 
     def _get_rslt_params(self, result, namespace):
-        """Common processing for pull results to separate
-           end-of-sequence, enum-context, and entities in IRETURNVALUE.
-           Returns tuple of entities in IRETURNVALUE, end_of_sequence,
-           and enumeration_context)
+        """
+        Common processing for pull results to separate end-of-sequence,
+        enum-context, and entities in IRETURNVALUE.
+
+        Returns tuple of entities in IRETURNVALUE, end_of_sequence,
+        and enumeration_context)
         """
         rtn_objects = []
         end_of_sequence = False
@@ -2910,9 +2944,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             of this object will be ignored.
 
           namespace (:term:`string`):
-            *New in pywbem 0.9.*
-
             Name of the CIM namespace to be used (case independent).
+
+            *New in pywbem 0.9.*
 
             If `None`, defaults to the namespace in the `path` attribute of the
             `NewInstance` parameter, or to the default namespace of the
@@ -3076,10 +3110,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     IncludeClassOrigin=None, PropertyList=None, **extra):
         # pylint: disable=invalid-name, line-too-long
         """
-        Instance-level use: Retrieve the instances associated to a source
-        instance.
-
-        Class-level use: Retrieve the classes associated to a source class.
+        Retrieve the instances associated to a source instance, or the classes
+        associated to a source class.
 
         This method performs the Associators operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -3310,11 +3342,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                         Role=None, ResultRole=None, **extra):
         # pylint: disable=invalid-name, line-too-long
         """
-        Instance-level use: Retrieve the instance paths of the instances
-        associated to a source instance.
-
-        Class-level use: Retrieve the class paths of the classes associated
-        to a source class.
+        Retrieve the instance paths of the instances associated to a source
+        instance, or the class paths of the classes associated to a source
+        class.
 
         This method performs the AssociatorNames operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -3485,11 +3515,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                    PropertyList=None, **extra):
         # pylint: disable=invalid-name, line-too-long
         """
-        Instance-level use: Retrieve the association instances that reference
-        a source instance.
-
-        Class-level use: Retrieve the association classes that reference a
-        source class.
+        Retrieve the association instances that reference a source instance,
+        or the association classes that reference a source class.
 
         This method performs the References operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -3699,11 +3726,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def ReferenceNames(self, ObjectName, ResultClass=None, Role=None, **extra):
         # pylint: disable=invalid-name, line-too-long
         """
-        Instance-level use: Retrieve the instance paths of the association
-        instances that reference a source instance.
-
-        Class-level use: Retrieve the class paths of the association classes
-        that reference a source class.
+        Retrieve the instance paths of the association instances that reference
+        a source instance, or the class paths of the association classes that
+        reference a source class.
 
         This method performs the ReferenceNames operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -4087,14 +4112,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                **extra):
         # pylint: disable=invalid-name,line-too-long
         """
+        Enumerate the instances of a class (including instances of its
+        subclasses) in a namespace, using the Python :term:`py:generator`
+        idiom to return the result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Enumerate the instances of a class (including instances of its
-        subclasses) in a namespace,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
-
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -4434,13 +4459,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                    MaxObjectCount=DEFAULT_ITER_MAXOBJECTCOUNT,
                                    **extra):
         """
+        Enumerate the instance paths of instances of a class (including
+        instances of its subclasses) in a namespace, using the
+        Python :term:`py:generator` idiom to return the result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Enumerate the instance paths of instances of a class (including
-        instances of its subclasses) in a namespace,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
 
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
@@ -4708,13 +4734,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                 **extra):
         # pylint: disable=invalid-name,line-too-long
         """
-        *New in pywbem 0.10 as experimental and finalized in 0.12.*
-
-        Retrieve the instances associated to a source instance,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
+        Retrieve the instances associated to a source instance, using the
         Python :term:`py:generator` idiom to return the result.
 
+        *New in pywbem 0.10 as experimental and finalized in 0.12.*
+
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -5040,14 +5066,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                     **extra):
         # pylint: disable=invalid-name
         """
+        Retrieve the instance paths of the instances associated to a source
+        instance, using the Python :term:`py:generator` idiom to return the
+        result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Retrieve the instance paths of the instances associated to a source
-        instance,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
-
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -5318,13 +5344,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                **extra):
         # pylint: disable=invalid-name,line-too-long
         """
+        Retrieve the association instances that reference a source instance,
+        using the Python :term:`py:generator` idiom to return the result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Retrieve the association instances that reference a source instance,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
-
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -5622,14 +5648,14 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                    **extra):
         # pylint: disable=invalid-name
         """
+        Retrieve the instance paths of the association instances that reference
+        a source instance, using the Python :term:`py:generator` idiom to
+        return the result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Retrieve the instance paths of the association instances that reference
-        a source instance,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
-
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -5881,13 +5907,13 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                            **extra):
         # pylint: disable=line-too-long
         """
+        Execute a query in a namespace, using the Python :term:`py:generator`
+        idiom to return the result.
+
         *New in pywbem 0.10 as experimental and finalized in 0.12.*
 
-        Execute a query in a namespace,
-        using the corresponding pull operations if supported by the WBEM server
-        or otherwise the corresponding traditional operation, and using the
-        Python :term:`py:generator` idiom to return the result.
-
+        This method uses the corresponding pull operations if supported by the
+        WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
         that frees the user of having to know whether the WBEM server supports
         pull operations.
@@ -6168,10 +6194,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name,line-too-long
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to enumerate the instances of a class
         (including instances of its subclasses) in a namespace.
+
+        *New in pywbem 0.9.*
 
         This method performs the OpenEnumerateInstances operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -6473,11 +6499,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # pylint: disable=invalid-name
 
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to enumerate the instance paths of
         instances of a class (including instances of its subclasses) in
         a namespace.
+
+        *New in pywbem 0.9.*
 
         This method performs the OpenEnumerateInstancePaths operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -6702,10 +6728,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # pylint: disable=invalid-name
         # pylint: disable=invalid-name,line-too-long
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to retrieve the instances associated
         to a source instance.
+
+        *New in pywbem 0.9.*
 
         This method does not support retrieving classes.
 
@@ -6980,10 +7006,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                     MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to retrieve the instance paths of the
         instances associated to a source instance.
+
+        *New in pywbem 0.9.*
 
         This method does not support retrieving classes.
 
@@ -7219,10 +7245,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # pylint: disable=invalid-name
         # pylint: disable=invalid-name,line-too-long
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to retrieve the association instances
         that reference a source instance.
+
+        *New in pywbem 0.9.*
 
         This method does not support retrieving classes.
 
@@ -7481,10 +7507,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                    MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to retrieve the instance paths of
         the association instances that reference a source instance.
+
+        *New in pywbem 0.9.*
 
         This method does not support retrieving classes.
 
@@ -7701,10 +7727,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                            MaxObjectCount=None, **extra):
         # pylint: disable=invalid-name
         """
-        *New in pywbem 0.9.*
-
         Open an enumeration session to execute a query in a namespace and to
         retrieve the instances representing the query result.
+
+        *New in pywbem 0.9.*
 
         This method performs the OpenQueryInstances operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -7928,10 +7954,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         # pylint: disable=invalid-name
 
         """
-        *New in pywbem 0.9.*
+        Retrieve the next set of instances (with instance paths) from an open
+        enumeration session.
 
-        Retrieve the next set of instances from an open enumeration session.
-        The retrieved instances include their instance paths.
+        *New in pywbem 0.9.*
 
         This operation can only be used on enumeration sessions that have been
         opened by one of the following methods:
@@ -8078,12 +8104,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
     def PullInstancePaths(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
-
         """
-        *New in pywbem 0.9.*
-
         Retrieve the next set of instance paths from an open enumeration
         session.
+
+        *New in pywbem 0.9.*
 
         This operation can only be used on enumeration sessions that have been
         opened by one of the following methods:
@@ -8228,10 +8253,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def PullInstances(self, context, MaxObjectCount, **extra):
         # pylint: disable=invalid-name
         """
-        *New in pywbem 0.9.*
+        Retrieve the next set of instances (without instance paths) from an
+        open enumeration session.
 
-        Retrieve the next set of instances from an open enumeration session.
-        The retrieved instances do not include an instance path.
+        *New in pywbem 0.9.*
 
         This operation can only be used on enumeration sessions that have been
         opened by one of the following methods:
@@ -8370,10 +8395,10 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def CloseEnumeration(self, context, **extra):
         # pylint: disable=invalid-name
         """
-        *New in pywbem 0.9.*
-
         Close an open enumeration session, causing an early termination of an
         incomplete enumeration session.
+
+        *New in pywbem 0.9.*
 
         This method performs the CloseEnumeration operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -9150,7 +9175,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def EnumerateQualifiers(self, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
-        Enumerate qualifier types (= declarations) in a namespace.
+        Enumerate the qualifier types (= qualifier declarations) in a
+        namespace.
 
         This method performs the EnumerateQualifiers operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -9236,7 +9262,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def GetQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
-        Retrieve a qualifier type (= declaration).
+        Retrieve a qualifier type (= qualifier declaration).
 
         This method performs the GetQualifier operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -9333,7 +9359,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def SetQualifier(self, QualifierDeclaration, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
-        Create or modify a qualifier type (= declaration) in a namespace.
+        Create or modify a qualifier type (= qualifier declaration) in a
+        namespace.
 
         This method performs the SetQualifier operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all
@@ -9406,7 +9433,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def DeleteQualifier(self, QualifierName, namespace=None, **extra):
         # pylint: disable=invalid-name
         """
-        Delete a qualifier type (= declaration).
+        Delete a qualifier type (= qualifier declaration).
 
         This method performs the DeleteQualifier operation
         (see :term:`DSP0200`). See :ref:`WBEM operations` for a list of all

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -57,10 +57,10 @@ real64                                    :class:`~pywbem.Real64`
 The CIM NULL value is represented with Python `None` which can be used for any
 CIM typed value to represent NULL.
 
-Note that constructors of pywbem classes that take CIM typed values as input
+Note that init methods of pywbem classes that take CIM typed values as input
 may support Python types in addition to those shown above. For example, the
 :class:`~pywbem.CIMProperty` class represents property values of CIM datetime
-type internally as :class:`~pywbem.CIMDateTime` objects, but its constructor
+type internally as :class:`~pywbem.CIMDateTime` objects, but its init method
 accepts :class:`py:datetime.timedelta` objects, :class:`py:datetime.datetime`
 objects, :term:`string`, in addition to
 :class:`~pywbem.CIMDateTime` objects.

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -315,6 +315,7 @@ class CIMDateTime(CIMType, _CIMComparisonMixin):
     hash value being based on their public attributes.
     """
 
+    #: The name of the CIM datatype ``"datetime"``
     cimtype = 'datetime'
 
     _timestamp_pattern = re.compile(
@@ -830,8 +831,11 @@ class Uint8(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'uint8'
+    #: The minimum valid value for the CIM datatype
     minvalue = 0
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2**8 - 1
 
 
@@ -841,8 +845,11 @@ class Sint8(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'sint8'
+    #: The minimum valid value for the CIM datatype
     minvalue = -2 ** (8 - 1)
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** (8 - 1) - 1
 
 
@@ -852,8 +859,11 @@ class Uint16(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'uint16'
+    #: The minimum valid value for the CIM datatype
     minvalue = 0
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2**16 - 1
 
 
@@ -863,8 +873,11 @@ class Sint16(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'sint16'
+    #: The minimum valid value for the CIM datatype
     minvalue = -2 ** (16 - 1)
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** (16 - 1) - 1
 
 
@@ -874,8 +887,11 @@ class Uint32(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'uint32'
+    #: The minimum valid value for the CIM datatype
     minvalue = 0
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** 32 - 1
 
 
@@ -885,8 +901,11 @@ class Sint32(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'sint32'
+    #: The minimum valid value for the CIM datatype
     minvalue = -2 ** (32 - 1)
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** (32 - 1) - 1
 
 
@@ -896,8 +915,11 @@ class Uint64(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'uint64'
+    #: The minimum valid value for the CIM datatype
     minvalue = 0
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** 64 - 1
 
 
@@ -907,8 +929,11 @@ class Sint64(CIMInt):
 
     For details on CIM integer data types, see :class:`~pywbem.CIMInt`.
     """
+    #: The name of the CIM datatype
     cimtype = 'sint64'
+    #: The minimum valid value for the CIM datatype
     minvalue = -2 ** (64 - 1)
+    #: The maximum valid value for the CIM datatype
     maxvalue = 2 ** (64 - 1) - 1
 
 
@@ -945,6 +970,7 @@ class Real32(CIMFloat):
     class, or to use them as dictionary keys or as members in sets. See
     :class:`~pywbem.CIMFloat` for details.
     """
+    #: The name of the CIM datatype
     cimtype = 'real32'
 
 
@@ -956,6 +982,7 @@ class Real64(CIMFloat):
     class, or to use them as dictionary keys or as members in sets. See
     :class:`~pywbem.CIMFloat` for details.
     """
+    #: The name of the CIM datatype
     cimtype = 'real64'
 
 

--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -32,8 +32,8 @@ DTD:
 
   https://www.dmtf.org/standards/wbem/CIM_DTD_V22.dtd
 
-There should be one class for each element described in the DTD.  The
-constructors take builtin Python types, or other cim_xml classes where
+There should be one class for each element described in the DTD.  Their
+init methods take builtin Python types, or other cim_xml classes where
 child elements are required.
 
 Every class is a subclass of the Element class and so shares the same
@@ -45,7 +45,6 @@ Note that converting using toprettyxml() inserts whitespace which may
 corrupt the data in the XML (!!) so you should only do this when
 displaying to humans who can ignore it, and never for computers.  XML
 always passes through all non-markup whitespace.
-
 """
 
 from __future__ import absolute_import

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -59,7 +59,9 @@ class Error(Exception):
     def conn_id(self):
         """
         :term:`connection id`: Connection ID of the connection in whose context
-        the error happened. `None` if the error did not happen in context
+        the error happened.
+
+        `None` if the error did not happen in context
         of any connection, or if the connection context was not known.
         """
         return self._conn_id
@@ -147,7 +149,9 @@ class HTTPError(Error):
     @property
     def status(self):
         """
-        :term:`integer`: HTTP status code (e.g. 500).
+        :term:`integer`: HTTP status code.
+
+        Example: 500
 
         See :term:`RFC2616` for a list of HTTP status codes and reason phrases.
         """
@@ -156,7 +160,9 @@ class HTTPError(Error):
     @property
     def reason(self):
         """
-        :term:`string`: HTTP reason phrase (e.g. "Internal Server Error").
+        :term:`string`: HTTP reason phrase.
+
+        Example: "Internal Server Error"
 
         See :term:`RFC2616` for a list of HTTP status codes and reason phrases.
         """
@@ -166,7 +172,9 @@ class HTTPError(Error):
     def cimerror(self):
         """
         :term:`string`: Value of `CIMError` HTTP header field in response, if
-        present. `None`, otherwise.
+        present.
+
+        `None`, otherwise.
 
         See :term:`DSP0200` for a list of values.
         """
@@ -176,7 +184,9 @@ class HTTPError(Error):
     def cimdetails(self):
         """
         dict: CIMOM-specific details on the situation reported in the `CIMError`
-        header field, with:
+        header field.
+
+        The value is a dictionary with:
 
         * Key: header field name (e.g. `PGErrorDetail`).
         * Value: header field value.
@@ -283,9 +293,11 @@ class CIMError(Error):
     @property
     def status_code(self):
         """
+        :term:`integer`: Numeric CIM status code.
+
         *New in pywbem 0.9.*
 
-        :term:`integer`: Numeric CIM status code (e.g. 5).
+        Example: 5
 
         See :ref:`CIM status codes` for constants defining the numeric CIM
         status code values."""
@@ -294,10 +306,11 @@ class CIMError(Error):
     @property
     def status_code_name(self):
         """
-        *New in pywbem 0.9.*
+        :term:`string`: Symbolic name of the CIM status code.
 
-        :term:`string`: Symbolic name of the CIM status code (e.g.
-        "CIM_ERR_INVALID_CLASS").
+        Example: "CIM_ERR_INVALID_CLASS"
+
+        *New in pywbem 0.9.*
 
         If the CIM status code is invalid, the string
         "Invalid status code <status_code>" is returned."""
@@ -306,11 +319,12 @@ class CIMError(Error):
     @property
     def status_description(self):
         """
+        :term:`string`: CIM status description text returned by the server,
+        representing a human readable message describing the error.
+
         *New in pywbem 0.9.*
 
-        :term:`string`: CIM status description text returned by the server,
-        representing a human readable message describing the error (e.g.
-        "The specified class does not exist.").
+        Example: "The specified class does not exist."
 
         If the server did not return a description, a short default text for
         the CIM status code is returned. If the CIM status code is invalid,
@@ -321,11 +335,13 @@ class CIMError(Error):
     @property
     def instances(self):
         """
+        List of :class:`~pywbem.CIMInstance`: CIM instances returned by the
+        WBEM server in the error response, that provide more details on the
+        error.
+
         *New in pywbem 0.13.*
 
-        List of :class:`~pywbem.CIMInstance`: List of CIM instances returned by
-        the WBEM server in the error response, that provide more details on the
-        error. `None` if there are no such instances.
+        `None` if there are no such instances.
         """
         return self.args[2]
 

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -101,7 +101,7 @@ class DMTFCIMSchema(object):
     def __init__(self, schema_version, schema_root_dir, use_experimental=False,
                  verbose=False):
         """
-        The constructor downloads the schema if the `schema_root_dir` or the
+        The init method downloads the schema if the `schema_root_dir` or the
         schema zip file do not exist into the directory defined by the
         `schema_root_dir` parameter and extracts the MOF files into
         `schema_mof_dir`.

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -375,7 +375,8 @@ class FakedWBEMConnection(WBEMConnection):
           If `None`, there is no delay.
 
           This attribute is settable. For details, see the description of the
-          same-named constructor parameter.
+          same-named init parameter of
+          :class:`this class <pywbem.FakedWBEMConnection>`.
         """
         return self._response_delay
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -140,10 +140,10 @@ def _uprint(dest, text):
 def method_callback_interface(conn, objectname, methodname, **params):
     # pylint: disable=unused-argument, invalid-name, line-too-long
     """
-    **Experimental:** *New in pywbem 0.12 as experimental.*
-
     Interface for user-provided callback functions for CIM method invocation
     on a faked connection.
+
+    **Experimental:** *New in pywbem 0.12 as experimental.*
 
     Parameters:
 
@@ -233,11 +233,11 @@ def _pretty_xml(xml_string):
 
 class FakedWBEMConnection(WBEMConnection):
     """
-    **Experimental:** *New in pywbem 0.12 as experimental.*
-
     A subclass of :class:`pywbem.WBEMConnection` that mocks the communication
     with a WBEM server by utilizing a local in-memory *mock repository* to
     generate responses in the same way the WBEM server would.
+
+    **Experimental:** *New in pywbem 0.12 as experimental.*
 
     For a description of the operation methods on this class, see
     :ref:`Faked WBEM operations`.

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -22,8 +22,8 @@ class TestCreateConnection(object):
     depend on actually creating a connection
     """
     def test_connection_defaults(self):  # pylint: disable=no-self-use
-        """Test creation of a connection with default constructor
-           parameters.
+        """
+        Test creation of a connection with default init parameters.
         """
         conn = WBEMConnection('http://localhost')
         assert conn.url == 'http://localhost'

--- a/testsuite/test_wbemconnection_mock.py
+++ b/testsuite/test_wbemconnection_mock.py
@@ -689,7 +689,7 @@ def conn_lite():
 class TestFakedWBEMConnection(object):
     """
     Test the basic characteristics of the FakedWBEMConnection including
-    constructor parameters,
+    init parameters.
     """
 
     @pytest.mark.parametrize(
@@ -699,8 +699,8 @@ class TestFakedWBEMConnection(object):
     def test_response_delay(self, tst_class, set_on_init, delay):
         # pylint: disable=no-self-use
         """
-        Test the response delay attribute set both in constructor and with
-        property
+        Test the response delay attribute set both in init parameter and with
+        attribute.
         """
         # pylint: disable=protected-access
         FakedWBEMConnection._reset_logging_config()

--- a/testsuite/wbemserver_mock.py
+++ b/testsuite/wbemserver_mock.py
@@ -25,7 +25,7 @@ TESTSUITE_SCHEMA_DIR = os.path.join(TEST_DIR, 'schema')
 #  CIM_ObjectManager class.
 #
 #  interop_namespace: The interop namespace. Note that that if the interop
-#  namespace is defined in the WbemServerMock constructor that overrides any
+#  namespace is defined in the WbemServerMock init method that overrides any
 #  value in this dictionary
 #
 #  other_namespaces: Any other namespaces that the users wants to be defined
@@ -90,7 +90,7 @@ class WbemServerMock(object):
         self.object_manager_name = \
             self.server_mock_data['object_manager']['Name']
 
-        # override dictionary interop namespace with constructor input
+        # override dictionary interop namespace with init parameter
         if interop_ns:
             self.interop_ns = interop_ns
         else:
@@ -179,7 +179,7 @@ class WbemServerMock(object):
                            object_manager_description):
         """
         Build a CIMObjectManager instance for the mock wbem server using
-        fixed data defined in this method and data from the constructor
+        fixed data defined in this method and data from the init parameter
         mock data.
         """
         omdict = {"SystemCreationClassName": "CIM_ComputerSystem",
@@ -292,7 +292,7 @@ class WbemServerMock(object):
     def build_mock(self):
         """
             Builds the classes and instances for a mock WBEMServer from data
-            in the constructor. This calls the builder for:
+            in the init parameter. This calls the builder for:
               the object manager
               the namespaces
               the profiles
@@ -313,7 +313,7 @@ class WbemServerMock(object):
             self.server_mock_data['object_manager']['ElementName'],
             self.server_mock_data['object_manager']['Description'])
 
-        # build CIM_Namespace instances based on the constructor attributes
+        # build CIM_Namespace instances based on the init parameters
         namespaces = [self.interop_ns]
         if self.server_mock_data['other_namespaces']:
             namespaces.extend(self.server_mock_data['other_namespaces'])


### PR DESCRIPTION
This PR is a follow up to PR #1419 and makes sure that the one-line descriptions that are now in the automatically generated method and attribute tables, are meaningful.

Ready for review and merge.