### PR TITLE
Added support for end2end testing against real WBEM servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ moflextab.py
 testsuite/runtests.log
 /testsuite/testtmp/
 /testsuite/schema/mof*/
+/testsuite/end2end/server_file.yml
 /epydoc-3.0.1-patches/
 swig-2.0*.tar.gz
 /swig-2.0*/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -439,6 +439,14 @@ This version contains all fixes up to pywbem 0.12.4.
   This is only a workaround; An issue against python-coveralls has been
   opened: https://github.com/z4r/python-coveralls/issues/66
 
+* Added the concept of end2end tests for pywbem.
+  The end2end tests execute test files named `test_*.py` within the
+  `testsuite/end2end` directory against groups of real WBEM servers defined by
+  a WBEM server definition file in YAML syntax:
+  `testsuite/end2end/server_file.yml`.
+  There is an example file `server_file_example.yml`.
+  There are some initial tests, and users can define their own tests.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/testsuite/end2end/pytest_end2end.py
+++ b/testsuite/end2end/pytest_end2end.py
@@ -1,0 +1,98 @@
+"""
+pytest support for pywbem end2end tests.
+"""
+
+from __future__ import absolute_import
+
+import os
+import pytest
+
+from pywbem import WBEMConnection
+from server_file import ServerDefinitionFile, ServerDefinition
+
+__all__ = ['server_definition', 'default_namespace', 'wbem_connection']
+
+# Server nickname or server group nickname in WBEM server definition file
+TESTSERVER = os.getenv('TESTSERVER', 'default')
+SD_LIST = list(ServerDefinitionFile().iter_servers(TESTSERVER))
+
+
+def fixtureid_server_definition(fixture_value):
+    """
+    Return a fixture ID to be used by py.test, for fixture
+    `server_definition()`.
+
+    Parameters:
+      * fixture_value (ServerDefinition): The server definition of the
+        WBEM server the test runs against.
+    """
+    sd = fixture_value
+    assert isinstance(sd, ServerDefinition)
+    return "server_definition={}".format(sd.nickname)
+
+
+@pytest.fixture(
+    params=SD_LIST,
+    scope='module',
+    ids=fixtureid_server_definition
+)
+def server_definition(request):
+    """
+    Fixture representing the set of WBEM server definitions to use for the
+    end2end tests.
+
+    Returns the `ServerDefinition` object of each server to test against.
+    """
+    return request.param
+
+
+@pytest.fixture(
+    scope='module'
+)
+def wbem_connection(request, server_definition):
+    """
+    Fixture representing the set of WBEMConnection objects to use for the
+    end2end tests.
+
+    Returns the `WBEMConnection` object of each server to test against.
+    """
+    sd = server_definition
+
+    x509 = dict(cert_file=sd.cert_file, key_file=sd.key_file) \
+        if sd.cert_file and sd.key_file else None
+
+    conn = WBEMConnection(
+        sd.url, (sd.user, sd.password),
+        x509=x509,
+        ca_certs=sd.ca_certs,
+        no_verification=sd.no_verification,
+        timeout=10)
+
+    return conn
+
+
+def fixtureid_default_namespace(fixture_value):
+    """
+    Return a fixture ID to be used by py.test, for fixture
+    `default_namespace()`.
+
+    Parameters:
+      * fixture_value (string): The default namespace for the test.
+    """
+    ns = fixture_value
+    return "default_namespace={}".format(ns)
+
+
+@pytest.fixture(
+    params=[None, 'root/cimv2', 'interop', 'root/interop'],
+    scope='module',
+    ids=fixtureid_default_namespace
+)
+def default_namespace(request):
+    """
+    Fixture representing the set of default namespaces to open connections
+    with.
+
+    Returns the default namespace as a string.
+    """
+    return request.param

