### PR TITLE
Improved Python version checking by using 'python_requires' keyword

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,9 @@ Released: not yet
   `embedded_object` value is not inferred from the property or parameter value
   in that case, so this saves performance.
 
+* Added the 'python_requires' keyword to the package definition, which makes pip
+  aware of the supported Python versions.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -63,6 +63,9 @@ from ._version import __version__  # noqa: F401
 
 _python_m = sys.version_info[0]  # pylint: disable=invalid-name
 _python_n = sys.version_info[1]  # pylint: disable=invalid-name
+
+# !!! Make sure to keep the supported Python versions in sync
+# between setup.py, setup.cfg and pywbem/__init__.py !!!
 if _python_m == 2 and _python_n < 6:   # pylint: disable=no-else-raise
     raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
 elif _python_m == 3 and _python_n < 4:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ classifier =
     Programming Language :: Python :: 3.7
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: System :: Systems Administration
+# !!! Make sure to keep the supported Python versions in sync 
+# between setup.py, setup.cfg and pywbem/__init__.py !!!
 
 [files]
 packages =

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,13 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr>=1.10'],
+
+    # Specifying python_requires in setup.cfg would be more logical
+    # but requires setuptools>=34.0.0, hence it is specified here.
+    # This works with the current minimum versions of
+    # setuptools=33.1.1 and pip=9.0.1.
+    # !!! Make sure to keep the supported Python versions in sync
+    # between setup.py, setup.cfg and pywbem/__init__.py !!!
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+
     pbr=True)


### PR DESCRIPTION
For details, see the commit message.

The test that the new pip based Python version check actually works was made with a Python version requirement that required >=2.7 and thus was expected to fail on Python 2.6. The failing installs on Python 2.6 can be seen in this Travis run:
https://travis-ci.org/pywbem/pywbem/builds/507180522