### PR TITLE
Add CIM-XML request and response data to CIM/XMLParseError

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -482,7 +482,8 @@ This version contains all fixes up to pywbem 0.12.4.
   have been added: `CIMXMLParseError` and `XMLParseError`, that are
   now raised instead of `ParseError`. Because these are subclasses,
   this change is backwards compatible for users that have caught
-  `ParseError`.
+  `ParseError`. The new subclasses have the CIM-XML request and
+  response data available as properties.
 
 **Cleanup:**
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -152,7 +152,7 @@ from .cim_http import get_cimobject_header, wbem_request
 from .tupleparse import TupleParser
 from .tupletree import xml_to_tupletree_sax
 from .cim_http import parse_url
-from .exceptions import CIMXMLParseError, CIMError
+from .exceptions import CIMXMLParseError, XMLParseError, CIMError
 from ._statistics import Statistics
 from ._recorder import LogOperationRecorder
 from ._logging import DEFAULT_LOG_DETAIL_LEVEL, LOG_DESTINATIONS, \
@@ -1727,7 +1727,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_reply = None
 
         # Send request and receive response
-        reply_xml, self._last_server_response_time = wbem_request(
+        reply_data, self._last_server_response_time = wbem_request(
             self.url, request_data, self.creds, cimxml_headers,
             x509=self.x509,
             verify_callback=self.verify_callback,
@@ -1740,18 +1740,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         # Set attributes recording the response, part 1.
         # Only those that can be done without parsing (which can fail).
-        self._last_raw_reply = reply_xml
-        self._last_reply_len = len(reply_xml)
+        self._last_raw_reply = reply_data
+        self._last_reply_len = len(reply_data)
 
         # Parse the XML into a tuple tree (may raise CIMXMLParseError or
         # XMLParseError):
-        tt_ = xml_to_tupletree_sax(reply_xml, "CIM-XML response")
+        tt_ = xml_to_tupletree_sax(reply_data, "CIM-XML response")
         tp = TupleParser(self.conn_id)
         tup_tree = tp.parse_cim(tt_)
 
         # Set attributes recording the response, part 2.
         if self.debug:
-            self._last_reply = _to_pretty_xml(reply_xml)
+            self._last_reply = _to_pretty_xml(reply_data)
 
         # Check the tuple tree
 
@@ -2028,7 +2028,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             self._last_reply = None
 
         # Send request and receive response
-        reply_xml, self._last_server_response_time = wbem_request(
+        reply_data, self._last_server_response_time = wbem_request(
             self.url, request_data, self.creds, cimxml_headers,
             x509=self.x509,
             verify_callback=self.verify_callback,
@@ -2041,18 +2041,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         # Set attributes recording the response, part 1.
         # Only those that can be done without parsing (which can fail).
-        self._last_raw_reply = reply_xml
-        self._last_reply_len = len(reply_xml)
+        self._last_raw_reply = reply_data
+        self._last_reply_len = len(reply_data)
 
         # Parse the XML into a tuple tree (may raise CIMXMLParseError or
         # XMLParseError):
-        tt_ = xml_to_tupletree_sax(reply_xml, "CIM-XML response")
+        tt_ = xml_to_tupletree_sax(reply_data, "CIM-XML response")
         tp = TupleParser(self.conn_id)
         tup_tree = tp.parse_cim(tt_)
 
         # Set attributes recording the response, part 2.
         if self.debug:
-            self._last_reply = _to_pretty_xml(reply_xml)
+            self._last_reply = _to_pretty_xml(reply_data)
 
         # Check the tuple tree
 
@@ -2473,6 +2473,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return instances
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -2582,6 +2587,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return instancenames
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -2749,6 +2759,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return instance
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -2937,6 +2952,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3074,6 +3094,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return instancename
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3139,6 +3164,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3372,6 +3402,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return objects
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3544,6 +3579,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return objects
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3757,6 +3797,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return objects
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -3911,6 +3956,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return objects
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -4032,6 +4082,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return result
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -4136,6 +4191,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return instances
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -6526,6 +6586,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -6751,6 +6816,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -7032,6 +7102,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -7270,6 +7345,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -7534,6 +7614,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -7755,6 +7840,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -7984,6 +8074,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                                    query_result_class)
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8136,6 +8231,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8284,6 +8384,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8426,6 +8531,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 *self._get_rslt_params(result, namespace))
             return result_tuple
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8509,6 +8619,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8679,6 +8794,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return classes
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8808,6 +8928,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return classnames
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -8968,6 +9093,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return klass
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9049,6 +9179,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9128,6 +9263,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9206,6 +9346,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9293,6 +9438,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return qualifierdecls
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9390,6 +9540,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             return qualifierdecl
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9464,6 +9619,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise
@@ -9536,6 +9696,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 **extra)
             return
 
+        except (CIMXMLParseError, XMLParseError) as exce:
+            exce.request_data = self.last_raw_request
+            exce.response_data = self.last_raw_reply
+            exc = exce
+            raise
         except Exception as exce:
             exc = exce
             raise

--- a/pywbem/exceptions.py
+++ b/pywbem/exceptions.py
@@ -222,6 +222,15 @@ class ParseError(Error):
 
     Derived from :exc:`~pywbem.Error`.
 
+    This class supports attaching the CIM-XML request and response data in
+    properties :attr:`~pywbem.ParseError.request_data` and
+    :attr:`~pywbem.ParseError.response_data`, respectively. When exceptions
+    of this class are raised by pywbem, these properties will always be
+    set.
+
+    The CIM-XML response data is part of the `str()` representation of the
+    exception.
+
     This exception is a base class for two more specific exceptions:
 
     * :exc:`~pywbem.CIMXMLParseError` - Issue at the CIM-XML level (e.g. NAME
@@ -245,6 +254,38 @@ class ParseError(Error):
             was not known.
         """
         super(ParseError, self).__init__(message, conn_id=conn_id)
+        self._request_data = None
+        self._response_data = None
+
+    @property
+    def request_data(self):
+        """
+        :term:`string`: CIM-XML request data (unformatted).
+        """
+        return self._request_data
+
+    @request_data.setter
+    def request_data(self, request_data):
+        """Setter method; for a description see the getter method."""
+        self._request_data = request_data
+
+    @property
+    def response_data(self):
+        """
+        :term:`string`: CIM-XML response data (unformatted).
+        """
+        return self._response_data
+
+    @response_data.setter
+    def response_data(self, response_data):
+        """Setter method; for a description see the getter method."""
+        self._response_data = response_data
+
+    def __str__(self):
+        error_str = super(ParseError, self).__str__()
+        ret_str = "{0}\nCIM-XML response: {1}". \
+            format(error_str, self.response_data)
+        return ret_str
 
 
 class CIMXMLParseError(ParseError):

--- a/testsuite/testclient/conftest.py
+++ b/testsuite/testclient/conftest.py
@@ -841,6 +841,28 @@ def runtestcase(testcase):
                                  "%s\n" %
                                  (tc_name, exp_exception, op_name,
                                   raised_traceback_str))
+        if isinstance(raised_exception,
+                      (pywbem.CIMXMLParseError, pywbem.XMLParseError)):
+            if raised_exception.request_data != conn.last_raw_request:
+                raise AssertionError("Testcase %s: The %s exception raised by "
+                                     "PyWBEM operation %s has unexpected "
+                                     "CIM-XML request data:\n"
+                                     "%s\n"
+                                     "Expected CIM-XML request data:\n"
+                                     "%s\n" %
+                                     (tc_name, raised_exception, op_name,
+                                      raised_exception.request_data,
+                                      conn.last_raw_request))
+            if raised_exception.response_data != conn.last_raw_reply:
+                raise AssertionError("Testcase %s: The %s exception raised by "
+                                     "PyWBEM operation %s has unexpected "
+                                     "CIM-XML response data:\n"
+                                     "%s\n"
+                                     "Expected CIM-XML response data:\n"
+                                     "%s\n" %
+                                     (tc_name, raised_exception, op_name,
+                                      raised_exception.response_data,
+                                      conn.last_raw_reply))
     else:
         if raised_exception is not None:
             raise AssertionError("Testcase %s: No exception was "


### PR DESCRIPTION
This is the second part of improvements on ParseError.

For details, see the commit message.
Ready for review and merge.

Particular review items:
* The `str()`of ParseError now includes the CIM-XML response, which may get quite lengthy.
* It does not contain the CIM-XML request, because that is not normally needed to understand what is going on.

Testing: It would be good to run this PR with `make end2end` against the smigood group.