### PR TITLE
Ks/remove more pylints

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -72,13 +72,20 @@ disable=I0011,
         too-many-nested-blocks, too-many-return-statements, too-many-arguments,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
-        consider-using-set-comprehension
+        consider-using-set-comprehension, unnecessary-pass, useless-return
 
 # Note: "useless-object-inheritance" is python 3 only. In Python 2,
 #        "new-style" objects must inherit from object, or else
 #        they will be "old-style". In Python 3, this distinction does not
 #        exist; all objects inherit from object, and so explicitly inheriting
 #        from it is useless.  Ignore as long as we are using pytnon 2.7
+
+# Note:  "unnecessary-pass" appears to be a completely harmless issue. We will
+#         ignore this warning at least for now.
+
+# Note:  "useless-return" this only appears in Python 3 and since the return
+#        serves as a clear signal of the end of the method and does not cause
+#        any code issues we will ignore this warning.
 
 # Note: "consider-using-set-comprehension" not allowed in python 2.6 so we
 #       ignore it as long as we are using 2.7

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -63,7 +63,7 @@ from ._version import __version__  # noqa: F401
 
 _python_m = sys.version_info[0]  # pylint: disable=invalid-name
 _python_n = sys.version_info[1]  # pylint: disable=invalid-name
-if _python_m == 2 and _python_n < 6:   # pylint: disable=no-else-return
+if _python_m == 2 and _python_n < 6:   # pylint: disable=no-else-raise
     raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
 elif _python_m == 3 and _python_n < 4:
     raise RuntimeError('On Python 3, pywbem requires Python 3.4 or higher')

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -569,11 +569,12 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         self.log(format, args, logging.INFO)
 
     def log_request(self, code='-', size='-'):
+        #  pylint: disable=unused-argument
         """
         This function is called during :meth:`send_response`.
 
         We override it to get a little more information logged in a somewhat
-        better format.
+        better format.  We do not use the size  method argument.
         """
         self.log('%s: HTTP status %s',
                  (self._get_log_prefix(), code),

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -52,8 +52,10 @@ __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
            'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse']
 
 if six.PY2:
+    # pylint: disable=invalid-name, undefined-variable
     _Longint = long  # noqa: F821
 else:
+    # pylint: disable=invalid-name
     _Longint = int
 
 OpArgsTuple = namedtuple("OpArgsTuple", ["method", "args"])
@@ -684,8 +686,8 @@ class LogOperationRecorder(BaseOperationRecorder):
             """ format ret as repr while clipping it to max_len if
                 max_len is not None.
             """
-            # format the 'summary' and 'paths' detail_levels
-            if self.api_detail_level == 'summary':
+            # Format the 'summary' and 'paths' detail_levels
+            if self.api_detail_level == 'summary':  # pylint: disable=R1705
                 if isinstance(ret, list):
                     if ret:
                         ret_type = type(ret[0]).__name__ if ret else ""

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -709,6 +709,7 @@ class Statistics(object):
                 # pylint: disable=protected-access
                 if stats._server_time_stored:
                     include_svr = True
+            # pylint: disable=protected-access
             if include_svr:
                 ret += OperationStatistic._formatted_header_w_svr
             else:

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -28,6 +28,7 @@ __all__ = ['Warning', 'ToleratedServerIssueWarning']
 
 
 class Warning(Error, six.moves.builtins.Warning):
+    # pylint: disable=redefined-builtin
     """
     Base class for pywbem specific warnings.
     """

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -455,11 +455,11 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
         :exc:`~pywbem.HTTPError`
     """
 
-    class HTTPBaseConnection:        # pylint: disable=no-init
+    class HTTPBaseConnection:  # pylint: disable=no-init
         """ Common base for specific connection classes. Implements
             the send method
         """
-        # pylint: disable=old-style-class,too-few-public-methods
+        # pylint: disable=too-few-public-methods
         def send(self, strng):
             """
             A copy of `httplib.HTTPConnection.send()`, with these fixes:
@@ -965,7 +965,7 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                     #   retrying causes testclient test case SocketError104 to
                     #   fail. Also, retrying needs to be tested with a real
                     #   WBEM server.
