### PR TITLE
Extend makefile to remove cover files from pywbem_mock

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Extend makefile clobber to remove cover files from pywbem_mock package.
+
 **Enhancements:**
 
 **Known issues:**

--- a/makefile
+++ b/makefile
@@ -496,7 +496,7 @@ all: install develop build builddoc check pylint test
 .PHONY: clobber
 clobber: clean
 	@echo "makefile: Removing everything for a fresh start"
-	-$(call RM_FUNC,*.done epydoc.log $(moftab_files) $(dist_files) pywbem/*cover wbemcli.log)
+	-$(call RM_FUNC,*.done epydoc.log $(moftab_files) $(dist_files) pywbem/*cover pywbem_mock/*cover wbemcli.log)
 	-$(call RMDIR_FUNC,$(doc_build_dir) .tox $(coverage_html_dir))
 	@echo "makefile: Done removing everything for a fresh start"
 	@echo "makefile: Target $@ done."


### PR DESCRIPTION
This is a minor change to makefile to remove the cover files from the pywbem_mock package as it does now from the pywbem package. This is a development issue only so there is no need to do rollback to 13, etc.  