### PR TITLE
Extend the manual test run_enum_performance.py to gather info

### DIFF
--- a/tests/manualtest/run_enum_performance.py
+++ b/tests/manualtest/run_enum_performance.py
@@ -8,24 +8,49 @@ because only OpenPegasus implements the defined class.
 
 from __future__ import absolute_import
 import sys as _sys
+import os as _os
 # pylint: disable=missing-docstring,superfluous-parens,no-self-use
 import datetime
 # pylint: disable=unused-import
 import warnings  # noqa F401
+import re
+import getpass as _getpass
 
 import argparse as _argparse
-from argparse import RawTextHelpFormatter
+from pywbem._cliutils import SmartFormatter as _SmartFormatter
 
-import getpass as _getpass
-import re
 
-from pywbem import WBEMConnection, Error, Uint64
+from pywbem import WBEMConnection, Error, Uint64, TestClientRecorder
 
 # Pegasus class/namespace to use for test
 TEST_NAMESPACE = "test/TestProvider"
 TEST_CLASSNAME = "TST_ResponseStressTestCxx"
 
-TABLE_FORMAT = '%-10.10s %-10.10s %-10.10s %-10.10s %-10.10s %-11.11s %-10.10s'
+# default values for the test parameters
+DEFAULT_RESPONSE_SIZE = [100, 1000, 10000]
+DEFAULT_RESPONSE_COUNT = [1, 100, 1000, 10000, 100000]
+DEFAULT_PULL_SIZE = [1, 100, 1000]
+
+
+STATS_LIST = []
+
+
+class _PywbemCustomFormatter(_SmartFormatter,
+                             _argparse.RawDescriptionHelpFormatter):
+    """
+    Define a custom Formatter to allow formatting help and epilog.
+
+    argparse formatter specifically allows multiple inheritance for the
+    formatter customization and actually recommends this in a discussion
+    in one of the issues:
+
+        https://bugs.python.org/issue13023
+
+    Also recommended in a StackOverflow discussion:
+
+    https://stackoverflow.com/questions/18462610/argumentparser-epilog-and-description-formatting-in-conjunction-with-argumentdef
+    """
+    pass
 
 
 def set_provider_parameters(conn, count, size):
@@ -52,6 +77,18 @@ def run_enum_instances(conn):
     return len(instances)
 
 
+def record_response_times(conn, max_object_count, op_count):
+    """
+    Record the server and client response times from the last response
+    by appending to a list.  Appends two calculations to the result (
+    difference between server time and overall response time and the
+    percentage of overall response time that is not server time.)
+    """
+    stats = (max_object_count, op_count, conn.last_server_response_time,
+             conn.last_operation_time)
+    STATS_LIST.append(stats)
+
+
 def run_pull_enum_instances(conn, max_object_count):
     """Execute an open request followed by pull requests"""
     op_count = 0
@@ -59,87 +96,175 @@ def run_pull_enum_instances(conn, max_object_count):
         TEST_CLASSNAME,
         MaxObjectCount=max_object_count)
     insts_pulled = result.instances
+    record_response_times(conn, max_object_count, op_count)
 
     op_count += 1
+
+    total_svr_response_time = 0
+    total_op_time = 0
 
     while not result.eos:
         result = conn.PullInstancesWithPath(result.context,
                                             MaxObjectCount=max_object_count)
+        record_response_times(conn, max_object_count, op_count)
         op_count += 1
         insts_pulled.extend(result.instances)
+        if conn.last_server_response_time:
+            total_svr_response_time += conn.last_server_response_time
+        else:
+            total_svr_response_time = 0
+        total_op_time += conn.last_operation_time
 
-    # return tuple containing info on the sequence
-    return [len(insts_pulled), op_count]
+    diff = total_op_time - total_svr_response_time
+    percentage = (diff / total_op_time) * 100
+
+    # return tuple containing info on the sequence (instances pulled,
+    #                                               zero origin opertion ctr)
+    #                                               tuple of time stats
+    return [len(insts_pulled), op_count,
+            (total_svr_response_time, total_op_time, diff, percentage)]
 
 
 def run_single_test(conn, response_count, response_size, max_obj_cnt_array):
