### PR TITLE
Fixed minimum package version of Sphinx and sphinx-git

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -79,8 +79,8 @@ coverage===4.0.3
 pytest-cov===2.4.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx===1.5.1
-sphinx-git===10.0.0
+Sphinx===1.7.6
+sphinx-git===10.1.1
 GitPython===2.1.1
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:


### PR DESCRIPTION
This fixes the recent build breaks in the manual-ci-run branch for minimum package versions.
Reason was Sphinx version too low.

Ready for review and merge.