### PR TITLE
Fixes for Python 2.6 (PyYAML version, format strings)

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -40,7 +40,8 @@ mock==2.0.0
 ordereddict==1.1
 pbr==1.10.0
 ply==3.10
-PyYAML==3.13
+PyYAML==3.11; python_version == '2.6'
+PyYAML==3.13; python_version >= '2.7'
 six==1.10.0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ mock>=2.0.0
 ordereddict>=1.1; python_version == '2.6'
 pbr>=1.10.0
 ply>=3.10
-PyYAML>=3.13  # yaml package
+PyYAML==3.11; python_version == '2.6'  # yaml package
+PyYAML>=3.13; python_version >= '2.7'  # yaml package
 six>=1.10.0
 
 

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -6,7 +6,8 @@
 pbr>=1.10.0
 six>=1.10.0
 ply>=3.10
-PyYAML>=3.13
+PyYAML==3.11; python_version == '2.6'  # yaml package
+PyYAML>=3.13; python_version >= '2.7'  # yaml package
 # M2Crypto>=0.31.0  # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.7.6
 sphinx-git>=10.1.1

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -57,7 +57,7 @@ def fixtureid_server_definition(fixture_value):
     """
     sd = fixture_value
     assert isinstance(sd, ServerDefinition)
-    return "server_definition={}".format(sd.nickname)
+    return "server_definition={0}".format(sd.nickname)
 
 
 @pytest.fixture(
@@ -154,7 +154,7 @@ def fixtureid_default_namespace(fixture_value):
       * fixture_value (string): The default namespace for the test.
     """
     ns = fixture_value
-    return "default_namespace={}".format(ns)
+    return "default_namespace={0}".format(ns)
 
 
 @pytest.fixture(

--- a/tests/unittest/utils/cmd_line_test_utils.py
+++ b/tests/unittest/utils/cmd_line_test_utils.py
@@ -169,7 +169,7 @@ def wbemcli_test(desc, args, exp_response, mock_file, condition, verbose=False):
             if test == 'startswith':
                 assert isinstance(test_value, six.string_types)
                 assert rtn_value.startswith(test_value), \
-                    "{}\n{}={!r}".format(desc, component, rtn_value)
+                    "{0}\n{1}={2!r}".format(desc, component, rtn_value)
             # test that lines match between test_value and rtn_value
             # base on regex match
             elif test == 'patterns':
@@ -299,11 +299,11 @@ def assert_rc(exp_rc, rc, stdout, stderr):
     """
 
     assert exp_rc == rc, \
-        "Unexpected exit code (expected {}, got {})\n" \
+        "Unexpected exit code (expected {0}, got {1})\n" \
         "  stdout:\n" \
-        "{}\n\n" \
+        "{2}\n\n" \
         "  stderr:\n" \
-        "{}". \
+        "{3}". \
         format(exp_rc, rc, stdout, stderr)
 
 
@@ -325,11 +325,11 @@ def assert_patterns(exp_patterns, act_lines, meaning):
         of the lines that are matched, e.g. 'stderr'.
     """
     assert len(act_lines) == len(exp_patterns), \
-        "Unexpected number of lines in test desc: {}:\n" \
-        "Expected line cnt={}:\n" \
-        "{}\n\n" \
-        "Actual line cnt={}:\n" \
-        "{}\n". \
+        "Unexpected number of lines in test desc: {0}:\n" \
+        "Expected line cnt={1}:\n" \
+        "{2}\n\n" \
+        "Actual line cnt={3}:\n" \
+        "{4}\n". \
         format(meaning, len(act_lines), '\n'.join(act_lines),
                len(exp_patterns), '\n'.join(exp_patterns))
 
@@ -338,12 +338,12 @@ def assert_patterns(exp_patterns, act_lines, meaning):
         # if not exp_line.endswith('$'):
         #    exp_line += '$'
         assert re.match(exp_line, act_line), \
-            "Unexpected line {} in test desc:{}:\n" \
+            "Unexpected line {0} in test desc:{1}:\n" \
             "Expected line vs. actual line:\n" \
             "------------\n" \
-            "{}\n" \
+            "{2}\n" \
             "------------\n" \
-            "{}\n" \
+            "{3}\n" \
             "------------\n". \
             format(i, meaning, exp_line, act_line)
 
@@ -367,21 +367,21 @@ def assert_lines(exp_lines, act_lines, meaning):
         of the lines that are matched, e.g. 'stderr'.
     """
     assert len(act_lines) == len(exp_lines), \
-        "Unexpected number of lines in {}:\n" \
-        "Expected lines cnt={}:\n" \
-        "{}\n" \
-        "Actual lines cnt={}:\n" \
-        "{}\n". \
+        "Unexpected number of lines in {0}:\n" \
+        "Expected lines cnt={1}:\n" \
+        "{2}\n" \
+        "Actual lines cnt={3}:\n" \
+        "{4}\n". \
         format(meaning, len(exp_lines), '\n'.join(exp_lines),
                len(act_lines), '\n'.join(act_lines))
 
     for i, act_line in enumerate(act_lines):
         exp_line = exp_lines[i]
         assert exp_line == act_line, \
-            "Unexpected line {} in {}:\n" \
+            "Unexpected line {0} in {1}:\n" \
             "  expected line vs. actual line:\n" \
             "------------\n" \
-            "{}\n" \
-            "{}\n" \
+            "{2}\n" \
+            "{3}\n" \
             "------------\n". \
             format(i, meaning, exp_line, act_line)


### PR DESCRIPTION
This fixes the current errors on Travis for Python 2.6.

For details, see the commit messages.