### PR TITLE
Split end2end profile testcases & cache objects for reuse

### DIFF
--- a/makefile
+++ b/makefile
@@ -201,13 +201,13 @@ pytest_opts := $(TESTOPTS) -k $(TESTCASES)
 else
 pytest_opts := $(TESTOPTS)
 endif
-pytest_end2end_opts := --tb=short $(pytest_opts)
+pytest_end2end_opts := -v --tb=short $(pytest_opts)
 
 pytest_warnings := default
 ifeq ($(python_m_version),3)
-  pytest_end2end_warnings := default,ignore::DeprecationWarning,ignore::ResourceWarning
+  pytest_end2end_warnings := default,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ResourceWarning
 else
-  pytest_end2end_warnings := default,ignore::DeprecationWarning
+  pytest_end2end_warnings := default,ignore::DeprecationWarning,ignore::PendingDeprecationWarning
 endif
 
 # Files to be put into distribution archive.

--- a/testsuite/end2end/_utils.py
+++ b/testsuite/end2end/_utils.py
@@ -108,19 +108,19 @@ class ServerObjectCache(object):
         list_dict = self._server_dict[server_url]
         if list_name in list_dict:
             raise KeyError(
-                "List {0} for server {1} is already in the cache".
+                "List {0!r} for server {1!r} is already in the cache".
                 format(list_name, server_url))
         list_dict[list_name] = deepcopy(obj_list)
 
     def del_list(self, server_url, list_name):
         if server_url not in self._server_dict:
             raise KeyError(
-                "Server {0} is not in the cache".
+                "Server {0!r} is not in the cache".
                 format(server_url))
         list_dict = self._server_dict[server_url]
         if list_name not in list_dict:
             raise KeyError(
-                "List {0} for server {1} is not in the cache".
+                "List {0!r} for server {1!r} is not in the cache".
                 format(list_name, server_url))
         del list_dict[list_name]
         if not list_dict:
@@ -129,12 +129,12 @@ class ServerObjectCache(object):
     def get_list(self, server_url, list_name):
         if server_url not in self._server_dict:
             raise KeyError(
-                "Server {0} is not in the cache".
+                "Server {0!r} is not in the cache".
                 format(server_url))
         list_dict = self._server_dict[server_url]
         if list_name not in list_dict:
             raise KeyError(
-                "List {0} for server {1} is not in the cache".
+                "List {0!r} for server {1!r} is not in the cache".
                 format(list_name, server_url))
         return list_dict[list_name]
 

--- a/testsuite/end2end/pytest_end2end.py
+++ b/testsuite/end2end/pytest_end2end.py
@@ -248,18 +248,6 @@ def assert_association_a1(test_self, source_path, source_role, assoc_class,
         "paths of result of Associators (a1)",
         far_class, far_role)
 
-    # Store the result in the object cache for use by the functions for the
-    # other approaches. The order of function invocations is guaranteed by
-    # the list of functions in the assert_association_func fixture.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    test_self.object_cache.add_list(
-        test_self.conn.url, a1_far_paths_id, a1_far_paths)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    test_self.object_cache.add_list(
-        test_self.conn.url, a1_assoc_paths_id, a1_assoc_paths)
-
     return a1_far_insts, a1_assoc_insts
 
 
@@ -312,32 +300,6 @@ def assert_association_a2(test_self, source_path, source_role, assoc_class,
         a2_far_paths,
         "paths of manually filtered result of Associators (a2)",
         far_class, far_role)
-
-    # Retrieve the result of approach a1 from the object cache.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    a1_far_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_far_paths_id)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    a1_assoc_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_assoc_paths_id)
-
-    # Check consistency with approach a1
-    assert len(a2_assoc_paths) == len(a1_assoc_paths)
-    for path in a2_assoc_paths:
-        test_self.assert_path_in(
-            path,
-            "path of manually filtered result of References (a2)",
-            a1_assoc_paths,
-            "path of manually filtered result of References (a1)")
-    assert len(a2_far_paths) == len(a1_far_paths)
-    for path in a2_far_paths:
-        test_self.assert_path_in(
-            path,
-            "path of manually filtered result of Associators (a2)",
-            a1_far_paths,
-            "path of result of Associators (a1)")
 
     return a2_far_insts, a2_assoc_insts
 
