### PR TITLE
Specify reference direction in WBEMServer.get_central_instances()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -426,6 +426,16 @@ This version contains all fixes up to pywbem 0.12.4.
   support the Interop namespace without representing it as a CIM instance.
   See issue #1430.
 
+* Added support for specifying the reference direction in
+  `WBEMServer.get_central_instances()` by adding an optional parameter
+  `reference_direction`. This was necessary because the DMTF 'Profile
+  Registration Profile' (PRP) and the SNIA PRP use the CIM_ReferencedProfile
+  association class in opposite ways: The DMTF PRP defines that the
+  'Dependent' end of that class goes to the referencing profile which
+  is defined to be the autonomous profile, while the SNIA PRP defines that
+  the 'Antecedent' end goes to the autonomous profile.
+  See issue #1411.
+
 **Cleanup:**
 
 * Moved class `NocaseDict` into its own module (Issue #848).

--- a/testsuite/test_wbemserverclass.py
+++ b/testsuite/test_wbemserverclass.py
@@ -114,7 +114,7 @@ class TestServerClass(BaseMethodsForTests):
             assert inst['RegisteredName'] == 'Indications'
 
         sel_prof = server.get_selected_profiles(registered_org='DMTF')
-        assert len(sel_prof) == 2
+        assert len(sel_prof) == 3
         for inst in sel_prof:
             assert org_vm.tovalues(inst['RegisteredOrganization']) == 'DMTF'
 
@@ -335,7 +335,85 @@ def test_delete_namespace(testcase,
     assert act_namespace == exp_namespace
 
 
-# TODO Break up tests to do individual tests for each group of methds so we can
+TESTCASES_GET_CENTRAL_INSTANCES = [
+
+    # Testcases for WBEMServer.get_central_instances()
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * profile_name: Name of the profile as tuple (org, name, version)
+    #   * central_class: Name of the central class of the profile.
+    #   * scoping_class: Name of the scoping class of the profile, or None for
+    #     autonomous profiles.
+    #   * scoping_path: List of class names for the scoping path (from central
+    #     class to scoping class, not including central or scoping classes), or
+    #     None for autonomous profiles.
+    #   * direction: Reference direction 'snia' or 'dmtf'.
+    #   * exp_paths: Expected returned instance paths, as a list of
+    #     CIMInstanceName objects.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+    (
+        "Valid central class",
+        dict(
+            profile_name=('SNIA', 'Server', '1.2.0'),
+            central_class='XXX_StorageComputerSystem',
+            scoping_class=None,
+            scoping_path=None,
+            direction='snia',
+            exp_paths=[
+                CIMInstanceName('XXX_StorageComputerSystem',
+                                keybindings={'Name': "10.1.2.3",
+                                             'CreationClassName':
+                                             'XXX_StorageComputerSystem'},
+                                host='FakedUrl',
+                                namespace='interop'), ]
+        ),
+        None, None, True
+    ),
+    # TODO add more central instance tests
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_GET_CENTRAL_INSTANCES)
+@pytest_extensions.simplified_test_function
+def test_get_central_instances(testcase, profile_name, central_class,
+                               scoping_class, scoping_path, direction,
+                               exp_paths):
+    """
+    Test the execution of WBEMSeever.get_central_instances()
+    """
+    mock_wbemserver = WbemServerMock(interop_ns='interop')
+    server = mock_wbemserver.wbem_server
+    profile_insts = server.get_selected_profiles(
+        registered_org=profile_name[0],
+        registered_name=profile_name[1],
+        registered_version=profile_name[2])
+    assert len(profile_insts) == 1
+    profile_inst = profile_insts[0]
+
+    # The code to be tested.
+    # Must start from a single good profile instance
+
+    # server.conn.display_repository()
+    act_paths = server.get_central_instances(profile_inst.path,
+                                             central_class=central_class,
+                                             scoping_class=scoping_class,
+                                             scoping_path=scoping_path,
+                                             reference_direction=direction)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    assert act_paths == exp_paths
+
+
+# TODO Break up tests to do individual tests for each group of methods so we can
 #      test for errors, variations on what is in the repo with each method.
 #      Right now we build it all in a single test.  Thus, for example we
 #      need to create a test group for find_central_instances since the


### PR DESCRIPTION
**Note: This PR is on top of PR #1550. Review only the delta.**
This PR splits off the addition of the 'reference_direction' parameter from Karl's PR #1533, but does not yet add the methods to automatically determine that direction.
For details, see the commit message.
Ready for review and merge.