### PR TITLE
Fixes #1592: Pinned lxml to <4.3.0 for Python 2.6

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,8 @@ pytest>=3.3.0,!=3.9.2; python_version > '2.6'
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.8.14,<0.9.1; python_version == '2.6'
 httpretty>=0.9.5; python_version > '2.6'
-lxml>=4.2.4
+lxml>=4.2.4,<4.3.0; python_version == '2.6'
+lxml>=4.2.4; python_version > '2.6'
 requests>=2.19.1
 decorator>=4.0.11
 yamlordereddictloader>=0.4.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -235,6 +235,9 @@ This version contains all fixes up to pywbem 0.12.4.
     it returned to indicate server implementation issues, have been
     changed to use the newly introduced `ModelError` exception.
 
+* For Python 2.6, pinned version of lxml to <4.3.0, because lxml 4.3.0 has
+  removed support for Python 2.6. See issue #1592.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -59,7 +59,8 @@ pytest==3.3.0; python_version > '2.6'
 testfixtures==4.3.3
 httpretty==0.8.14; python_version == '2.6'
 httpretty==0.9.5; python_version > '2.6'
-lxml==4.2.4
+lxml==4.2.4; python_version == '2.6'
+lxml==4.2.4; python_version > '2.6'
 requests==2.19.1
 decorator==4.0.11
 yamlordereddictloader==0.4.0


### PR DESCRIPTION
For details, see the commit message.