### PR TITLE
Fixed location of CIM Schema MOF file archive on DMTF site

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -238,6 +238,9 @@ This version contains all fixes up to pywbem 0.12.4.
 * For Python 2.6, pinned version of lxml to <4.3.0, because lxml 4.3.0 has
   removed support for Python 2.6. See issue #1592.
 
+* Fixed the URL on the DMTF site from which the MOF archive is downloaded.
+  This has changed on the DMTF site and needed to be adjusted.
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -177,7 +177,8 @@ class DMTFCIMSchema(object):
         cim_schema_version = 'cim_schema_{0}'.format(self.schema_version_str)
         mof_zip_bn = '{0}{1}-MOFs.zip'.format(cim_schema_version, schema_type)
         self._schema_zip_url = \
-            'http://www.dmtf.org/standards/cim/cim_schema_v{0}{1}{2}/{3}'. \
+            'https://www.dmtf.org/sites/default/files/cim/' \
+            'cim_schema_v{0}{1}{2}/{3}'. \
             format(schema_version[0], schema_version[1], schema_version[2],
                    mof_zip_bn)
         schema_mof_bld_name = cim_schema_version + '.mof'


### PR DESCRIPTION
For details, see the commit message.