### PR TITLE
Fixes #1640: Added support for running pylint also on Python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,8 @@ script:
   - make build
   - if [[ -n $_MANUAL_CI_RUN ]]; then make builddoc; fi
   - make check
-  - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi
+  # - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi
+  - make pylint
   - make test
 
 after_success:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,8 +49,14 @@ Sphinx>=1.7.6; python_version >= '2.7'
 sphinx-git>=10.1.1; python_version >= '2.7'
 GitPython>=2.1.1; python_version >= '2.7'
 
-# PyLint (no imports, invoked via pylint script) - does not support py3:
-pylint>=1.6.4; python_version == '2.7'
+# PyLint (no imports, invoked via pylint script)
+# Pylint requires astroid
+# Pylint 1.x supports py2.7 and py3.4/5/6 but not py3.7+
+# Pylint 2.x supports py3.4+
+pylint>=1.6.4,<2.0.0; python_version == '2.7'
+pylint>=2.2.2; python_version >= '3.4'
+astroid>=1.4.9,<2.0.0; python_version == '2.7'
+astroid>=2.1.0; python_version >= '3.4'
 
 # Flake8 (no imports, invoked via flake8 script):
 flake8>=2.6.2,<3.0.0; python_version == '2.6'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -611,6 +611,8 @@ This version contains all fixes up to pywbem 0.12.4.
   object classes (e.g. `CIMinstance`) by adding validation against the CIM-XML
   DTD, and by adding tests for the `indent` parameter of `tocimxmlstr()`.
 
+* Added support for running pylint also on Python 3.x. See issue #1640.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/makefile
+++ b/makefile
@@ -559,15 +559,15 @@ $(moftab_files): install.done $(moftab_dependent_files) build_moftab.py
 # Status 1 to 16 will be bit-ORed.
 # The make command checks for statuses: 1,2,32
 pylint.log: makefile $(pylint_rc_file) $(py_src_files)
-ifeq ($(python_mn_version),27)
+ifeq ($(python_mn_version),26)
+	@echo "makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
+else
 	@echo "makefile: Running Pylint"
 	rm -f pylint.log
 	pylint --version
 	-bash -c 'set -o pipefail; PYTHONPATH=. pylint --rcfile=$(pylint_rc_file) $(py_src_files) 2>&1 |tee pylint.tmp.log; rc=$$?; if (($$rc >= 32 || $$rc & 0x03)); then exit $$rc; fi'
 	mv -f pylint.tmp.log pylint.log
 	@echo "makefile: Done running Pylint; Log file: $@"
-else
-	@echo "makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
 endif
 
 flake8.log: makefile $(flake8_rc_file) $(py_src_files)

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -83,7 +83,10 @@ sphinx-git==10.1.1
 GitPython==2.1.1
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:
-pylint==1.6.4
+pylint==1.6.4; python_version == '2.7'
+pylint==2.2.2; python_version >= '3.4'
+astroid==1.4.9; python_version == '2.7'
+astroid==2.1.0; python_version >= '3.4'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 #
@@ -109,7 +112,6 @@ jupyter==1.0.0
 alabaster==0.7.9
 appnope==0.1.0
 args==0.1.0
-astroid==1.4.9
 Babel==2.3.4
 bleach==1.5.0
 chardet==3.0.2


### PR DESCRIPTION
For details, see the commit message.

Note that pylint is generally not run in travis build except for the manual-ci-run. I have rebased it on this change, so have a look there for pylint results and how it runs.