### PR TITLE
Fixes #1595: Made warnings consistent in pywbem and end2end

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -507,6 +507,10 @@ This version contains all fixes up to pywbem 0.12.4.
 
 * Added and improved CIM-XML response checks at operation level (Issue #919).
 
+* Changed some warnings classified as `UserWarning` to be classified as
+  `pywbem.ToleratedServerIssueWarning`, because that better fits the nature
+  of the warnings. See issue #1595.
+
 **Build, test, quality:**
 
 * Add tests for WBEMSubscriptionManager class using pywbem_mock.  This involved

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -52,6 +52,7 @@ from six.moves import urllib
 
 from .cim_obj import CIMClassName, CIMInstanceName
 from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
+from ._warnings import ToleratedServerIssueWarning
 from ._utils import _ensure_unicode, _ensure_bytes, _format
 
 _ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
@@ -521,8 +522,9 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
             self.verify_callback = verify_callback
             # issue 297: Verify_callback is  not used in py 3
             if verify_callback is not None and six.PY3:
-                warnings.warn("verify_callback parameter ignored",
-                              UserWarning)
+                warnings.warn("The 'verify_callback' parameter was specified "
+                              "on WBEMConnection() but is not used on "
+                              "Python 3", UserWarning)
 
         def connect(self):
             # pylint: disable=too-many-branches
@@ -815,13 +817,15 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                         warnings.warn("Ignoring socket error ECONNRESET "
                                       "(connection reset), continuing with "
                                       "reading the response.",
-                                      UserWarning, stacklevel=2)
+                                      ToleratedServerIssueWarning,
+                                      stacklevel=2)
                         # continue with reading response
                     elif exc.args[0] == errno.EPIPE:
                         warnings.warn("Ignoring socket error EPIPE "
                                       "(broken pipe), continuing with "
                                       "reading the response.",
-                                      UserWarning, stacklevel=2)
+                                      ToleratedServerIssueWarning,
+                                      stacklevel=2)
                         # continue with reading response
                     else:
                         raise
@@ -902,7 +906,8 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                                             "(retrying - this was attempt "
                                             "{1} of {2})",
                                             exc, num_tries + 1, try_limit),
-                                        UserWarning, stacklevel=2)
+                                        ToleratedServerIssueWarning,
+                                        stacklevel=2)
                                     continue  # with next retry
                         elif 'Local' in auth_chal:
                             try:
@@ -966,7 +971,8 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                                     "returning any response (retrying - this "
                                     "was attempt {0} of {1} at {2})",
                                     num_tries + 1, try_limit, datetime.now()),
-                            UserWarning, stacklevel=2)
+                            ToleratedServerIssueWarning,
+                            stacklevel=2)
                         continue  # with next retry
                     else:
                         raise ConnectionError(

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -1820,8 +1820,8 @@ class CIMInstanceName(_CIMComparisonMixin):
         * :term:`DSP0207` restricts the namespace types (URI schemes) to be one
           of ``http``, ``https``, ``cimxml-wbem``, or ``cimxml-wbems``. Pywbem
           tolerates any namespace type, but issues a
-          :exc:`~py:exceptions.UserWarning` if it is not one of the namespace
-          types defined in :term:`DSP0207`.
+          :exc:`~py:exceptions.UserWarning` if it is not one of
+          the namespace types defined in :term:`DSP0207`.
 
         * :term:`DSP0207` requires a slash before the namespace name. For local
           WBEM URIs (no namespace type, no authority), that slash is the first
@@ -3508,8 +3508,8 @@ class CIMClassName(_CIMComparisonMixin):
         * :term:`DSP0207` restricts the namespace types (URI schemes) to be one
           of ``http``, ``https``, ``cimxml-wbem``, or ``cimxml-wbems``. Pywbem
           tolerates any namespace type, but issues a
-          :exc:`~py:exceptions.UserWarning` if it is not one of the namespace
-          types defined in :term:`DSP0207`.
+          :exc:`~py:exceptions.UserWarning` if it is not one of
+          the namespace types defined in :term:`DSP0207`.
 
         * :term:`DSP0207` requires a slash before the namespace name. For local
           WBEM URIs (no namespace type, no authority), that slash is the first

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -90,6 +90,8 @@ from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
 from .cim_types import CIMDateTime, type_from_name
 from .tupletree import xml_to_tupletree_sax
 from .exceptions import CIMXMLParseError
+from ._warnings import ToleratedServerIssueWarning
+
 
 __all__ = []
 
@@ -2266,7 +2268,7 @@ class TupleParser(object):
         elif data_ == '':
             warnings.warn("WBEM server sent invalid empty boolean value in a "
                           "CIM-XML response.",
-                          UserWarning,
+                          ToleratedServerIssueWarning,
                           stacklevel=_stacklevel_above_module(__name__))
             return None
         else:

--- a/testsuite/end2end/pytest_end2end.py
+++ b/testsuite/end2end/pytest_end2end.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from pywbem import WBEMConnection, WBEMServer, ConnectionError, AuthError, \
-    Error
+    Error, ToleratedServerIssueWarning
 from server_file import ServerDefinitionFile, ServerDefinition
 from _utils import latest_profile_inst, ServerObjectCache
 from assertions import assert_association_a1, assert_association_a2, \
@@ -113,13 +113,13 @@ def wbem_connection(request, server_definition):
         msg = "Test server at {0!r} cannot be reached. {1}: {2}". \
             format(sd.url, exc.__class__.__name__, exc)
         sd.skip_msg = msg
-        warnings.warn(msg, RuntimeWarning)
+        warnings.warn(msg, ToleratedServerIssueWarning)
         pytest.skip(msg)
     except AuthError as exc:
         msg = "Test server at {0!r} cannot be authenticated with. {1}: {2}". \
             format(sd.url, exc.__class__.__name__, exc)
         sd.skip_msg = msg
-        warnings.warn(msg, RuntimeWarning)
+        warnings.warn(msg, ToleratedServerIssueWarning)
         pytest.skip(msg)
     except Error:
         sd.skip_msg = None

--- a/testsuite/end2end/test_profile_generic.py
+++ b/testsuite/end2end/test_profile_generic.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function
 
 import warnings
 import pytest
-from pywbem import WBEMServer, ValueMapping
+from pywbem import WBEMServer, ValueMapping, ToleratedServerIssueWarning
 
 # Note: The wbem_connection fixture uses the server_definition fixture, and
 # due to the way py.test searches for fixtures, it also need to be imported.
@@ -93,7 +93,8 @@ def test_warn_undefined_profiles(  # noqa: F811
         if pd_key not in PROFILE_DEFINITION_DICT:
             warnings.warn(
                 "{0} {1!r} profile version {2} advertised on server {3} "
-                "(at {4}) is not defined in profiles.yml".
+                "(at {4}) is not defined in profiles.yml. This may be caused "
+                "by an incorrectly implemented profile name".
                 format(org, name, version, server_def.nickname,
                        wbem_connection.url),
-                RuntimeWarning)
+                ToleratedServerIssueWarning)

--- a/testsuite/end2end/test_profile_snia_server.py
+++ b/testsuite/end2end/test_profile_snia_server.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function
 
 import warnings
 
+from pywbem import ToleratedServerIssueWarning
 from pywbem._utils import _format
 
 # Note: The wbem_connection fixture uses the server_definition fixture, and
@@ -173,9 +174,10 @@ class Test_SNIA_Server_Profile(ProfileTest):
                     wbem_connection, inst,
                     'FunctionalProfilesSupported', 0)
             except AssertionError as exc:
