### PR TITLE
Fixes #1600: Fixed strange failure pattern in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
 # of commits. For pywbem, it started failing with the default depth 50
 # when the number of commits since the last tag exceeded about 150.
 git:
-  depth: 200
+  depth: 400
 
 # By default, notification emails are sent to the PR creator and commiter.
 notifications:


### PR DESCRIPTION
Since yesterday, there are occasionally strange failure patterns in
some PRs. They only show up in the Travis "push" runs, and happen for
all jobs within the run. The Travis "pr" run is fine, as is the Appveyor
run. When merging such PRs, the Travis run on the merged master runs fine.

Examples:

    PR #1598: https://travis-ci.org/pywbem/pywbem/builds/478256455
    PR #1596: https://travis-ci.org/pywbem/pywbem/builds/478657486
    PR #1591: https://travis-ci.org/pywbem/pywbem/builds/478658486
    PR #1406: https://travis-ci.org/pywbem/pywbem/builds/478658809

It turns out the reason for this was the depth of the shallow git
checkout that is done by Travis. The branches that failed had just
exceeded 200 commits since the last tag (0.12.0), and the depth
parameter in .travis.yml was 200.

This change fixes that by increasing the depthg parameter to 400.

Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>