--- a/testsuite/end2end/server_file.py
+++ b/testsuite/end2end/server_file.py
@@ -1,0 +1,254 @@
+"""
+Encapsulation of WBEM server definition file defining WBEM servers for pywbem
+end2end tests.
+"""
+
+from __future__ import absolute_import
+
+from collections import OrderedDict
+import errno
+import yaml
+import yamlordereddictloader
+
+SERVER_FILE = 'server_file.yml'
+SERVER_EXAMPLE_FILE = 'server_file_example.yml'
+
+
+class ServerDefinitionFileError(Exception):
+    """
+    An error in the WBEM server definition file.
+    """
+    pass
+
+
+class ServerDefinitionFile(object):
+    """
+    Encapsulation of the WBEM server definition file.
+    """
+
+    def __init__(self, filename=SERVER_FILE):
+        self._filename = filename
+        self._servers = OrderedDict()
+        self._server_groups = OrderedDict()
+        self._load_file()
+
+    def _load_file(self):
+        try:
+            with open(self._filename) as fp:
+                try:
+                    data = yaml.load(fp, Loader=yamlordereddictloader.Loader)
+                except (yaml.parser.ParserError,
+                        yaml.scanner.ScannerError) as exc:
+                    raise ServerDefinitionFileError(
+                        "Invalid YAML syntax in WBEM server definition file "
+                        "{0!r}: {1} {2}".
+                        format(self._filename, exc.__class__.__name__,
+                               exc))
+        except IOError as exc:
+            if exc.errno == errno.ENOENT:
+                raise ServerDefinitionFileError(
+                    "The WBEM server definition file {0!r} was not found; "
+                    "copy it from {1!r}".
+                    format(self._filename, SERVER_EXAMPLE_FILE))
+            else:
+                raise
+        else:
+            if data is None:
+                raise ServerDefinitionFileError(
+                    "The WBEM server definition file {0!r} is empty".
+                    format(self._filename))
+            if not isinstance(data, OrderedDict):
+                raise ServerDefinitionFileError(
+                    "The WBEM server definition file {0!r} must contain a "
+                    "dictionary at the top level, but contains {1}".
+                    format(self._filename, type(data)))
+            servers = data.get('servers', None)
+            if servers is None:
+                raise ServerDefinitionFileError(
+                    "The WBEM server definition file {0!r} does not define a "
+                    "'servers' item, but items: {1}".
+                    format(self._filename, data.keys()))
+            if not isinstance(servers, OrderedDict):
+                raise ServerDefinitionFileError(
+                    "The 'servers' item in WBEM server definition file "
+                    "{0!r} must be a dictionary, but is {1}".
+                    format(self._filename, type(servers)))
+            self._servers.update(servers)
+            server_groups = data.get('server_groups', OrderedDict())
+            if not isinstance(server_groups, OrderedDict):
+                raise ServerDefinitionFileError(
+                    "The 'server_groups' item in WBEM server definition file "
+                    "{0!r} must be a dictionary, but is {1}".
+                    format(self._filename, type(server_groups)))
+            for sg_nick in server_groups:
+                server_group = server_groups[sg_nick]
+                if not isinstance(server_group, list):
+                    raise ServerDefinitionFileError(
+                        "Server group {0!r} in WBEM server definition file "
+                        "{1!r} must be a list, but is {2}".
+                        format(sg_nick, self._filename, type(server_group)))
+                for srv_nick in server_group:
+                    if not isinstance(srv_nick, str):
+                        raise ServerDefinitionFileError(
+                            "Server {0!r} in server group {1!r} in WBEM "
+                            "server definition file {2!r} must be a string, "
+                            "but is {3}".
+                            format(srv_nick, sg_nick, self._filename,
+                                   type(srv_nick)))
+                    if srv_nick not in self._servers:
+                        raise ServerDefinitionFileError(
+                            "Server group {0!r} in WBEM server definition "
+                            "file {1!r} references an unknown server {2!r}".
+                            format(sg_nick, self._filename, srv_nick))
+            self._server_groups.update(server_groups)
+
+    @property
+    def filename(self):
+        """
+        Path name of the WBEM server definition file.
+        """
+        return self._filename
+
+    def get_server(self, nickname):
+        """
+        Return a `ServerDefinition` object for the server with the specified
+        nickname.
+        """
+        try:
+            server_dict = self._servers[nickname]
+        except KeyError:
+            raise ValueError(
+                "Server nickname {0!r} not found in WBEM server definition "
+                "file {1!r}".
+                format(nickname, self._filename))
+        return ServerDefinition(nickname, server_dict)
+
+    def iter_servers(self, nickname):
+        """
+        Iterate through the servers of the server group with the specified
+        nickname, or the single server with the specified nickname, and yield
+        a `ServerDefinition` object for each server.
+        """
+        if nickname in self._servers:
+            yield self.get_server(nickname)
+        elif nickname in self._server_groups:
+            for srv_nickname in self._server_groups[nickname]:
+                # The server definition file parsing has already ensured that
+                # the group only specifies existing server nicknames.
+                yield self.get_server(srv_nickname)
+        else:
+            raise ValueError(
+                "Server group or server nickname {0!r} not found in WBEM "
+                "server definition file {1!r}".
+                format(nickname, self._filename))
+
+
+class ServerDefinition(object):
+    """
+    Encapsulation of a WBEM server definition (e.g. from a WBEM server
+    definition file).
+    """
+
+    def __init__(self, nickname, server_dict):
+        self._nickname = nickname
+        self._description = server_dict.get('description', '')
+        self._url = self._required_attr(server_dict, 'url', nickname)
+        self._user = self._required_attr(server_dict, 'user', nickname)
+        self._password = self._required_attr(server_dict, 'password', nickname)
+        self._cert_file = server_dict.get('cert_file', None)
+        self._key_file = server_dict.get('key_file', None)
+        self._ca_certs = server_dict.get('ca_certs', None)
+        self._no_verification = server_dict.get('no_verification', True)
+
+    def _required_attr(self, server_dict, attr_name, nickname):
+        try:
+            return server_dict[attr_name]
+        except KeyError:
+            raise ServerDefinitionFileError(
+                "Required server attribute is missing in definition of server "
+                "{0}: {1}".format(nickname, attr_name))
+
+    def __repr__(self):
+        return "ServerDefinition(" \
+            "nickname={s.nickname!r}, " \
+            "description={s.description!r}, " \
+            "url={s.url!r}, " \
+            "user={s.user!r}, " \
+            "password=..., " \
+            "cert_file={s.cert_file!r}, " \
+            "key_file={s.key_file!r}, " \
+            "ca_certs={s.ca_certs!r}, " \
+            "no_verification={s.no_verification!r})". \
+            format(s=self)
+
+    @property
+    def nickname(self):
+        """
+        Nickname of the WBEM server.
+        """
+        return self._nickname
+
+    @property
+    def description(self):
+        """
+        Short description of the WBEM server.
+        """
+        return self._description
+
+    @property
+    def url(self):
+        """
+        URL of the WBEM server.
+
+        For details see url parameter of pywbem.WBEMConnections().
+        """
+        return self._url
+
+    @property
+    def user(self):
+        """
+        User for logging on to the WBEM server.
+        """
+        return self._user
+
+    @property
+    def password(self):
+        """
+        Password of that user.
+        """
+        return self._password
+
+    @property
+    def cert_file(self):
+        """
+        Path name of file containing X.509 client certificate to be presented
+        to server, or `None` for not presenting a client certificate to the
+        server.
+        """
+        return self._cert_file
+
+    @property
+    def key_file(self):
+        """
+        Path name of file containing X.509 private key of the client
+        certificate, or `None` for not presenting a client certificate to the
+        server.
+        """
+        return self._key_file
+
+    @property
+    def ca_certs(self):
+        """
+        Path name of CA certificate file or path name of directory containing
+        CA certificate files to be used for verifying the returned server
+        certificate, or `None` for using the pywbem default locations.
+        """
+        return self._ca_certs
+
+    @property
+    def no_verification(self):
+        """
+        Boolean controlling whether the returned server certificate is to be
+        verified.
+        """
+        return self._no_verification

