### PR TITLE
Fixes #1614 - Fix order of method_callback parameters

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -241,6 +241,9 @@ This version contains all fixes up to pywbem 0.12.4.
 * Fixed the URL on the DMTF site from which the MOF archive is downloaded.
   This has changed on the DMTF site and needed to be adjusted.
 
+* Fixed order of parameters in example method_callback_interface defined in
+  pywbem_mock FakedWBEMConnection. (See issue #1614)
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -339,7 +339,7 @@ with a simple callback function.
     import pywbem
     import pywbem_mock
 
-    def method1_callback(conn, objectname, methodname, params):
+    def method1_callback(conn, methodname, objectname, **params):
         """
         Callback function that demonstrates what can be done, without being
         really useful.
@@ -650,12 +650,20 @@ classes (superclasses, etc.).
 
     conn = pywbem_mock.FakedWBEMConnection(default_namespace='root/interop')
 
-    classes = ['CIM_RegisteredProfile', 'CIM_Namespace', 'CIM_ObjectManager',
-               'CIM_ElementConformsToProfile', 'CIM_ReferencedProfile']
+    # Leaf classes that are to be compiled along with their dependent classes
+    leaf_classes = ['CIM_RegisteredProfile',
+                    'CIM_Namespace',
+                    'CIM_ObjectManager',
+                    'CIM_ElementConformsToProfile',
+                    'CIM_ReferencedProfile']
 
-    conn.compile_mof_schema((2, 49, 0), my_schema_mof, 'my_schema_dir',
+    # Compile dmtf schema version 2.49.0, the qualifier declarations and
+    # the classes in 'classes' and all dependent classes and keep the
+    # schema in directory my_schema_dir
+    conn.compile_dmtf_schema((2, 49, 0), "my_schema_dir", classes,
                             verbose=True)
 
+    # Display the resulting repository
     conn.display_repository()
 
 .. _`Example: Set up qualifier types and classes from MOF`:

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -137,7 +137,7 @@ def _uprint(dest, text):
             format(type(text)))
 
 
-def method_callback_interface(conn, objectname, methodname, **params):
+def method_callback_interface(conn, methodname, objectname, **params):
     # pylint: disable=unused-argument, invalid-name, line-too-long
     """
     Interface for user-provided callback functions for CIM method invocation
@@ -151,6 +151,11 @@ def method_callback_interface(conn, objectname, methodname, **params):
         Faked connection. This can be used to access the mock repository of the
         faked connection, via its operation methods (e.g. `GetClass`).
 
+      methodname (:term:`string`):
+        The CIM method name that is being invoked. This is the method name for
+        which the callback function was registered. This parameter allows a
+        single callback function to be registered for multiple methods.
+
       objectname (:class:`~pywbem.CIMInstanceName` or :class:`~pywbem.CIMClassName`):
         The object path of the target object of the invoked method, as follows:
 
@@ -163,11 +168,6 @@ def method_callback_interface(conn, objectname, methodname, **params):
           :class:`~pywbem.CIMClassName` object which has its `namespace`
           property set to the target namespace of the invocation. Its `host`
           property will not be set.
-
-      methodname (:term:`string`):
-        The CIM method name that is being invoked. This is the method name for
-        which the callback function was registered. This parameter allows a
-        single callback function to be registered for multiple methods.
 
       params (:ref:`NocaseDict`):
         The input parameters for the method that were passed to the


### PR DESCRIPTION
Fixes two errors in documentation of mock.

1. method_callback_interface reversed two parameters. This was only in the interface definition. The
code and test code is correct.

2. Error in example of compile_dmtf_schema in mocksupport.rst.  Misnamed and parameters not correct.

This PR changes no executing code.

See commit message for details