### PR TITLE
Fixes #1430: Added Interop namespace to set of all namespaces in WBEMServer, if missing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -421,10 +421,10 @@ This version contains all fixes up to pywbem 0.12.4.
   determining the central instances. See issue #1438.
 
 * In the `WBEMServer` class, the Interop namespace is now added to the set
-  of namespaces in the `namespaces`  and `namespace_paths` properties, if
-  missing there. This accomodates the behavior of a particular WBEM server
-  that was found not to include the Interop namespace when enumerating the
-  namespace instances. See issue #1430.
+  of namespaces in the `namespaces`  property, if missing there. This
+  accomodates the behavior of a particular WBEM server that was found to
+  support the Interop namespace without representing it as a CIM instance.
+  See issue #1430.
 
 **Cleanup:**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -420,6 +420,12 @@ This version contains all fixes up to pywbem 0.12.4.
   `ToleratedServerIssueWarning` and to continue with the next approach for
   determining the central instances. See issue #1438.
 
+* In the `WBEMServer` class, the Interop namespace is now added to the set
+  of namespaces in the `namespaces`  and `namespace_paths` properties, if
+  missing there. This accomodates the behavior of a particular WBEM server
+  that was found not to include the Interop namespace when enumerating the
+  namespace instances. See issue #1430.
+
 **Cleanup:**
 
 * Moved class `NocaseDict` into its own module (Issue #848).


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.

**How to test against a real server:**
* No other commits needed on top of the branch of `andy/add-interop-to-namespaces`
* Specifically, PR #1550 is not needed for this test.
* Have `testsuite/end2end/server_file.yml` set up so that the default server is the server nicknamed "Fujitsu" that had the behavior of not including the Interop namespace in the enumeration result.
* Issue:
  ```
  make end2end
  grep ToleratedServerIssueWarning end2end_*.log
  ```
* Verify that the make succeeds and that there is one occurrence of `ToleratedServerIssueWarning`.