### PR TITLE
Fix several pylint issues in compiler, tupleparse, and tests.

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.2
 Name: pywbem
-Version: 0.13.1.dev29
+Version: 0.13.1.dev41
 Summary: pywbem - A WBEM client
 Home-page: https://pywbem.github.io/pywbem/
 Author: Tim Potter
@@ -50,3 +50,4 @@ Classifier: Programming Language :: Python :: 3.6
 Classifier: Programming Language :: Python :: 3.7
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Classifier: Topic :: System :: Systems Administration
+Requires-Python: >=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -229,7 +229,7 @@ def t_COMMENT(t):
     return  # discard token
 
 
-def t_MCOMMENT(t):  # pylint: disable=useless-return
+def t_MCOMMENT(t):
     r'/\*(.|\n)*?\*/'
     t.lineno += t.value.count('\n')
     return  # discard token
@@ -310,8 +310,7 @@ def t_stringValue(t):  # pylint: disable=missing-docstring
     return t
 
 
-identifier_re = r'([a-zA-Z_]|({0}))([0-9a-zA-Z_]|({1}))*'.format(
-    # pylint: disable=duplicate-string-formatting-argument
+identifier_re = r'([a-zA-Z_]|({0}))([0-9a-zA-Z_]|({1}))*'.format(  # noqa E501 pylint: disable=W1308
     utf8Char, utf8Char)
 
 
@@ -321,7 +320,7 @@ def t_IDENTIFIER(t):  # pylint: disable=missing-docstring
     return t
 
 
-def t_newline(t):  # pylint: disable=missing-docstring,useless-return
+def t_newline(t):  # pylint: disable=missing-docstring
     r'\n+'
     t.lexer.lineno += len(t.value)
     t.lexer.linestart = t.lexpos

--- a/pywbem/tupleparse.py
+++ b/pywbem/tupleparse.py
@@ -965,7 +965,7 @@ class TupleParser(object):
 
         classname = attrs(tup_tree)['CLASSNAME']
 
-        if k0_name == 'KEYVALUE' or k0_name == 'VALUE.REFERENCE':
+        if k0_name in ('KEYVALUE', 'VALUE.REFERENCE'):
             if len(k) != 1:
                 raise CIMXMLParseError(
                     _format("Element {0!A} has more than one child element "

--- a/tests/end2endtest/utils/assertions.py
+++ b/tests/end2endtest/utils/assertions.py
@@ -908,10 +908,10 @@ def std_uri(instance):
     """
     if instance is None or instance.path is None:
         return ''
-    else:
-        path = instance.path.copy()
-        path.host = None
-        return path.to_wbem_uri(format='canonical')
+
+    path = instance.path.copy()
+    path.host = None
+    return path.to_wbem_uri(format='canonical')
 
 
 def assert_profile_tree(conn, profile_inst, profile_ancestry,

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -79,6 +79,7 @@ def server_definition(request):
     scope='module'
 )
 def wbem_connection(request, server_definition):
+    # pylint: disable=redefined-outer-name, unused-argument
     """
     Fixture representing the set of WBEMConnection objects to use for the
     end2end tests.  This fixture uses the  server_definition
@@ -189,6 +190,7 @@ def fixtureid_profile_definition(fixture_value):
 
 
 def _apply_profile_definition_defaults(pd):
+    """Set the reference_direction parameter"""
     if 'reference_direction' not in pd:
         pd['reference_direction'] = None
     if pd['reference_direction'] is None:


### PR DESCRIPTION
The change in tupleparser (change from two compares to in [...] and
assertions (remove useless else) change code. The others only change
pylint comments.

This gets us down to about 100 pylint comments not counting TODO and XXX
comments.