### PR TITLE
Add method to reset statistics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -521,6 +521,10 @@ This version contains all fixes up to pywbem 0.12.4.
 
 * Corrected the hint how to exit in wbemcli when running on Windows.
 
+* Added method to statistics (class Statistics, method reset()) to reset
+  the statistics on a WBEMConnection. This simply resets all of the statistics
+  values gathered on that connection to their initial values.
+
 **Cleanup:**
 
 * Moved class `NocaseDict` into its own module (Issue #848).

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -140,6 +140,7 @@ from __future__ import absolute_import
 
 import time
 import copy
+import six
 
 from ._utils import _format
 
@@ -716,3 +717,19 @@ class Statistics(object):
         else:
             ret += "Disabled"
         return ret.strip()
+
+    def reset(self):
+        """
+        Reset all statistics and clear any statistic names.
+        All statistics must be inactive before a reset will execute
+
+        Returns: True if reset, False if not
+        """
+        # Test for any stats being currently timed.
+        for stat in six.itervalues(self._op_stats):
+            if stat._start_time is not None:  # pylint: disable=protected-access
+                return False
+
+        # clear all statistics
+        self._op_stats = {}
+        return True


### PR DESCRIPTION
See commit message for detailed info.

Adds a new method to statistics to clear the statistics for a connection,.

In working on another pr that involved using statistics, I realized that there was no method to clear the statistics for a connection so created this.

