### PR TITLE
Modify mof_compiler.py to remove unused production defs.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,14 @@ Released: not yet
 
 * Fixed AttributeError on __offset in CIMDateTime.repr(). See issue #1681.
 
+* Removed the associationDeclaration and IndicationDeclaration mof parser
+  production rules from mof_compiler.py because: a) They were orderd in
+  p_mp_createClass so that the classDeclaration production was always used,
+  b) When reordered, they still created a YACC reduce/reduce conflict where the
+  result was that YACC used the classDeclaration production to resolve the
+  conflict, c) they represent exactly the same syntax as the classDeclaration.
+  In effect, these production rules were never really used executed.
+
 **Enhancements:**
 
 * Added the possibility to specify a value of `False` for the `embedded_object`


### PR DESCRIPTION
Modify mof_compiler to remove unused productions for
associationDeclaration, IndicationDeclaration, and the association
features lists

The pywbem compiler YACC includes productions for association declaration
and indication declaration.  While these are defined in DSP0004,
in this compiler they are never used because the the order of
executing the CreateClass production was classDeclaration,
associationDeclaration, indicationDeclaration and the syntax of
association and indication declarations is really a subset of the
class declaration.

Since the association and Indication abnf definitions are the same
syntax as the class declaration except that the keywords "Indication"
/ "Association" (i.e. the qualifiers association and indication) are the
first entry in the qualifier list, the pywbem  mof compiler always uses
the class declaration because it is the first entry.