### PR TITLE
Removed notion of pattern profiles from end2end tests

### DIFF
--- a/tests/end2endtest/test_profile_generic.py
+++ b/tests/end2endtest/test_profile_generic.py
@@ -33,13 +33,6 @@ def test_get_central_instances(  # noqa: F811
         profile_definition['registered_org'],
         profile_definition['registered_name'])
 
-    if profile_definition['type'] == 'pattern':
-        pytest.skip("Server {0} at {1}: The {2} {3!r} profile is a pattern "
-                    "and is not expected to be advertised".
-                    format(wbem_connection.server_definition.nickname,
-                           wbem_connection.url,
-                           profile_definition['registered_org'],
-                           profile_definition['registered_name']))
     if not profile_insts:
         pytest.skip("Server {0} at {1}: The {2} {3!r} profile is not "
                     "advertised".

--- a/tests/profiles/profiles.yml
+++ b/tests/profiles/profiles.yml
@@ -16,7 +16,6 @@
 #   - specification: Item is a specification (e.g. SNIA SMI-S).
 #   - autonomous: Item is an autonomous profile (e.g. SNIA Array).
 #   - component: Item is a component profile (e.g. SNIA FC Target Ports).
-#   - pattern: Item is a pattern profile (that is still advertised).
 # * reference_direction: Scoping profile reference direction: 'dmtf' or 'snia',
 #   or null to imply it from registered_org.
 #   Optional, defaults to null.


### PR DESCRIPTION
I don't think an end2end test is needed for this one.