### PR TITLE
Moved new warning classes into separate module and added to docs

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -399,9 +399,9 @@ This version contains all fixes up to pywbem 0.12.4.
 * Improved the quality of any `ParseError` exception messages when the SAX
   parser detects errors in CIM-XML responses. See issue #1438.
 
-* Added a `ServerWarning` class and its base class `Warning`. The new
-  `ServerWarning` is raised in cases when the WBEM server exhibits some
-  incorrect behavior that is tolerated by pywbem.
+* Added a `ToleratedServerIssueWarning` class and its base class `Warning`.
+  The new `ToleratedServerIssueWarning` is raised in cases when the WBEM server
+  exhibits some incorrect behavior that is tolerated by pywbem.
 
 * Added a `ModelError` exception class that indicates an error with the model
   implemented by the WBEM server, that was detected by the pywbem client.

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -21,6 +21,7 @@ A number of these topics apply also to the other APIs of the pywbem package.
    client/conversion.rst
    client/status.rst
    client/exceptions.rst
+   client/warnings.rst
    client/statistics.rst
    client/logging.rst
    client/recording.rst

--- a/docs/client/warnings.rst
+++ b/docs/client/warnings.rst
@@ -1,0 +1,39 @@
+
+.. _`Warnings`:
+
+Warnings
+--------
+
+.. automodule:: pywbem._warnings
+
+.. autoclass:: pywbem.Warning
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.Warning
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.Warning
+      :attributes:
+
+   .. rubric:: Details
+
+.. autoclass:: pywbem.ToleratedServerIssueWarning
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.ToleratedServerIssueWarning
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.ToleratedServerIssueWarning
+      :attributes:
+
+   .. rubric:: Details

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -57,6 +57,7 @@ from ._listener import *  # noqa: F403,F401
 from ._recorder import *  # noqa: F403,F401
 from ._statistics import *  # noqa: F403,F401
 from ._logging import *  # noqa: F403,F401
+from ._warnings import *  # noqa: F403,F401
 
 from ._version import __version__  # noqa: F401
 

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -1,0 +1,42 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+"""
+The following warnings are pywbem specific warnings that can be issued by
+the WBEM client library.
+"""
+
+import six
+from .exceptions import Error
+
+# This module is meant to be safe for 'import *'.
+
+__all__ = ['Warning', 'ToleratedServerIssueWarning']
+
+
+class Warning(Error, six.moves.builtins.Warning):
+    """
+    Base class for pywbem specific warnings.
+    """
+    pass
+
+
+class ToleratedServerIssueWarning(Warning):
+    """
+    This warning indicates an issue with the WBEM server that has been
+    tolerated by pywbem.
+    """
+    pass

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -19,15 +19,12 @@ The following exceptions are pywbem specific exceptions that can be raised at
 the WBEM client library API.
 """
 
-import six
-
 from .cim_constants import _statuscode2name, _statuscode2string
 
 # This module is meant to be safe for 'import *'.
 
 __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
-           'VersionError', 'ParseError', 'CIMError', 'ModelError', 'Warning',
-           'ServerWarning']
+           'VersionError', 'ParseError', 'ModelError', 'CIMError']
 
 
 class Error(Exception):
@@ -368,20 +365,5 @@ class ModelError(Error):
     defined in advertised management profiles.
 
     Derived from :exc:`~pywbem.Error`.
-    """
-    pass
-
-
-class Warning(Error, six.moves.builtins.Warning):
-    """
-    Base class for pywbem specific warnings.
-    """
-    pass
-
-
-class ServerWarning(Warning):
-    """
-    This warning indicates an issue with the WBEM server that has been
-    tolerated by pywbem.
     """
     pass

--- a/testsuite/test_exceptions.py
+++ b/testsuite/test_exceptions.py
@@ -10,8 +10,7 @@ import six
 import pytest
 
 from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError,\
-    ParseError, VersionError, CIMError, ModelError, Warning, ServerWarning, \
-    CIMInstance
+    ParseError, VersionError, CIMError, ModelError, CIMInstance
 
 # Test connection ID used for showing connection information in exception
 # messages
@@ -70,15 +69,12 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     ParseError,
     VersionError,
     ModelError,
-    Warning,
-    ServerWarning,
 ], scope='module')
 def simple_class(request):
     """
-    Fixture representing variations of the simple exception and warning
-    classes.
+    Fixture representing variations of the simple exception classes.
 
-    Returns the exception or warning class.
+    Returns the exception class.
     """
     return request.param
 
@@ -93,7 +89,7 @@ def simple_class(request):
 def simple_args(request):
     """
     Fixture representing variations of positional init arguments for the simple
-    exception or warning classes.
+    exception classes.
 
     Returns a tuple of positional arguments for initializing an exception
     object.
@@ -110,8 +106,7 @@ def simple_args(request):
 def conn_info(request):
     """
     Fixture representing variations for the conn_id keyword argument for all
