### PR TITLE
Fixed minimum versions for RTD Sphinx runs

### DIFF
--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -5,8 +5,8 @@
 
 pbr>=1.10.0
 six>=1.10.0
-ply>=3.8
+ply>=3.10
 PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
-Sphinx>=1.4.9
-sphinx-git>=10.0.0
+Sphinx>=1.7.6
+sphinx-git>=10.1.1


### PR DESCRIPTION
This makes the Python package versions used for Sphinx runs on RTD consistent with development.

Ready for review and merge.