-                    if False:
+                    if False:  # pylint: disable=using-constant-test
                         warnings.warn(
                             _format("The server closed the connection without "
                                     "returning any response (retrying - this "

--- a/pywbem/cim_obj.py
+++ b/pywbem/cim_obj.py
@@ -304,6 +304,7 @@ _KB_VAL = r'(?:{0}|{1}|{2})'.format(
 # To get all repetitions, capture a repeated group instead of repeating a
 # capturing group: https://www.regular-expressions.info/captureall.html
 WBEM_URI_KEYBINDINGS_REGEXP = re.compile(
+    # pylint: disable=duplicate-string-formatting-argument
     r'^(\w+={0})((?:,\w+={1})*)$'.format(_KB_VAL, _KB_VAL),
     flags=(re.UNICODE | re.IGNORECASE))
 
@@ -810,7 +811,7 @@ def _scalar_value_tomof(
     if value is None:
         return mofval(u'NULL', indent, maxline, line_pos, end_space)
 
-    if type == 'string':
+    if type == 'string':  # pylint: disable=no-else-raise
         if isinstance(value, six.string_types):
             return mofstr(value, indent, maxline, line_pos, end_space,
                           avoid_splits)
@@ -2502,13 +2503,12 @@ class CIMInstance(_CIMComparisonMixin):
     def path(self, path):
         """Setter method; for a description see the getter method."""
 
+        # pylint: disable=attribute-defined-outside-init
         if path is None:
-            # pylint: disable=attribute-defined-outside-init
             self._path = None
         else:
             # The provided path is deep copied because its keybindings may be
             # updated when setting properties (in __setitem__()).
-            # pylint: disable=attribute-defined-outside-init
             self._path = path.copy()
 
             # We perform this check after the initialization to avoid errors
@@ -8183,6 +8183,8 @@ def _infer_is_array(value):
 
 def _check_array_parms(is_array, array_size, value, element_kind,
                        element_name):
+    # pylint: disable=unused-argument
+    # The array_size argument is unused.
     """
     Check whether array-related parameters are ok.
     """

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -84,8 +84,10 @@ from .config import DEBUG_WARNING_ORIGIN, ENFORCE_INTEGER_RANGE
 from ._utils import _ensure_unicode, _hash_item, _format, _to_unicode
 
 if six.PY2:
+    # pylint: disable=invalid-name,undefined-variable
     _Longint = long  # noqa: F821
 else:
+    # pylint: disable=invalid-name
     _Longint = int
 
 

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -229,7 +229,7 @@ def t_COMMENT(t):
     return  # discard token
 
 
-def t_MCOMMENT(t):
+def t_MCOMMENT(t):  # pylint: disable=useless-return
     r'/\*(.|\n)*?\*/'
     t.lineno += t.value.count('\n')
     return  # discard token
@@ -311,6 +311,7 @@ def t_stringValue(t):  # pylint: disable=missing-docstring
 
 
 identifier_re = r'([a-zA-Z_]|({0}))([0-9a-zA-Z_]|({1}))*'.format(
+    # pylint: disable=duplicate-string-formatting-argument
     utf8Char, utf8Char)
 
 
@@ -320,7 +321,7 @@ def t_IDENTIFIER(t):  # pylint: disable=missing-docstring
     return t
 
 
-def t_newline(t):  # pylint: disable=missing-docstring
+def t_newline(t):  # pylint: disable=missing-docstring,useless-return
     r'\n+'
     t.lexer.lineno += len(t.value)
     t.lexer.linestart = t.lexpos

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -31,10 +31,10 @@ from pywbem import MOFWBEMConnection, CIMError, CIM_ERR_INVALID_PARAMETER, \
     CIM_ERR_NOT_FOUND
 from pywbem._nocasedict import NocaseDict
 
-from ._resolvermixin import ResolverMixin
 from pywbem._utils import _format
+from ._resolvermixin import ResolverMixin
 
-# TODO: Use the BaseWBEMConnection and recreate the complete MOFWBEMConnection
+# TODO: FutureUse the BaseWBEMConnection and recreate complete MOFWBEMConnection
 
 
 class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
@@ -133,8 +133,8 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                                 conn_id=self.conn_id)
                         raise
 
-        ccr = self.conn._resolve_class(cc, namespace,
-                                       self.qualifiers[namespace])
+        ccr = self.conn._resolve_class(  # pylint: disable=protected-access
+            cc, namespace, self.qualifiers[namespace])
         if namespace not in self.classes:
             self.classes[namespace] = NocaseDict()
         self.classes[namespace][ccr.classname] = ccr

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -199,10 +199,10 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                                 "{3!A} without override.",
                                 type_str, oname, new_class.classname,
                                 superclass.classname))
-                else:
-                    # TODO need to finish this.  For now just let
-                    # parameter slide. Keep tht new one.
-                    continue
+
+                # TODO need to finish this.  For now just let
+                # parameter slide. Keep the new one.
+                continue
 
             # process object override
             # get override name

--- a/tests/end2endtest/test_profile_generic.py
+++ b/tests/end2endtest/test_profile_generic.py
@@ -21,6 +21,7 @@ from .utils.utils import latest_profile_inst, server_func_asserted, \
 
 def test_get_central_instances(
         profile_definition, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the central instances of the profile can be determined using
     WBEMServer.gen_central_instances().
@@ -73,6 +74,7 @@ def test_get_central_instances(
 
 
 def test_undefined_profiles(wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the server advertises only profiles defined in profiles.yml.
     """

--- a/tests/end2endtest/test_profile_snia_server.py
+++ b/tests/end2endtest/test_profile_snia_server.py
@@ -10,9 +10,13 @@ from pywbem import ToleratedServerIssueWarning
 from pywbem._utils import _format
 
 # Note: The wbem_connection fixture uses the server_definition fixture, and
-# due to the way py.test searches for fixtures, it also need to be imported.
+# due to the way py.test searches for fixtures, it also must be imported.
+
+# pylint: disable=line-too-long,unused-import
 from .utils.pytest_extensions import wbem_connection, server_definition  # noqa: F401, E501
 from .utils.pytest_extensions import assert_association_func  # noqa: F401
+# pylint: enable=line-too-long,unused-import
+
 from .utils.pytest_extensions import ProfileTest
 from .utils.assertions import assert_number_of_instances_equal, \
     assert_number_of_instances_minimum, assert_instance_of, \
@@ -26,11 +30,12 @@ class Test_SNIA_Server_Profile(ProfileTest):
     All end2end tests for SNIA 'Server' profile.
     """
 
-    def init_profile(self, conn):
+    def init_profile(self, conn):  # pylint: disable=arguments-differ
         super(Test_SNIA_Server_Profile, self).init_profile(
-            conn, 'SNIA', 'Server')
+            conn, profile_org='SNIA', profile_name='Server')
 
     def test_get_central_instances(self, wbem_connection):  # noqa: F811
+        # pylint: disable=redefined-outer-name
         """
         Test WBEMServer.get_central_instances() for this profile.
         """
@@ -54,6 +59,7 @@ class Test_SNIA_Server_Profile(ProfileTest):
             wbem_connection, central_inst_paths, central_insts_msg, 1)
 
     def test_central_instance(self, wbem_connection):  # noqa: F811
+        # pylint: disable=redefined-outer-name
         """
         Test the CIM_ObjectManager central instance.
         """
@@ -81,6 +87,7 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
     def test_Namespace(
             self, assert_association_func, wbem_connection):  # noqa: F811
+        # pylint: disable=redefined-outer-name
         """
         Test the associated CIM_Namespace instances.
         """
@@ -135,6 +142,7 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
     def test_ObjectManagerCommunicationMechanism(
             self, assert_association_func, wbem_connection):  # noqa: F811
+        # pylint: disable=redefined-outer-name
         """
         Test the associated CIM_ObjectManagerCommunicationMechanism instances.
         """
@@ -208,6 +216,7 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
     def test_System(
             self, assert_association_func, wbem_connection):  # noqa: F811
+        # pylint: disable=redefined-outer-name
         """
         Test the associated CIM_System instance.
         """

--- a/tests/end2endtest/test_server.py
+++ b/tests/end2endtest/test_server.py
@@ -9,13 +9,16 @@ from pywbem import WBEMServer
 
 # Note: The wbem_connection fixture uses the server_definition fixture, and
 # due to the way py.test searches for fixtures, it also need to be imported.
+# pylint: disable=line-too-long,unused-import
 from .utils.pytest_extensions import wbem_connection, server_definition  # noqa: F401, E501
+# pylint: enable=line-too-long
 from .utils.pytest_extensions import default_namespace  # noqa: F401, E501
 from .utils.utils import server_func_asserted, server_prop_asserted
 
 
 def test_namespace_consistency(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the Interop namespace and all namespaces and namespace paths can
     be determined, and verify consistency between them.
@@ -43,6 +46,7 @@ def test_namespace_consistency(
 
 def test_namespace_getinstance(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that GetInstance on the instance paths of all namespaces succeeds.
     """
@@ -65,6 +69,7 @@ def test_namespace_getinstance(
 
 def test_brand_version(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the server brand and version can be determined.
     """
@@ -85,6 +90,7 @@ def test_brand_version(
 
 def test_cimom_inst(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the instance representing the server can be determined and that
     GetInstance on it succeeds.
@@ -109,6 +115,7 @@ def test_cimom_inst(
 
 def test_profiles(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the registered profiles advertised by the server can be
     determined and that GetInstance on them succeeds.
@@ -137,6 +144,7 @@ def test_profiles(
 
 def test_get_selected_profiles_no_filter(
         default_namespace, wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test that the get_selected_profiles() method without filtering returns
     the same profiles as the profiles attribute.

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -32,7 +32,7 @@ PROFILES_YAML_FILE = os.path.join('tests', 'profiles', 'profiles.yml')
 # definition file.
 with open(PROFILES_YAML_FILE, 'r') as _fp:
     PROFILE_DEFINITION_LIST = yaml.load(_fp)
-del _fp
+del _fp  # pylint: disable=undefined-loop-variable
 
 # Profile definition dictionary.
 # The dict key is 'org:name', for optimized direct access.
@@ -43,7 +43,7 @@ for _pd in PROFILE_DEFINITION_LIST:
     _key = '{0}:{1}'.format(_pd['registered_org'],
                             _pd['registered_name'])
     PROFILE_DEFINITION_DICT[_key] = _pd
-del _pd, _key
+del _pd, _key  # pylint: disable=undefined-loop-variable
 
 
 def fixtureid_server_definition(fixture_value):
@@ -287,7 +287,7 @@ class ProfileTest(object):
 
     object_cache = ServerObjectCache()
 
-    def init_profile(self, conn, profile_org, profile_name):
+    def init_profile(self, conn, profile_org=None, profile_name=None):
         """
         Initialize attributes for the profile.
 
@@ -361,4 +361,5 @@ class ProfileTest(object):
             self.object_cache.add_list(
                 self.conn.url, central_paths_id, central_paths)
 
+        # pylint: disable=attribute-defined-outside-init
         self.central_inst_paths = central_paths

--- a/tests/end2endtest/utils/server_definition_file.py
+++ b/tests/end2endtest/utils/server_definition_file.py
@@ -40,6 +40,7 @@ class ServerDefinitionFile(object):
         self._load_file()
 
     def _load_file(self):
+        """Load the yaml file."""
         try:
             with open(self._filepath) as fp:
                 try:
@@ -52,7 +53,7 @@ class ServerDefinitionFile(object):
                         format(self._filepath, exc.__class__.__name__,
                                exc))
         except IOError as exc:
-            if exc.errno == errno.ENOENT:
+            if exc.errno == errno.ENOENT:  # pylint: disable=no-else-raise
                 raise ServerDefinitionFileError(
                     "The WBEM server definition file {0!r} was not found; "
                     "copy it from {1!r}".
@@ -96,6 +97,7 @@ class ServerDefinitionFile(object):
             self._server_groups.update(server_groups)
 
     def _check_sg(self, sg_nick, server_groups, servers, visited_sg_nicks):
+        """Check server groups for nicknames"""
         visited_sg_nicks.append(sg_nick)
         server_group = server_groups[sg_nick]
         if not isinstance(server_group, list):
@@ -153,7 +155,8 @@ class ServerDefinitionFile(object):
         """
         if nickname in self._servers:
             return [self.get_server(nickname)]
-        elif nickname in self._server_groups:
+
+        if nickname in self._server_groups:  # pylint: disable no-else-return
             sd_list = list()  # of ServerDefinition objects
             sd_nick_list = list()  # of server nicknames
             for item_nick in self._server_groups[nickname]:
@@ -195,6 +198,8 @@ class ServerDefinition(object):
             'implementation_namespace', None)
 
     def _required_attr(self, server_dict, attr_name, nickname):
+        # pylint: disable=no-self-use
+        """Return the sever_dict attribute or a KeyError"""
         try:
             return server_dict[attr_name]
         except KeyError:

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -23,8 +23,7 @@ def latest_profile_inst(profile_insts):
         if profile_version > latest_version:
             latest_version = profile_version
             latest_i = i
-    latest_profile_inst = profile_insts[latest_i]
-    return latest_profile_inst
+    return profile_insts[latest_i]
 
 
 def path_equal(inst1_path, inst2_path):
@@ -56,6 +55,7 @@ def path_equal(inst1_path, inst2_path):
         if key_name not in inst2_path.keybindings:
             return False
         key2_value = inst2_path.keybindings[key_name]
+        # pylint: disable=no-else-return
         if isinstance(key1_value, CIMInstanceName) and \
                 isinstance(key2_value, CIMInstanceName) and \
                 not path_equal(key1_value, key2_value):
@@ -103,6 +103,7 @@ class ServerObjectCache(object):
         self._server_dict = dict()
 
     def add_list(self, server_url, list_name, obj_list):
+        """Add obj_list to the list named list_name"""
         if server_url not in self._server_dict:
             self._server_dict[server_url] = dict()
         list_dict = self._server_dict[server_url]
@@ -113,6 +114,7 @@ class ServerObjectCache(object):
         list_dict[list_name] = deepcopy(obj_list)
 
     def del_list(self, server_url, list_name):
+        """Delete list_name"""
         if server_url not in self._server_dict:
             raise KeyError(
                 "Server {0!r} is not in the cache".
@@ -127,6 +129,7 @@ class ServerObjectCache(object):
             del self._server_dict[server_url]
 
     def get_list(self, server_url, list_name):
+        """Get the list named list_name"""
         if server_url not in self._server_dict:
             raise KeyError(
                 "Server {0!r} is not in the cache".
@@ -202,6 +205,7 @@ def instance_of(conn, path_list, classname):
                 namespace=namespace, ClassName=classname,
                 asserted=False)
         except CIMError as exc:
+            # pylint: disable=no-else-raise
             if exc.status_code == CIM_ERR_INVALID_CLASS:
                 raise AssertionError(
                     "Server {0} at {1}: Class {2!r} does not exist in "
@@ -260,123 +264,163 @@ class WBEMConnectionAsserted(WBEMConnection):
                    exc.__class__.__name__, exc, parm_str))
 
     def EnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('EnumerateInstances', *args, **kwargs)
 
     def EnumerateInstanceNames(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('EnumerateInstanceNames', *args, **kwargs)
 
     def GetInstance(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('GetInstance', *args, **kwargs)
 
     def ModifyInstance(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('ModifyInstance', *args, **kwargs)
 
     def CreateInstance(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('CreateInstance', *args, **kwargs)
 
     def DeleteInstance(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('DeleteInstance', *args, **kwargs)
 
     def Associators(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('Associators', *args, **kwargs)
 
     def AssociatorNames(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('AssociatorNames', *args, **kwargs)
 
     def References(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('References', *args, **kwargs)
 
     def ReferenceNames(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('ReferenceNames', *args, **kwargs)
 
     def InvokeMethod(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('InvokeMethod', *args, **kwargs)
 
     def ExecQuery(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('ExecQuery', *args, **kwargs)
 
     def IterEnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterEnumerateInstances', *args, **kwargs)
 
     def IterEnumerateInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterEnumerateInstancePaths', *args, **kwargs)
 
     def IterAssociatorInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterAssociatorInstances', *args, **kwargs)
 
     def IterAssociatorInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterAssociatorInstancePaths', *args, **kwargs)
 
     def IterReferenceInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterReferenceInstances', *args, **kwargs)
 
     def IterReferenceInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterReferenceInstancePaths', *args, **kwargs)
 
     def IterQueryInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('IterQueryInstances', *args, **kwargs)
 
     def OpenEnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenEnumerateInstances', *args, **kwargs)
 
     def OpenEnumerateInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenEnumerateInstancePaths', *args, **kwargs)
 
     def OpenAssociatorInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenAssociatorInstances', *args, **kwargs)
 
     def OpenAssociatorInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenAssociatorInstancePaths', *args, **kwargs)
 
     def OpenReferenceInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenReferenceInstances', *args, **kwargs)
 
     def OpenReferenceInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenReferenceInstancePaths', *args, **kwargs)
 
     def OpenQueryInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('OpenQueryInstances', *args, **kwargs)
 
     def PullInstancesWithPath(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('PullInstancesWithPath', *args, **kwargs)
 
     def PullInstancePaths(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('PullInstancePaths', *args, **kwargs)
 
     def PullInstances(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('PullInstances', *args, **kwargs)
 
     def CloseEnumeration(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('CloseEnumeration', *args, **kwargs)
 
     def EnumerateClasses(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('EnumerateClasses', *args, **kwargs)
 
     def EnumerateClassNames(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('EnumerateClassNames', *args, **kwargs)
 
     def GetClass(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('GetClass', *args, **kwargs)
 
     def ModifyClass(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('ModifyClass', *args, **kwargs)
 
     def CreateClass(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('CreateClass', *args, **kwargs)
 
     def DeleteClass(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('DeleteClass', *args, **kwargs)
 
     def EnumerateQualifiers(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('EnumerateQualifiers', *args, **kwargs)
 
     def GetQualifier(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('GetQualifier', *args, **kwargs)
 
     def SetQualifier(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('SetQualifier', *args, **kwargs)
 
     def DeleteQualifier(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
         return self._call_func('DeleteQualifier', *args, **kwargs)
 
 

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -911,7 +911,7 @@ class EnumerateInstances(ClientTest):
             self.cimcall(self.conn.EnumerateInstances,
                          TEST_CLASS,
                          namespace='root/blah')
-            self.assertFalse(True)      # should never get here
+            self.fail()      # should never get here
 
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_NAMESPACE:
@@ -921,7 +921,7 @@ class EnumerateInstances(ClientTest):
         """ Confirm correct error with nonexistent classname."""
         try:
             self.cimcall(self.conn.EnumerateInstances, 'CIM_BlahBlah')
-            self.assertFalse(True)
+            self.fail()  # should never get here
 
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_INVALID_CLASS:
@@ -932,7 +932,7 @@ class EnumerateInstances(ClientTest):
         try:
             self.cimcall(self.conn.EnumerateInstances, TEST_CLASS,
                          blablah=3)
-            self.assertFalse(True)  # Expecting exception
+            self.fail()  # Expecting exception
 
         except CIMError as ce:
             if ce.args[0] != CIM_ERR_NOT_SUPPORTED:
@@ -4575,7 +4575,7 @@ class IterEnumerateInstances(PegasusServerTestBase):
                       FilterQueryLanguage=None, FilterQuery=None,
                       OperationTimeout=None, ContinueOnError=None,
                       MaxObjectCount=None, ignore_value_diff=False,
-                      expected_response_count=None, pull_disabled=False):
+                      expected_response_count=None):
         # pylint: disable=invalid-name
         """
         Run test by executing interEnumInstances, open/pull instance,
@@ -4608,7 +4608,7 @@ class IterEnumerateInstances(PegasusServerTestBase):
         if expected_response_count is not None:
             self.assertEqual(len(iter_instances), expected_response_count)
 
-        # execute pull operation
+        # execute open/pull sequence
         result = self.cimcall(self.conn.OpenEnumerateInstances, ClassName,
                               namespace=namespace, LocalOnly=LocalOnly,
                               DeepInheritance=DeepInheritance,
@@ -4758,8 +4758,7 @@ class IterEnumerateInstances(PegasusServerTestBase):
         property_list = ['Id', 'SequenceNumber', 'ResponseCount', 'S1']
         self.run_enum_test(TEST_PEG_STRESS_CLASSNAME,
                            namespace=TEST_PEG_STRESS_NAMESPACE,
-                           MaxObjectCount=100, PropertyList=property_list,
-                           pull_disabled=True)
+                           MaxObjectCount=100, PropertyList=property_list)
 
         # pylint: disable=protected-access
         self.assertEqual(self.conn.use_pull_operations, False)
@@ -4891,7 +4890,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
     def run_enumpath_test(self, ClassName, namespace=None,
                           FilterQueryLanguage=None, FilterQuery=None,
                           OperationTimeout=None, ContinueOnError=None,
-                          MaxObjectCount=None, pull_disabled=False):
+                          MaxObjectCount=None):
         # pylint: disable=invalid-name,
         """
         Run test by executing interEnumInstances, open/pull instance,
@@ -4914,7 +4913,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
         for path in generator:
             iter_paths.append(path)
 
-        # execute pull operation
+        # execute open/pull operation sequence
         result = self.cimcall(self.conn.OpenEnumerateInstancePaths, ClassName,
                               namespace=namespace,
                               FilterQueryLanguage=FilterQueryLanguage,
@@ -4936,7 +4935,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
 
         self.assertPathsEqual(iter_paths, pulled_paths, True)
 
-        # execute original enumerate instance paths operation
+        # Execute original enumerate instance paths operation
         # Ignore host here because EnumerateInstanceNames does not return
         # it.
         orig_paths = self.cimcall(self.conn.EnumerateInstanceNames, ClassName,
@@ -4967,7 +4966,6 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
 
         To force the original operation, recall self.setup with
         has_pull_operation = False
-
         """
 
         # Force a new setup to set the use_pull_operations False.
@@ -4978,7 +4976,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
 
         self.run_enumpath_test(TEST_PEG_STRESS_CLASSNAME,
                                namespace=TEST_PEG_STRESS_NAMESPACE,
-                               MaxObjectCount=100, pull_disabled=True)
+                               MaxObjectCount=100)
 
         # pylint: disable=protected-access
         self.assertEqual(self.conn.use_pull_operations, False)
@@ -5246,7 +5244,7 @@ class IterReferenceInstancePaths(PegasusServerTestBase):
         for path in generator:
             iter_paths.append(path)
 
-        # execute pull operation
+        # execute open/pull operation sequence
         result = self.cimcall(self.conn.OpenReferenceInstancePaths,
                               InstanceName, ResultClass=ResultClass, Role=Role,
                               FilterQueryLanguage=FilterQueryLanguage,

--- a/tests/manualtest/run_enum_performance.py
+++ b/tests/manualtest/run_enum_performance.py
@@ -170,8 +170,6 @@ def run_single_test(conn, response_count, response_size, max_obj_cnt_array):
         total_server_responsetime = pull_stats[0]
         total_operationtime = pull_stats[1]
 
-        print("TIME %s %s" % (client_pull_time, client_pulltime_str))
-
         inst_per_sec = insts_pulled / client_pull_time.total_seconds()
 
         pywbem_processingtime = total_operationtime - total_server_responsetime
@@ -179,9 +177,9 @@ def run_single_test(conn, response_count, response_size, max_obj_cnt_array):
         # total_operationtime exists only if the server returns it
         if total_operationtime:
             percentage = "{:0.2f}".format((pywbem_processingtime /
-                                          conn.last_operation_time) * 100)
+                                           conn.last_operation_time) * 100)
         else:
-            percentage = 100
+            percentage = 100  # This is fake but we don't know svr time.
 
         row = ['Open/Pull', insts_pulled, response_size, max_obj_cnt,
                pull_opcount,
@@ -199,8 +197,7 @@ def run_tests(conn, response_sizes, response_counts, pull_sizes, verbose):
     """
     Run test based on limits provided defined in the input variables
     """
-    # Run the enumeration one time to eliminate any server startup time
-    # loss
+    # Run the enumeration one time to eliminate server startup time loss
     conn.EnumerateInstances(TEST_CLASSNAME)
 
     if conn.last_server_response_time is None:
@@ -210,10 +207,10 @@ def run_tests(conn, response_sizes, response_counts, pull_sizes, verbose):
     header = ['Operation', 'Response\nCount', 'RespSize\nBytes',
               'MaxObjCnt\nRequest',
               'Result\nCount',
-              'Total execution\ntime',
-              'inst/sec (hh:mm:ss)',
+              'Total execution\ntime (hh:mm:ss)',
+              'inst/sec',
               'svr time\nsec',
-              'op resp time\nsec',
+              'operation\nresp time\nsec',
               'totalop - svr\nresp time\nsec',
               'totalop - svr\nresp time\npercent']
 
@@ -237,7 +234,6 @@ def run_tests(conn, response_sizes, response_counts, pull_sizes, verbose):
               format(*headers))
 
         print('\n\nDetailed statistics for each pull  operations')
-        global STATS_LIST
         for st in STATS_LIST:
             diff = conn.last_operation_time - conn.last_server_response_time
             percentage = (diff / conn.last_operation_time) * 100
@@ -481,5 +477,4 @@ def main(prog):
 
 
 if __name__ == '__main__':
-    prog = _os.path.basename(_sys.argv[0])
-    _sys.exit(main(prog))
+    _sys.exit(main(_os.path.basename(_sys.argv[0])))

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -4997,6 +4997,7 @@ class CIMInstanceDict(DictionaryTestCase):
 
         if six.PY2:
             with self.assertRaises(ValueError if CHECK_0_12_0 else TypeError):
+                # pylint: disable=undefined-variable
                 obj['Foo'] = long(43)  # noqa: F821
 
         # Setting properties to CIM data type values

--- a/tests/unittest/pywbem/test_cim_xml.py
+++ b/tests/unittest/pywbem/test_cim_xml.py
@@ -153,8 +153,8 @@ def sample_INSTANCENAME_node():
             'type',
             cim_xml.KEYVALUE('dog', 'string')),
          cim_xml.KEYBINDING(
-            'age',
-            cim_xml.KEYVALUE('2', 'numeric'))])
+             'age',
+             cim_xml.KEYVALUE('2', 'numeric'))])
 
 
 def sample_INSTANCENAME_str():
@@ -1491,9 +1491,9 @@ class Message(CIMXMLTest):
                         'FooMethod',
                         sample_LOCALNAMESPACEPATH_node())),
                  cim_xml.SIMPLEREQ(
-                    cim_xml.IMETHODCALL(
-                        'FooMethod',
-                        sample_LOCALNAMESPACEPATH_node()))]),
+                     cim_xml.IMETHODCALL(
+                         'FooMethod',
+                         sample_LOCALNAMESPACEPATH_node()))]),
             '1001', '1.0'))
 
         # SIMPLERSP
@@ -1533,9 +1533,9 @@ class MultiReq(CIMXMLTest):
                     'FooMethod',
                     sample_LOCALNAMESPACEPATH_node())),
              cim_xml.SIMPLEREQ(
-                cim_xml.IMETHODCALL(
-                    'FooMethod',
-                    sample_LOCALNAMESPACEPATH_node()))]))
+                 cim_xml.IMETHODCALL(
+                     'FooMethod',
+                     sample_LOCALNAMESPACEPATH_node()))]))
 
 
 class MultiExpReq(CIMXMLTest):
@@ -1816,7 +1816,7 @@ class MultiExpRsp(CIMXMLTest):
                 [cim_xml.SIMPLEEXPRSP(
                     cim_xml.EXPMETHODRESPONSE('FooMethod')),
                  cim_xml.SIMPLEEXPRSP(
-                    cim_xml.EXPMETHODRESPONSE('FooMethod'))]))
+                     cim_xml.EXPMETHODRESPONSE('FooMethod'))]))
 
 
 class SimpleRsp(CIMXMLTest):

--- a/tests/unittest/pywbem/test_logging.py
+++ b/tests/unittest/pywbem/test_logging.py
@@ -410,6 +410,7 @@ class BaseLoggingExecutionTests(object):
         WBEMConnection._reset_logging_config()
         configure_loggers_from_string(
             'all=file', TEST_OUTPUT_LOG, propagate=True, connection=True)
+        # pylint: disable=attribute-defined-outside-init
         self.logger = logging.getLogger(LOGGER_API_CALLS_NAME)
         assert self.logger is not None
 

--- a/tests/unittest/pywbem/test_tupletree.py
+++ b/tests/unittest/pywbem/test_tupletree.py
@@ -69,6 +69,7 @@ def xml_to_tupletree(xml_string):
 
 
 class Test_xml_to_tupletree_sax(object):
+    # pylint: disable=too-few-public-methods
     """
     Exhaustive tests for tupletree.xml_to_tupletree_sax(), with inline input
     XML and expected tupletrees (for success) or exceptions (for failures).

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -42,7 +42,7 @@ VERBOSE = True
 TESTSUITE_SCHEMA_DIR = os.path.join('tests', 'schema')
 
 
-class BaseMethodsForTests(object):
+class BaseMethodsForTests(object):  # pylint: disable=too-few-public-methods
     """
     Common methods for test of WBEMServer class.  This includes methods to
     build the DMTF schema and to build individual instances.


### PR DESCRIPTION
This removes a number of pylint issues, many by simply setting pylint disable.

Changes very few lines of executable code other than the changes for clean up of the unnecessary else where we drop the else and out-dent the code.

Eliminate 120 to 150 pylints as far as I can tell.