-    exception and warning classes, and the corresponding expected connection
-    info string.
+    exception classes, and the corresponding expected connection info string.
 
     Returns a tuple of:
     * conn_id_kwarg: dict with the 'conn_id' keyword argument. May be empty.
@@ -123,10 +118,7 @@ def conn_info(request):
 def test_simple(simple_class, simple_args, conn_info):
     # pylint: disable=redefined-outer-name
     """
-    Test the simple exception and warning classes.
-
-    Note, the Python `Warning` class is derived from the `Exception` class and
-    thus can be treated like exception classes.
+    Test the simple exception classes.
     """
 
     conn_id_kwarg, exp_conn_str = conn_info

--- a/testsuite/test_warnings.py
+++ b/testsuite/test_warnings.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+"""
+Test _warnings module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import six
+import pytest
+
+from pywbem import Warning, ToleratedServerIssueWarning
+
+# Test connection ID used for showing connection information in exception
+# messages
+TEST_CONN_ID = 'fake-conn-id'
+
+# The expected connection information in exception messages
+TEST_CONN_STR = 'Connection id: %s' % TEST_CONN_ID
+TEST_CONN_STR_NONE = 'Connection id: None'
+
+
+def _assert_subscription(exc):
+    """
+    Test the exception defined by exc for required args.
+    """
+
+    # Access by subscription is only supported in Python 2:
+    if six.PY2:
+        assert exc[:] == exc.args
+        for i, _ in enumerate(exc.args):
+            assert exc[i] == exc.args[i]
+            assert exc[i:] == exc.args[i:]
+            assert exc[0:i] == exc.args[0:i]
+    else:
+        try:
+            _ = exc[:]
+        except TypeError:
+            pass
+        else:
+            assert False, "Access by slice did not fail in Python 3"
+        for i, _ in enumerate(exc.args):
+            try:
+                _ = exc[i]  # noqa: F841
+            except TypeError:
+                pass
+            else:
+                assert False, "Access by index did not fail in Python 3"
+
+
+def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
+    """
+    Test the exception defined by exc for connection related information.
+    """
+    exp_conn_id = conn_id_kwarg.get('conn_id', None)
+    exc_str = str(exc)
+    assert exc.conn_id is exp_conn_id
+    assert exc.conn_str == exp_conn_str
+    assert exp_conn_str in exc_str
+
+
+@pytest.fixture(params=[
+    # The warning classes for which the simple test should be done:
+    Warning,
+    ToleratedServerIssueWarning,
+], scope='module')
+def simple_class(request):
+    """
+    Fixture representing variations of the simple warning classes.
+
+    Returns the warning class.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[
+    # Tuple of positional init arguments for the simple warning classes
+    (),
+    ('',),
+    ('foo',),
+    ('foo', 42),
+], scope='module')
+def simple_args(request):
+    """
+    Fixture representing variations of positional init arguments for the simple
+    warning classes.
+
+    Returns a tuple of positional arguments for initializing a warning object.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[
+    # Tuple of (conn_id_kwarg, exp_conn_str)
+    (dict(), TEST_CONN_STR_NONE),
+    (dict(conn_id=None), TEST_CONN_STR_NONE),
+    (dict(conn_id=TEST_CONN_ID), TEST_CONN_STR),
+], scope='module')
+def conn_info(request):
+    """
+    Fixture representing variations for the conn_id keyword argument for all
+    warning classes, and the corresponding expected connection info string.
+
+    Returns a tuple of:
+    * conn_id_kwarg: dict with the 'conn_id' keyword argument. May be empty.
+    * exp_conn_str: Expected connection info string.
+    """
+    return request.param
+
+
+def test_simple(simple_class, simple_args, conn_info):
+    # pylint: disable=redefined-outer-name
+    """
+    Test the simple warning classes.
+
+    Note, the Python `Warning` class is derived from the `Exception` class and
+    thus can be treated like exception classes.
+    """
+
+    conn_id_kwarg, exp_conn_str = conn_info
+
+    exc = simple_class(*simple_args, **conn_id_kwarg)
+
+    # exc has no len()
+    assert len(exc.args) == len(simple_args)
+    for i, _ in enumerate(simple_args):
+        assert exc.args[i] == simple_args[i]
+        assert exc.args[i:] == simple_args[i:]
+        assert exc.args[0:i] == simple_args[0:i]
+        assert exc.args[:] == simple_args[:]
+
+    _assert_connection(exc, conn_id_kwarg, exp_conn_str)
+    _assert_subscription(exc)


### PR DESCRIPTION
This is a small fixup after merging PR #1539.

For details, see the commit message.
Ready for review and merge.

Also, there is the following **discussion point**:

* The warning class has been named `ServerWarning`, but it is defined as: "indicates an issue with the WBEM server that has been tolerated by pywbem". With that definition, a class name of `ToleratedServerIssueWarning` would be more appropriate. Discuss which name to use finally.