-    """run a single test for a defined response_count and response size"""
+    """
+    Run a single test for a defined response_count and response size
+    """
+    table_data_format1 = '{0:10.10} {1:8d} {2:10d} {3:10.10} {4:10.10} ' \
+                         '{5:11.11} {6:10.2f} {7:10.3f} ' \
+                         '{8:10.3f} {9:10.3f} {10:11.3f}'
+
+    table_data_format2 = '{0:10.10} {1:8d} {2:10d} {3:10d} {4:9d}  ' \
+                         '{5:11.11} {6:10.2f} {7:10.3f} ' \
+                         '{8:10.3f} {9:10.3f} {10:11.3f}'
 
     set_provider_parameters(conn, response_count, response_size)
 
     start_time = datetime.datetime.now()
     enum_count = run_enum_instances(conn)
     enum_time = datetime.datetime.now() - start_time
-    inst_per_sec = '%06.2f' % (enum_count / enum_time.total_seconds())
-    print(TABLE_FORMAT % ('Enum', enum_count, response_size,
-                          'na', 'na', enum_time, inst_per_sec))
+    inst_per_sec = enum_count / enum_time.total_seconds()
+    if conn.last_server_response_time:
+        diff = conn.last_operation_time - conn.last_server_response_time
+    else:
+        diff = conn.last_operation_time
+        conn.last_server_response_time = 0
+    percentage = (diff / conn.last_operation_time) * 100
+
+    print(table_data_format1.format(
+        'Enum', enum_count, response_size, '', '', str(enum_time),
+        inst_per_sec,
+        conn.last_server_response_time,
+        conn.last_operation_time, diff, percentage))
 
     for max_obj_cnt in max_obj_cnt_array:
         pull_start_time = datetime.datetime.now()
         pull_result = run_pull_enum_instances(conn, max_obj_cnt)
         pull_time = datetime.datetime.now() - pull_start_time
-        inst_per_sec = '%06.2f' % (pull_result[0] / pull_time.total_seconds())
+        inst_per_sec = pull_result[0] / pull_time.total_seconds()
 
-        print(TABLE_FORMAT % ('Open/Pull', pull_result[0], response_size,
-                              max_obj_cnt, pull_result[1], pull_time,
-                              inst_per_sec))
+        stats = pull_result[2]
+        diff = stats[1] - stats[0]
+        percentage = (diff / stats[1]) * 100
+
+        print(table_data_format2.format(
+            'Open/Pull', pull_result[0], response_size, max_obj_cnt,
+            pull_result[1],
+            str(pull_time),
+            inst_per_sec,
+            stats[0],
+            stats[1], diff, percentage))
 
 
-def run_tests(conn):
-    """Run test based on limits provided"""
+def run_tests(conn, response_sizes, response_counts, pull_sizes, verbose):
+    """
+    Run test based on limits provided defined in the input variables
+    """
+    # Run the enumeration one time to eliminate any server startup time
+    # loss and test for the server_response time
+    run_enum_instances(conn)
+    if conn.last_server_response_time is None:
+        print('WARNING: Server probably not returning server response time')
 
-    print(TABLE_FORMAT % ('Operation', 'Response', 'RespSize', 'MaxObjCnt',
-                          'Request', 'Time', 'inst/sec'))
-    print(TABLE_FORMAT % ('', 'Count', 'Bytes', 'Request',
-                          'Count', '', ''))
-    for response_size in [100, 1000, 10000]:
-        for response_count in [1, 100, 1000, 10000, 100000]:
-            pull_sizes = [1, 100, 1000]
+    table_format = '{0:10.10} {1:10.10} {2:10.10} {3:10.10} ' \
+        '{4:10.10} {5:11.11} {6:10.10} {7:10.10} ' \
+        '{8:10.10} {9:10.10} {10:11.11}'
+
+    print(table_format.format('Operation', 'Response', 'RespSize', 'MaxObjCnt',
+                              'Result', 'Exec time', 'inst/sec', 'svr-time',
+                              'resp-time', 'svr response', 'other proc'))
+    print(table_format.format('', 'Count', 'Bytes', 'Request',
+                              'Count', '', '', 'sec',
+                              'sec', 'sec', 'percent'))
+
+    for response_size in response_sizes:
+        for response_count in response_counts:
             run_single_test(conn, response_count, response_size, pull_sizes)
 