--- a/testsuite/end2end/server_file_example.yml
+++ b/testsuite/end2end/server_file_example.yml
@@ -1,0 +1,59 @@
+# WBEM server definition file for pywbem end2end tests
+#
+# This file has the following format:
+#
+# servers:                       # Dict of WBEM servers.
+#   NICKNAME1:                   # Nickname of the WBEM server.
+#     description: DESC          # Short description of the WBEM server.
+#                                # Optional, default: empty.
+#     url: URL                   # URL of the WBEM server; for details see url
+#                                # parameter of pywbem.WBEMConnections().
+#                                # Mandatory.
+#     user: USER                 # User for logging on to the WBEM server.
+#                                # Mandatory.
+#     password: PASSWORD         # Password of that user.
+#                                # Mandatory.
+#     cert_file: CERT_FILE       # Path name of file containing X.509 client
+#                                # certificate to be presented to server, or
+#                                # null for not presenting a client certificate
+#                                # to the server.
+#                                # Optional, default: null.
+#     key_file: KEY_FILE         # Path name of file containing X.509 private
+#                                # key of the client certificate, or null for
+#                                # not presenting a client certificate to the
+#                                # server.
+#                                # Optional, default: null.
+#     ca_certs: CA_CERTS         # Path name of CA certificate file or path
+#                                # name of directory containing CA certificate
+#                                # files to be used for verifying the returned
+#                                # server certificate, or null for using the
+#                                # pywbem default locations.
+#                                # Optional, default: null.
+#     no_verification: BOOL      # Boolean controlling whether the returned
+#                                # server certificate is to be verified.
+#                                # Optional, default: true.
+#
+# server_groups:                 # Dict of WBEM server groups (optional).
+#   NICKNAME42:                  # Nickname of WBEM server group.
+#     - NICKNAME1                # Nicknames of servers in that group.
+#     - NICKNAME2
+
+# Note: This is an example file that should be copied to server_file.yml and
+# modified as needed.
+
+servers:
+  srv1:
+    description: My WBEM server
+    url: https://srv1.xxx.com:5989
+    user: USER
+    password: PASSWORD
+    cert_file: ~/.ssh/cert_file
+    key_file: ~/.ssh/key_file
+    ca_certs: ~/.ssh/ca_certs/
+    no_verification: false
+
+server_groups:
+  default:
+    - srv1
+  all:
+    - srv1

