### PR TITLE
Fixes #1564: Added toleration support for CIM-XML responses with empty TYPE attr

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -519,6 +519,11 @@ This version contains all fixes up to pywbem 0.12.4.
   profiles, and that is used to drive profile discovery related tests against
   WBEM servers.
 
+* Added toleration support in the CIM-XML response parsing for WBEM servers
+  that return attribute `TYPE` with an empty string instead of omitting it.
+  As part of that, improved the checking for valid values of the TYPE
+  attribute. See issue #1564.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
For details, see the commit message.
Ready for review, test and merge.

Note: This should be end2end tested at least with the Brocade server in the SMI-S testlab.