+    if verbose:
+        print('\n\n')
+        print(conn.statistics.formatted())
+        print("\n\nIndividual Returns for response-count=%s" % response_count)
+        headers = ('ObjsCnt', 'Pull#', 'SvrTime', 'RspTime',
+                   'OpTime-SvrTime', '%Not Svr')
 
-def main(prog):
-    """
-    Parse command line arguments, connect to the WBEM server and open the
-    interactive shell.
-    """
+        print("{0:6s} {1:5s} {2:7s} {3:7s} {4:14s} {5:10s}".
+              format(*headers))
 
+        print('\n\nDetailed statistics for each pull  operations')
+        global STATS_LIST
+        for st in STATS_LIST:
+            diff = conn.last_operation_time - conn.last_server_response_time
+            percentage = (diff / conn.last_operation_time) * 100
+            print(
+                '{0:6d} {1:5d} {2:7.3f} {3:7.3f} {4:14.3f} {5:7.1f}%'
+                .format(st[0], st[1], st[2], st[3], diff, percentage))
+
+
+def parse_args():
+    """
+    Parse the input arguments and return the args dictionary
+    """
+    prog = _os.path.basename(_sys.argv[0])
     usage = '%(prog)s [options] server'
+    # pylint: disable=line-too-long
     desc = """
 Provide performance information on EnumerateInstances vs. Open & Pull
 enumeration sequences responses.
 
-Generates a table of response times for an array of max_object_count,
-response sizes, etc.values.
+This test runs only against the OpenPegasus server because it requires a
+provider in the server that will generate responses with the number of
+responses built and the size of the responses settable by a method
+invoke.  In OpenPegasus, that is the 'TST_ResponseStressTestCxx' test
+class and its corresponding provider.
+
+Further, this test uses the capability of the server to return information
+on the server response time as part of the response. This capability is
+included in the OpenPegasus server and is enabled by setting a property
+`GatherStatisticalData` in the `CIM_ObjectManager`.
+
+Executing a test generates several tables of response times for the various
+test parameters
 """
     epilog = """
 Examples:
-  %s https://localhost:15345 -n vendor -u sheldon -p penny
-          - (https localhost, port=15345, namespace=vendor user=sheldon
-         password=penny)
+  %s http://blah  --response-count 10000 --pull-size 100 1000 --response-size 100 1000
 
-  %s http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
-""" % (prog, prog)
+  Test against server blah with the number of responses instances to a
+  single request set to 10,000, the size of the maxObjectCnt request variable
+  for each open and pull request set to 100 and then 1,000 and the size
+  of the response objects set to first 100 and then 1000.
+""" % (prog)  # noqa: E501
+# pylint: enable=line-too-long
 
     argparser = _argparse.ArgumentParser(
         prog=prog, usage=usage, description=desc, epilog=epilog,
-        add_help=False, formatter_class=RawTextHelpFormatter)
+        add_help=False, formatter_class=_PywbemCustomFormatter)
 
     pos_arggroup = argparser.add_argument_group(
         'Positional arguments')
     pos_arggroup.add_argument(
         'server', metavar='server', nargs='?',
-        help='Host name or url of the WBEM server in this format:\n'
+        help='R|Host name or url of the WBEM server in this format:\n'
              '    [{scheme}://]{host}[:{port}]\n'
              '- scheme: Defines the protocol to use;\n'
              '    - "https" for HTTPs protocol\n'
@@ -162,12 +287,12 @@ Examples:
     server_arggroup.add_argument(
         '-t', '--timeout', dest='timeout', metavar='timeout', type=int,
         default=None,
-        help='Timeout of the completion of WBEM Server operation\n'
+        help='R|Timeout of the completion of WBEM Server operation\n'
              'in seconds(integer between 0 and 300).\n'
              'Default: No timeout')
 
     security_arggroup = argparser.add_argument_group(
-        'Connection security related options',
+        'Connection security related options. ',
         'Specify user name and password or certificates and keys')
     security_arggroup.add_argument(
         '-u', '--user', dest='user', metavar='user',
@@ -175,19 +300,19 @@ Examples:
              'Default: No user name.')
     security_arggroup.add_argument(
         '-p', '--password', dest='password', metavar='password',
-        help='Password for authenticating with the WBEM server.\n'
+        help='R|Password for authenticating with the WBEM server.\n'
              'Default: Will be prompted for, if user name\nspecified.')
     security_arggroup.add_argument(
         '-nvc', '--no-verify-cert', dest='no_verify_cert',
         action='store_true',
-        help='Client will not verify certificate returned by the WBEM\n'
+        help='R|Client will not verify certificate returned by the WBEM\n'
              'server (see cacerts). This bypasses the client-side\n'
              'verification of the server identity, but allows\n'
              'encrypted communication with a server for which the\n'
              'client does not have certificates.')
     security_arggroup.add_argument(
         '--cacerts', dest='ca_certs', metavar='cacerts',
-        help='File or directory containing certificates that will be\n'
+        help='R|File or directory containing certificates that will be\n'
              'matched against a certificate received from the WBEM\n'
              'server. Set the --no-verify-cert option to bypass\n'
              'client verification of the WBEM server certificate.\n'
@@ -196,72 +321,134 @@ Examples:
 
     security_arggroup.add_argument(
         '--certfile', dest='cert_file', metavar='certfile',
-        help='Client certificate file for authenticating with the\n'
+        help='R|Client certificate file for authenticating with the\n'
              'WBEM server. If option specified the client attempts\n'
              'to execute mutual authentication.\n'
              'Default: Simple authentication.')
     security_arggroup.add_argument(
         '--keyfile', dest='key_file', metavar='keyfile',
-        help='Client private key file for authenticating with the\n'
+        help='R|Client private key file for authenticating with the\n'
              'WBEM server. Not required if private key is part of the\n'
              'certfile option. Not allowed if no certfile option.\n'
              'Default: No client key file. Client private key should\n'
              'then be part  of the certfile')
 
+    tests_arggroup = argparser.add_argument_group(
+        'Test related options',
+        'Specify parameters of the test')
+
+    tests_arggroup.add_argument(
+        '--response-count', dest='response_count', nargs='+',
+        metavar='int', type=int,
+        action='store', default=DEFAULT_RESPONSE_COUNT,
+        help='R|The number of instances that will be returned for each test\n'
+             'in the form for each test. May be multiple integers. The test\n'
+             'will be executed for each integer defined. The format is:\n'
+             '  -r 1000 10000 100000\n'
+             'Default: %s' % DEFAULT_RESPONSE_COUNT)
+
+    tests_arggroup.add_argument(
+        '--pull-size', dest='pull_size', nargs='+',
+        metavar='int', type=int,
+        action='store', default=DEFAULT_PULL_SIZE,
+        help='The maxObjectCount defined for each pull operation  that will\n'
+             'be tested. This defines the MaxObjectCount for each open and \n'
+             'pull request for each test. May be multiple integers. The test\n'
+             'will be executed for each integer defined. The format is:\n'
+             '    -P 100 200 300\n'
+             'Default: %s' % DEFAULT_PULL_SIZE)
+
+    tests_arggroup.add_argument(
+        '--response-size', dest='response_size', nargs='+',
+        metavar='int', type=int,
+        action='store', default=DEFAULT_RESPONSE_SIZE,
+        help='R|The response sizes that will be tested. This defines the size\n'
+             'of each response in bytes to be returned from the server.'
+             'May be multiple integers. The test will be executed for each\n'
+             'integer defined. The format is:\n'
+             '   -R 100 200 300\n'
+             'Default: %s' % DEFAULT_RESPONSE_SIZE)
+
     general_arggroup = argparser.add_argument_group(
         'General options')
+
+    general_arggroup.add_argument(
+        '--record', dest='record', type=str,
+        default=None,
+        help='Create a yaml output file recording the test in the filename '
+             'defined by the string. If this parameter not provided no '
+             'output file is created.')
+
     general_arggroup.add_argument(
         '-v', '--verbose', dest='verbose',
         action='store_true', default=False,
-        help='Print more messages while processing')
+        help='Print more messages while processing. Displays detailed counts'
+             'for each pull operation.')
     general_arggroup.add_argument(
         '-h', '--help', action='help',
         help='Show this help message and exit')
 
-    opts = argparser.parse_args()
+    return argparser.parse_args()
 
-    if not opts.server:
-        argparser.error('No WBEM server specified')
 
-    if opts.server[0] == '/':
-        url = opts.server
+def main(prog):
+    """
+    Parse command line arguments, connect to the WBEM server and open the
+    interactive shell.
+    """
+    args = parse_args()
 
-    elif re.match(r"^https{0,1}://", opts.server) is not None:
-        url = opts.server
+    if not args.server:
+        _argparse.error('No WBEM server specified')
 
-    elif re.match(r"^[a-zA-Z0-9]+://", opts.server) is not None:
-        argparser.error('Invalid scheme on server argument.'
+    if args.server[0] == '/':
+        url = args.server
+
+    elif re.match(r"^https{0,1}://", args.server) is not None:
+        url = args.server
+
+    elif re.match(r"^[a-zA-Z0-9]+://", args.server) is not None:
+        _argparse.error('Invalid scheme on server argument.'
                         ' Use "http" or "https"')
 
     else:
-        url = '%s://%s' % ('https', opts.server)
+        url = '%s://%s' % ('https', args.server)
 
     creds = None
 
-    if opts.key_file is not None and opts.cert_file is None:
-        argparser.error('keyfile option requires certfile option')
+    if args.key_file is not None and args.cert_file is None:
+        _argparse.error('keyfile option requires certfile option')
 
-    if opts.user is not None and opts.password is None:
-        opts.password = _getpass.getpass('Enter password for %s: '
-                                         % opts.user)
+    if args.user is not None and args.password is None:
+        args.password = _getpass.getpass('Enter password for %s: '
+                                         % args.user)
 
-    if opts.user is not None or opts.password is not None:
-        creds = (opts.user, opts.password)
+    if args.user is not None or args.password is not None:
+        creds = (args.user, args.password)
 
     # if client cert and key provided, create dictionary for
     # wbem connection
     x509_dict = None
-    if opts.cert_file is not None:
-        x509_dict = {"cert_file": opts.cert_file}
-        if opts.key_file is not None:
-            x509_dict.update({'key_file': opts.key_file})
+    if args.cert_file is not None:
+        x509_dict = {"cert_file": args.cert_file}
+        if args.key_file is not None:
+            x509_dict.update({'key_file': args.key_file})
 
     conn = WBEMConnection(url, creds, default_namespace=TEST_NAMESPACE,
                           no_verification=True,
-                          x509=x509_dict, ca_certs=opts.ca_certs,
-                          timeout=opts.timeout)
+                          x509=x509_dict, ca_certs=args.ca_certs,
+                          timeout=args.timeout,
+                          stats_enabled=True)
 
-    run_tests(conn)
+    if args.record is not None:
+        yamlfp = TestClientRecorder.open_file(args.record, 'a')
+        conn.add_operation_recorder(TestClientRecorder(yamlfp))
+
+    print('Test with response sizes=%s response_counts=%s, pull_sizes=%s\n' %
+          (args.response_size, args.response_count, args.pull_size))
+
+    run_tests(conn, args.response_size, args.response_count, args.pull_size,
+              args.verbose)
 
     return 0
 


### PR DESCRIPTION
This is part of answering issue #1630 

Extend test that compares enum and pull operations to determine how much time is spent in server vs in parser for responses.

NOTE: This code is now completely dependent on a WBEM server that
includes a class and method that will generate instance responses with
size and number of instances defined by a method that is part of
that class.  I.e. OpenPegasus.

We can chose to review and commit this code as is or just use it to gather data on the response timing issue.