--- a/testsuite/end2end/test_interop.py
+++ b/testsuite/end2end/test_interop.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+"""
+End2end tests for interop namespace.
+"""
+
+from __future__ import absolute_import, print_function
+
+# Note: The wbem_connection fixture uses the server_definition fixture, and
+# due to the way py.test searches for fixtures, it also need to be imported.
+from pytest_end2end import wbem_connection, default_namespace, server_definition  # noqa: F401, E501
+
+from pywbem import WBEMServer
+
+
+def test_interop_in_namespaces(  # noqa: F811
+        wbem_connection, default_namespace):
+    """
+    Determine interop namespace, determine all namespaces, and verify that
+    the interop namespace is in all namespaces.
+    """
+    wbem_connection.default_namespace = default_namespace
+    server = WBEMServer(wbem_connection)
+
+    interop_ns = server.interop_ns
+    namespaces = server.namespaces
+
+    assert interop_ns in namespaces, \
+        "for server at URL {1!r}".format(wbem_connection.url)


### PR DESCRIPTION
To use the end2end support:
1. Create a `testsuite/end2end/server_file.yml` file, e.g. by copying the example file and adjusting it.
2. Run `TESTSERVER=xxx make end2end` to test against server or server group `xxx`.

COMMENT: I think you mean:
     make end2end TESTSERVER=xxx

Ready for review and for serious test against real WBEM servers.

TODO:
* Unit testcases for `server_file.py` and `pytest_end2end.py`