### PR TITLE
Fixes #1622: Fixed error with wbemcli.bat in path names with blanks

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -244,6 +244,10 @@ This version contains all fixes up to pywbem 0.12.4.
 * Fixed order of parameters in example method_callback_interface defined in
   pywbem_mock FakedWBEMConnection. (See issue #1614)
 
+* Fixed an error "Python : can't open file 'C:\Users\firstname' :
+  No such file or directory" when invoking wbemcli.bat on native Windows
+  in a directory whose path name contained blanks. (See issue #1622)
+
 **Enhancements:**
 
 * Extend pywbem MOF compiler to search for dependent classes including:

--- a/wbemcli.bat
+++ b/wbemcli.bat
@@ -1,5 +1,5 @@
 @setlocal enableextensions
 @set errorlevel=
-@python %~d0%~p0%~n0 %*
+@python "%~d0%~p0%~n0" %*
 @endlocal
 @exit /b %errorlevel%


### PR DESCRIPTION
For details, see the commit message.