### PR TITLE
Fixes #1435: Excluded pytest 3.9.2 due to TypeError

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,6 +15,10 @@ exclude =
 
 # remove the comment and it will ignore noga entries at least in files.
 #disable_noqa
-    
+
+# Globally disabled flake8 issues:    
+# * W504 (line break after binary operator) is issued since 10/2018 in situations
+#   that are ok (e.g. within brackets).
 ignore =
+    W504
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@
 # Unit test (imports into testcases):
 unittest2>=1.1.0
 pytest>=3.0.7,<3.3.0; python_version == '2.6'
-pytest>=3.3.0; python_version > '2.6'
+pytest>=3.3.0,!=3.9.2; python_version > '2.6'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.8.14,<0.9.1; python_version == '2.6'

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,15 +70,5 @@ universal = 1
 [pbr]
 warnerrors = true
 
-[flake8]
-ignore =
-    # unable to detect undefined names (when using wildcard import)
-    F403
-exclude =
-    .git,
-    .tox,
-    __pycache__,
-    *.pyc,
-    docs/conf.py,
-    build_doc,
-    dist
+# flake8 config is in .flake8 file
+

--- a/testsuite/test_statistics.py
+++ b/testsuite/test_statistics.py
@@ -419,7 +419,7 @@ class StatisticsOutputTests(unittest.TestCase, RegexpMixin):
         # test repr output
         self.assert_regexp_matches(
             stat_repr,
-            'Statistics\(')  # pylint: disable=anomalous-backslash-in-string
+            r'Statistics\(')
 
         self.assert_regexp_contains(
             stat_repr,


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.