@@ -395,32 +357,6 @@ def assert_association_a3(test_self, source_path, source_role, assoc_class,
         a3_far_paths,
         "result of AssociatorNames (a3)",
         far_class, far_role)
-
-    # Retrieve the result of approach a1 from the object cache.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    a1_far_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_far_paths_id)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    a1_assoc_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_assoc_paths_id)
-
-    # Check consistency with approach a1
-    assert len(a3_assoc_paths) == len(a1_assoc_paths)
-    for path in a3_assoc_paths:
-        test_self.assert_path_in(
-            path,
-            "manually filtered result of ReferenceNames (a3)",
-            a1_assoc_paths,
-            "path of manually filtered result of References (a1)")
-    assert len(a3_far_paths) == len(a1_far_paths)
-    for path in a3_far_paths:
-        test_self.assert_path_in(
-            path,
-            "result of AssociatorNames (a3)",
-            a1_far_paths,
-            "path of result of Associators (a1)")
 
     return a3_far_insts, a3_assoc_insts
 
@@ -485,32 +421,6 @@ def assert_association_a4(test_self, source_path, source_role, assoc_class,
         "manually filtered result of AssociatorNames (a4)",
         far_class, far_role)
 
-    # Retrieve the result of approach a1 from the object cache.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    a1_far_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_far_paths_id)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    a1_assoc_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_assoc_paths_id)
-
-    # Check consistency with approach a1
-    assert len(a4_assoc_paths) == len(a1_assoc_paths)
-    for path in a4_assoc_paths:
-        test_self.assert_path_in(
-            path,
-            "manually filtered result of ReferenceNames (a4)",
-            a1_assoc_paths,
-            "path of manually filtered result of References (a1)")
-    assert len(a4_far_paths) == len(a1_far_paths)
-    for path in a4_far_paths:
-        test_self.assert_path_in(
-            path,
-            "manually filtered result of AssociatorNames (a4)",
-            a1_far_paths,
-            "path of result of Associators (a1)")
-
     return a4_far_insts, a4_assoc_insts
 
 
@@ -564,34 +474,6 @@ def assert_association_a5(test_self, source_path, source_role, assoc_class,
         "far ends of manually filtered result of "
         "EnumerateInstances on association class (a5)",
         far_class, far_role)
-
-    # Retrieve the result of approach a1 from the object cache.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    a1_far_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_far_paths_id)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    a1_assoc_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_assoc_paths_id)
-
-    # Check consistency with approach a1
-    assert len(a5_assoc_paths) == len(a1_assoc_paths)
-    for path in a5_assoc_paths:
-        test_self.assert_path_in(
-            path,
-            "path of manually filtered result of EnumerateInstances on "
-            "association class (a5)",
-            a1_assoc_paths,
-            "path of manually filtered result of References (a1)")
-    assert len(a5_far_paths) == len(a1_far_paths)
-    for path in a5_far_paths:
-        test_self.assert_path_in(
-            path,
-            "far ends of manually filtered result of EnumerateInstances "
-            "on association class (a5)",
-            a1_far_paths,
-            "path of result of Associators (a1)")
 
     return a5_far_insts, a5_assoc_insts
 
@@ -650,34 +532,6 @@ def assert_association_a6(test_self, source_path, source_role, assoc_class,
         "far ends of manually filtered result of "
         "EnumerateInstanceNames on association class (a6)",
         far_class, far_role)
