### PR TITLE
Removed deprecation of setting WBEMConnection.default_namespace

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -74,6 +74,10 @@ This version contains all fixes up to pywbem 0.12.4.
   `WBEMConnection` class will be removed in the next pywbem version after
   0.13.
 
+* Removed the deprecation for setting the `default_namespace` attribute
+  of `WBEMConnection` that had been introduced in pywbem 0.12; setting it
+  is now fully supported again.
+
 **Finalizations:**
 
 * Finalized the `use_pull_operations` property and init argument of the

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -727,7 +727,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         For details, see the description of the same-named init
         parameter of :class:`this class <pywbem.WBEMConnection>`.
 
-        This attribute is settable, but setting it has been deprecated.
+        This attribute is settable.
         """
         return self._default_namespace
 
@@ -735,9 +735,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
     def default_namespace(self, default_namespace):
         """Setter method; for a description see the getter method."""
         # pylint: disable=attribute-defined-outside-init
-        warnings.warn(
-            "Setting the WBEMConnection.default_namespace property is "
-            "deprecated", DeprecationWarning, 2)
+        # Note: Setting it is not deprecated.
         self._set_default_namespace(default_namespace)
 
     def _set_default_namespace(self, default_namespace):

--- a/testsuite/test_cim_operations.py
+++ b/testsuite/test_cim_operations.py
@@ -36,7 +36,6 @@ class TestCreateConnection(object):
         'attr_name, value', [
             ('url', 'http:/myserver'),
             ('creds', ('x', 'y')),
-            ('default_namespace', 'foo'),
             ('x509', dict(cert_file='c', key_file='k')),
             ('verify_callback', lambda a, b, c, d, e: True),
             ('ca_certs', 'xxx'),
@@ -126,8 +125,7 @@ class TestCreateConnection(object):
         of wbem connection when setting the attribute"""
         conn = WBEMConnection('http://localhost', None,
                               default_namespace=None)
-        with pytest.warns(DeprecationWarning):
-            conn.default_namespace = '//root/blah//'
+        conn.default_namespace = '//root/blah//'
         assert conn.default_namespace == 'root/blah'
 
     def test_add_operation_recorder(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.