-                warnings.warn("A disabled check failed: {0}: {1}".
+                warnings.warn("Downgraded the following test failure to a "
+                              "warning: {0}: {1}".
                               format(exc.__class__.__name__, exc),
-                              RuntimeWarning)
+                              ToleratedServerIssueWarning)
 
             # Note: The SNIA Server profile mandates that the
             #       MultipleOperationsSupported property is False, but it does
@@ -187,9 +189,10 @@ class Test_SNIA_Server_Profile(ProfileTest):
                     wbem_connection, inst,
                     'MultipleOperationsSupported', [False])
             except AssertionError as exc:
-                warnings.warn("A disabled check failed: {0}: {1}".
+                warnings.warn("Downgraded the following test failure to a "
+                              "warning: {0}: {1}".
                               format(exc.__class__.__name__, exc),
-                              RuntimeWarning)
+                              ToleratedServerIssueWarning)
 
         # Check that there is at least one associated istance
         assert_number_of_instances_minimum(

--- a/testsuite/test_tupleparse.py
+++ b/testsuite/test_tupleparse.py
@@ -11,7 +11,8 @@ from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
     CIMQualifierDeclaration, \
     CIMDateTime, Uint8, Sint8, Uint16, Sint16, Uint32, Sint32, Uint64, Sint64, \
-    Real32, Real64, ParseError
+    Real32, Real64, ParseError, ToleratedServerIssueWarning
+
 import pytest_extensions
 
 
@@ -1205,7 +1206,7 @@ TESTCASES_TUPLEPARSE_XML = [
             '<KEYVALUE VALUETYPE="boolean"></KEYVALUE>',
             exp_result=None,
         ),
-        None, UserWarning, True
+        None, ToleratedServerIssueWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean without TYPE (WS string)",
@@ -1214,7 +1215,7 @@ TESTCASES_TUPLEPARSE_XML = [
             '<KEYVALUE VALUETYPE="boolean">  </KEYVALUE>',
             exp_result=None,
         ),
-        None, UserWarning, True
+        None, ToleratedServerIssueWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean without TYPE (ASCII string)",
@@ -1306,7 +1307,7 @@ TESTCASES_TUPLEPARSE_XML = [
             '<KEYVALUE VALUETYPE="boolean" TYPE="boolean"></KEYVALUE>',
             exp_result=None,
         ),
-        None, UserWarning, True
+        None, ToleratedServerIssueWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean with TYPE boolean (WS string)",
@@ -1315,7 +1316,7 @@ TESTCASES_TUPLEPARSE_XML = [
             '<KEYVALUE VALUETYPE="boolean" TYPE="boolean">  </KEYVALUE>',
             exp_result=None,
         ),
-        None, UserWarning, True
+        None, ToleratedServerIssueWarning, True
     ),
     (
         "KEYVALUE with VALUETYPE boolean with TYPE boolean (ASCII string)",
@@ -7747,7 +7748,7 @@ TESTCASES_TUPLEPARSE_XML = [
             '<SCOPE CLASS=""/>',
             exp_result=None,
         ),
-        ParseError, UserWarning, True
+        ParseError, ToleratedServerIssueWarning, True
     ),
     (
         "SCOPE with all supported scope attributes with different values",


### PR DESCRIPTION
For details, see the commit message.