-
-    # Retrieve the result of approach a1 from the object cache.
-    prefix = ':'.join([test_self.profile_id, source_path.to_wbem_uri(),
-                       source_role, assoc_class, far_role, far_class])
-    a1_far_paths_id = prefix + ':a1_far_paths'
-    a1_far_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_far_paths_id)
-    a1_assoc_paths_id = prefix + ':a1_assoc_paths'
-    a1_assoc_paths = test_self.object_cache.get_list(
-        test_self.conn.url, a1_assoc_paths_id)
-
-    # Check consistency with approach a1
-    assert len(a6_assoc_paths) == len(a1_assoc_paths)
-    for path in a6_assoc_paths:
-        test_self.assert_path_in(
-            path,
-            "manually filtered result of EnumerateInstanceNames on "
-            "association class (a6)",
-            a1_assoc_paths,
-            "path of manually filtered result of References (a1)")
-    assert len(a6_far_paths) == len(a1_far_paths)
-    for path in a6_far_paths:
-        test_self.assert_path_in(
-            path,
-            "far ends of manually filtered result of "
-            "EnumerateInstanceNames on association class (a6)",
-            a1_far_paths,
-            "path of result of Associators (a1)")
 
     return a6_far_insts, a6_assoc_insts
 
@@ -1059,3 +913,46 @@ class ProfileTest(object):
             self.assert_path_in(
                 path, assoc_paths_msg,
                 assoc_insts, "path of {0}".format(assoc_insts_msg))
+
+        # Check consistency across the association approaches
+        # Py test does not seem to have a reliable order of executing the
+        # testcases w.r.t. items in fixtures. Therefore, we have to assume
+        # that this function is invoked in arbitrary order w.r.t. the
+        # association approaches. The algorithn we use is that the
+        # first approach defines the results all subsequent approaches
+        # compare against.
+        prefix = ':'.join([self.profile_id, source_path.to_wbem_uri(),
+                           source_role, assoc_class, far_role, far_class])
+        far_paths_id = prefix + ':far_paths'
+        assoc_paths_id = prefix + ':assoc_paths'
+        if not self.object_cache.has_list(self.conn.url, far_paths_id):
+            # This is the first approach executed (not necessarily a1).
+            # Store the results in the object cache.
+            self.object_cache.add_list(
+                self.conn.url, far_paths_id, far_paths)
+            self.object_cache.add_list(
+                self.conn.url, assoc_paths_id, assoc_paths)
+        else:
+            # This is not the first approach executed.
+
+            # Retrieve the result of the first approach from the object cache.
+            first_far_paths = self.object_cache.get_list(
+                self.conn.url, far_paths_id)
+            first_assoc_paths = self.object_cache.get_list(
+                self.conn.url, assoc_paths_id)
+
+            # Check consistency with first approach
+            assert len(assoc_paths) == len(first_assoc_paths)
+            for path in assoc_paths:
+                self.assert_path_in(
+                    path,
+                    assoc_paths_msg,
+                    first_assoc_paths,
+                    assoc_paths_msg + " of first executed association approach")
+            assert len(far_paths) == len(first_far_paths)
+            for path in far_paths:
+                self.assert_path_in(
+                    path,
+                    far_paths_msg,
+                    first_far_paths,
+                    far_paths_msg + " of first executed association approach")

--- a/testsuite/end2end/test_profile_snia_server.py
+++ b/testsuite/end2end/test_profile_snia_server.py
@@ -9,7 +9,7 @@ import warnings
 # Note: The wbem_connection fixture uses the server_definition fixture, and
 # due to the way py.test searches for fixtures, it also need to be imported.
 from pytest_end2end import wbem_connection, server_definition  # noqa: F401, E501
-
+from pytest_end2end import assert_association_func  # noqa: F401
 from pytest_end2end import ProfileTest
 
 
@@ -22,9 +22,9 @@ class Test_SNIA_Server_Profile(ProfileTest):
         super(Test_SNIA_Server_Profile, self).init_profile(
             conn, 'SNIA', 'Server')
 
-    def test_instances(self, wbem_connection):  # noqa: F811
+    def test_get_central_instances(self, wbem_connection):  # noqa: F811
         """
-        Test the instances of the profile.
+        Test WBEMServer.get_central_instances() for this profile.
         """
         self.init_profile(wbem_connection)
 
@@ -35,15 +35,23 @@ class Test_SNIA_Server_Profile(ProfileTest):
             scoping_path=self.profile_definition['scoping_path'],
             reference_direction=self.profile_definition['reference_direction'])
 
-        # Check that there is one central instance
+        # Check that there is just one central instance for this profile
         assert len(central_inst_paths) == 1
-        central_inst_path = central_inst_paths[0]
 
-        # Test the CIM_ObjectManager central instance
+    def test_central_instance(self, wbem_connection):  # noqa: F811
+        """
+        Test the CIM_ObjectManager central instance.
+        """
+        self.init_central_instances(wbem_connection)
+        central_inst_path = self.central_inst_paths[0]
+
         self.assert_instance_of(central_inst_path, 'CIM_ObjectManager')
+
         central_inst = self.conn.GetInstance(central_inst_path)
+
         self.assert_instance_of(central_inst, 'CIM_ObjectManager')
         self.assert_instance_consistency(central_inst, central_inst_path)
+
         mandatory_property_list = [
             'SystemCreationClassName', 'SystemName',
             'CreationClassName', 'Name',
@@ -52,13 +60,22 @@ class Test_SNIA_Server_Profile(ProfileTest):
         ]
         self.assert_mandatory_properties(central_inst, mandatory_property_list)
 
-        # Test the associated CIM_Namespace instances
-        far_insts, _ = self.assert_association(
+    def test_Namespace(  # noqa: F811
+            self, wbem_connection, assert_association_func):
+        """
+        Test the associated CIM_Namespace instances.
+        """
+        self.init_central_instances(wbem_connection)
+        central_inst_path = self.central_inst_paths[0]
+
+        far_insts, _ = assert_association_func(
+            test_self=self,
             source_path=central_inst_path,
             source_role='Antecedent',
             assoc_class='CIM_NamespaceInManager',
             far_role='Dependent',
             far_class='CIM_Namespace')
+
         mandatory_property_list = [
             'SystemCreationClassName', 'SystemName',
             'ObjectManagerCreationClassName', 'ObjectManagerName',
@@ -77,13 +94,22 @@ class Test_SNIA_Server_Profile(ProfileTest):
         determined_names = [ns.lower() for ns in self.server.namespaces]
         assert set(inst_names) == set(determined_names)
 
-        # Test the associated CIM_ObjectManagerCommunicationMechanism instances
-        far_insts, _ = self.assert_association(
+    def test_ObjectManagerCommunicationMechanism(  # noqa: F811
+            self, wbem_connection, assert_association_func):
+        """
+        Test the associated CIM_ObjectManagerCommunicationMechanism instances.
+        """
+        self.init_central_instances(wbem_connection)
+        central_inst_path = self.central_inst_paths[0]
+
+        far_insts, _ = assert_association_func(
+            test_self=self,
             source_path=central_inst_path,
             source_role='Antecedent',
             assoc_class='CIM_CommMechanismForManager',
             far_role='Dependent',
             far_class='CIM_ObjectManagerCommunicationMechanism')
+
         mandatory_property_list = [
             'SystemCreationClassName', 'SystemName',
             'CreationClassName', 'Name',
@@ -128,13 +154,22 @@ class Test_SNIA_Server_Profile(ProfileTest):
         # Check that there is at least one associated CIM_ObjectManagerComm...
         assert len(far_insts) >= 1
 
-        # Test the associated CIM_System instances
-        far_insts, _ = self.assert_association(
+    def test_System(  # noqa: F811
+            self, wbem_connection, assert_association_func):
+        """
+        Test the associated CIM_System instance.
+        """
+        self.init_central_instances(wbem_connection)
+        central_inst_path = self.central_inst_paths[0]
+
+        far_insts, _ = assert_association_func(
+            test_self=self,
             source_path=central_inst_path,
             source_role='Dependent',
             assoc_class='CIM_HostedService',
             far_role='Antecedent',
             far_class='CIM_System')
+
         mandatory_property_list = [
             'CreationClassName', 'Name',
             'NameFormat', 'Description', 'ElementName', 'OperationalStatus',
@@ -146,4 +181,3 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
         # Check that there is one associated CIM_System instance
         assert len(far_insts) == 1
-        # system_inst = far_insts[0]


### PR DESCRIPTION
For details, see the commit message.

Testing: `make end2end` against the smigood group. Please compare the total execution time to before the change.