### PR TITLE
[DONTMERGE] Alternate change to compiler.  This is for doc only

### DIFF
--- a/alttestmofout.txt
+++ b/alttestmofout.txt
@@ -1,0 +1,11606 @@
+MOF repository: Namespace root/cimv2 in WBEM server http://192.168.3.135
+Executing in dry-run mode
+Created by PLY version 3.11 (http://www.dabeaz.com/ply)
+
+Grammar
+
+Rule 0     S' -> mofSpecification
+Rule 1     mofSpecification -> mofProductionList
+Rule 2     mofProductionList -> empty
+Rule 3     mofProductionList -> mofProductionList mofProduction
+Rule 4     mofProduction -> compilerDirective
+Rule 5     mofProduction -> mp_createClass
+Rule 6     mofProduction -> mp_setQualifier
+Rule 7     mofProduction -> mp_createInstance
+Rule 8     mp_createClass -> assocDeclaration
+Rule 9     mp_createClass -> indicDeclaration
+Rule 10    mp_createClass -> classDeclaration
+Rule 11    mp_createInstance -> instanceDeclaration
+Rule 12    mp_setQualifier -> qualifierDeclaration
+Rule 13    compilerDirective -> # PRAGMA pragmaName ( pragmaParameter )
+Rule 14    pragmaName -> identifier
+Rule 15    pragmaParameter -> stringValue
+Rule 16    classDeclaration -> CLASS className { classFeatureList } ;
+Rule 17    classDeclaration -> CLASS className superClass { classFeatureList } ;
+Rule 18    classDeclaration -> CLASS className alias { classFeatureList } ;
+Rule 19    classDeclaration -> CLASS className alias superClass { classFeatureList } ;
+Rule 20    classDeclaration -> qualifierList CLASS className { classFeatureList } ;
+Rule 21    classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ;
+Rule 22    classDeclaration -> qualifierList CLASS className alias { classFeatureList } ;
+Rule 23    classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ;
+Rule 24    classFeatureList -> empty
+Rule 25    classFeatureList -> classFeatureList classFeature
+Rule 26    assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ;
+Rule 27    assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
+Rule 28    assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
+Rule 29    assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
+Rule 30    indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ;
+Rule 31    indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ;
+Rule 32    indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ;
+Rule 33    indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ;
+Rule 34    qualifierListEmpty -> empty
+Rule 35    qualifierListEmpty -> qualifierListEmpty , qualifier
+Rule 36    associationFeatureList -> empty
+Rule 37    associationFeatureList -> associationFeatureList associationFeature
+Rule 38    className -> identifier
+Rule 39    alias -> AS aliasIdentifier
+Rule 40    aliasIdentifier -> $ identifier
+Rule 41    superClass -> : className
+Rule 42    classFeature -> propertyDeclaration
+Rule 43    classFeature -> methodDeclaration
+Rule 44    classFeature -> referenceDeclaration
+Rule 45    associationFeature -> classFeature
+Rule 46    qualifierList -> [ qualifier qualifierListEmpty ]
+Rule 47    qualifier -> qualifierName
+Rule 48    qualifier -> qualifierName : flavorList
+Rule 49    qualifier -> qualifierName qualifierParameter
+Rule 50    qualifier -> qualifierName qualifierParameter : flavorList
+Rule 51    flavorList -> flavor
+Rule 52    flavorList -> flavorList flavor
+Rule 53    qualifierParameter -> ( constantValue )
+Rule 54    qualifierParameter -> arrayInitializer
+Rule 55    flavor -> ENABLEOVERRIDE
+Rule 56    flavor -> DISABLEOVERRIDE
+Rule 57    flavor -> RESTRICTED
+Rule 58    flavor -> TOSUBCLASS
+Rule 59    flavor -> TOINSTANCE
+Rule 60    flavor -> TRANSLATABLE
+Rule 61    propertyDeclaration -> propertyDeclaration_1
+Rule 62    propertyDeclaration -> propertyDeclaration_2
+Rule 63    propertyDeclaration -> propertyDeclaration_3
+Rule 64    propertyDeclaration -> propertyDeclaration_4
+Rule 65    propertyDeclaration -> propertyDeclaration_5
+Rule 66    propertyDeclaration -> propertyDeclaration_6
+Rule 67    propertyDeclaration -> propertyDeclaration_7
+Rule 68    propertyDeclaration -> propertyDeclaration_8
+Rule 69    propertyDeclaration_1 -> dataType propertyName ;
+Rule 70    propertyDeclaration_2 -> dataType propertyName defaultValue ;
+Rule 71    propertyDeclaration_3 -> dataType propertyName array ;
+Rule 72    propertyDeclaration_4 -> dataType propertyName array defaultValue ;
+Rule 73    propertyDeclaration_5 -> qualifierList dataType propertyName ;
+Rule 74    propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ;
+Rule 75    propertyDeclaration_7 -> qualifierList dataType propertyName array ;
+Rule 76    propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ;
+Rule 77    referenceDeclaration -> objectRef referenceName ;
+Rule 78    referenceDeclaration -> objectRef referenceName defaultValue ;
+Rule 79    referenceDeclaration -> qualifierList objectRef referenceName ;
+Rule 80    referenceDeclaration -> qualifierList objectRef referenceName defaultValue ;
+Rule 81    methodDeclaration -> dataType methodName ( ) ;
+Rule 82    methodDeclaration -> dataType methodName ( parameterList ) ;
+Rule 83    methodDeclaration -> qualifierList dataType methodName ( ) ;
+Rule 84    methodDeclaration -> qualifierList dataType methodName ( parameterList ) ;
+Rule 85    propertyName -> identifier
+Rule 86    referenceName -> identifier
+Rule 87    methodName -> identifier
+Rule 88    dataType -> DT_UINT8
+Rule 89    dataType -> DT_SINT8
+Rule 90    dataType -> DT_UINT16
+Rule 91    dataType -> DT_SINT16
+Rule 92    dataType -> DT_UINT32
+Rule 93    dataType -> DT_SINT32
+Rule 94    dataType -> DT_UINT64
+Rule 95    dataType -> DT_SINT64
+Rule 96    dataType -> DT_REAL32
+Rule 97    dataType -> DT_REAL64
+Rule 98    dataType -> DT_CHAR16
+Rule 99    dataType -> DT_STR
+Rule 100   dataType -> DT_BOOL
+Rule 101   dataType -> DT_DATETIME
+Rule 102   objectRef -> className REF
+Rule 103   parameterList -> parameter
+Rule 104   parameterList -> parameterList , parameter
+Rule 105   parameter -> parameter_1
+Rule 106   parameter -> parameter_2
+Rule 107   parameter -> parameter_3
+Rule 108   parameter -> parameter_4
+Rule 109   parameter_1 -> dataType parameterName
+Rule 110   parameter_1 -> dataType parameterName array
+Rule 111   parameter_2 -> qualifierList dataType parameterName
+Rule 112   parameter_2 -> qualifierList dataType parameterName array
+Rule 113   parameter_3 -> objectRef parameterName
+Rule 114   parameter_3 -> objectRef parameterName array
+Rule 115   parameter_4 -> qualifierList objectRef parameterName
+Rule 116   parameter_4 -> qualifierList objectRef parameterName array
+Rule 117   parameterName -> identifier
+Rule 118   array -> [ ]
+Rule 119   array -> [ integerValue ]
+Rule 120   defaultValue -> = initializer
+Rule 121   initializer -> constantValue
+Rule 122   initializer -> arrayInitializer
+Rule 123   initializer -> referenceInitializer
+Rule 124   arrayInitializer -> { constantValueList }
+Rule 125   arrayInitializer -> { }
+Rule 126   constantValueList -> constantValue
+Rule 127   constantValueList -> constantValueList , constantValue
+Rule 128   stringValueList -> stringValue
+Rule 129   stringValueList -> stringValueList stringValue
+Rule 130   constantValue -> integerValue
+Rule 131   constantValue -> floatValue
+Rule 132   constantValue -> charValue
+Rule 133   constantValue -> stringValueList
+Rule 134   constantValue -> booleanValue
+Rule 135   constantValue -> nullValue
+Rule 136   integerValue -> binaryValue
+Rule 137   integerValue -> octalValue
+Rule 138   integerValue -> decimalValue
+Rule 139   integerValue -> hexValue
+Rule 140   referenceInitializer -> objectHandle
+Rule 141   referenceInitializer -> aliasIdentifier
+Rule 142   objectHandle -> identifier
+Rule 143   qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ;
+Rule 144   qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ;
+Rule 145   qualifierName -> identifier
+Rule 146   qualifierName -> ASSOCIATION
+Rule 147   qualifierName -> INDICATION
+Rule 148   qualifierType -> qualifierType_1
+Rule 149   qualifierType -> qualifierType_2
+Rule 150   qualifierType_1 -> : dataType array
+Rule 151   qualifierType_1 -> : dataType array defaultValue
+Rule 152   qualifierType_2 -> : dataType
+Rule 153   qualifierType_2 -> : dataType defaultValue
+Rule 154   scope -> , SCOPE ( metaElementList )
+Rule 155   metaElementList -> metaElement
+Rule 156   metaElementList -> metaElementList , metaElement
+Rule 157   metaElement -> SCHEMA
+Rule 158   metaElement -> CLASS
+Rule 159   metaElement -> ASSOCIATION
+Rule 160   metaElement -> INDICATION
+Rule 161   metaElement -> QUALIFIER
+Rule 162   metaElement -> PROPERTY
+Rule 163   metaElement -> REFERENCE
+Rule 164   metaElement -> METHOD
+Rule 165   metaElement -> PARAMETER
+Rule 166   metaElement -> ANY
+Rule 167   defaultFlavor -> , FLAVOR ( flavorListWithComma )
+Rule 168   flavorListWithComma -> flavor
+Rule 169   flavorListWithComma -> flavorListWithComma , flavor
+Rule 170   instanceDeclaration -> INSTANCE OF className { valueInitializerList } ;
+Rule 171   instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ;
+Rule 172   instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ;
+Rule 173   instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ;
+Rule 174   valueInitializerList -> valueInitializer
+Rule 175   valueInitializerList -> valueInitializerList valueInitializer
+Rule 176   valueInitializer -> identifier defaultValue ;
+Rule 177   valueInitializer -> qualifierList identifier defaultValue ;
+Rule 178   booleanValue -> FALSE
+Rule 179   booleanValue -> TRUE
+Rule 180   nullValue -> NULL
+Rule 181   identifier -> IDENTIFIER
+Rule 182   identifier -> ANY
+Rule 183   identifier -> AS
+Rule 184   identifier -> CLASS
+Rule 185   identifier -> DISABLEOVERRIDE
+Rule 186   identifier -> dataType
+Rule 187   identifier -> ENABLEOVERRIDE
+Rule 188   identifier -> FLAVOR
+Rule 189   identifier -> INSTANCE
+Rule 190   identifier -> METHOD
+Rule 191   identifier -> OF
+Rule 192   identifier -> PARAMETER
+Rule 193   identifier -> PRAGMA
+Rule 194   identifier -> PROPERTY
+Rule 195   identifier -> QUALIFIER
+Rule 196   identifier -> REFERENCE
+Rule 197   identifier -> RESTRICTED
+Rule 198   identifier -> SCHEMA
+Rule 199   identifier -> SCOPE
+Rule 200   identifier -> TOSUBCLASS
+Rule 201   identifier -> TOINSTANCE
+Rule 202   identifier -> TRANSLATABLE
+Rule 203   empty -> <empty>
+
+Terminals, with rules where they appear
+
+#                    : 13
+$                    : 40
+(                    : 13 53 81 82 83 84 154 167
+)                    : 13 53 81 82 83 84 154 167
+,                    : 35 104 127 154 156 167 169
+:                    : 41 48 50 150 151 152 153
+;                    : 16 17 18 19 20 21 22 23 26 27 28 29 30 31 32 33 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 143 144 170 171 172 173 176 177
+=                    : 120
+ANY                  : 166 182
+AS                   : 39 183
+ASSOCIATION          : 26 27 28 29 146 159
+CLASS                : 16 17 18 19 20 21 22 23 26 27 28 29 30 31 32 33 158 184
+DISABLEOVERRIDE      : 56 185
+DT_BOOL              : 100
+DT_CHAR16            : 98
+DT_DATETIME          : 101
+DT_REAL32            : 96
+DT_REAL64            : 97
+DT_SINT16            : 91
+DT_SINT32            : 93
+DT_SINT64            : 95
+DT_SINT8             : 89
+DT_STR               : 99
+DT_UINT16            : 90
+DT_UINT32            : 92
+DT_UINT64            : 94
+DT_UINT8             : 88
+ENABLEOVERRIDE       : 55 187
+FALSE                : 178
+FLAVOR               : 167 188
+IDENTIFIER           : 181
+INDICATION           : 30 31 32 33 147 160
+INSTANCE             : 170 171 172 173 189
+METHOD               : 164 190
+NULL                 : 180
+OF                   : 170 171 172 173 191
+PARAMETER            : 165 192
+PRAGMA               : 13 193
+PROPERTY             : 162 194
+QUALIFIER            : 143 144 161 195
+REF                  : 102
+REFERENCE            : 163 196
+RESTRICTED           : 57 197
+SCHEMA               : 157 198
+SCOPE                : 154 199
+TOINSTANCE           : 59 201
+TOSUBCLASS           : 58 200
+TRANSLATABLE         : 60 202
+TRUE                 : 179
+[                    : 26 27 28 29 30 31 32 33 46 118 119
+]                    : 26 27 28 29 30 31 32 33 46 118 119
+binaryValue          : 136
+charValue            : 132
+decimalValue         : 138
+error                :
+floatValue           : 131
+hexValue             : 139
+octalValue           : 137
+stringValue          : 15 128 129
+{                    : 16 17 18 19 20 21 22 23 26 27 28 29 30 31 32 33 124 125 170 171 172 173
+}                    : 16 17 18 19 20 21 22 23 26 27 28 29 30 31 32 33 124 125 170 171 172 173
+
+Nonterminals, with rules where they appear
+
+alias                : 18 19 22 23 28 29 32 33 171 173
+aliasIdentifier      : 39 141
+array                : 71 72 75 76 110 112 114 116 150 151
+arrayInitializer     : 54 122
+assocDeclaration     : 8
+associationFeature   : 37
+associationFeatureList : 26 27 28 29 37
+booleanValue         : 134
+classDeclaration     : 10
+classFeature         : 25 45
+classFeatureList     : 16 17 18 19 20 21 22 23 25 30 31 32 33
+className            : 16 17 18 19 20 21 22 23 26 27 28 29 30 31 32 33 41 102 170 171 172 173
+compilerDirective    : 4
+constantValue        : 53 121 126 127
+constantValueList    : 124 127
+dataType             : 69 70 71 72 73 74 75 76 81 82 83 84 109 110 111 112 150 151 152 153 186
+defaultFlavor        : 144
+defaultValue         : 70 72 74 76 78 80 151 153 176 177
+empty                : 2 24 34 36
+flavor               : 51 52 168 169
+flavorList           : 48 50 52
+flavorListWithComma  : 167 169
+identifier           : 14 38 40 85 86 87 117 142 145 176 177
+indicDeclaration     : 9
+initializer          : 120
+instanceDeclaration  : 11
+integerValue         : 119 130
+metaElement          : 155 156
+metaElementList      : 154 156
+methodDeclaration    : 43
+methodName           : 81 82 83 84
+mofProduction        : 3
+mofProductionList    : 1 3
+mofSpecification     : 0
+mp_createClass       : 5
+mp_createInstance    : 7
+mp_setQualifier      : 6
+nullValue            : 135
+objectHandle         : 140
+objectRef            : 77 78 79 80 113 114 115 116
+parameter            : 103 104
+parameterList        : 82 84 104
+parameterName        : 109 110 111 112 113 114 115 116
+parameter_1          : 105
+parameter_2          : 106
+parameter_3          : 107
+parameter_4          : 108
+pragmaName           : 13
+pragmaParameter      : 13
+propertyDeclaration  : 42
+propertyDeclaration_1 : 61
+propertyDeclaration_2 : 62
+propertyDeclaration_3 : 63
+propertyDeclaration_4 : 64
+propertyDeclaration_5 : 65
+propertyDeclaration_6 : 66
+propertyDeclaration_7 : 67
+propertyDeclaration_8 : 68
+propertyName         : 69 70 71 72 73 74 75 76
+qualifier            : 35 46
+qualifierDeclaration : 12
+qualifierList        : 20 21 22 23 73 74 75 76 79 80 83 84 111 112 115 116 172 173 177
+qualifierListEmpty   : 26 27 28 29 30 31 32 33 35 46
+qualifierName        : 47 48 49 50 143 144
+qualifierParameter   : 49 50
+qualifierType        : 143 144
+qualifierType_1      : 148
+qualifierType_2      : 149
+referenceDeclaration : 44
+referenceInitializer : 123
+referenceName        : 77 78 79 80
+scope                : 143 144
+stringValueList      : 129 133
+superClass           : 17 19 21 23 27 29 31 33
+valueInitializer     : 174 175
+valueInitializerList : 170 171 172 173 175
+
+Generating LALR tables
+Parsing method: LALR
+
+state 0
+
+    (0) S' -> . mofSpecification
+    (1) mofSpecification -> . mofProductionList
+    (2) mofProductionList -> . empty
+    (3) mofProductionList -> . mofProductionList mofProduction
+    (203) empty -> .
+
+    #               reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    $end            reduce using rule 203 (empty -> .)
+
+    mofSpecification               shift and go to state 1
+    mofProductionList              shift and go to state 2
+    empty                          shift and go to state 3
+
+state 1
+
+    (0) S' -> mofSpecification .
+
+
+
+state 2
+
+    (1) mofSpecification -> mofProductionList .
+    (3) mofProductionList -> mofProductionList . mofProduction
+    (4) mofProduction -> . compilerDirective
+    (5) mofProduction -> . mp_createClass
+    (6) mofProduction -> . mp_setQualifier
+    (7) mofProduction -> . mp_createInstance
+    (13) compilerDirective -> . # PRAGMA pragmaName ( pragmaParameter )
+    (8) mp_createClass -> . assocDeclaration
+    (9) mp_createClass -> . indicDeclaration
+    (10) mp_createClass -> . classDeclaration
+    (12) mp_setQualifier -> . qualifierDeclaration
+    (11) mp_createInstance -> . instanceDeclaration
+    (26) assocDeclaration -> . [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> . [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> . [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> . [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
+    (30) indicDeclaration -> . [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ;
+    (31) indicDeclaration -> . [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ;
+    (32) indicDeclaration -> . [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ;
+    (33) indicDeclaration -> . [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ;
+    (16) classDeclaration -> . CLASS className { classFeatureList } ;
+    (17) classDeclaration -> . CLASS className superClass { classFeatureList } ;
+    (18) classDeclaration -> . CLASS className alias { classFeatureList } ;
+    (19) classDeclaration -> . CLASS className alias superClass { classFeatureList } ;
+    (20) classDeclaration -> . qualifierList CLASS className { classFeatureList } ;
+    (21) classDeclaration -> . qualifierList CLASS className superClass { classFeatureList } ;
+    (22) classDeclaration -> . qualifierList CLASS className alias { classFeatureList } ;
+    (23) classDeclaration -> . qualifierList CLASS className alias superClass { classFeatureList } ;
+    (143) qualifierDeclaration -> . QUALIFIER qualifierName qualifierType scope ;
+    (144) qualifierDeclaration -> . QUALIFIER qualifierName qualifierType scope defaultFlavor ;
+    (170) instanceDeclaration -> . INSTANCE OF className { valueInitializerList } ;
+    (171) instanceDeclaration -> . INSTANCE OF className alias { valueInitializerList } ;
+    (172) instanceDeclaration -> . qualifierList INSTANCE OF className { valueInitializerList } ;
+    (173) instanceDeclaration -> . qualifierList INSTANCE OF className alias { valueInitializerList } ;
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+
+    $end            reduce using rule 1 (mofSpecification -> mofProductionList .)
+    #               shift and go to state 9
+    [               shift and go to state 15
+    CLASS           shift and go to state 16
+    QUALIFIER       shift and go to state 18
+    INSTANCE        shift and go to state 19
+
+    mofProduction                  shift and go to state 4
+    compilerDirective              shift and go to state 5
+    mp_createClass                 shift and go to state 6
+    mp_setQualifier                shift and go to state 7
+    mp_createInstance              shift and go to state 8
+    assocDeclaration               shift and go to state 10
+    indicDeclaration               shift and go to state 11
+    classDeclaration               shift and go to state 12
+    qualifierDeclaration           shift and go to state 13
+    instanceDeclaration            shift and go to state 14
+    qualifierList                  shift and go to state 17
+
+state 3
+
+    (2) mofProductionList -> empty .
+
+    #               reduce using rule 2 (mofProductionList -> empty .)
+    [               reduce using rule 2 (mofProductionList -> empty .)
+    CLASS           reduce using rule 2 (mofProductionList -> empty .)
+    QUALIFIER       reduce using rule 2 (mofProductionList -> empty .)
+    INSTANCE        reduce using rule 2 (mofProductionList -> empty .)
+    $end            reduce using rule 2 (mofProductionList -> empty .)
+
+
+state 4
+
+    (3) mofProductionList -> mofProductionList mofProduction .
+
+    #               reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    [               reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    CLASS           reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    QUALIFIER       reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    INSTANCE        reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    $end            reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+
+
+state 5
+
+    (4) mofProduction -> compilerDirective .
+
+    #               reduce using rule 4 (mofProduction -> compilerDirective .)
+    [               reduce using rule 4 (mofProduction -> compilerDirective .)
+    CLASS           reduce using rule 4 (mofProduction -> compilerDirective .)
+    QUALIFIER       reduce using rule 4 (mofProduction -> compilerDirective .)
+    INSTANCE        reduce using rule 4 (mofProduction -> compilerDirective .)
+    $end            reduce using rule 4 (mofProduction -> compilerDirective .)
+
+
+state 6
+
+    (5) mofProduction -> mp_createClass .
+
+    #               reduce using rule 5 (mofProduction -> mp_createClass .)
+    [               reduce using rule 5 (mofProduction -> mp_createClass .)
+    CLASS           reduce using rule 5 (mofProduction -> mp_createClass .)
+    QUALIFIER       reduce using rule 5 (mofProduction -> mp_createClass .)
+    INSTANCE        reduce using rule 5 (mofProduction -> mp_createClass .)
+    $end            reduce using rule 5 (mofProduction -> mp_createClass .)
+
+
+state 7
+
+    (6) mofProduction -> mp_setQualifier .
+
+    #               reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    [               reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    CLASS           reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    QUALIFIER       reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    INSTANCE        reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    $end            reduce using rule 6 (mofProduction -> mp_setQualifier .)
+
+
+state 8
+
+    (7) mofProduction -> mp_createInstance .
+
+    #               reduce using rule 7 (mofProduction -> mp_createInstance .)
+    [               reduce using rule 7 (mofProduction -> mp_createInstance .)
+    CLASS           reduce using rule 7 (mofProduction -> mp_createInstance .)
+    QUALIFIER       reduce using rule 7 (mofProduction -> mp_createInstance .)
+    INSTANCE        reduce using rule 7 (mofProduction -> mp_createInstance .)
+    $end            reduce using rule 7 (mofProduction -> mp_createInstance .)
+
+
+state 9
+
+    (13) compilerDirective -> # . PRAGMA pragmaName ( pragmaParameter )
+
+    PRAGMA          shift and go to state 20
+
+
+state 10
+
+    (8) mp_createClass -> assocDeclaration .
+
+    #               reduce using rule 8 (mp_createClass -> assocDeclaration .)
+    [               reduce using rule 8 (mp_createClass -> assocDeclaration .)
+    CLASS           reduce using rule 8 (mp_createClass -> assocDeclaration .)
+    QUALIFIER       reduce using rule 8 (mp_createClass -> assocDeclaration .)
+    INSTANCE        reduce using rule 8 (mp_createClass -> assocDeclaration .)
+    $end            reduce using rule 8 (mp_createClass -> assocDeclaration .)
+
+
+state 11
+
+    (9) mp_createClass -> indicDeclaration .
+
+    #               reduce using rule 9 (mp_createClass -> indicDeclaration .)
+    [               reduce using rule 9 (mp_createClass -> indicDeclaration .)
+    CLASS           reduce using rule 9 (mp_createClass -> indicDeclaration .)
+    QUALIFIER       reduce using rule 9 (mp_createClass -> indicDeclaration .)
+    INSTANCE        reduce using rule 9 (mp_createClass -> indicDeclaration .)
+    $end            reduce using rule 9 (mp_createClass -> indicDeclaration .)
+
+
+state 12
+
+    (10) mp_createClass -> classDeclaration .
+
+    #               reduce using rule 10 (mp_createClass -> classDeclaration .)
+    [               reduce using rule 10 (mp_createClass -> classDeclaration .)
+    CLASS           reduce using rule 10 (mp_createClass -> classDeclaration .)
+    QUALIFIER       reduce using rule 10 (mp_createClass -> classDeclaration .)
+    INSTANCE        reduce using rule 10 (mp_createClass -> classDeclaration .)
+    $end            reduce using rule 10 (mp_createClass -> classDeclaration .)
+
+
+state 13
+
+    (12) mp_setQualifier -> qualifierDeclaration .
+
+    #               reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+    [               reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+    CLASS           reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+    QUALIFIER       reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+    INSTANCE        reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+    $end            reduce using rule 12 (mp_setQualifier -> qualifierDeclaration .)
+
+
+state 14
+
+    (11) mp_createInstance -> instanceDeclaration .
+
+    #               reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+    [               reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+    CLASS           reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+    QUALIFIER       reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+    INSTANCE        reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+    $end            reduce using rule 11 (mp_createInstance -> instanceDeclaration .)
+
+
+state 15
+
+    (26) assocDeclaration -> [ . ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> [ . ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ . ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ . ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
+    (30) indicDeclaration -> [ . INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ;
+    (31) indicDeclaration -> [ . INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ . INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ;
+    (33) indicDeclaration -> [ . INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ;
+    (46) qualifierList -> [ . qualifier qualifierListEmpty ]
+    (47) qualifier -> . qualifierName
+    (48) qualifier -> . qualifierName : flavorList
+    (49) qualifier -> . qualifierName qualifierParameter
+    (50) qualifier -> . qualifierName qualifierParameter : flavorList
+    (145) qualifierName -> . identifier
+    (146) qualifierName -> . ASSOCIATION
+    (147) qualifierName -> . INDICATION
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 21
+    INDICATION      shift and go to state 23
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifier                      shift and go to state 24
+    qualifierName                  shift and go to state 25
+    identifier                     shift and go to state 26
+    dataType                       shift and go to state 31
+
+state 16
+
+    (16) classDeclaration -> CLASS . className { classFeatureList } ;
+    (17) classDeclaration -> CLASS . className superClass { classFeatureList } ;
+    (18) classDeclaration -> CLASS . className alias { classFeatureList } ;
+    (19) classDeclaration -> CLASS . className alias superClass { classFeatureList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 62
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 17
+
+    (20) classDeclaration -> qualifierList . CLASS className { classFeatureList } ;
+    (21) classDeclaration -> qualifierList . CLASS className superClass { classFeatureList } ;
+    (22) classDeclaration -> qualifierList . CLASS className alias { classFeatureList } ;
+    (23) classDeclaration -> qualifierList . CLASS className alias superClass { classFeatureList } ;
+    (172) instanceDeclaration -> qualifierList . INSTANCE OF className { valueInitializerList } ;
+    (173) instanceDeclaration -> qualifierList . INSTANCE OF className alias { valueInitializerList } ;
+
+    CLASS           shift and go to state 64
+    INSTANCE        shift and go to state 65
+
+
+state 18
+
+    (143) qualifierDeclaration -> QUALIFIER . qualifierName qualifierType scope ;
+    (144) qualifierDeclaration -> QUALIFIER . qualifierName qualifierType scope defaultFlavor ;
+    (145) qualifierName -> . identifier
+    (146) qualifierName -> . ASSOCIATION
+    (147) qualifierName -> . INDICATION
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 67
+    INDICATION      shift and go to state 68
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifierName                  shift and go to state 66
+    identifier                     shift and go to state 26
+    dataType                       shift and go to state 31
+
+state 19
+
+    (170) instanceDeclaration -> INSTANCE . OF className { valueInitializerList } ;
+    (171) instanceDeclaration -> INSTANCE . OF className alias { valueInitializerList } ;
+
+    OF              shift and go to state 69
+
+
+state 20
+
+    (13) compilerDirective -> # PRAGMA . pragmaName ( pragmaParameter )
+    (14) pragmaName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    pragmaName                     shift and go to state 70
+    identifier                     shift and go to state 71
+    dataType                       shift and go to state 31
+
+state 21
+
+    (26) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
+    (146) qualifierName -> ASSOCIATION .
+    (34) qualifierListEmpty -> . empty
+    (35) qualifierListEmpty -> . qualifierListEmpty , qualifier
+    (203) empty -> .
+
+  ! reduce/reduce conflict for ] resolved using rule 146 (qualifierName -> ASSOCIATION .)
+  ! reduce/reduce conflict for , resolved using rule 146 (qualifierName -> ASSOCIATION .)
+    :               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    (               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    {               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ]               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ,               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+
+  ! ]               [ reduce using rule 203 (empty -> .) ]
+  ! ,               [ reduce using rule 203 (empty -> .) ]
+
+    qualifierListEmpty             shift and go to state 72
+    empty                          shift and go to state 73
+
+state 22
+
+    (184) identifier -> CLASS .
+
+    :               reduce using rule 184 (identifier -> CLASS .)
+    (               reduce using rule 184 (identifier -> CLASS .)
+    {               reduce using rule 184 (identifier -> CLASS .)
+    ]               reduce using rule 184 (identifier -> CLASS .)
+    ,               reduce using rule 184 (identifier -> CLASS .)
+    AS              reduce using rule 184 (identifier -> CLASS .)
+    REF             reduce using rule 184 (identifier -> CLASS .)
+    ;               reduce using rule 184 (identifier -> CLASS .)
+    =               reduce using rule 184 (identifier -> CLASS .)
+    [               reduce using rule 184 (identifier -> CLASS .)
+    )               reduce using rule 184 (identifier -> CLASS .)
+
+
+state 23
+
+    (30) indicDeclaration -> [ INDICATION . qualifierListEmpty ] CLASS className { classFeatureList } ;
+    (31) indicDeclaration -> [ INDICATION . qualifierListEmpty ] CLASS className superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ INDICATION . qualifierListEmpty ] CLASS className alias { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION . qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ;
+    (147) qualifierName -> INDICATION .
+    (34) qualifierListEmpty -> . empty
+    (35) qualifierListEmpty -> . qualifierListEmpty , qualifier
+    (203) empty -> .
+
+  ! reduce/reduce conflict for ] resolved using rule 147 (qualifierName -> INDICATION .)
+  ! reduce/reduce conflict for , resolved using rule 147 (qualifierName -> INDICATION .)
+    :               reduce using rule 147 (qualifierName -> INDICATION .)
+    (               reduce using rule 147 (qualifierName -> INDICATION .)
+    {               reduce using rule 147 (qualifierName -> INDICATION .)
+    ]               reduce using rule 147 (qualifierName -> INDICATION .)
+    ,               reduce using rule 147 (qualifierName -> INDICATION .)
+
+  ! ]               [ reduce using rule 203 (empty -> .) ]
+  ! ,               [ reduce using rule 203 (empty -> .) ]
+
+    qualifierListEmpty             shift and go to state 74
+    empty                          shift and go to state 73
+
+state 24
+
+    (46) qualifierList -> [ qualifier . qualifierListEmpty ]
+    (34) qualifierListEmpty -> . empty
+    (35) qualifierListEmpty -> . qualifierListEmpty , qualifier
+    (203) empty -> .
+
+    ]               reduce using rule 203 (empty -> .)
+    ,               reduce using rule 203 (empty -> .)
+
+    qualifierListEmpty             shift and go to state 75
+    empty                          shift and go to state 73
+
+state 25
+
+    (47) qualifier -> qualifierName .
+    (48) qualifier -> qualifierName . : flavorList
+    (49) qualifier -> qualifierName . qualifierParameter
+    (50) qualifier -> qualifierName . qualifierParameter : flavorList
+    (53) qualifierParameter -> . ( constantValue )
+    (54) qualifierParameter -> . arrayInitializer
+    (124) arrayInitializer -> . { constantValueList }
+    (125) arrayInitializer -> . { }
+
+    ]               reduce using rule 47 (qualifier -> qualifierName .)
+    ,               reduce using rule 47 (qualifier -> qualifierName .)
+    :               shift and go to state 76
+    (               shift and go to state 78
+    {               shift and go to state 80
+
+    qualifierParameter             shift and go to state 77
+    arrayInitializer               shift and go to state 79
+
+state 26
+
+    (145) qualifierName -> identifier .
+
+    :               reduce using rule 145 (qualifierName -> identifier .)
+    (               reduce using rule 145 (qualifierName -> identifier .)
+    {               reduce using rule 145 (qualifierName -> identifier .)
+    ]               reduce using rule 145 (qualifierName -> identifier .)
+    ,               reduce using rule 145 (qualifierName -> identifier .)
+
+
+state 27
+
+    (181) identifier -> IDENTIFIER .
+
+    :               reduce using rule 181 (identifier -> IDENTIFIER .)
+    (               reduce using rule 181 (identifier -> IDENTIFIER .)
+    {               reduce using rule 181 (identifier -> IDENTIFIER .)
+    ]               reduce using rule 181 (identifier -> IDENTIFIER .)
+    ,               reduce using rule 181 (identifier -> IDENTIFIER .)
+    AS              reduce using rule 181 (identifier -> IDENTIFIER .)
+    REF             reduce using rule 181 (identifier -> IDENTIFIER .)
+    ;               reduce using rule 181 (identifier -> IDENTIFIER .)
+    =               reduce using rule 181 (identifier -> IDENTIFIER .)
+    [               reduce using rule 181 (identifier -> IDENTIFIER .)
+    )               reduce using rule 181 (identifier -> IDENTIFIER .)
+
+
+state 28
+
+    (182) identifier -> ANY .
+
+    :               reduce using rule 182 (identifier -> ANY .)
+    (               reduce using rule 182 (identifier -> ANY .)
+    {               reduce using rule 182 (identifier -> ANY .)
+    ]               reduce using rule 182 (identifier -> ANY .)
+    ,               reduce using rule 182 (identifier -> ANY .)
+    AS              reduce using rule 182 (identifier -> ANY .)
+    REF             reduce using rule 182 (identifier -> ANY .)
+    ;               reduce using rule 182 (identifier -> ANY .)
+    =               reduce using rule 182 (identifier -> ANY .)
+    [               reduce using rule 182 (identifier -> ANY .)
+    )               reduce using rule 182 (identifier -> ANY .)
+
+
+state 29
+
+    (183) identifier -> AS .
+
+    :               reduce using rule 183 (identifier -> AS .)
+    (               reduce using rule 183 (identifier -> AS .)
+    {               reduce using rule 183 (identifier -> AS .)
+    ]               reduce using rule 183 (identifier -> AS .)
+    ,               reduce using rule 183 (identifier -> AS .)
+    AS              reduce using rule 183 (identifier -> AS .)
+    REF             reduce using rule 183 (identifier -> AS .)
+    ;               reduce using rule 183 (identifier -> AS .)
+    =               reduce using rule 183 (identifier -> AS .)
+    [               reduce using rule 183 (identifier -> AS .)
+    )               reduce using rule 183 (identifier -> AS .)
+
+
+state 30
+
+    (185) identifier -> DISABLEOVERRIDE .
+
+    :               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    (               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    {               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    ]               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    ,               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    AS              reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    REF             reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    ;               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    =               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    [               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+    )               reduce using rule 185 (identifier -> DISABLEOVERRIDE .)
+
+
+state 31
+
+    (186) identifier -> dataType .
+
+    :               reduce using rule 186 (identifier -> dataType .)
+    (               reduce using rule 186 (identifier -> dataType .)
+    {               reduce using rule 186 (identifier -> dataType .)
+    ]               reduce using rule 186 (identifier -> dataType .)
+    ,               reduce using rule 186 (identifier -> dataType .)
+    AS              reduce using rule 186 (identifier -> dataType .)
+    ;               reduce using rule 186 (identifier -> dataType .)
+    =               reduce using rule 186 (identifier -> dataType .)
+    [               reduce using rule 186 (identifier -> dataType .)
+    )               reduce using rule 186 (identifier -> dataType .)
+
+
+state 32
+
+    (187) identifier -> ENABLEOVERRIDE .
+
+    :               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    (               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    {               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    ]               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    ,               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    AS              reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    REF             reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    ;               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    =               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    [               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+    )               reduce using rule 187 (identifier -> ENABLEOVERRIDE .)
+
+
+state 33
+
+    (188) identifier -> FLAVOR .
+
+    :               reduce using rule 188 (identifier -> FLAVOR .)
+    (               reduce using rule 188 (identifier -> FLAVOR .)
+    {               reduce using rule 188 (identifier -> FLAVOR .)
+    ]               reduce using rule 188 (identifier -> FLAVOR .)
+    ,               reduce using rule 188 (identifier -> FLAVOR .)
+    AS              reduce using rule 188 (identifier -> FLAVOR .)
+    REF             reduce using rule 188 (identifier -> FLAVOR .)
+    ;               reduce using rule 188 (identifier -> FLAVOR .)
+    =               reduce using rule 188 (identifier -> FLAVOR .)
+    [               reduce using rule 188 (identifier -> FLAVOR .)
+    )               reduce using rule 188 (identifier -> FLAVOR .)
+
+
+state 34
+
+    (189) identifier -> INSTANCE .
+
+    :               reduce using rule 189 (identifier -> INSTANCE .)
+    (               reduce using rule 189 (identifier -> INSTANCE .)
+    {               reduce using rule 189 (identifier -> INSTANCE .)
+    ]               reduce using rule 189 (identifier -> INSTANCE .)
+    ,               reduce using rule 189 (identifier -> INSTANCE .)
+    AS              reduce using rule 189 (identifier -> INSTANCE .)
+    REF             reduce using rule 189 (identifier -> INSTANCE .)
+    ;               reduce using rule 189 (identifier -> INSTANCE .)
+    =               reduce using rule 189 (identifier -> INSTANCE .)
+    [               reduce using rule 189 (identifier -> INSTANCE .)
+    )               reduce using rule 189 (identifier -> INSTANCE .)
+
+
+state 35
+
+    (190) identifier -> METHOD .
+
+    :               reduce using rule 190 (identifier -> METHOD .)
+    (               reduce using rule 190 (identifier -> METHOD .)
+    {               reduce using rule 190 (identifier -> METHOD .)
+    ]               reduce using rule 190 (identifier -> METHOD .)
+    ,               reduce using rule 190 (identifier -> METHOD .)
+    AS              reduce using rule 190 (identifier -> METHOD .)
+    REF             reduce using rule 190 (identifier -> METHOD .)
+    ;               reduce using rule 190 (identifier -> METHOD .)
+    =               reduce using rule 190 (identifier -> METHOD .)
+    [               reduce using rule 190 (identifier -> METHOD .)
+    )               reduce using rule 190 (identifier -> METHOD .)
+
+
+state 36
+
+    (191) identifier -> OF .
+
+    :               reduce using rule 191 (identifier -> OF .)
+    (               reduce using rule 191 (identifier -> OF .)
+    {               reduce using rule 191 (identifier -> OF .)
+    ]               reduce using rule 191 (identifier -> OF .)
+    ,               reduce using rule 191 (identifier -> OF .)
+    AS              reduce using rule 191 (identifier -> OF .)
+    REF             reduce using rule 191 (identifier -> OF .)
+    ;               reduce using rule 191 (identifier -> OF .)
+    =               reduce using rule 191 (identifier -> OF .)
+    [               reduce using rule 191 (identifier -> OF .)
+    )               reduce using rule 191 (identifier -> OF .)
+
+
+state 37
+
+    (192) identifier -> PARAMETER .
+
+    :               reduce using rule 192 (identifier -> PARAMETER .)
+    (               reduce using rule 192 (identifier -> PARAMETER .)
+    {               reduce using rule 192 (identifier -> PARAMETER .)
+    ]               reduce using rule 192 (identifier -> PARAMETER .)
+    ,               reduce using rule 192 (identifier -> PARAMETER .)
+    AS              reduce using rule 192 (identifier -> PARAMETER .)
+    REF             reduce using rule 192 (identifier -> PARAMETER .)
+    ;               reduce using rule 192 (identifier -> PARAMETER .)
+    =               reduce using rule 192 (identifier -> PARAMETER .)
+    [               reduce using rule 192 (identifier -> PARAMETER .)
+    )               reduce using rule 192 (identifier -> PARAMETER .)
+
+
+state 38
+
+    (193) identifier -> PRAGMA .
+
+    :               reduce using rule 193 (identifier -> PRAGMA .)
+    (               reduce using rule 193 (identifier -> PRAGMA .)
+    {               reduce using rule 193 (identifier -> PRAGMA .)
+    ]               reduce using rule 193 (identifier -> PRAGMA .)
+    ,               reduce using rule 193 (identifier -> PRAGMA .)
+    AS              reduce using rule 193 (identifier -> PRAGMA .)
+    REF             reduce using rule 193 (identifier -> PRAGMA .)
+    ;               reduce using rule 193 (identifier -> PRAGMA .)
+    =               reduce using rule 193 (identifier -> PRAGMA .)
+    [               reduce using rule 193 (identifier -> PRAGMA .)
+    )               reduce using rule 193 (identifier -> PRAGMA .)
+
+
+state 39
+
+    (194) identifier -> PROPERTY .
+
+    :               reduce using rule 194 (identifier -> PROPERTY .)
+    (               reduce using rule 194 (identifier -> PROPERTY .)
+    {               reduce using rule 194 (identifier -> PROPERTY .)
+    ]               reduce using rule 194 (identifier -> PROPERTY .)
+    ,               reduce using rule 194 (identifier -> PROPERTY .)
+    AS              reduce using rule 194 (identifier -> PROPERTY .)
+    REF             reduce using rule 194 (identifier -> PROPERTY .)
+    ;               reduce using rule 194 (identifier -> PROPERTY .)
+    =               reduce using rule 194 (identifier -> PROPERTY .)
+    [               reduce using rule 194 (identifier -> PROPERTY .)
+    )               reduce using rule 194 (identifier -> PROPERTY .)
+
+
+state 40
+
+    (195) identifier -> QUALIFIER .
+
+    :               reduce using rule 195 (identifier -> QUALIFIER .)
+    (               reduce using rule 195 (identifier -> QUALIFIER .)
+    {               reduce using rule 195 (identifier -> QUALIFIER .)
+    ]               reduce using rule 195 (identifier -> QUALIFIER .)
+    ,               reduce using rule 195 (identifier -> QUALIFIER .)
+    AS              reduce using rule 195 (identifier -> QUALIFIER .)
+    REF             reduce using rule 195 (identifier -> QUALIFIER .)
+    ;               reduce using rule 195 (identifier -> QUALIFIER .)
+    =               reduce using rule 195 (identifier -> QUALIFIER .)
+    [               reduce using rule 195 (identifier -> QUALIFIER .)
+    )               reduce using rule 195 (identifier -> QUALIFIER .)
+
+
+state 41
+
+    (196) identifier -> REFERENCE .
+
+    :               reduce using rule 196 (identifier -> REFERENCE .)
+    (               reduce using rule 196 (identifier -> REFERENCE .)
+    {               reduce using rule 196 (identifier -> REFERENCE .)
+    ]               reduce using rule 196 (identifier -> REFERENCE .)
+    ,               reduce using rule 196 (identifier -> REFERENCE .)
+    AS              reduce using rule 196 (identifier -> REFERENCE .)
+    REF             reduce using rule 196 (identifier -> REFERENCE .)
+    ;               reduce using rule 196 (identifier -> REFERENCE .)
+    =               reduce using rule 196 (identifier -> REFERENCE .)
+    [               reduce using rule 196 (identifier -> REFERENCE .)
+    )               reduce using rule 196 (identifier -> REFERENCE .)
+
+
+state 42
+
+    (197) identifier -> RESTRICTED .
+
+    :               reduce using rule 197 (identifier -> RESTRICTED .)
+    (               reduce using rule 197 (identifier -> RESTRICTED .)
+    {               reduce using rule 197 (identifier -> RESTRICTED .)
+    ]               reduce using rule 197 (identifier -> RESTRICTED .)
+    ,               reduce using rule 197 (identifier -> RESTRICTED .)
+    AS              reduce using rule 197 (identifier -> RESTRICTED .)
+    REF             reduce using rule 197 (identifier -> RESTRICTED .)
+    ;               reduce using rule 197 (identifier -> RESTRICTED .)
+    =               reduce using rule 197 (identifier -> RESTRICTED .)
+    [               reduce using rule 197 (identifier -> RESTRICTED .)
+    )               reduce using rule 197 (identifier -> RESTRICTED .)
+
+
+state 43
+
+    (198) identifier -> SCHEMA .
+
+    :               reduce using rule 198 (identifier -> SCHEMA .)
+    (               reduce using rule 198 (identifier -> SCHEMA .)
+    {               reduce using rule 198 (identifier -> SCHEMA .)
+    ]               reduce using rule 198 (identifier -> SCHEMA .)
+    ,               reduce using rule 198 (identifier -> SCHEMA .)
+    AS              reduce using rule 198 (identifier -> SCHEMA .)
+    REF             reduce using rule 198 (identifier -> SCHEMA .)
+    ;               reduce using rule 198 (identifier -> SCHEMA .)
+    =               reduce using rule 198 (identifier -> SCHEMA .)
+    [               reduce using rule 198 (identifier -> SCHEMA .)
+    )               reduce using rule 198 (identifier -> SCHEMA .)
+
+
+state 44
+
+    (199) identifier -> SCOPE .
+
+    :               reduce using rule 199 (identifier -> SCOPE .)
+    (               reduce using rule 199 (identifier -> SCOPE .)
+    {               reduce using rule 199 (identifier -> SCOPE .)
+    ]               reduce using rule 199 (identifier -> SCOPE .)
+    ,               reduce using rule 199 (identifier -> SCOPE .)
+    AS              reduce using rule 199 (identifier -> SCOPE .)
+    REF             reduce using rule 199 (identifier -> SCOPE .)
+    ;               reduce using rule 199 (identifier -> SCOPE .)
+    =               reduce using rule 199 (identifier -> SCOPE .)
+    [               reduce using rule 199 (identifier -> SCOPE .)
+    )               reduce using rule 199 (identifier -> SCOPE .)
+
+
+state 45
+
+    (200) identifier -> TOSUBCLASS .
+
+    :               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    (               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    {               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    ]               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    ,               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    AS              reduce using rule 200 (identifier -> TOSUBCLASS .)
+    REF             reduce using rule 200 (identifier -> TOSUBCLASS .)
+    ;               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    =               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    [               reduce using rule 200 (identifier -> TOSUBCLASS .)
+    )               reduce using rule 200 (identifier -> TOSUBCLASS .)
+
+
+state 46
+
+    (201) identifier -> TOINSTANCE .
+
+    :               reduce using rule 201 (identifier -> TOINSTANCE .)
+    (               reduce using rule 201 (identifier -> TOINSTANCE .)
+    {               reduce using rule 201 (identifier -> TOINSTANCE .)
+    ]               reduce using rule 201 (identifier -> TOINSTANCE .)
+    ,               reduce using rule 201 (identifier -> TOINSTANCE .)
+    AS              reduce using rule 201 (identifier -> TOINSTANCE .)
+    REF             reduce using rule 201 (identifier -> TOINSTANCE .)
+    ;               reduce using rule 201 (identifier -> TOINSTANCE .)
+    =               reduce using rule 201 (identifier -> TOINSTANCE .)
+    [               reduce using rule 201 (identifier -> TOINSTANCE .)
+    )               reduce using rule 201 (identifier -> TOINSTANCE .)
+
+
+state 47
+
+    (202) identifier -> TRANSLATABLE .
+
+    :               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    (               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    {               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    ]               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    ,               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    AS              reduce using rule 202 (identifier -> TRANSLATABLE .)
+    REF             reduce using rule 202 (identifier -> TRANSLATABLE .)
+    ;               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    =               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    [               reduce using rule 202 (identifier -> TRANSLATABLE .)
+    )               reduce using rule 202 (identifier -> TRANSLATABLE .)
+
+
+state 48
+
+    (88) dataType -> DT_UINT8 .
+
+    :               reduce using rule 88 (dataType -> DT_UINT8 .)
+    (               reduce using rule 88 (dataType -> DT_UINT8 .)
+    {               reduce using rule 88 (dataType -> DT_UINT8 .)
+    ]               reduce using rule 88 (dataType -> DT_UINT8 .)
+    ,               reduce using rule 88 (dataType -> DT_UINT8 .)
+    AS              reduce using rule 88 (dataType -> DT_UINT8 .)
+    [               reduce using rule 88 (dataType -> DT_UINT8 .)
+    =               reduce using rule 88 (dataType -> DT_UINT8 .)
+    IDENTIFIER      reduce using rule 88 (dataType -> DT_UINT8 .)
+    ANY             reduce using rule 88 (dataType -> DT_UINT8 .)
+    CLASS           reduce using rule 88 (dataType -> DT_UINT8 .)
+    DISABLEOVERRIDE reduce using rule 88 (dataType -> DT_UINT8 .)
+    ENABLEOVERRIDE  reduce using rule 88 (dataType -> DT_UINT8 .)
+    FLAVOR          reduce using rule 88 (dataType -> DT_UINT8 .)
+    INSTANCE        reduce using rule 88 (dataType -> DT_UINT8 .)
+    METHOD          reduce using rule 88 (dataType -> DT_UINT8 .)
+    OF              reduce using rule 88 (dataType -> DT_UINT8 .)
+    PARAMETER       reduce using rule 88 (dataType -> DT_UINT8 .)
+    PRAGMA          reduce using rule 88 (dataType -> DT_UINT8 .)
+    PROPERTY        reduce using rule 88 (dataType -> DT_UINT8 .)
+    QUALIFIER       reduce using rule 88 (dataType -> DT_UINT8 .)
+    REFERENCE       reduce using rule 88 (dataType -> DT_UINT8 .)
+    RESTRICTED      reduce using rule 88 (dataType -> DT_UINT8 .)
+    SCHEMA          reduce using rule 88 (dataType -> DT_UINT8 .)
+    SCOPE           reduce using rule 88 (dataType -> DT_UINT8 .)
+    TOSUBCLASS      reduce using rule 88 (dataType -> DT_UINT8 .)
+    TOINSTANCE      reduce using rule 88 (dataType -> DT_UINT8 .)
+    TRANSLATABLE    reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_UINT8        reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_SINT8        reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_UINT16       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_SINT16       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_UINT32       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_SINT32       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_UINT64       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_SINT64       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_REAL32       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_REAL64       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_CHAR16       reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_STR          reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_BOOL         reduce using rule 88 (dataType -> DT_UINT8 .)
+    DT_DATETIME     reduce using rule 88 (dataType -> DT_UINT8 .)
+    REF             reduce using rule 88 (dataType -> DT_UINT8 .)
+    ;               reduce using rule 88 (dataType -> DT_UINT8 .)
+    )               reduce using rule 88 (dataType -> DT_UINT8 .)
+
+
+state 49
+
+    (89) dataType -> DT_SINT8 .
+
+    :               reduce using rule 89 (dataType -> DT_SINT8 .)
+    (               reduce using rule 89 (dataType -> DT_SINT8 .)
+    {               reduce using rule 89 (dataType -> DT_SINT8 .)
+    ]               reduce using rule 89 (dataType -> DT_SINT8 .)
+    ,               reduce using rule 89 (dataType -> DT_SINT8 .)
+    AS              reduce using rule 89 (dataType -> DT_SINT8 .)
+    [               reduce using rule 89 (dataType -> DT_SINT8 .)
+    =               reduce using rule 89 (dataType -> DT_SINT8 .)
+    IDENTIFIER      reduce using rule 89 (dataType -> DT_SINT8 .)
+    ANY             reduce using rule 89 (dataType -> DT_SINT8 .)
+    CLASS           reduce using rule 89 (dataType -> DT_SINT8 .)
+    DISABLEOVERRIDE reduce using rule 89 (dataType -> DT_SINT8 .)
+    ENABLEOVERRIDE  reduce using rule 89 (dataType -> DT_SINT8 .)
+    FLAVOR          reduce using rule 89 (dataType -> DT_SINT8 .)
+    INSTANCE        reduce using rule 89 (dataType -> DT_SINT8 .)
+    METHOD          reduce using rule 89 (dataType -> DT_SINT8 .)
+    OF              reduce using rule 89 (dataType -> DT_SINT8 .)
+    PARAMETER       reduce using rule 89 (dataType -> DT_SINT8 .)
+    PRAGMA          reduce using rule 89 (dataType -> DT_SINT8 .)
+    PROPERTY        reduce using rule 89 (dataType -> DT_SINT8 .)
+    QUALIFIER       reduce using rule 89 (dataType -> DT_SINT8 .)
+    REFERENCE       reduce using rule 89 (dataType -> DT_SINT8 .)
+    RESTRICTED      reduce using rule 89 (dataType -> DT_SINT8 .)
+    SCHEMA          reduce using rule 89 (dataType -> DT_SINT8 .)
+    SCOPE           reduce using rule 89 (dataType -> DT_SINT8 .)
+    TOSUBCLASS      reduce using rule 89 (dataType -> DT_SINT8 .)
+    TOINSTANCE      reduce using rule 89 (dataType -> DT_SINT8 .)
+    TRANSLATABLE    reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_UINT8        reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_SINT8        reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_UINT16       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_SINT16       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_UINT32       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_SINT32       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_UINT64       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_SINT64       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_REAL32       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_REAL64       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_CHAR16       reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_STR          reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_BOOL         reduce using rule 89 (dataType -> DT_SINT8 .)
+    DT_DATETIME     reduce using rule 89 (dataType -> DT_SINT8 .)
+    REF             reduce using rule 89 (dataType -> DT_SINT8 .)
+    ;               reduce using rule 89 (dataType -> DT_SINT8 .)
+    )               reduce using rule 89 (dataType -> DT_SINT8 .)
+
+
+state 50
+
+    (90) dataType -> DT_UINT16 .
+
+    :               reduce using rule 90 (dataType -> DT_UINT16 .)
+    (               reduce using rule 90 (dataType -> DT_UINT16 .)
+    {               reduce using rule 90 (dataType -> DT_UINT16 .)
+    ]               reduce using rule 90 (dataType -> DT_UINT16 .)
+    ,               reduce using rule 90 (dataType -> DT_UINT16 .)
+    AS              reduce using rule 90 (dataType -> DT_UINT16 .)
+    [               reduce using rule 90 (dataType -> DT_UINT16 .)
+    =               reduce using rule 90 (dataType -> DT_UINT16 .)
+    IDENTIFIER      reduce using rule 90 (dataType -> DT_UINT16 .)
+    ANY             reduce using rule 90 (dataType -> DT_UINT16 .)
+    CLASS           reduce using rule 90 (dataType -> DT_UINT16 .)
+    DISABLEOVERRIDE reduce using rule 90 (dataType -> DT_UINT16 .)
+    ENABLEOVERRIDE  reduce using rule 90 (dataType -> DT_UINT16 .)
+    FLAVOR          reduce using rule 90 (dataType -> DT_UINT16 .)
+    INSTANCE        reduce using rule 90 (dataType -> DT_UINT16 .)
+    METHOD          reduce using rule 90 (dataType -> DT_UINT16 .)
+    OF              reduce using rule 90 (dataType -> DT_UINT16 .)
+    PARAMETER       reduce using rule 90 (dataType -> DT_UINT16 .)
+    PRAGMA          reduce using rule 90 (dataType -> DT_UINT16 .)
+    PROPERTY        reduce using rule 90 (dataType -> DT_UINT16 .)
+    QUALIFIER       reduce using rule 90 (dataType -> DT_UINT16 .)
+    REFERENCE       reduce using rule 90 (dataType -> DT_UINT16 .)
+    RESTRICTED      reduce using rule 90 (dataType -> DT_UINT16 .)
+    SCHEMA          reduce using rule 90 (dataType -> DT_UINT16 .)
+    SCOPE           reduce using rule 90 (dataType -> DT_UINT16 .)
+    TOSUBCLASS      reduce using rule 90 (dataType -> DT_UINT16 .)
+    TOINSTANCE      reduce using rule 90 (dataType -> DT_UINT16 .)
+    TRANSLATABLE    reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_UINT8        reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_SINT8        reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_UINT16       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_SINT16       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_UINT32       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_SINT32       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_UINT64       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_SINT64       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_REAL32       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_REAL64       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_CHAR16       reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_STR          reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_BOOL         reduce using rule 90 (dataType -> DT_UINT16 .)
+    DT_DATETIME     reduce using rule 90 (dataType -> DT_UINT16 .)
+    REF             reduce using rule 90 (dataType -> DT_UINT16 .)
+    ;               reduce using rule 90 (dataType -> DT_UINT16 .)
+    )               reduce using rule 90 (dataType -> DT_UINT16 .)
+
+
+state 51
+
+    (91) dataType -> DT_SINT16 .
+
+    :               reduce using rule 91 (dataType -> DT_SINT16 .)
+    (               reduce using rule 91 (dataType -> DT_SINT16 .)
+    {               reduce using rule 91 (dataType -> DT_SINT16 .)
+    ]               reduce using rule 91 (dataType -> DT_SINT16 .)
+    ,               reduce using rule 91 (dataType -> DT_SINT16 .)
+    AS              reduce using rule 91 (dataType -> DT_SINT16 .)
+    [               reduce using rule 91 (dataType -> DT_SINT16 .)
+    =               reduce using rule 91 (dataType -> DT_SINT16 .)
+    IDENTIFIER      reduce using rule 91 (dataType -> DT_SINT16 .)
+    ANY             reduce using rule 91 (dataType -> DT_SINT16 .)
+    CLASS           reduce using rule 91 (dataType -> DT_SINT16 .)
+    DISABLEOVERRIDE reduce using rule 91 (dataType -> DT_SINT16 .)
+    ENABLEOVERRIDE  reduce using rule 91 (dataType -> DT_SINT16 .)
+    FLAVOR          reduce using rule 91 (dataType -> DT_SINT16 .)
+    INSTANCE        reduce using rule 91 (dataType -> DT_SINT16 .)
+    METHOD          reduce using rule 91 (dataType -> DT_SINT16 .)
+    OF              reduce using rule 91 (dataType -> DT_SINT16 .)
+    PARAMETER       reduce using rule 91 (dataType -> DT_SINT16 .)
+    PRAGMA          reduce using rule 91 (dataType -> DT_SINT16 .)
+    PROPERTY        reduce using rule 91 (dataType -> DT_SINT16 .)
+    QUALIFIER       reduce using rule 91 (dataType -> DT_SINT16 .)
+    REFERENCE       reduce using rule 91 (dataType -> DT_SINT16 .)
+    RESTRICTED      reduce using rule 91 (dataType -> DT_SINT16 .)
+    SCHEMA          reduce using rule 91 (dataType -> DT_SINT16 .)
+    SCOPE           reduce using rule 91 (dataType -> DT_SINT16 .)
+    TOSUBCLASS      reduce using rule 91 (dataType -> DT_SINT16 .)
+    TOINSTANCE      reduce using rule 91 (dataType -> DT_SINT16 .)
+    TRANSLATABLE    reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_UINT8        reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_SINT8        reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_UINT16       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_SINT16       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_UINT32       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_SINT32       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_UINT64       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_SINT64       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_REAL32       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_REAL64       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_CHAR16       reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_STR          reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_BOOL         reduce using rule 91 (dataType -> DT_SINT16 .)
+    DT_DATETIME     reduce using rule 91 (dataType -> DT_SINT16 .)
+    REF             reduce using rule 91 (dataType -> DT_SINT16 .)
+    ;               reduce using rule 91 (dataType -> DT_SINT16 .)
+    )               reduce using rule 91 (dataType -> DT_SINT16 .)
+
+
+state 52
+
+    (92) dataType -> DT_UINT32 .
+
+    :               reduce using rule 92 (dataType -> DT_UINT32 .)
+    (               reduce using rule 92 (dataType -> DT_UINT32 .)
+    {               reduce using rule 92 (dataType -> DT_UINT32 .)
+    ]               reduce using rule 92 (dataType -> DT_UINT32 .)
+    ,               reduce using rule 92 (dataType -> DT_UINT32 .)
+    AS              reduce using rule 92 (dataType -> DT_UINT32 .)
+    [               reduce using rule 92 (dataType -> DT_UINT32 .)
+    =               reduce using rule 92 (dataType -> DT_UINT32 .)
+    IDENTIFIER      reduce using rule 92 (dataType -> DT_UINT32 .)
+    ANY             reduce using rule 92 (dataType -> DT_UINT32 .)
+    CLASS           reduce using rule 92 (dataType -> DT_UINT32 .)
+    DISABLEOVERRIDE reduce using rule 92 (dataType -> DT_UINT32 .)
+    ENABLEOVERRIDE  reduce using rule 92 (dataType -> DT_UINT32 .)
+    FLAVOR          reduce using rule 92 (dataType -> DT_UINT32 .)
+    INSTANCE        reduce using rule 92 (dataType -> DT_UINT32 .)
+    METHOD          reduce using rule 92 (dataType -> DT_UINT32 .)
+    OF              reduce using rule 92 (dataType -> DT_UINT32 .)
+    PARAMETER       reduce using rule 92 (dataType -> DT_UINT32 .)
+    PRAGMA          reduce using rule 92 (dataType -> DT_UINT32 .)
+    PROPERTY        reduce using rule 92 (dataType -> DT_UINT32 .)
+    QUALIFIER       reduce using rule 92 (dataType -> DT_UINT32 .)
+    REFERENCE       reduce using rule 92 (dataType -> DT_UINT32 .)
+    RESTRICTED      reduce using rule 92 (dataType -> DT_UINT32 .)
+    SCHEMA          reduce using rule 92 (dataType -> DT_UINT32 .)
+    SCOPE           reduce using rule 92 (dataType -> DT_UINT32 .)
+    TOSUBCLASS      reduce using rule 92 (dataType -> DT_UINT32 .)
+    TOINSTANCE      reduce using rule 92 (dataType -> DT_UINT32 .)
+    TRANSLATABLE    reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_UINT8        reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_SINT8        reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_UINT16       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_SINT16       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_UINT32       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_SINT32       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_UINT64       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_SINT64       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_REAL32       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_REAL64       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_CHAR16       reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_STR          reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_BOOL         reduce using rule 92 (dataType -> DT_UINT32 .)
+    DT_DATETIME     reduce using rule 92 (dataType -> DT_UINT32 .)
+    REF             reduce using rule 92 (dataType -> DT_UINT32 .)
+    ;               reduce using rule 92 (dataType -> DT_UINT32 .)
+    )               reduce using rule 92 (dataType -> DT_UINT32 .)
+
+
+state 53
+
+    (93) dataType -> DT_SINT32 .
+
+    :               reduce using rule 93 (dataType -> DT_SINT32 .)
+    (               reduce using rule 93 (dataType -> DT_SINT32 .)
+    {               reduce using rule 93 (dataType -> DT_SINT32 .)
+    ]               reduce using rule 93 (dataType -> DT_SINT32 .)
+    ,               reduce using rule 93 (dataType -> DT_SINT32 .)
+    AS              reduce using rule 93 (dataType -> DT_SINT32 .)
+    [               reduce using rule 93 (dataType -> DT_SINT32 .)
+    =               reduce using rule 93 (dataType -> DT_SINT32 .)
+    IDENTIFIER      reduce using rule 93 (dataType -> DT_SINT32 .)
+    ANY             reduce using rule 93 (dataType -> DT_SINT32 .)
+    CLASS           reduce using rule 93 (dataType -> DT_SINT32 .)
+    DISABLEOVERRIDE reduce using rule 93 (dataType -> DT_SINT32 .)
+    ENABLEOVERRIDE  reduce using rule 93 (dataType -> DT_SINT32 .)
+    FLAVOR          reduce using rule 93 (dataType -> DT_SINT32 .)
+    INSTANCE        reduce using rule 93 (dataType -> DT_SINT32 .)
+    METHOD          reduce using rule 93 (dataType -> DT_SINT32 .)
+    OF              reduce using rule 93 (dataType -> DT_SINT32 .)
+    PARAMETER       reduce using rule 93 (dataType -> DT_SINT32 .)
+    PRAGMA          reduce using rule 93 (dataType -> DT_SINT32 .)
+    PROPERTY        reduce using rule 93 (dataType -> DT_SINT32 .)
+    QUALIFIER       reduce using rule 93 (dataType -> DT_SINT32 .)
+    REFERENCE       reduce using rule 93 (dataType -> DT_SINT32 .)
+    RESTRICTED      reduce using rule 93 (dataType -> DT_SINT32 .)
+    SCHEMA          reduce using rule 93 (dataType -> DT_SINT32 .)
+    SCOPE           reduce using rule 93 (dataType -> DT_SINT32 .)
+    TOSUBCLASS      reduce using rule 93 (dataType -> DT_SINT32 .)
+    TOINSTANCE      reduce using rule 93 (dataType -> DT_SINT32 .)
+    TRANSLATABLE    reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_UINT8        reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_SINT8        reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_UINT16       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_SINT16       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_UINT32       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_SINT32       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_UINT64       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_SINT64       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_REAL32       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_REAL64       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_CHAR16       reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_STR          reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_BOOL         reduce using rule 93 (dataType -> DT_SINT32 .)
+    DT_DATETIME     reduce using rule 93 (dataType -> DT_SINT32 .)
+    REF             reduce using rule 93 (dataType -> DT_SINT32 .)
+    ;               reduce using rule 93 (dataType -> DT_SINT32 .)
+    )               reduce using rule 93 (dataType -> DT_SINT32 .)
+
+
+state 54
+
+    (94) dataType -> DT_UINT64 .
+
+    :               reduce using rule 94 (dataType -> DT_UINT64 .)
+    (               reduce using rule 94 (dataType -> DT_UINT64 .)
+    {               reduce using rule 94 (dataType -> DT_UINT64 .)
+    ]               reduce using rule 94 (dataType -> DT_UINT64 .)
+    ,               reduce using rule 94 (dataType -> DT_UINT64 .)
+    AS              reduce using rule 94 (dataType -> DT_UINT64 .)
+    [               reduce using rule 94 (dataType -> DT_UINT64 .)
+    =               reduce using rule 94 (dataType -> DT_UINT64 .)
+    IDENTIFIER      reduce using rule 94 (dataType -> DT_UINT64 .)
+    ANY             reduce using rule 94 (dataType -> DT_UINT64 .)
+    CLASS           reduce using rule 94 (dataType -> DT_UINT64 .)
+    DISABLEOVERRIDE reduce using rule 94 (dataType -> DT_UINT64 .)
+    ENABLEOVERRIDE  reduce using rule 94 (dataType -> DT_UINT64 .)
+    FLAVOR          reduce using rule 94 (dataType -> DT_UINT64 .)
+    INSTANCE        reduce using rule 94 (dataType -> DT_UINT64 .)
+    METHOD          reduce using rule 94 (dataType -> DT_UINT64 .)
+    OF              reduce using rule 94 (dataType -> DT_UINT64 .)
+    PARAMETER       reduce using rule 94 (dataType -> DT_UINT64 .)
+    PRAGMA          reduce using rule 94 (dataType -> DT_UINT64 .)
+    PROPERTY        reduce using rule 94 (dataType -> DT_UINT64 .)
+    QUALIFIER       reduce using rule 94 (dataType -> DT_UINT64 .)
+    REFERENCE       reduce using rule 94 (dataType -> DT_UINT64 .)
+    RESTRICTED      reduce using rule 94 (dataType -> DT_UINT64 .)
+    SCHEMA          reduce using rule 94 (dataType -> DT_UINT64 .)
+    SCOPE           reduce using rule 94 (dataType -> DT_UINT64 .)
+    TOSUBCLASS      reduce using rule 94 (dataType -> DT_UINT64 .)
+    TOINSTANCE      reduce using rule 94 (dataType -> DT_UINT64 .)
+    TRANSLATABLE    reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_UINT8        reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_SINT8        reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_UINT16       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_SINT16       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_UINT32       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_SINT32       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_UINT64       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_SINT64       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_REAL32       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_REAL64       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_CHAR16       reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_STR          reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_BOOL         reduce using rule 94 (dataType -> DT_UINT64 .)
+    DT_DATETIME     reduce using rule 94 (dataType -> DT_UINT64 .)
+    REF             reduce using rule 94 (dataType -> DT_UINT64 .)
+    ;               reduce using rule 94 (dataType -> DT_UINT64 .)
+    )               reduce using rule 94 (dataType -> DT_UINT64 .)
+
+
+state 55
+
+    (95) dataType -> DT_SINT64 .
+
+    :               reduce using rule 95 (dataType -> DT_SINT64 .)
+    (               reduce using rule 95 (dataType -> DT_SINT64 .)
+    {               reduce using rule 95 (dataType -> DT_SINT64 .)
+    ]               reduce using rule 95 (dataType -> DT_SINT64 .)
+    ,               reduce using rule 95 (dataType -> DT_SINT64 .)
+    AS              reduce using rule 95 (dataType -> DT_SINT64 .)
+    [               reduce using rule 95 (dataType -> DT_SINT64 .)
+    =               reduce using rule 95 (dataType -> DT_SINT64 .)
+    IDENTIFIER      reduce using rule 95 (dataType -> DT_SINT64 .)
+    ANY             reduce using rule 95 (dataType -> DT_SINT64 .)
+    CLASS           reduce using rule 95 (dataType -> DT_SINT64 .)
+    DISABLEOVERRIDE reduce using rule 95 (dataType -> DT_SINT64 .)
+    ENABLEOVERRIDE  reduce using rule 95 (dataType -> DT_SINT64 .)
+    FLAVOR          reduce using rule 95 (dataType -> DT_SINT64 .)
+    INSTANCE        reduce using rule 95 (dataType -> DT_SINT64 .)
+    METHOD          reduce using rule 95 (dataType -> DT_SINT64 .)
+    OF              reduce using rule 95 (dataType -> DT_SINT64 .)
+    PARAMETER       reduce using rule 95 (dataType -> DT_SINT64 .)
+    PRAGMA          reduce using rule 95 (dataType -> DT_SINT64 .)
+    PROPERTY        reduce using rule 95 (dataType -> DT_SINT64 .)
+    QUALIFIER       reduce using rule 95 (dataType -> DT_SINT64 .)
+    REFERENCE       reduce using rule 95 (dataType -> DT_SINT64 .)
+    RESTRICTED      reduce using rule 95 (dataType -> DT_SINT64 .)
+    SCHEMA          reduce using rule 95 (dataType -> DT_SINT64 .)
+    SCOPE           reduce using rule 95 (dataType -> DT_SINT64 .)
+    TOSUBCLASS      reduce using rule 95 (dataType -> DT_SINT64 .)
+    TOINSTANCE      reduce using rule 95 (dataType -> DT_SINT64 .)
+    TRANSLATABLE    reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_UINT8        reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_SINT8        reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_UINT16       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_SINT16       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_UINT32       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_SINT32       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_UINT64       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_SINT64       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_REAL32       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_REAL64       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_CHAR16       reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_STR          reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_BOOL         reduce using rule 95 (dataType -> DT_SINT64 .)
+    DT_DATETIME     reduce using rule 95 (dataType -> DT_SINT64 .)
+    REF             reduce using rule 95 (dataType -> DT_SINT64 .)
+    ;               reduce using rule 95 (dataType -> DT_SINT64 .)
+    )               reduce using rule 95 (dataType -> DT_SINT64 .)
+
+
+state 56
+
+    (96) dataType -> DT_REAL32 .
+
+    :               reduce using rule 96 (dataType -> DT_REAL32 .)
+    (               reduce using rule 96 (dataType -> DT_REAL32 .)
+    {               reduce using rule 96 (dataType -> DT_REAL32 .)
+    ]               reduce using rule 96 (dataType -> DT_REAL32 .)
+    ,               reduce using rule 96 (dataType -> DT_REAL32 .)
+    AS              reduce using rule 96 (dataType -> DT_REAL32 .)
+    [               reduce using rule 96 (dataType -> DT_REAL32 .)
+    =               reduce using rule 96 (dataType -> DT_REAL32 .)
+    IDENTIFIER      reduce using rule 96 (dataType -> DT_REAL32 .)
+    ANY             reduce using rule 96 (dataType -> DT_REAL32 .)
+    CLASS           reduce using rule 96 (dataType -> DT_REAL32 .)
+    DISABLEOVERRIDE reduce using rule 96 (dataType -> DT_REAL32 .)
+    ENABLEOVERRIDE  reduce using rule 96 (dataType -> DT_REAL32 .)
+    FLAVOR          reduce using rule 96 (dataType -> DT_REAL32 .)
+    INSTANCE        reduce using rule 96 (dataType -> DT_REAL32 .)
+    METHOD          reduce using rule 96 (dataType -> DT_REAL32 .)
+    OF              reduce using rule 96 (dataType -> DT_REAL32 .)
+    PARAMETER       reduce using rule 96 (dataType -> DT_REAL32 .)
+    PRAGMA          reduce using rule 96 (dataType -> DT_REAL32 .)
+    PROPERTY        reduce using rule 96 (dataType -> DT_REAL32 .)
+    QUALIFIER       reduce using rule 96 (dataType -> DT_REAL32 .)
+    REFERENCE       reduce using rule 96 (dataType -> DT_REAL32 .)
+    RESTRICTED      reduce using rule 96 (dataType -> DT_REAL32 .)
+    SCHEMA          reduce using rule 96 (dataType -> DT_REAL32 .)
+    SCOPE           reduce using rule 96 (dataType -> DT_REAL32 .)
+    TOSUBCLASS      reduce using rule 96 (dataType -> DT_REAL32 .)
+    TOINSTANCE      reduce using rule 96 (dataType -> DT_REAL32 .)
+    TRANSLATABLE    reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_UINT8        reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_SINT8        reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_UINT16       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_SINT16       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_UINT32       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_SINT32       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_UINT64       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_SINT64       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_REAL32       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_REAL64       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_CHAR16       reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_STR          reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_BOOL         reduce using rule 96 (dataType -> DT_REAL32 .)
+    DT_DATETIME     reduce using rule 96 (dataType -> DT_REAL32 .)
+    REF             reduce using rule 96 (dataType -> DT_REAL32 .)
+    ;               reduce using rule 96 (dataType -> DT_REAL32 .)
+    )               reduce using rule 96 (dataType -> DT_REAL32 .)
+
+
+state 57
+
+    (97) dataType -> DT_REAL64 .
+
+    :               reduce using rule 97 (dataType -> DT_REAL64 .)
+    (               reduce using rule 97 (dataType -> DT_REAL64 .)
+    {               reduce using rule 97 (dataType -> DT_REAL64 .)
+    ]               reduce using rule 97 (dataType -> DT_REAL64 .)
+    ,               reduce using rule 97 (dataType -> DT_REAL64 .)
+    AS              reduce using rule 97 (dataType -> DT_REAL64 .)
+    [               reduce using rule 97 (dataType -> DT_REAL64 .)
+    =               reduce using rule 97 (dataType -> DT_REAL64 .)
+    IDENTIFIER      reduce using rule 97 (dataType -> DT_REAL64 .)
+    ANY             reduce using rule 97 (dataType -> DT_REAL64 .)
+    CLASS           reduce using rule 97 (dataType -> DT_REAL64 .)
+    DISABLEOVERRIDE reduce using rule 97 (dataType -> DT_REAL64 .)
+    ENABLEOVERRIDE  reduce using rule 97 (dataType -> DT_REAL64 .)
+    FLAVOR          reduce using rule 97 (dataType -> DT_REAL64 .)
+    INSTANCE        reduce using rule 97 (dataType -> DT_REAL64 .)
+    METHOD          reduce using rule 97 (dataType -> DT_REAL64 .)
+    OF              reduce using rule 97 (dataType -> DT_REAL64 .)
+    PARAMETER       reduce using rule 97 (dataType -> DT_REAL64 .)
+    PRAGMA          reduce using rule 97 (dataType -> DT_REAL64 .)
+    PROPERTY        reduce using rule 97 (dataType -> DT_REAL64 .)
+    QUALIFIER       reduce using rule 97 (dataType -> DT_REAL64 .)
+    REFERENCE       reduce using rule 97 (dataType -> DT_REAL64 .)
+    RESTRICTED      reduce using rule 97 (dataType -> DT_REAL64 .)
+    SCHEMA          reduce using rule 97 (dataType -> DT_REAL64 .)
+    SCOPE           reduce using rule 97 (dataType -> DT_REAL64 .)
+    TOSUBCLASS      reduce using rule 97 (dataType -> DT_REAL64 .)
+    TOINSTANCE      reduce using rule 97 (dataType -> DT_REAL64 .)
+    TRANSLATABLE    reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_UINT8        reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_SINT8        reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_UINT16       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_SINT16       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_UINT32       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_SINT32       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_UINT64       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_SINT64       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_REAL32       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_REAL64       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_CHAR16       reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_STR          reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_BOOL         reduce using rule 97 (dataType -> DT_REAL64 .)
+    DT_DATETIME     reduce using rule 97 (dataType -> DT_REAL64 .)
+    REF             reduce using rule 97 (dataType -> DT_REAL64 .)
+    ;               reduce using rule 97 (dataType -> DT_REAL64 .)
+    )               reduce using rule 97 (dataType -> DT_REAL64 .)
+
+
+state 58
+
+    (98) dataType -> DT_CHAR16 .
+
+    :               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    (               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    {               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    ]               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    ,               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    AS              reduce using rule 98 (dataType -> DT_CHAR16 .)
+    [               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    =               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    IDENTIFIER      reduce using rule 98 (dataType -> DT_CHAR16 .)
+    ANY             reduce using rule 98 (dataType -> DT_CHAR16 .)
+    CLASS           reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DISABLEOVERRIDE reduce using rule 98 (dataType -> DT_CHAR16 .)
+    ENABLEOVERRIDE  reduce using rule 98 (dataType -> DT_CHAR16 .)
+    FLAVOR          reduce using rule 98 (dataType -> DT_CHAR16 .)
+    INSTANCE        reduce using rule 98 (dataType -> DT_CHAR16 .)
+    METHOD          reduce using rule 98 (dataType -> DT_CHAR16 .)
+    OF              reduce using rule 98 (dataType -> DT_CHAR16 .)
+    PARAMETER       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    PRAGMA          reduce using rule 98 (dataType -> DT_CHAR16 .)
+    PROPERTY        reduce using rule 98 (dataType -> DT_CHAR16 .)
+    QUALIFIER       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    REFERENCE       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    RESTRICTED      reduce using rule 98 (dataType -> DT_CHAR16 .)
+    SCHEMA          reduce using rule 98 (dataType -> DT_CHAR16 .)
+    SCOPE           reduce using rule 98 (dataType -> DT_CHAR16 .)
+    TOSUBCLASS      reduce using rule 98 (dataType -> DT_CHAR16 .)
+    TOINSTANCE      reduce using rule 98 (dataType -> DT_CHAR16 .)
+    TRANSLATABLE    reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_UINT8        reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_SINT8        reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_UINT16       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_SINT16       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_UINT32       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_SINT32       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_UINT64       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_SINT64       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_REAL32       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_REAL64       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_CHAR16       reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_STR          reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_BOOL         reduce using rule 98 (dataType -> DT_CHAR16 .)
+    DT_DATETIME     reduce using rule 98 (dataType -> DT_CHAR16 .)
+    REF             reduce using rule 98 (dataType -> DT_CHAR16 .)
+    ;               reduce using rule 98 (dataType -> DT_CHAR16 .)
+    )               reduce using rule 98 (dataType -> DT_CHAR16 .)
+
+
+state 59
+
+    (99) dataType -> DT_STR .
+
+    :               reduce using rule 99 (dataType -> DT_STR .)
+    (               reduce using rule 99 (dataType -> DT_STR .)
+    {               reduce using rule 99 (dataType -> DT_STR .)
+    ]               reduce using rule 99 (dataType -> DT_STR .)
+    ,               reduce using rule 99 (dataType -> DT_STR .)
+    AS              reduce using rule 99 (dataType -> DT_STR .)
+    [               reduce using rule 99 (dataType -> DT_STR .)
+    =               reduce using rule 99 (dataType -> DT_STR .)
+    IDENTIFIER      reduce using rule 99 (dataType -> DT_STR .)
+    ANY             reduce using rule 99 (dataType -> DT_STR .)
+    CLASS           reduce using rule 99 (dataType -> DT_STR .)
+    DISABLEOVERRIDE reduce using rule 99 (dataType -> DT_STR .)
+    ENABLEOVERRIDE  reduce using rule 99 (dataType -> DT_STR .)
+    FLAVOR          reduce using rule 99 (dataType -> DT_STR .)
+    INSTANCE        reduce using rule 99 (dataType -> DT_STR .)
+    METHOD          reduce using rule 99 (dataType -> DT_STR .)
+    OF              reduce using rule 99 (dataType -> DT_STR .)
+    PARAMETER       reduce using rule 99 (dataType -> DT_STR .)
+    PRAGMA          reduce using rule 99 (dataType -> DT_STR .)
+    PROPERTY        reduce using rule 99 (dataType -> DT_STR .)
+    QUALIFIER       reduce using rule 99 (dataType -> DT_STR .)
+    REFERENCE       reduce using rule 99 (dataType -> DT_STR .)
+    RESTRICTED      reduce using rule 99 (dataType -> DT_STR .)
+    SCHEMA          reduce using rule 99 (dataType -> DT_STR .)
+    SCOPE           reduce using rule 99 (dataType -> DT_STR .)
+    TOSUBCLASS      reduce using rule 99 (dataType -> DT_STR .)
+    TOINSTANCE      reduce using rule 99 (dataType -> DT_STR .)
+    TRANSLATABLE    reduce using rule 99 (dataType -> DT_STR .)
+    DT_UINT8        reduce using rule 99 (dataType -> DT_STR .)
+    DT_SINT8        reduce using rule 99 (dataType -> DT_STR .)
+    DT_UINT16       reduce using rule 99 (dataType -> DT_STR .)
+    DT_SINT16       reduce using rule 99 (dataType -> DT_STR .)
+    DT_UINT32       reduce using rule 99 (dataType -> DT_STR .)
+    DT_SINT32       reduce using rule 99 (dataType -> DT_STR .)
+    DT_UINT64       reduce using rule 99 (dataType -> DT_STR .)
+    DT_SINT64       reduce using rule 99 (dataType -> DT_STR .)
+    DT_REAL32       reduce using rule 99 (dataType -> DT_STR .)
+    DT_REAL64       reduce using rule 99 (dataType -> DT_STR .)
+    DT_CHAR16       reduce using rule 99 (dataType -> DT_STR .)
+    DT_STR          reduce using rule 99 (dataType -> DT_STR .)
+    DT_BOOL         reduce using rule 99 (dataType -> DT_STR .)
+    DT_DATETIME     reduce using rule 99 (dataType -> DT_STR .)
+    REF             reduce using rule 99 (dataType -> DT_STR .)
+    ;               reduce using rule 99 (dataType -> DT_STR .)
+    )               reduce using rule 99 (dataType -> DT_STR .)
+
+
+state 60
+
+    (100) dataType -> DT_BOOL .
+
+    :               reduce using rule 100 (dataType -> DT_BOOL .)
+    (               reduce using rule 100 (dataType -> DT_BOOL .)
+    {               reduce using rule 100 (dataType -> DT_BOOL .)
+    ]               reduce using rule 100 (dataType -> DT_BOOL .)
+    ,               reduce using rule 100 (dataType -> DT_BOOL .)
+    AS              reduce using rule 100 (dataType -> DT_BOOL .)
+    [               reduce using rule 100 (dataType -> DT_BOOL .)
+    =               reduce using rule 100 (dataType -> DT_BOOL .)
+    IDENTIFIER      reduce using rule 100 (dataType -> DT_BOOL .)
+    ANY             reduce using rule 100 (dataType -> DT_BOOL .)
+    CLASS           reduce using rule 100 (dataType -> DT_BOOL .)
+    DISABLEOVERRIDE reduce using rule 100 (dataType -> DT_BOOL .)
+    ENABLEOVERRIDE  reduce using rule 100 (dataType -> DT_BOOL .)
+    FLAVOR          reduce using rule 100 (dataType -> DT_BOOL .)
+    INSTANCE        reduce using rule 100 (dataType -> DT_BOOL .)
+    METHOD          reduce using rule 100 (dataType -> DT_BOOL .)
+    OF              reduce using rule 100 (dataType -> DT_BOOL .)
+    PARAMETER       reduce using rule 100 (dataType -> DT_BOOL .)
+    PRAGMA          reduce using rule 100 (dataType -> DT_BOOL .)
+    PROPERTY        reduce using rule 100 (dataType -> DT_BOOL .)
+    QUALIFIER       reduce using rule 100 (dataType -> DT_BOOL .)
+    REFERENCE       reduce using rule 100 (dataType -> DT_BOOL .)
+    RESTRICTED      reduce using rule 100 (dataType -> DT_BOOL .)
+    SCHEMA          reduce using rule 100 (dataType -> DT_BOOL .)
+    SCOPE           reduce using rule 100 (dataType -> DT_BOOL .)
+    TOSUBCLASS      reduce using rule 100 (dataType -> DT_BOOL .)
+    TOINSTANCE      reduce using rule 100 (dataType -> DT_BOOL .)
+    TRANSLATABLE    reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_UINT8        reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_SINT8        reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_UINT16       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_SINT16       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_UINT32       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_SINT32       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_UINT64       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_SINT64       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_REAL32       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_REAL64       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_CHAR16       reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_STR          reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_BOOL         reduce using rule 100 (dataType -> DT_BOOL .)
+    DT_DATETIME     reduce using rule 100 (dataType -> DT_BOOL .)
+    REF             reduce using rule 100 (dataType -> DT_BOOL .)
+    ;               reduce using rule 100 (dataType -> DT_BOOL .)
+    )               reduce using rule 100 (dataType -> DT_BOOL .)
+
+
+state 61
+
+    (101) dataType -> DT_DATETIME .
+
+    :               reduce using rule 101 (dataType -> DT_DATETIME .)
+    (               reduce using rule 101 (dataType -> DT_DATETIME .)
+    {               reduce using rule 101 (dataType -> DT_DATETIME .)
+    ]               reduce using rule 101 (dataType -> DT_DATETIME .)
+    ,               reduce using rule 101 (dataType -> DT_DATETIME .)
+    AS              reduce using rule 101 (dataType -> DT_DATETIME .)
+    [               reduce using rule 101 (dataType -> DT_DATETIME .)
+    =               reduce using rule 101 (dataType -> DT_DATETIME .)
+    IDENTIFIER      reduce using rule 101 (dataType -> DT_DATETIME .)
+    ANY             reduce using rule 101 (dataType -> DT_DATETIME .)
+    CLASS           reduce using rule 101 (dataType -> DT_DATETIME .)
+    DISABLEOVERRIDE reduce using rule 101 (dataType -> DT_DATETIME .)
+    ENABLEOVERRIDE  reduce using rule 101 (dataType -> DT_DATETIME .)
+    FLAVOR          reduce using rule 101 (dataType -> DT_DATETIME .)
+    INSTANCE        reduce using rule 101 (dataType -> DT_DATETIME .)
+    METHOD          reduce using rule 101 (dataType -> DT_DATETIME .)
+    OF              reduce using rule 101 (dataType -> DT_DATETIME .)
+    PARAMETER       reduce using rule 101 (dataType -> DT_DATETIME .)
+    PRAGMA          reduce using rule 101 (dataType -> DT_DATETIME .)
+    PROPERTY        reduce using rule 101 (dataType -> DT_DATETIME .)
+    QUALIFIER       reduce using rule 101 (dataType -> DT_DATETIME .)
+    REFERENCE       reduce using rule 101 (dataType -> DT_DATETIME .)
+    RESTRICTED      reduce using rule 101 (dataType -> DT_DATETIME .)
+    SCHEMA          reduce using rule 101 (dataType -> DT_DATETIME .)
+    SCOPE           reduce using rule 101 (dataType -> DT_DATETIME .)
+    TOSUBCLASS      reduce using rule 101 (dataType -> DT_DATETIME .)
+    TOINSTANCE      reduce using rule 101 (dataType -> DT_DATETIME .)
+    TRANSLATABLE    reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_UINT8        reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_SINT8        reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_UINT16       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_SINT16       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_UINT32       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_SINT32       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_UINT64       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_SINT64       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_REAL32       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_REAL64       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_CHAR16       reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_STR          reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_BOOL         reduce using rule 101 (dataType -> DT_DATETIME .)
+    DT_DATETIME     reduce using rule 101 (dataType -> DT_DATETIME .)
+    REF             reduce using rule 101 (dataType -> DT_DATETIME .)
+    ;               reduce using rule 101 (dataType -> DT_DATETIME .)
+    )               reduce using rule 101 (dataType -> DT_DATETIME .)
+
+
+state 62
+
+    (16) classDeclaration -> CLASS className . { classFeatureList } ;
+    (17) classDeclaration -> CLASS className . superClass { classFeatureList } ;
+    (18) classDeclaration -> CLASS className . alias { classFeatureList } ;
+    (19) classDeclaration -> CLASS className . alias superClass { classFeatureList } ;
+    (41) superClass -> . : className
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 81
+    :               shift and go to state 84
+    AS              shift and go to state 85
+
+    superClass                     shift and go to state 82
+    alias                          shift and go to state 83
+
+state 63
+
+    (38) className -> identifier .
+
+    {               reduce using rule 38 (className -> identifier .)
+    :               reduce using rule 38 (className -> identifier .)
+    AS              reduce using rule 38 (className -> identifier .)
+    REF             reduce using rule 38 (className -> identifier .)
+
+
+state 64
+
+    (20) classDeclaration -> qualifierList CLASS . className { classFeatureList } ;
+    (21) classDeclaration -> qualifierList CLASS . className superClass { classFeatureList } ;
+    (22) classDeclaration -> qualifierList CLASS . className alias { classFeatureList } ;
+    (23) classDeclaration -> qualifierList CLASS . className alias superClass { classFeatureList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 86
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 65
+
+    (172) instanceDeclaration -> qualifierList INSTANCE . OF className { valueInitializerList } ;
+    (173) instanceDeclaration -> qualifierList INSTANCE . OF className alias { valueInitializerList } ;
+
+    OF              shift and go to state 87
+
+
+state 66
+
+    (143) qualifierDeclaration -> QUALIFIER qualifierName . qualifierType scope ;
+    (144) qualifierDeclaration -> QUALIFIER qualifierName . qualifierType scope defaultFlavor ;
+    (148) qualifierType -> . qualifierType_1
+    (149) qualifierType -> . qualifierType_2
+    (150) qualifierType_1 -> . : dataType array
+    (151) qualifierType_1 -> . : dataType array defaultValue
+    (152) qualifierType_2 -> . : dataType
+    (153) qualifierType_2 -> . : dataType defaultValue
+
+    :               shift and go to state 91
+
+    qualifierType                  shift and go to state 88
+    qualifierType_1                shift and go to state 89
+    qualifierType_2                shift and go to state 90
+
+state 67
+
+    (146) qualifierName -> ASSOCIATION .
+
+    :               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    (               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    {               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ]               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ,               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+
+
+state 68
+
+    (147) qualifierName -> INDICATION .
+
+    :               reduce using rule 147 (qualifierName -> INDICATION .)
+    (               reduce using rule 147 (qualifierName -> INDICATION .)
+    {               reduce using rule 147 (qualifierName -> INDICATION .)
+    ]               reduce using rule 147 (qualifierName -> INDICATION .)
+    ,               reduce using rule 147 (qualifierName -> INDICATION .)
+
+
+state 69
+
+    (170) instanceDeclaration -> INSTANCE OF . className { valueInitializerList } ;
+    (171) instanceDeclaration -> INSTANCE OF . className alias { valueInitializerList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 92
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 70
+
+    (13) compilerDirective -> # PRAGMA pragmaName . ( pragmaParameter )
+
+    (               shift and go to state 93
+
+
+state 71
+
+    (14) pragmaName -> identifier .
+
+    (               reduce using rule 14 (pragmaName -> identifier .)
+
+
+state 72
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty . ] CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty . ] CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty . ] CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty . ] CLASS className alias superClass { associationFeatureList } ;
+    (35) qualifierListEmpty -> qualifierListEmpty . , qualifier
+
+    ]               shift and go to state 94
+    ,               shift and go to state 95
+
+
+state 73
+
+    (34) qualifierListEmpty -> empty .
+
+    ]               reduce using rule 34 (qualifierListEmpty -> empty .)
+    ,               reduce using rule 34 (qualifierListEmpty -> empty .)
+
+
+state 74
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty . ] CLASS className { classFeatureList } ;
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty . ] CLASS className superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty . ] CLASS className alias { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty . ] CLASS className alias superClass { classFeatureList } ;
+    (35) qualifierListEmpty -> qualifierListEmpty . , qualifier
+
+    ]               shift and go to state 96
+    ,               shift and go to state 95
+
+
+state 75
+
+    (46) qualifierList -> [ qualifier qualifierListEmpty . ]
+    (35) qualifierListEmpty -> qualifierListEmpty . , qualifier
+
+    ]               shift and go to state 97
+    ,               shift and go to state 95
+
+
+state 76
+
+    (48) qualifier -> qualifierName : . flavorList
+    (51) flavorList -> . flavor
+    (52) flavorList -> . flavorList flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavorList                     shift and go to state 98
+    flavor                         shift and go to state 99
+
+state 77
+
+    (49) qualifier -> qualifierName qualifierParameter .
+    (50) qualifier -> qualifierName qualifierParameter . : flavorList
+
+    ]               reduce using rule 49 (qualifier -> qualifierName qualifierParameter .)
+    ,               reduce using rule 49 (qualifier -> qualifierName qualifierParameter .)
+    :               shift and go to state 106
+
+
+state 78
+
+    (53) qualifierParameter -> ( . constantValue )
+    (130) constantValue -> . integerValue
+    (131) constantValue -> . floatValue
+    (132) constantValue -> . charValue
+    (133) constantValue -> . stringValueList
+    (134) constantValue -> . booleanValue
+    (135) constantValue -> . nullValue
+    (136) integerValue -> . binaryValue
+    (137) integerValue -> . octalValue
+    (138) integerValue -> . decimalValue
+    (139) integerValue -> . hexValue
+    (128) stringValueList -> . stringValue
+    (129) stringValueList -> . stringValueList stringValue
+    (178) booleanValue -> . FALSE
+    (179) booleanValue -> . TRUE
+    (180) nullValue -> . NULL
+
+    floatValue      shift and go to state 109
+    charValue       shift and go to state 110
+    binaryValue     shift and go to state 114
+    octalValue      shift and go to state 115
+    decimalValue    shift and go to state 116
+    hexValue        shift and go to state 117
+    stringValue     shift and go to state 118
+    FALSE           shift and go to state 119
+    TRUE            shift and go to state 120
+    NULL            shift and go to state 121
+
+    constantValue                  shift and go to state 107
+    integerValue                   shift and go to state 108
+    stringValueList                shift and go to state 111
+    booleanValue                   shift and go to state 112
+    nullValue                      shift and go to state 113
+
+state 79
+
+    (54) qualifierParameter -> arrayInitializer .
+
+    :               reduce using rule 54 (qualifierParameter -> arrayInitializer .)
+    ]               reduce using rule 54 (qualifierParameter -> arrayInitializer .)
+    ,               reduce using rule 54 (qualifierParameter -> arrayInitializer .)
+
+
+state 80
+
+    (124) arrayInitializer -> { . constantValueList }
+    (125) arrayInitializer -> { . }
+    (126) constantValueList -> . constantValue
+    (127) constantValueList -> . constantValueList , constantValue
+    (130) constantValue -> . integerValue
+    (131) constantValue -> . floatValue
+    (132) constantValue -> . charValue
+    (133) constantValue -> . stringValueList
+    (134) constantValue -> . booleanValue
+    (135) constantValue -> . nullValue
+    (136) integerValue -> . binaryValue
+    (137) integerValue -> . octalValue
+    (138) integerValue -> . decimalValue
+    (139) integerValue -> . hexValue
+    (128) stringValueList -> . stringValue
+    (129) stringValueList -> . stringValueList stringValue
+    (178) booleanValue -> . FALSE
+    (179) booleanValue -> . TRUE
+    (180) nullValue -> . NULL
+
+    }               shift and go to state 123
+    floatValue      shift and go to state 109
+    charValue       shift and go to state 110
+    binaryValue     shift and go to state 114
+    octalValue      shift and go to state 115
+    decimalValue    shift and go to state 116
+    hexValue        shift and go to state 117
+    stringValue     shift and go to state 118
+    FALSE           shift and go to state 119
+    TRUE            shift and go to state 120
+    NULL            shift and go to state 121
+
+    constantValueList              shift and go to state 122
+    constantValue                  shift and go to state 124
+    integerValue                   shift and go to state 108
+    stringValueList                shift and go to state 111
+    booleanValue                   shift and go to state 112
+    nullValue                      shift and go to state 113
+
+state 81
+
+    (16) classDeclaration -> CLASS className { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 125
+    empty                          shift and go to state 126
+
+state 82
+
+    (17) classDeclaration -> CLASS className superClass . { classFeatureList } ;
+
+    {               shift and go to state 127
+
+
+state 83
+
+    (18) classDeclaration -> CLASS className alias . { classFeatureList } ;
+    (19) classDeclaration -> CLASS className alias . superClass { classFeatureList } ;
+    (41) superClass -> . : className
+
+    {               shift and go to state 128
+    :               shift and go to state 84
+
+    superClass                     shift and go to state 129
+
+state 84
+
+    (41) superClass -> : . className
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 130
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 85
+
+    (39) alias -> AS . aliasIdentifier
+    (40) aliasIdentifier -> . $ identifier
+
+    $               shift and go to state 132
+
+    aliasIdentifier                shift and go to state 131
+
+state 86
+
+    (20) classDeclaration -> qualifierList CLASS className . { classFeatureList } ;
+    (21) classDeclaration -> qualifierList CLASS className . superClass { classFeatureList } ;
+    (22) classDeclaration -> qualifierList CLASS className . alias { classFeatureList } ;
+    (23) classDeclaration -> qualifierList CLASS className . alias superClass { classFeatureList } ;
+    (41) superClass -> . : className
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 133
+    :               shift and go to state 84
+    AS              shift and go to state 85
+
+    superClass                     shift and go to state 134
+    alias                          shift and go to state 135
+
+state 87
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF . className { valueInitializerList } ;
+    (173) instanceDeclaration -> qualifierList INSTANCE OF . className alias { valueInitializerList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 136
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 88
+
+    (143) qualifierDeclaration -> QUALIFIER qualifierName qualifierType . scope ;
+    (144) qualifierDeclaration -> QUALIFIER qualifierName qualifierType . scope defaultFlavor ;
+    (154) scope -> . , SCOPE ( metaElementList )
+
+    ,               shift and go to state 138
+
+    scope                          shift and go to state 137
+
+state 89
+
+    (148) qualifierType -> qualifierType_1 .
+
+    ,               reduce using rule 148 (qualifierType -> qualifierType_1 .)
+
+
+state 90
+
+    (149) qualifierType -> qualifierType_2 .
+
+    ,               reduce using rule 149 (qualifierType -> qualifierType_2 .)
+
+
+state 91
+
+    (150) qualifierType_1 -> : . dataType array
+    (151) qualifierType_1 -> : . dataType array defaultValue
+    (152) qualifierType_2 -> : . dataType
+    (153) qualifierType_2 -> : . dataType defaultValue
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    dataType                       shift and go to state 139
+
+state 92
+
+    (170) instanceDeclaration -> INSTANCE OF className . { valueInitializerList } ;
+    (171) instanceDeclaration -> INSTANCE OF className . alias { valueInitializerList } ;
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 140
+    AS              shift and go to state 85
+
+    alias                          shift and go to state 141
+
+state 93
+
+    (13) compilerDirective -> # PRAGMA pragmaName ( . pragmaParameter )
+    (15) pragmaParameter -> . stringValue
+
+    stringValue     shift and go to state 143
+
+    pragmaParameter                shift and go to state 142
+
+state 94
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] . CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] . CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] . CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] . CLASS className alias superClass { associationFeatureList } ;
+
+    CLASS           shift and go to state 144
+
+
+state 95
+
+    (35) qualifierListEmpty -> qualifierListEmpty , . qualifier
+    (47) qualifier -> . qualifierName
+    (48) qualifier -> . qualifierName : flavorList
+    (49) qualifier -> . qualifierName qualifierParameter
+    (50) qualifier -> . qualifierName qualifierParameter : flavorList
+    (145) qualifierName -> . identifier
+    (146) qualifierName -> . ASSOCIATION
+    (147) qualifierName -> . INDICATION
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 67
+    INDICATION      shift and go to state 68
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifier                      shift and go to state 145
+    qualifierName                  shift and go to state 25
+    identifier                     shift and go to state 26
+    dataType                       shift and go to state 31
+
+state 96
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] . CLASS className { classFeatureList } ;
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] . CLASS className superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] . CLASS className alias { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] . CLASS className alias superClass { classFeatureList } ;
+
+    CLASS           shift and go to state 146
+
+
+state 97
+
+    (46) qualifierList -> [ qualifier qualifierListEmpty ] .
+
+    CLASS           reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    INSTANCE        reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT8        reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT8        reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT16       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT16       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT32       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT32       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT64       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT64       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_REAL32       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_REAL64       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_CHAR16       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_STR          reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_BOOL         reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_DATETIME     reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    IDENTIFIER      reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    ANY             reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    AS              reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DISABLEOVERRIDE reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    ENABLEOVERRIDE  reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    FLAVOR          reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    METHOD          reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    OF              reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PARAMETER       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PRAGMA          reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PROPERTY        reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    QUALIFIER       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    REFERENCE       reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    RESTRICTED      reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    SCHEMA          reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    SCOPE           reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TOSUBCLASS      reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TOINSTANCE      reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TRANSLATABLE    reduce using rule 46 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+
+
+state 98
+
+    (48) qualifier -> qualifierName : flavorList .
+    (52) flavorList -> flavorList . flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ]               reduce using rule 48 (qualifier -> qualifierName : flavorList .)
+    ,               reduce using rule 48 (qualifier -> qualifierName : flavorList .)
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavor                         shift and go to state 147
+
+state 99
+
+    (51) flavorList -> flavor .
+
+    ENABLEOVERRIDE  reduce using rule 51 (flavorList -> flavor .)
+    DISABLEOVERRIDE reduce using rule 51 (flavorList -> flavor .)
+    RESTRICTED      reduce using rule 51 (flavorList -> flavor .)
+    TOSUBCLASS      reduce using rule 51 (flavorList -> flavor .)
+    TOINSTANCE      reduce using rule 51 (flavorList -> flavor .)
+    TRANSLATABLE    reduce using rule 51 (flavorList -> flavor .)
+    ]               reduce using rule 51 (flavorList -> flavor .)
+    ,               reduce using rule 51 (flavorList -> flavor .)
+
+
+state 100
+
+    (55) flavor -> ENABLEOVERRIDE .
+
+    ENABLEOVERRIDE  reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    DISABLEOVERRIDE reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    RESTRICTED      reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    TOSUBCLASS      reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    TOINSTANCE      reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    TRANSLATABLE    reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    ]               reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    ,               reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+    )               reduce using rule 55 (flavor -> ENABLEOVERRIDE .)
+
+
+state 101
+
+    (56) flavor -> DISABLEOVERRIDE .
+
+    ENABLEOVERRIDE  reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    DISABLEOVERRIDE reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    RESTRICTED      reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    TOSUBCLASS      reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    TOINSTANCE      reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    TRANSLATABLE    reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    ]               reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    ,               reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+    )               reduce using rule 56 (flavor -> DISABLEOVERRIDE .)
+
+
+state 102
+
+    (57) flavor -> RESTRICTED .
+
+    ENABLEOVERRIDE  reduce using rule 57 (flavor -> RESTRICTED .)
+    DISABLEOVERRIDE reduce using rule 57 (flavor -> RESTRICTED .)
+    RESTRICTED      reduce using rule 57 (flavor -> RESTRICTED .)
+    TOSUBCLASS      reduce using rule 57 (flavor -> RESTRICTED .)
+    TOINSTANCE      reduce using rule 57 (flavor -> RESTRICTED .)
+    TRANSLATABLE    reduce using rule 57 (flavor -> RESTRICTED .)
+    ]               reduce using rule 57 (flavor -> RESTRICTED .)
+    ,               reduce using rule 57 (flavor -> RESTRICTED .)
+    )               reduce using rule 57 (flavor -> RESTRICTED .)
+
+
+state 103
+
+    (58) flavor -> TOSUBCLASS .
+
+    ENABLEOVERRIDE  reduce using rule 58 (flavor -> TOSUBCLASS .)
+    DISABLEOVERRIDE reduce using rule 58 (flavor -> TOSUBCLASS .)
+    RESTRICTED      reduce using rule 58 (flavor -> TOSUBCLASS .)
+    TOSUBCLASS      reduce using rule 58 (flavor -> TOSUBCLASS .)
+    TOINSTANCE      reduce using rule 58 (flavor -> TOSUBCLASS .)
+    TRANSLATABLE    reduce using rule 58 (flavor -> TOSUBCLASS .)
+    ]               reduce using rule 58 (flavor -> TOSUBCLASS .)
+    ,               reduce using rule 58 (flavor -> TOSUBCLASS .)
+    )               reduce using rule 58 (flavor -> TOSUBCLASS .)
+
+
+state 104
+
+    (59) flavor -> TOINSTANCE .
+
+    ENABLEOVERRIDE  reduce using rule 59 (flavor -> TOINSTANCE .)
+    DISABLEOVERRIDE reduce using rule 59 (flavor -> TOINSTANCE .)
+    RESTRICTED      reduce using rule 59 (flavor -> TOINSTANCE .)
+    TOSUBCLASS      reduce using rule 59 (flavor -> TOINSTANCE .)
+    TOINSTANCE      reduce using rule 59 (flavor -> TOINSTANCE .)
+    TRANSLATABLE    reduce using rule 59 (flavor -> TOINSTANCE .)
+    ]               reduce using rule 59 (flavor -> TOINSTANCE .)
+    ,               reduce using rule 59 (flavor -> TOINSTANCE .)
+    )               reduce using rule 59 (flavor -> TOINSTANCE .)
+
+
+state 105
+
+    (60) flavor -> TRANSLATABLE .
+
+    ENABLEOVERRIDE  reduce using rule 60 (flavor -> TRANSLATABLE .)
+    DISABLEOVERRIDE reduce using rule 60 (flavor -> TRANSLATABLE .)
+    RESTRICTED      reduce using rule 60 (flavor -> TRANSLATABLE .)
+    TOSUBCLASS      reduce using rule 60 (flavor -> TRANSLATABLE .)
+    TOINSTANCE      reduce using rule 60 (flavor -> TRANSLATABLE .)
+    TRANSLATABLE    reduce using rule 60 (flavor -> TRANSLATABLE .)
+    ]               reduce using rule 60 (flavor -> TRANSLATABLE .)
+    ,               reduce using rule 60 (flavor -> TRANSLATABLE .)
+    )               reduce using rule 60 (flavor -> TRANSLATABLE .)
+
+
+state 106
+
+    (50) qualifier -> qualifierName qualifierParameter : . flavorList
+    (51) flavorList -> . flavor
+    (52) flavorList -> . flavorList flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavorList                     shift and go to state 148
+    flavor                         shift and go to state 99
+
+state 107
+
+    (53) qualifierParameter -> ( constantValue . )
+
+    )               shift and go to state 149
+
+
+state 108
+
+    (130) constantValue -> integerValue .
+
+    )               reduce using rule 130 (constantValue -> integerValue .)
+    }               reduce using rule 130 (constantValue -> integerValue .)
+    ,               reduce using rule 130 (constantValue -> integerValue .)
+    ;               reduce using rule 130 (constantValue -> integerValue .)
+
+
+state 109
+
+    (131) constantValue -> floatValue .
+
+    )               reduce using rule 131 (constantValue -> floatValue .)
+    }               reduce using rule 131 (constantValue -> floatValue .)
+    ,               reduce using rule 131 (constantValue -> floatValue .)
+    ;               reduce using rule 131 (constantValue -> floatValue .)
+
+
+state 110
+
+    (132) constantValue -> charValue .
+
+    )               reduce using rule 132 (constantValue -> charValue .)
+    }               reduce using rule 132 (constantValue -> charValue .)
+    ,               reduce using rule 132 (constantValue -> charValue .)
+    ;               reduce using rule 132 (constantValue -> charValue .)
+
+
+state 111
+
+    (133) constantValue -> stringValueList .
+    (129) stringValueList -> stringValueList . stringValue
+
+    )               reduce using rule 133 (constantValue -> stringValueList .)
+    }               reduce using rule 133 (constantValue -> stringValueList .)
+    ,               reduce using rule 133 (constantValue -> stringValueList .)
+    ;               reduce using rule 133 (constantValue -> stringValueList .)
+    stringValue     shift and go to state 150
+
+
+state 112
+
+    (134) constantValue -> booleanValue .
+
+    )               reduce using rule 134 (constantValue -> booleanValue .)
+    }               reduce using rule 134 (constantValue -> booleanValue .)
+    ,               reduce using rule 134 (constantValue -> booleanValue .)
+    ;               reduce using rule 134 (constantValue -> booleanValue .)
+
+
+state 113
+
+    (135) constantValue -> nullValue .
+
+    )               reduce using rule 135 (constantValue -> nullValue .)
+    }               reduce using rule 135 (constantValue -> nullValue .)
+    ,               reduce using rule 135 (constantValue -> nullValue .)
+    ;               reduce using rule 135 (constantValue -> nullValue .)
+
+
+state 114
+
+    (136) integerValue -> binaryValue .
+
+    )               reduce using rule 136 (integerValue -> binaryValue .)
+    }               reduce using rule 136 (integerValue -> binaryValue .)
+    ,               reduce using rule 136 (integerValue -> binaryValue .)
+    ]               reduce using rule 136 (integerValue -> binaryValue .)
+    ;               reduce using rule 136 (integerValue -> binaryValue .)
+
+
+state 115
+
+    (137) integerValue -> octalValue .
+
+    )               reduce using rule 137 (integerValue -> octalValue .)
+    }               reduce using rule 137 (integerValue -> octalValue .)
+    ,               reduce using rule 137 (integerValue -> octalValue .)
+    ]               reduce using rule 137 (integerValue -> octalValue .)
+    ;               reduce using rule 137 (integerValue -> octalValue .)
+
+
+state 116
+
+    (138) integerValue -> decimalValue .
+
+    )               reduce using rule 138 (integerValue -> decimalValue .)
+    }               reduce using rule 138 (integerValue -> decimalValue .)
+    ,               reduce using rule 138 (integerValue -> decimalValue .)
+    ]               reduce using rule 138 (integerValue -> decimalValue .)
+    ;               reduce using rule 138 (integerValue -> decimalValue .)
+
+
+state 117
+
+    (139) integerValue -> hexValue .
+
+    )               reduce using rule 139 (integerValue -> hexValue .)
+    }               reduce using rule 139 (integerValue -> hexValue .)
+    ,               reduce using rule 139 (integerValue -> hexValue .)
+    ]               reduce using rule 139 (integerValue -> hexValue .)
+    ;               reduce using rule 139 (integerValue -> hexValue .)
+
+
+state 118
+
+    (128) stringValueList -> stringValue .
+
+    stringValue     reduce using rule 128 (stringValueList -> stringValue .)
+    )               reduce using rule 128 (stringValueList -> stringValue .)
+    }               reduce using rule 128 (stringValueList -> stringValue .)
+    ,               reduce using rule 128 (stringValueList -> stringValue .)
+    ;               reduce using rule 128 (stringValueList -> stringValue .)
+
+
+state 119
+
+    (178) booleanValue -> FALSE .
+
+    )               reduce using rule 178 (booleanValue -> FALSE .)
+    }               reduce using rule 178 (booleanValue -> FALSE .)
+    ,               reduce using rule 178 (booleanValue -> FALSE .)
+    ;               reduce using rule 178 (booleanValue -> FALSE .)
+
+
+state 120
+
+    (179) booleanValue -> TRUE .
+
+    )               reduce using rule 179 (booleanValue -> TRUE .)
+    }               reduce using rule 179 (booleanValue -> TRUE .)
+    ,               reduce using rule 179 (booleanValue -> TRUE .)
+    ;               reduce using rule 179 (booleanValue -> TRUE .)
+
+
+state 121
+
+    (180) nullValue -> NULL .
+
+    )               reduce using rule 180 (nullValue -> NULL .)
+    }               reduce using rule 180 (nullValue -> NULL .)
+    ,               reduce using rule 180 (nullValue -> NULL .)
+    ;               reduce using rule 180 (nullValue -> NULL .)
+
+
+state 122
+
+    (124) arrayInitializer -> { constantValueList . }
+    (127) constantValueList -> constantValueList . , constantValue
+
+    }               shift and go to state 151
+    ,               shift and go to state 152
+
+
+state 123
+
+    (125) arrayInitializer -> { } .
+
+    :               reduce using rule 125 (arrayInitializer -> { } .)
+    ]               reduce using rule 125 (arrayInitializer -> { } .)
+    ,               reduce using rule 125 (arrayInitializer -> { } .)
+    ;               reduce using rule 125 (arrayInitializer -> { } .)
+
+
+state 124
+
+    (126) constantValueList -> constantValue .
+
+    }               reduce using rule 126 (constantValueList -> constantValue .)
+    ,               reduce using rule 126 (constantValueList -> constantValue .)
+
+
+state 125
+
+    (16) classDeclaration -> CLASS className { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 154
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 126
+
+    (24) classFeatureList -> empty .
+
+    }               reduce using rule 24 (classFeatureList -> empty .)
+    DT_UINT8        reduce using rule 24 (classFeatureList -> empty .)
+    DT_SINT8        reduce using rule 24 (classFeatureList -> empty .)
+    DT_UINT16       reduce using rule 24 (classFeatureList -> empty .)
+    DT_SINT16       reduce using rule 24 (classFeatureList -> empty .)
+    DT_UINT32       reduce using rule 24 (classFeatureList -> empty .)
+    DT_SINT32       reduce using rule 24 (classFeatureList -> empty .)
+    DT_UINT64       reduce using rule 24 (classFeatureList -> empty .)
+    DT_SINT64       reduce using rule 24 (classFeatureList -> empty .)
+    DT_REAL32       reduce using rule 24 (classFeatureList -> empty .)
+    DT_REAL64       reduce using rule 24 (classFeatureList -> empty .)
+    DT_CHAR16       reduce using rule 24 (classFeatureList -> empty .)
+    DT_STR          reduce using rule 24 (classFeatureList -> empty .)
+    DT_BOOL         reduce using rule 24 (classFeatureList -> empty .)
+    DT_DATETIME     reduce using rule 24 (classFeatureList -> empty .)
+    [               reduce using rule 24 (classFeatureList -> empty .)
+    IDENTIFIER      reduce using rule 24 (classFeatureList -> empty .)
+    ANY             reduce using rule 24 (classFeatureList -> empty .)
+    AS              reduce using rule 24 (classFeatureList -> empty .)
+    CLASS           reduce using rule 24 (classFeatureList -> empty .)
+    DISABLEOVERRIDE reduce using rule 24 (classFeatureList -> empty .)
+    ENABLEOVERRIDE  reduce using rule 24 (classFeatureList -> empty .)
+    FLAVOR          reduce using rule 24 (classFeatureList -> empty .)
+    INSTANCE        reduce using rule 24 (classFeatureList -> empty .)
+    METHOD          reduce using rule 24 (classFeatureList -> empty .)
+    OF              reduce using rule 24 (classFeatureList -> empty .)
+    PARAMETER       reduce using rule 24 (classFeatureList -> empty .)
+    PRAGMA          reduce using rule 24 (classFeatureList -> empty .)
+    PROPERTY        reduce using rule 24 (classFeatureList -> empty .)
+    QUALIFIER       reduce using rule 24 (classFeatureList -> empty .)
+    REFERENCE       reduce using rule 24 (classFeatureList -> empty .)
+    RESTRICTED      reduce using rule 24 (classFeatureList -> empty .)
+    SCHEMA          reduce using rule 24 (classFeatureList -> empty .)
+    SCOPE           reduce using rule 24 (classFeatureList -> empty .)
+    TOSUBCLASS      reduce using rule 24 (classFeatureList -> empty .)
+    TOINSTANCE      reduce using rule 24 (classFeatureList -> empty .)
+    TRANSLATABLE    reduce using rule 24 (classFeatureList -> empty .)
+
+
+state 127
+
+    (17) classDeclaration -> CLASS className superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 171
+    empty                          shift and go to state 126
+
+state 128
+
+    (18) classDeclaration -> CLASS className alias { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 172
+    empty                          shift and go to state 126
+
+state 129
+
+    (19) classDeclaration -> CLASS className alias superClass . { classFeatureList } ;
+
+    {               shift and go to state 173
+
+
+state 130
+
+    (41) superClass -> : className .
+
+    {               reduce using rule 41 (superClass -> : className .)
+
+
+state 131
+
+    (39) alias -> AS aliasIdentifier .
+
+    {               reduce using rule 39 (alias -> AS aliasIdentifier .)
+    :               reduce using rule 39 (alias -> AS aliasIdentifier .)
+
+
+state 132
+
+    (40) aliasIdentifier -> $ . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    identifier                     shift and go to state 174
+    dataType                       shift and go to state 31
+
+state 133
+
+    (20) classDeclaration -> qualifierList CLASS className { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 175
+    empty                          shift and go to state 126
+
+state 134
+
+    (21) classDeclaration -> qualifierList CLASS className superClass . { classFeatureList } ;
+
+    {               shift and go to state 176
+
+
+state 135
+
+    (22) classDeclaration -> qualifierList CLASS className alias . { classFeatureList } ;
+    (23) classDeclaration -> qualifierList CLASS className alias . superClass { classFeatureList } ;
+    (41) superClass -> . : className
+
+    {               shift and go to state 177
+    :               shift and go to state 84
+
+    superClass                     shift and go to state 178
+
+state 136
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF className . { valueInitializerList } ;
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className . alias { valueInitializerList } ;
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 179
+    AS              shift and go to state 85
+
+    alias                          shift and go to state 180
+
+state 137
+
+    (143) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope . ;
+    (144) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope . defaultFlavor ;
+    (167) defaultFlavor -> . , FLAVOR ( flavorListWithComma )
+
+    ;               shift and go to state 181
+    ,               shift and go to state 183
+
+    defaultFlavor                  shift and go to state 182
+
+state 138
+
+    (154) scope -> , . SCOPE ( metaElementList )
+
+    SCOPE           shift and go to state 184
+
+
+state 139
+
+    (150) qualifierType_1 -> : dataType . array
+    (151) qualifierType_1 -> : dataType . array defaultValue
+    (152) qualifierType_2 -> : dataType .
+    (153) qualifierType_2 -> : dataType . defaultValue
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+    (120) defaultValue -> . = initializer
+
+    ,               reduce using rule 152 (qualifierType_2 -> : dataType .)
+    [               shift and go to state 187
+    =               shift and go to state 188
+
+    array                          shift and go to state 185
+    defaultValue                   shift and go to state 186
+
+state 140
+
+    (170) instanceDeclaration -> INSTANCE OF className { . valueInitializerList } ;
+    (174) valueInitializerList -> . valueInitializer
+    (175) valueInitializerList -> . valueInitializerList valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    valueInitializerList           shift and go to state 189
+    valueInitializer               shift and go to state 190
+    identifier                     shift and go to state 191
+    qualifierList                  shift and go to state 192
+    dataType                       shift and go to state 31
+
+state 141
+
+    (171) instanceDeclaration -> INSTANCE OF className alias . { valueInitializerList } ;
+
+    {               shift and go to state 193
+
+
+state 142
+
+    (13) compilerDirective -> # PRAGMA pragmaName ( pragmaParameter . )
+
+    )               shift and go to state 194
+
+
+state 143
+
+    (15) pragmaParameter -> stringValue .
+
+    )               reduce using rule 15 (pragmaParameter -> stringValue .)
+
+
+state 144
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS . className { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS . className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS . className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS . className alias superClass { associationFeatureList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 195
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 145
+
+    (35) qualifierListEmpty -> qualifierListEmpty , qualifier .
+
+    ]               reduce using rule 35 (qualifierListEmpty -> qualifierListEmpty , qualifier .)
+    ,               reduce using rule 35 (qualifierListEmpty -> qualifierListEmpty , qualifier .)
+
+
+state 146
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS . className { classFeatureList } ;
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS . className superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS . className alias { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS . className alias superClass { classFeatureList } ;
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    className                      shift and go to state 196
+    identifier                     shift and go to state 63
+    dataType                       shift and go to state 31
+
+state 147
+
+    (52) flavorList -> flavorList flavor .
+
+    ENABLEOVERRIDE  reduce using rule 52 (flavorList -> flavorList flavor .)
+    DISABLEOVERRIDE reduce using rule 52 (flavorList -> flavorList flavor .)
+    RESTRICTED      reduce using rule 52 (flavorList -> flavorList flavor .)
+    TOSUBCLASS      reduce using rule 52 (flavorList -> flavorList flavor .)
+    TOINSTANCE      reduce using rule 52 (flavorList -> flavorList flavor .)
+    TRANSLATABLE    reduce using rule 52 (flavorList -> flavorList flavor .)
+    ]               reduce using rule 52 (flavorList -> flavorList flavor .)
+    ,               reduce using rule 52 (flavorList -> flavorList flavor .)
+
+
+state 148
+
+    (50) qualifier -> qualifierName qualifierParameter : flavorList .
+    (52) flavorList -> flavorList . flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ]               reduce using rule 50 (qualifier -> qualifierName qualifierParameter : flavorList .)
+    ,               reduce using rule 50 (qualifier -> qualifierName qualifierParameter : flavorList .)
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavor                         shift and go to state 147
+
+state 149
+
+    (53) qualifierParameter -> ( constantValue ) .
+
+    :               reduce using rule 53 (qualifierParameter -> ( constantValue ) .)
+    ]               reduce using rule 53 (qualifierParameter -> ( constantValue ) .)
+    ,               reduce using rule 53 (qualifierParameter -> ( constantValue ) .)
+
+
+state 150
+
+    (129) stringValueList -> stringValueList stringValue .
+
+    stringValue     reduce using rule 129 (stringValueList -> stringValueList stringValue .)
+    )               reduce using rule 129 (stringValueList -> stringValueList stringValue .)
+    }               reduce using rule 129 (stringValueList -> stringValueList stringValue .)
+    ,               reduce using rule 129 (stringValueList -> stringValueList stringValue .)
+    ;               reduce using rule 129 (stringValueList -> stringValueList stringValue .)
+
+
+state 151
+
+    (124) arrayInitializer -> { constantValueList } .
+
+    :               reduce using rule 124 (arrayInitializer -> { constantValueList } .)
+    ]               reduce using rule 124 (arrayInitializer -> { constantValueList } .)
+    ,               reduce using rule 124 (arrayInitializer -> { constantValueList } .)
+    ;               reduce using rule 124 (arrayInitializer -> { constantValueList } .)
+
+
+state 152
+
+    (127) constantValueList -> constantValueList , . constantValue
+    (130) constantValue -> . integerValue
+    (131) constantValue -> . floatValue
+    (132) constantValue -> . charValue
+    (133) constantValue -> . stringValueList
+    (134) constantValue -> . booleanValue
+    (135) constantValue -> . nullValue
+    (136) integerValue -> . binaryValue
+    (137) integerValue -> . octalValue
+    (138) integerValue -> . decimalValue
+    (139) integerValue -> . hexValue
+    (128) stringValueList -> . stringValue
+    (129) stringValueList -> . stringValueList stringValue
+    (178) booleanValue -> . FALSE
+    (179) booleanValue -> . TRUE
+    (180) nullValue -> . NULL
+
+    floatValue      shift and go to state 109
+    charValue       shift and go to state 110
+    binaryValue     shift and go to state 114
+    octalValue      shift and go to state 115
+    decimalValue    shift and go to state 116
+    hexValue        shift and go to state 117
+    stringValue     shift and go to state 118
+    FALSE           shift and go to state 119
+    TRUE            shift and go to state 120
+    NULL            shift and go to state 121
+
+    constantValue                  shift and go to state 197
+    integerValue                   shift and go to state 108
+    stringValueList                shift and go to state 111
+    booleanValue                   shift and go to state 112
+    nullValue                      shift and go to state 113
+
+state 153
+
+    (102) objectRef -> className . REF
+
+    REF             shift and go to state 198
+
+
+state 154
+
+    (16) classDeclaration -> CLASS className { classFeatureList } . ;
+
+    ;               shift and go to state 199
+
+
+state 155
+
+    (25) classFeatureList -> classFeatureList classFeature .
+
+    }               reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT8        reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT8        reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT16       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT16       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT32       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT32       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT64       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT64       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_REAL32       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_REAL64       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_CHAR16       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_STR          reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_BOOL         reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DT_DATETIME     reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    [               reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    IDENTIFIER      reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    ANY             reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    AS              reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    CLASS           reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    DISABLEOVERRIDE reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    ENABLEOVERRIDE  reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    FLAVOR          reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    INSTANCE        reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    METHOD          reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    OF              reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    PARAMETER       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    PRAGMA          reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    PROPERTY        reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    QUALIFIER       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    REFERENCE       reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    RESTRICTED      reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    SCHEMA          reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    SCOPE           reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    TOSUBCLASS      reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    TOINSTANCE      reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+    TRANSLATABLE    reduce using rule 25 (classFeatureList -> classFeatureList classFeature .)
+
+
+state 156
+
+    (42) classFeature -> propertyDeclaration .
+
+    }               reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_UINT8        reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_SINT8        reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_UINT16       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_SINT16       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_UINT32       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_SINT32       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_UINT64       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_SINT64       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_REAL32       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_REAL64       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_CHAR16       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_STR          reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_BOOL         reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DT_DATETIME     reduce using rule 42 (classFeature -> propertyDeclaration .)
+    [               reduce using rule 42 (classFeature -> propertyDeclaration .)
+    IDENTIFIER      reduce using rule 42 (classFeature -> propertyDeclaration .)
+    ANY             reduce using rule 42 (classFeature -> propertyDeclaration .)
+    AS              reduce using rule 42 (classFeature -> propertyDeclaration .)
+    CLASS           reduce using rule 42 (classFeature -> propertyDeclaration .)
+    DISABLEOVERRIDE reduce using rule 42 (classFeature -> propertyDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 42 (classFeature -> propertyDeclaration .)
+    FLAVOR          reduce using rule 42 (classFeature -> propertyDeclaration .)
+    INSTANCE        reduce using rule 42 (classFeature -> propertyDeclaration .)
+    METHOD          reduce using rule 42 (classFeature -> propertyDeclaration .)
+    OF              reduce using rule 42 (classFeature -> propertyDeclaration .)
+    PARAMETER       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    PRAGMA          reduce using rule 42 (classFeature -> propertyDeclaration .)
+    PROPERTY        reduce using rule 42 (classFeature -> propertyDeclaration .)
+    QUALIFIER       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    REFERENCE       reduce using rule 42 (classFeature -> propertyDeclaration .)
+    RESTRICTED      reduce using rule 42 (classFeature -> propertyDeclaration .)
+    SCHEMA          reduce using rule 42 (classFeature -> propertyDeclaration .)
+    SCOPE           reduce using rule 42 (classFeature -> propertyDeclaration .)
+    TOSUBCLASS      reduce using rule 42 (classFeature -> propertyDeclaration .)
+    TOINSTANCE      reduce using rule 42 (classFeature -> propertyDeclaration .)
+    TRANSLATABLE    reduce using rule 42 (classFeature -> propertyDeclaration .)
+
+
+state 157
+
+    (43) classFeature -> methodDeclaration .
+
+    }               reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_UINT8        reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_SINT8        reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_UINT16       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_SINT16       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_UINT32       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_SINT32       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_UINT64       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_SINT64       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_REAL32       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_REAL64       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_CHAR16       reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_STR          reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_BOOL         reduce using rule 43 (classFeature -> methodDeclaration .)
+    DT_DATETIME     reduce using rule 43 (classFeature -> methodDeclaration .)
+    [               reduce using rule 43 (classFeature -> methodDeclaration .)
+    IDENTIFIER      reduce using rule 43 (classFeature -> methodDeclaration .)
+    ANY             reduce using rule 43 (classFeature -> methodDeclaration .)
+    AS              reduce using rule 43 (classFeature -> methodDeclaration .)
+    CLASS           reduce using rule 43 (classFeature -> methodDeclaration .)
+    DISABLEOVERRIDE reduce using rule 43 (classFeature -> methodDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 43 (classFeature -> methodDeclaration .)
+    FLAVOR          reduce using rule 43 (classFeature -> methodDeclaration .)
+    INSTANCE        reduce using rule 43 (classFeature -> methodDeclaration .)
+    METHOD          reduce using rule 43 (classFeature -> methodDeclaration .)
+    OF              reduce using rule 43 (classFeature -> methodDeclaration .)
+    PARAMETER       reduce using rule 43 (classFeature -> methodDeclaration .)
+    PRAGMA          reduce using rule 43 (classFeature -> methodDeclaration .)
+    PROPERTY        reduce using rule 43 (classFeature -> methodDeclaration .)
+    QUALIFIER       reduce using rule 43 (classFeature -> methodDeclaration .)
+    REFERENCE       reduce using rule 43 (classFeature -> methodDeclaration .)
+    RESTRICTED      reduce using rule 43 (classFeature -> methodDeclaration .)
+    SCHEMA          reduce using rule 43 (classFeature -> methodDeclaration .)
+    SCOPE           reduce using rule 43 (classFeature -> methodDeclaration .)
+    TOSUBCLASS      reduce using rule 43 (classFeature -> methodDeclaration .)
+    TOINSTANCE      reduce using rule 43 (classFeature -> methodDeclaration .)
+    TRANSLATABLE    reduce using rule 43 (classFeature -> methodDeclaration .)
+
+
+state 158
+
+    (44) classFeature -> referenceDeclaration .
+
+    }               reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_UINT8        reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_SINT8        reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_UINT16       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_SINT16       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_UINT32       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_SINT32       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_UINT64       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_SINT64       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_REAL32       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_REAL64       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_CHAR16       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_STR          reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_BOOL         reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DT_DATETIME     reduce using rule 44 (classFeature -> referenceDeclaration .)
+    [               reduce using rule 44 (classFeature -> referenceDeclaration .)
+    IDENTIFIER      reduce using rule 44 (classFeature -> referenceDeclaration .)
+    ANY             reduce using rule 44 (classFeature -> referenceDeclaration .)
+    AS              reduce using rule 44 (classFeature -> referenceDeclaration .)
+    CLASS           reduce using rule 44 (classFeature -> referenceDeclaration .)
+    DISABLEOVERRIDE reduce using rule 44 (classFeature -> referenceDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 44 (classFeature -> referenceDeclaration .)
+    FLAVOR          reduce using rule 44 (classFeature -> referenceDeclaration .)
+    INSTANCE        reduce using rule 44 (classFeature -> referenceDeclaration .)
+    METHOD          reduce using rule 44 (classFeature -> referenceDeclaration .)
+    OF              reduce using rule 44 (classFeature -> referenceDeclaration .)
+    PARAMETER       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    PRAGMA          reduce using rule 44 (classFeature -> referenceDeclaration .)
+    PROPERTY        reduce using rule 44 (classFeature -> referenceDeclaration .)
+    QUALIFIER       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    REFERENCE       reduce using rule 44 (classFeature -> referenceDeclaration .)
+    RESTRICTED      reduce using rule 44 (classFeature -> referenceDeclaration .)
+    SCHEMA          reduce using rule 44 (classFeature -> referenceDeclaration .)
+    SCOPE           reduce using rule 44 (classFeature -> referenceDeclaration .)
+    TOSUBCLASS      reduce using rule 44 (classFeature -> referenceDeclaration .)
+    TOINSTANCE      reduce using rule 44 (classFeature -> referenceDeclaration .)
+    TRANSLATABLE    reduce using rule 44 (classFeature -> referenceDeclaration .)
+
+
+state 159
+
+    (61) propertyDeclaration -> propertyDeclaration_1 .
+
+    }               reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT8        reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT8        reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT16       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT16       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT32       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT32       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT64       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT64       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_REAL32       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_REAL64       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_CHAR16       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_STR          reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_BOOL         reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_DATETIME     reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    [               reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    IDENTIFIER      reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    ANY             reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    AS              reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    CLASS           reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    DISABLEOVERRIDE reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    ENABLEOVERRIDE  reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    FLAVOR          reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    INSTANCE        reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    METHOD          reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    OF              reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    PARAMETER       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    PRAGMA          reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    PROPERTY        reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    QUALIFIER       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    REFERENCE       reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    RESTRICTED      reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    SCHEMA          reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    SCOPE           reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    TOSUBCLASS      reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    TOINSTANCE      reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+    TRANSLATABLE    reduce using rule 61 (propertyDeclaration -> propertyDeclaration_1 .)
+
+
+state 160
+
+    (62) propertyDeclaration -> propertyDeclaration_2 .
+
+    }               reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT8        reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT8        reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT16       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT16       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT32       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT32       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT64       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT64       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_REAL32       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_REAL64       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_CHAR16       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_STR          reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_BOOL         reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_DATETIME     reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    [               reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    IDENTIFIER      reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    ANY             reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    AS              reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    CLASS           reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    DISABLEOVERRIDE reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    ENABLEOVERRIDE  reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    FLAVOR          reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    INSTANCE        reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    METHOD          reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    OF              reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    PARAMETER       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    PRAGMA          reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    PROPERTY        reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    QUALIFIER       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    REFERENCE       reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    RESTRICTED      reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    SCHEMA          reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    SCOPE           reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    TOSUBCLASS      reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    TOINSTANCE      reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+    TRANSLATABLE    reduce using rule 62 (propertyDeclaration -> propertyDeclaration_2 .)
+
+
+state 161
+
+    (63) propertyDeclaration -> propertyDeclaration_3 .
+
+    }               reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT8        reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT8        reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT16       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT16       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT32       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT32       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT64       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT64       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_REAL32       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_REAL64       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_CHAR16       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_STR          reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_BOOL         reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_DATETIME     reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    [               reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    IDENTIFIER      reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    ANY             reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    AS              reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    CLASS           reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    DISABLEOVERRIDE reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    ENABLEOVERRIDE  reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    FLAVOR          reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    INSTANCE        reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    METHOD          reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    OF              reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    PARAMETER       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    PRAGMA          reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    PROPERTY        reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    QUALIFIER       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    REFERENCE       reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    RESTRICTED      reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    SCHEMA          reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    SCOPE           reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    TOSUBCLASS      reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    TOINSTANCE      reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+    TRANSLATABLE    reduce using rule 63 (propertyDeclaration -> propertyDeclaration_3 .)
+
+
+state 162
+
+    (64) propertyDeclaration -> propertyDeclaration_4 .
+
+    }               reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT8        reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT8        reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT16       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT16       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT32       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT32       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT64       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT64       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_REAL32       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_REAL64       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_CHAR16       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_STR          reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_BOOL         reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_DATETIME     reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    [               reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    IDENTIFIER      reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    ANY             reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    AS              reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    CLASS           reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    DISABLEOVERRIDE reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    ENABLEOVERRIDE  reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    FLAVOR          reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    INSTANCE        reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    METHOD          reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    OF              reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    PARAMETER       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    PRAGMA          reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    PROPERTY        reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    QUALIFIER       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    REFERENCE       reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    RESTRICTED      reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    SCHEMA          reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    SCOPE           reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    TOSUBCLASS      reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    TOINSTANCE      reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+    TRANSLATABLE    reduce using rule 64 (propertyDeclaration -> propertyDeclaration_4 .)
+
+
+state 163
+
+    (65) propertyDeclaration -> propertyDeclaration_5 .
+
+    }               reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT8        reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT8        reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT16       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT16       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT32       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT32       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT64       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT64       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_REAL32       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_REAL64       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_CHAR16       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_STR          reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_BOOL         reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_DATETIME     reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    [               reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    IDENTIFIER      reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    ANY             reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    AS              reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    CLASS           reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    DISABLEOVERRIDE reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    ENABLEOVERRIDE  reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    FLAVOR          reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    INSTANCE        reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    METHOD          reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    OF              reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    PARAMETER       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    PRAGMA          reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    PROPERTY        reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    QUALIFIER       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    REFERENCE       reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    RESTRICTED      reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    SCHEMA          reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    SCOPE           reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    TOSUBCLASS      reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    TOINSTANCE      reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+    TRANSLATABLE    reduce using rule 65 (propertyDeclaration -> propertyDeclaration_5 .)
+
+
+state 164
+
+    (66) propertyDeclaration -> propertyDeclaration_6 .
+
+    }               reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT8        reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT8        reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT16       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT16       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT32       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT32       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT64       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT64       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_REAL32       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_REAL64       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_CHAR16       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_STR          reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_BOOL         reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_DATETIME     reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    [               reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    IDENTIFIER      reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    ANY             reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    AS              reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    CLASS           reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    DISABLEOVERRIDE reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    ENABLEOVERRIDE  reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    FLAVOR          reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    INSTANCE        reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    METHOD          reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    OF              reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    PARAMETER       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    PRAGMA          reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    PROPERTY        reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    QUALIFIER       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    REFERENCE       reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    RESTRICTED      reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    SCHEMA          reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    SCOPE           reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    TOSUBCLASS      reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    TOINSTANCE      reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+    TRANSLATABLE    reduce using rule 66 (propertyDeclaration -> propertyDeclaration_6 .)
+
+
+state 165
+
+    (67) propertyDeclaration -> propertyDeclaration_7 .
+
+    }               reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT8        reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT8        reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT16       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT16       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT32       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT32       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT64       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT64       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_REAL32       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_REAL64       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_CHAR16       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_STR          reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_BOOL         reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_DATETIME     reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    [               reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    IDENTIFIER      reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    ANY             reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    AS              reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    CLASS           reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    DISABLEOVERRIDE reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    ENABLEOVERRIDE  reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    FLAVOR          reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    INSTANCE        reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    METHOD          reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    OF              reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    PARAMETER       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    PRAGMA          reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    PROPERTY        reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    QUALIFIER       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    REFERENCE       reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    RESTRICTED      reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    SCHEMA          reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    SCOPE           reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    TOSUBCLASS      reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    TOINSTANCE      reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+    TRANSLATABLE    reduce using rule 67 (propertyDeclaration -> propertyDeclaration_7 .)
+
+
+state 166
+
+    (68) propertyDeclaration -> propertyDeclaration_8 .
+
+    }               reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT8        reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT8        reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT16       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT16       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT32       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT32       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT64       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT64       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_REAL32       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_REAL64       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_CHAR16       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_STR          reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_BOOL         reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_DATETIME     reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    [               reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    IDENTIFIER      reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    ANY             reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    AS              reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    CLASS           reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    DISABLEOVERRIDE reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    ENABLEOVERRIDE  reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    FLAVOR          reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    INSTANCE        reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    METHOD          reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    OF              reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    PARAMETER       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    PRAGMA          reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    PROPERTY        reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    QUALIFIER       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    REFERENCE       reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    RESTRICTED      reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    SCHEMA          reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    SCOPE           reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    TOSUBCLASS      reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    TOINSTANCE      reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+    TRANSLATABLE    reduce using rule 68 (propertyDeclaration -> propertyDeclaration_8 .)
+
+
+state 167
+
+    (81) methodDeclaration -> dataType . methodName ( ) ;
+    (82) methodDeclaration -> dataType . methodName ( parameterList ) ;
+    (69) propertyDeclaration_1 -> dataType . propertyName ;
+    (70) propertyDeclaration_2 -> dataType . propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> dataType . propertyName array ;
+    (72) propertyDeclaration_4 -> dataType . propertyName array defaultValue ;
+    (186) identifier -> dataType .
+    (87) methodName -> . identifier
+    (85) propertyName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 186 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    dataType                       shift and go to state 31
+    methodName                     shift and go to state 200
+    propertyName                   shift and go to state 201
+    identifier                     shift and go to state 202
+
+state 168
+
+    (83) methodDeclaration -> qualifierList . dataType methodName ( ) ;
+    (84) methodDeclaration -> qualifierList . dataType methodName ( parameterList ) ;
+    (79) referenceDeclaration -> qualifierList . objectRef referenceName ;
+    (80) referenceDeclaration -> qualifierList . objectRef referenceName defaultValue ;
+    (73) propertyDeclaration_5 -> qualifierList . dataType propertyName ;
+    (74) propertyDeclaration_6 -> qualifierList . dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> qualifierList . dataType propertyName array ;
+    (76) propertyDeclaration_8 -> qualifierList . dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    dataType                       shift and go to state 203
+    objectRef                      shift and go to state 204
+    className                      shift and go to state 153
+    identifier                     shift and go to state 63
+
+state 169
+
+    (77) referenceDeclaration -> objectRef . referenceName ;
+    (78) referenceDeclaration -> objectRef . referenceName defaultValue ;
+    (86) referenceName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    referenceName                  shift and go to state 205
+    identifier                     shift and go to state 206
+    dataType                       shift and go to state 31
+
+state 170
+
+    (46) qualifierList -> [ . qualifier qualifierListEmpty ]
+    (47) qualifier -> . qualifierName
+    (48) qualifier -> . qualifierName : flavorList
+    (49) qualifier -> . qualifierName qualifierParameter
+    (50) qualifier -> . qualifierName qualifierParameter : flavorList
+    (145) qualifierName -> . identifier
+    (146) qualifierName -> . ASSOCIATION
+    (147) qualifierName -> . INDICATION
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 67
+    INDICATION      shift and go to state 68
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifier                      shift and go to state 24
+    qualifierName                  shift and go to state 25
+    identifier                     shift and go to state 26
+    dataType                       shift and go to state 31
+
+state 171
+
+    (17) classDeclaration -> CLASS className superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 207
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 172
+
+    (18) classDeclaration -> CLASS className alias { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 208
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 173
+
+    (19) classDeclaration -> CLASS className alias superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 209
+    empty                          shift and go to state 126
+
+state 174
+
+    (40) aliasIdentifier -> $ identifier .
+
+    {               reduce using rule 40 (aliasIdentifier -> $ identifier .)
+    :               reduce using rule 40 (aliasIdentifier -> $ identifier .)
+    ,               reduce using rule 40 (aliasIdentifier -> $ identifier .)
+    ;               reduce using rule 40 (aliasIdentifier -> $ identifier .)
+
+
+state 175
+
+    (20) classDeclaration -> qualifierList CLASS className { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 210
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    qualifierList                  shift and go to state 168
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 176
+
+    (21) classDeclaration -> qualifierList CLASS className superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 211
+    empty                          shift and go to state 126
+
+state 177
+
+    (22) classDeclaration -> qualifierList CLASS className alias { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 212
+    empty                          shift and go to state 126
+
+state 178
+
+    (23) classDeclaration -> qualifierList CLASS className alias superClass . { classFeatureList } ;
+
+    {               shift and go to state 213
+
+
+state 179
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF className { . valueInitializerList } ;
+    (174) valueInitializerList -> . valueInitializer
+    (175) valueInitializerList -> . valueInitializerList valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifierList                  shift and go to state 192
+    valueInitializerList           shift and go to state 214
+    valueInitializer               shift and go to state 190
+    identifier                     shift and go to state 191
+    dataType                       shift and go to state 31
+
+state 180
+
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className alias . { valueInitializerList } ;
+
+    {               shift and go to state 215
+
+
+state 181
+
+    (143) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .
+
+    #               reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    [               reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    CLASS           reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    QUALIFIER       reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    INSTANCE        reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    $end            reduce using rule 143 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+
+
+state 182
+
+    (144) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor . ;
+
+    ;               shift and go to state 216
+
+
+state 183
+
+    (167) defaultFlavor -> , . FLAVOR ( flavorListWithComma )
+
+    FLAVOR          shift and go to state 217
+
+
+state 184
+
+    (154) scope -> , SCOPE . ( metaElementList )
+
+    (               shift and go to state 218
+
+
+state 185
+
+    (150) qualifierType_1 -> : dataType array .
+    (151) qualifierType_1 -> : dataType array . defaultValue
+    (120) defaultValue -> . = initializer
+
+    ,               reduce using rule 150 (qualifierType_1 -> : dataType array .)
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 219
+
+state 186
+
+    (153) qualifierType_2 -> : dataType defaultValue .
+
+    ,               reduce using rule 153 (qualifierType_2 -> : dataType defaultValue .)
+
+
+state 187
+
+    (118) array -> [ . ]
+    (119) array -> [ . integerValue ]
+    (136) integerValue -> . binaryValue
+    (137) integerValue -> . octalValue
+    (138) integerValue -> . decimalValue
+    (139) integerValue -> . hexValue
+
+    ]               shift and go to state 220
+    binaryValue     shift and go to state 114
+    octalValue      shift and go to state 115
+    decimalValue    shift and go to state 116
+    hexValue        shift and go to state 117
+
+    integerValue                   shift and go to state 221
+
+state 188
+
+    (120) defaultValue -> = . initializer
+    (121) initializer -> . constantValue
+    (122) initializer -> . arrayInitializer
+    (123) initializer -> . referenceInitializer
+    (130) constantValue -> . integerValue
+    (131) constantValue -> . floatValue
+    (132) constantValue -> . charValue
+    (133) constantValue -> . stringValueList
+    (134) constantValue -> . booleanValue
+    (135) constantValue -> . nullValue
+    (124) arrayInitializer -> . { constantValueList }
+    (125) arrayInitializer -> . { }
+    (140) referenceInitializer -> . objectHandle
+    (141) referenceInitializer -> . aliasIdentifier
+    (136) integerValue -> . binaryValue
+    (137) integerValue -> . octalValue
+    (138) integerValue -> . decimalValue
+    (139) integerValue -> . hexValue
+    (128) stringValueList -> . stringValue
+    (129) stringValueList -> . stringValueList stringValue
+    (178) booleanValue -> . FALSE
+    (179) booleanValue -> . TRUE
+    (180) nullValue -> . NULL
+    (142) objectHandle -> . identifier
+    (40) aliasIdentifier -> . $ identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    floatValue      shift and go to state 109
+    charValue       shift and go to state 110
+    {               shift and go to state 80
+    binaryValue     shift and go to state 114
+    octalValue      shift and go to state 115
+    decimalValue    shift and go to state 116
+    hexValue        shift and go to state 117
+    stringValue     shift and go to state 118
+    FALSE           shift and go to state 119
+    TRUE            shift and go to state 120
+    NULL            shift and go to state 121
+    $               shift and go to state 132
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    initializer                    shift and go to state 222
+    constantValue                  shift and go to state 223
+    arrayInitializer               shift and go to state 224
+    referenceInitializer           shift and go to state 225
+    integerValue                   shift and go to state 108
+    stringValueList                shift and go to state 111
+    booleanValue                   shift and go to state 112
+    nullValue                      shift and go to state 113
+    objectHandle                   shift and go to state 226
+    aliasIdentifier                shift and go to state 227
+    identifier                     shift and go to state 228
+    dataType                       shift and go to state 31
+
+state 189
+
+    (170) instanceDeclaration -> INSTANCE OF className { valueInitializerList . } ;
+    (175) valueInitializerList -> valueInitializerList . valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    }               shift and go to state 229
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    valueInitializer               shift and go to state 230
+    identifier                     shift and go to state 191
+    qualifierList                  shift and go to state 192
+    dataType                       shift and go to state 31
+
+state 190
+
+    (174) valueInitializerList -> valueInitializer .
+
+    }               reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    IDENTIFIER      reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    ANY             reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    AS              reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    CLASS           reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DISABLEOVERRIDE reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    ENABLEOVERRIDE  reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    FLAVOR          reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    INSTANCE        reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    METHOD          reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    OF              reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    PARAMETER       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    PRAGMA          reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    PROPERTY        reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    QUALIFIER       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    REFERENCE       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    RESTRICTED      reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    SCHEMA          reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    SCOPE           reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    TOSUBCLASS      reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    TOINSTANCE      reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    TRANSLATABLE    reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    [               reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_UINT8        reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_SINT8        reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_UINT16       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_SINT16       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_UINT32       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_SINT32       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_UINT64       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_SINT64       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_REAL32       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_REAL64       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_CHAR16       reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_STR          reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_BOOL         reduce using rule 174 (valueInitializerList -> valueInitializer .)
+    DT_DATETIME     reduce using rule 174 (valueInitializerList -> valueInitializer .)
+
+
+state 191
+
+    (176) valueInitializer -> identifier . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 231
+
+state 192
+
+    (177) valueInitializer -> qualifierList . identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    identifier                     shift and go to state 232
+    dataType                       shift and go to state 31
+
+state 193
+
+    (171) instanceDeclaration -> INSTANCE OF className alias { . valueInitializerList } ;
+    (174) valueInitializerList -> . valueInitializer
+    (175) valueInitializerList -> . valueInitializerList valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    valueInitializerList           shift and go to state 233
+    valueInitializer               shift and go to state 190
+    identifier                     shift and go to state 191
+    qualifierList                  shift and go to state 192
+    dataType                       shift and go to state 31
+
+state 194
+
+    (13) compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .
+
+    #               reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    [               reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    CLASS           reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    QUALIFIER       reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    INSTANCE        reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    $end            reduce using rule 13 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+
+
+state 195
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className . { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className . superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className . alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className . alias superClass { associationFeatureList } ;
+    (41) superClass -> . : className
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 234
+    :               shift and go to state 84
+    AS              shift and go to state 85
+
+    superClass                     shift and go to state 235
+    alias                          shift and go to state 236
+
+state 196
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className . { classFeatureList } ;
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className . superClass { classFeatureList } ;
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className . alias { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className . alias superClass { classFeatureList } ;
+    (41) superClass -> . : className
+    (39) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 237
+    :               shift and go to state 84
+    AS              shift and go to state 85
+
+    superClass                     shift and go to state 238
+    alias                          shift and go to state 239
+
+state 197
+
+    (127) constantValueList -> constantValueList , constantValue .
+
+    }               reduce using rule 127 (constantValueList -> constantValueList , constantValue .)
+    ,               reduce using rule 127 (constantValueList -> constantValueList , constantValue .)
+
+
+state 198
+
+    (102) objectRef -> className REF .
+
+    IDENTIFIER      reduce using rule 102 (objectRef -> className REF .)
+    ANY             reduce using rule 102 (objectRef -> className REF .)
+    AS              reduce using rule 102 (objectRef -> className REF .)
+    CLASS           reduce using rule 102 (objectRef -> className REF .)
+    DISABLEOVERRIDE reduce using rule 102 (objectRef -> className REF .)
+    ENABLEOVERRIDE  reduce using rule 102 (objectRef -> className REF .)
+    FLAVOR          reduce using rule 102 (objectRef -> className REF .)
+    INSTANCE        reduce using rule 102 (objectRef -> className REF .)
+    METHOD          reduce using rule 102 (objectRef -> className REF .)
+    OF              reduce using rule 102 (objectRef -> className REF .)
+    PARAMETER       reduce using rule 102 (objectRef -> className REF .)
+    PRAGMA          reduce using rule 102 (objectRef -> className REF .)
+    PROPERTY        reduce using rule 102 (objectRef -> className REF .)
+    QUALIFIER       reduce using rule 102 (objectRef -> className REF .)
+    REFERENCE       reduce using rule 102 (objectRef -> className REF .)
+    RESTRICTED      reduce using rule 102 (objectRef -> className REF .)
+    SCHEMA          reduce using rule 102 (objectRef -> className REF .)
+    SCOPE           reduce using rule 102 (objectRef -> className REF .)
+    TOSUBCLASS      reduce using rule 102 (objectRef -> className REF .)
+    TOINSTANCE      reduce using rule 102 (objectRef -> className REF .)
+    TRANSLATABLE    reduce using rule 102 (objectRef -> className REF .)
+    DT_UINT8        reduce using rule 102 (objectRef -> className REF .)
+    DT_SINT8        reduce using rule 102 (objectRef -> className REF .)
+    DT_UINT16       reduce using rule 102 (objectRef -> className REF .)
+    DT_SINT16       reduce using rule 102 (objectRef -> className REF .)
+    DT_UINT32       reduce using rule 102 (objectRef -> className REF .)
+    DT_SINT32       reduce using rule 102 (objectRef -> className REF .)
+    DT_UINT64       reduce using rule 102 (objectRef -> className REF .)
+    DT_SINT64       reduce using rule 102 (objectRef -> className REF .)
+    DT_REAL32       reduce using rule 102 (objectRef -> className REF .)
+    DT_REAL64       reduce using rule 102 (objectRef -> className REF .)
+    DT_CHAR16       reduce using rule 102 (objectRef -> className REF .)
+    DT_STR          reduce using rule 102 (objectRef -> className REF .)
+    DT_BOOL         reduce using rule 102 (objectRef -> className REF .)
+    DT_DATETIME     reduce using rule 102 (objectRef -> className REF .)
+
+
+state 199
+
+    (16) classDeclaration -> CLASS className { classFeatureList } ; .
+
+    #               reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    [               reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    CLASS           reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    INSTANCE        reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    $end            reduce using rule 16 (classDeclaration -> CLASS className { classFeatureList } ; .)
+
+
+state 200
+
+    (81) methodDeclaration -> dataType methodName . ( ) ;
+    (82) methodDeclaration -> dataType methodName . ( parameterList ) ;
+
+    (               shift and go to state 240
+
+
+state 201
+
+    (69) propertyDeclaration_1 -> dataType propertyName . ;
+    (70) propertyDeclaration_2 -> dataType propertyName . defaultValue ;
+    (71) propertyDeclaration_3 -> dataType propertyName . array ;
+    (72) propertyDeclaration_4 -> dataType propertyName . array defaultValue ;
+    (120) defaultValue -> . = initializer
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    ;               shift and go to state 241
+    =               shift and go to state 188
+    [               shift and go to state 187
+
+    defaultValue                   shift and go to state 242
+    array                          shift and go to state 243
+
+state 202
+
+    (87) methodName -> identifier .
+    (85) propertyName -> identifier .
+
+    (               reduce using rule 87 (methodName -> identifier .)
+    ;               reduce using rule 85 (propertyName -> identifier .)
+    =               reduce using rule 85 (propertyName -> identifier .)
+    [               reduce using rule 85 (propertyName -> identifier .)
+
+
+state 203
+
+    (83) methodDeclaration -> qualifierList dataType . methodName ( ) ;
+    (84) methodDeclaration -> qualifierList dataType . methodName ( parameterList ) ;
+    (73) propertyDeclaration_5 -> qualifierList dataType . propertyName ;
+    (74) propertyDeclaration_6 -> qualifierList dataType . propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> qualifierList dataType . propertyName array ;
+    (76) propertyDeclaration_8 -> qualifierList dataType . propertyName array defaultValue ;
+    (186) identifier -> dataType .
+    (87) methodName -> . identifier
+    (85) propertyName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 186 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    dataType                       shift and go to state 31
+    methodName                     shift and go to state 244
+    propertyName                   shift and go to state 245
+    identifier                     shift and go to state 202
+
+state 204
+
+    (79) referenceDeclaration -> qualifierList objectRef . referenceName ;
+    (80) referenceDeclaration -> qualifierList objectRef . referenceName defaultValue ;
+    (86) referenceName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    referenceName                  shift and go to state 246
+    identifier                     shift and go to state 206
+    dataType                       shift and go to state 31
+
+state 205
+
+    (77) referenceDeclaration -> objectRef referenceName . ;
+    (78) referenceDeclaration -> objectRef referenceName . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    ;               shift and go to state 247
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 248
+
+state 206
+
+    (86) referenceName -> identifier .
+
+    ;               reduce using rule 86 (referenceName -> identifier .)
+    =               reduce using rule 86 (referenceName -> identifier .)
+
+
+state 207
+
+    (17) classDeclaration -> CLASS className superClass { classFeatureList } . ;
+
+    ;               shift and go to state 249
+
+
+state 208
+
+    (18) classDeclaration -> CLASS className alias { classFeatureList } . ;
+
+    ;               shift and go to state 250
+
+
+state 209
+
+    (19) classDeclaration -> CLASS className alias superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 251
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 210
+
+    (20) classDeclaration -> qualifierList CLASS className { classFeatureList } . ;
+
+    ;               shift and go to state 252
+
+
+state 211
+
+    (21) classDeclaration -> qualifierList CLASS className superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 253
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    qualifierList                  shift and go to state 168
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 212
+
+    (22) classDeclaration -> qualifierList CLASS className alias { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 254
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    qualifierList                  shift and go to state 168
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 213
+
+    (23) classDeclaration -> qualifierList CLASS className alias superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 255
+    empty                          shift and go to state 126
+
+state 214
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList . } ;
+    (175) valueInitializerList -> valueInitializerList . valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    }               shift and go to state 256
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifierList                  shift and go to state 192
+    valueInitializer               shift and go to state 230
+    identifier                     shift and go to state 191
+    dataType                       shift and go to state 31
+
+state 215
+
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className alias { . valueInitializerList } ;
+    (174) valueInitializerList -> . valueInitializer
+    (175) valueInitializerList -> . valueInitializerList valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifierList                  shift and go to state 192
+    valueInitializerList           shift and go to state 257
+    valueInitializer               shift and go to state 190
+    identifier                     shift and go to state 191
+    dataType                       shift and go to state 31
+
+state 216
+
+    (144) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .
+
+    #               reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    [               reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    CLASS           reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    QUALIFIER       reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    INSTANCE        reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    $end            reduce using rule 144 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+
+
+state 217
+
+    (167) defaultFlavor -> , FLAVOR . ( flavorListWithComma )
+
+    (               shift and go to state 258
+
+
+state 218
+
+    (154) scope -> , SCOPE ( . metaElementList )
+    (155) metaElementList -> . metaElement
+    (156) metaElementList -> . metaElementList , metaElement
+    (157) metaElement -> . SCHEMA
+    (158) metaElement -> . CLASS
+    (159) metaElement -> . ASSOCIATION
+    (160) metaElement -> . INDICATION
+    (161) metaElement -> . QUALIFIER
+    (162) metaElement -> . PROPERTY
+    (163) metaElement -> . REFERENCE
+    (164) metaElement -> . METHOD
+    (165) metaElement -> . PARAMETER
+    (166) metaElement -> . ANY
+
+    SCHEMA          shift and go to state 261
+    CLASS           shift and go to state 262
+    ASSOCIATION     shift and go to state 263
+    INDICATION      shift and go to state 264
+    QUALIFIER       shift and go to state 265
+    PROPERTY        shift and go to state 266
+    REFERENCE       shift and go to state 267
+    METHOD          shift and go to state 268
+    PARAMETER       shift and go to state 269
+    ANY             shift and go to state 270
+
+    metaElementList                shift and go to state 259
+    metaElement                    shift and go to state 260
+
+state 219
+
+    (151) qualifierType_1 -> : dataType array defaultValue .
+
+    ,               reduce using rule 151 (qualifierType_1 -> : dataType array defaultValue .)
+
+
+state 220
+
+    (118) array -> [ ] .
+
+    =               reduce using rule 118 (array -> [ ] .)
+    ,               reduce using rule 118 (array -> [ ] .)
+    ;               reduce using rule 118 (array -> [ ] .)
+    )               reduce using rule 118 (array -> [ ] .)
+
+
+state 221
+
+    (119) array -> [ integerValue . ]
+
+    ]               shift and go to state 271
+
+
+state 222
+
+    (120) defaultValue -> = initializer .
+
+    ,               reduce using rule 120 (defaultValue -> = initializer .)
+    ;               reduce using rule 120 (defaultValue -> = initializer .)
+
+
+state 223
+
+    (121) initializer -> constantValue .
+
+    ,               reduce using rule 121 (initializer -> constantValue .)
+    ;               reduce using rule 121 (initializer -> constantValue .)
+
+
+state 224
+
+    (122) initializer -> arrayInitializer .
+
+    ,               reduce using rule 122 (initializer -> arrayInitializer .)
+    ;               reduce using rule 122 (initializer -> arrayInitializer .)
+
+
+state 225
+
+    (123) initializer -> referenceInitializer .
+
+    ,               reduce using rule 123 (initializer -> referenceInitializer .)
+    ;               reduce using rule 123 (initializer -> referenceInitializer .)
+
+
+state 226
+
+    (140) referenceInitializer -> objectHandle .
+
+    ,               reduce using rule 140 (referenceInitializer -> objectHandle .)
+    ;               reduce using rule 140 (referenceInitializer -> objectHandle .)
+
+
+state 227
+
+    (141) referenceInitializer -> aliasIdentifier .
+
+    ,               reduce using rule 141 (referenceInitializer -> aliasIdentifier .)
+    ;               reduce using rule 141 (referenceInitializer -> aliasIdentifier .)
+
+
+state 228
+
+    (142) objectHandle -> identifier .
+
+    ,               reduce using rule 142 (objectHandle -> identifier .)
+    ;               reduce using rule 142 (objectHandle -> identifier .)
+
+
+state 229
+
+    (170) instanceDeclaration -> INSTANCE OF className { valueInitializerList } . ;
+
+    ;               shift and go to state 272
+
+
+state 230
+
+    (175) valueInitializerList -> valueInitializerList valueInitializer .
+
+    }               reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    IDENTIFIER      reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    ANY             reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    AS              reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    CLASS           reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DISABLEOVERRIDE reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    ENABLEOVERRIDE  reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    FLAVOR          reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    INSTANCE        reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    METHOD          reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    OF              reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PARAMETER       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PRAGMA          reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PROPERTY        reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    QUALIFIER       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    REFERENCE       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    RESTRICTED      reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    SCHEMA          reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    SCOPE           reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TOSUBCLASS      reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TOINSTANCE      reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TRANSLATABLE    reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    [               reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT8        reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT8        reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT16       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT16       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT32       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT32       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT64       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT64       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_REAL32       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_REAL64       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_CHAR16       reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_STR          reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_BOOL         reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_DATETIME     reduce using rule 175 (valueInitializerList -> valueInitializerList valueInitializer .)
+
+
+state 231
+
+    (176) valueInitializer -> identifier defaultValue . ;
+
+    ;               shift and go to state 273
+
+
+state 232
+
+    (177) valueInitializer -> qualifierList identifier . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 274
+
+state 233
+
+    (171) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList . } ;
+    (175) valueInitializerList -> valueInitializerList . valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    }               shift and go to state 275
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    valueInitializer               shift and go to state 230
+    identifier                     shift and go to state 191
+    qualifierList                  shift and go to state 192
+    dataType                       shift and go to state 31
+
+state 234
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { . associationFeatureList } ;
+    (36) associationFeatureList -> . empty
+    (37) associationFeatureList -> . associationFeatureList associationFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    associationFeatureList         shift and go to state 276
+    empty                          shift and go to state 277
+
+state 235
+
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass . { associationFeatureList } ;
+
+    {               shift and go to state 278
+
+
+state 236
+
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias . { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias . superClass { associationFeatureList } ;
+    (41) superClass -> . : className
+
+    {               shift and go to state 279
+    :               shift and go to state 84
+
+    superClass                     shift and go to state 280
+
+state 237
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 281
+    empty                          shift and go to state 126
+
+state 238
+
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass . { classFeatureList } ;
+
+    {               shift and go to state 282
+
+
+state 239
+
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias . { classFeatureList } ;
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias . superClass { classFeatureList } ;
+    (41) superClass -> . : className
+
+    {               shift and go to state 283
+    :               shift and go to state 84
+
+    superClass                     shift and go to state 284
+
+state 240
+
+    (81) methodDeclaration -> dataType methodName ( . ) ;
+    (82) methodDeclaration -> dataType methodName ( . parameterList ) ;
+    (103) parameterList -> . parameter
+    (104) parameterList -> . parameterList , parameter
+    (105) parameter -> . parameter_1
+    (106) parameter -> . parameter_2
+    (107) parameter -> . parameter_3
+    (108) parameter -> . parameter_4
+    (109) parameter_1 -> . dataType parameterName
+    (110) parameter_1 -> . dataType parameterName array
+    (111) parameter_2 -> . qualifierList dataType parameterName
+    (112) parameter_2 -> . qualifierList dataType parameterName array
+    (113) parameter_3 -> . objectRef parameterName
+    (114) parameter_3 -> . objectRef parameterName array
+    (115) parameter_4 -> . qualifierList objectRef parameterName
+    (116) parameter_4 -> . qualifierList objectRef parameterName array
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    )               shift and go to state 286
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    dataType                       shift and go to state 285
+    parameterList                  shift and go to state 287
+    parameter                      shift and go to state 288
+    parameter_1                    shift and go to state 289
+    parameter_2                    shift and go to state 290
+    parameter_3                    shift and go to state 291
+    parameter_4                    shift and go to state 292
+    qualifierList                  shift and go to state 293
+    objectRef                      shift and go to state 294
+    className                      shift and go to state 153
+    identifier                     shift and go to state 63
+
+state 241
+
+    (69) propertyDeclaration_1 -> dataType propertyName ; .
+
+    }               reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT8        reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT8        reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT16       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT16       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT32       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT32       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT64       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT64       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_REAL32       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_REAL64       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_CHAR16       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_STR          reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_BOOL         reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_DATETIME     reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    [               reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    IDENTIFIER      reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    ANY             reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    AS              reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    CLASS           reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DISABLEOVERRIDE reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    ENABLEOVERRIDE  reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    FLAVOR          reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    INSTANCE        reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    METHOD          reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    OF              reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PARAMETER       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PRAGMA          reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PROPERTY        reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    QUALIFIER       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    REFERENCE       reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    RESTRICTED      reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    SCHEMA          reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    SCOPE           reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TOSUBCLASS      reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TOINSTANCE      reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TRANSLATABLE    reduce using rule 69 (propertyDeclaration_1 -> dataType propertyName ; .)
+
+
+state 242
+
+    (70) propertyDeclaration_2 -> dataType propertyName defaultValue . ;
+
+    ;               shift and go to state 295
+
+
+state 243
+
+    (71) propertyDeclaration_3 -> dataType propertyName array . ;
+    (72) propertyDeclaration_4 -> dataType propertyName array . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    ;               shift and go to state 296
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 297
+
+state 244
+
+    (83) methodDeclaration -> qualifierList dataType methodName . ( ) ;
+    (84) methodDeclaration -> qualifierList dataType methodName . ( parameterList ) ;
+
+    (               shift and go to state 298
+
+
+state 245
+
+    (73) propertyDeclaration_5 -> qualifierList dataType propertyName . ;
+    (74) propertyDeclaration_6 -> qualifierList dataType propertyName . defaultValue ;
+    (75) propertyDeclaration_7 -> qualifierList dataType propertyName . array ;
+    (76) propertyDeclaration_8 -> qualifierList dataType propertyName . array defaultValue ;
+    (120) defaultValue -> . = initializer
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    ;               shift and go to state 299
+    =               shift and go to state 188
+    [               shift and go to state 187
+
+    defaultValue                   shift and go to state 300
+    array                          shift and go to state 301
+
+state 246
+
+    (79) referenceDeclaration -> qualifierList objectRef referenceName . ;
+    (80) referenceDeclaration -> qualifierList objectRef referenceName . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    ;               shift and go to state 302
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 303
+
+state 247
+
+    (77) referenceDeclaration -> objectRef referenceName ; .
+
+    }               reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT8        reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT8        reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT16       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT16       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT32       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT32       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT64       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT64       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_REAL32       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_REAL64       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_CHAR16       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_STR          reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_BOOL         reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_DATETIME     reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    [               reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    IDENTIFIER      reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    ANY             reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    AS              reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    CLASS           reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    DISABLEOVERRIDE reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    ENABLEOVERRIDE  reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    FLAVOR          reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    INSTANCE        reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    METHOD          reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    OF              reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    PARAMETER       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    PRAGMA          reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    PROPERTY        reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    QUALIFIER       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    REFERENCE       reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    RESTRICTED      reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    SCHEMA          reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    SCOPE           reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    TOSUBCLASS      reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    TOINSTANCE      reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+    TRANSLATABLE    reduce using rule 77 (referenceDeclaration -> objectRef referenceName ; .)
+
+
+state 248
+
+    (78) referenceDeclaration -> objectRef referenceName defaultValue . ;
+
+    ;               shift and go to state 304
+
+
+state 249
+
+    (17) classDeclaration -> CLASS className superClass { classFeatureList } ; .
+
+    #               reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    [               reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    $end            reduce using rule 17 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+
+
+state 250
+
+    (18) classDeclaration -> CLASS className alias { classFeatureList } ; .
+
+    #               reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    [               reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    CLASS           reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    INSTANCE        reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    $end            reduce using rule 18 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+
+
+state 251
+
+    (19) classDeclaration -> CLASS className alias superClass { classFeatureList } . ;
+
+    ;               shift and go to state 305
+
+
+state 252
+
+    (20) classDeclaration -> qualifierList CLASS className { classFeatureList } ; .
+
+    #               reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    [               reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    CLASS           reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    INSTANCE        reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    $end            reduce using rule 20 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+
+
+state 253
+
+    (21) classDeclaration -> qualifierList CLASS className superClass { classFeatureList } . ;
+
+    ;               shift and go to state 306
+
+
+state 254
+
+    (22) classDeclaration -> qualifierList CLASS className alias { classFeatureList } . ;
+
+    ;               shift and go to state 307
+
+
+state 255
+
+    (23) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 308
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    qualifierList                  shift and go to state 168
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 256
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } . ;
+
+    ;               shift and go to state 309
+
+
+state 257
+
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList . } ;
+    (175) valueInitializerList -> valueInitializerList . valueInitializer
+    (176) valueInitializer -> . identifier defaultValue ;
+    (177) valueInitializer -> . qualifierList identifier defaultValue ;
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    }               shift and go to state 310
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    [               shift and go to state 170
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    qualifierList                  shift and go to state 192
+    valueInitializer               shift and go to state 230
+    identifier                     shift and go to state 191
+    dataType                       shift and go to state 31
+
+state 258
+
+    (167) defaultFlavor -> , FLAVOR ( . flavorListWithComma )
+    (168) flavorListWithComma -> . flavor
+    (169) flavorListWithComma -> . flavorListWithComma , flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavorListWithComma            shift and go to state 311
+    flavor                         shift and go to state 312
+
+state 259
+
+    (154) scope -> , SCOPE ( metaElementList . )
+    (156) metaElementList -> metaElementList . , metaElement
+
+    )               shift and go to state 314
+    ,               shift and go to state 313
+
+
+state 260
+
+    (155) metaElementList -> metaElement .
+
+    )               reduce using rule 155 (metaElementList -> metaElement .)
+    ,               reduce using rule 155 (metaElementList -> metaElement .)
+
+
+state 261
+
+    (157) metaElement -> SCHEMA .
+
+    )               reduce using rule 157 (metaElement -> SCHEMA .)
+    ,               reduce using rule 157 (metaElement -> SCHEMA .)
+
+
+state 262
+
+    (158) metaElement -> CLASS .
+
+    )               reduce using rule 158 (metaElement -> CLASS .)
+    ,               reduce using rule 158 (metaElement -> CLASS .)
+
+
+state 263
+
+    (159) metaElement -> ASSOCIATION .
+
+    )               reduce using rule 159 (metaElement -> ASSOCIATION .)
+    ,               reduce using rule 159 (metaElement -> ASSOCIATION .)
+
+
+state 264
+
+    (160) metaElement -> INDICATION .
+
+    )               reduce using rule 160 (metaElement -> INDICATION .)
+    ,               reduce using rule 160 (metaElement -> INDICATION .)
+
+
+state 265
+
+    (161) metaElement -> QUALIFIER .
+
+    )               reduce using rule 161 (metaElement -> QUALIFIER .)
+    ,               reduce using rule 161 (metaElement -> QUALIFIER .)
+
+
+state 266
+
+    (162) metaElement -> PROPERTY .
+
+    )               reduce using rule 162 (metaElement -> PROPERTY .)
+    ,               reduce using rule 162 (metaElement -> PROPERTY .)
+
+
+state 267
+
+    (163) metaElement -> REFERENCE .
+
+    )               reduce using rule 163 (metaElement -> REFERENCE .)
+    ,               reduce using rule 163 (metaElement -> REFERENCE .)
+
+
+state 268
+
+    (164) metaElement -> METHOD .
+
+    )               reduce using rule 164 (metaElement -> METHOD .)
+    ,               reduce using rule 164 (metaElement -> METHOD .)
+
+
+state 269
+
+    (165) metaElement -> PARAMETER .
+
+    )               reduce using rule 165 (metaElement -> PARAMETER .)
+    ,               reduce using rule 165 (metaElement -> PARAMETER .)
+
+
+state 270
+
+    (166) metaElement -> ANY .
+
+    )               reduce using rule 166 (metaElement -> ANY .)
+    ,               reduce using rule 166 (metaElement -> ANY .)
+
+
+state 271
+
+    (119) array -> [ integerValue ] .
+
+    =               reduce using rule 119 (array -> [ integerValue ] .)
+    ,               reduce using rule 119 (array -> [ integerValue ] .)
+    ;               reduce using rule 119 (array -> [ integerValue ] .)
+    )               reduce using rule 119 (array -> [ integerValue ] .)
+
+
+state 272
+
+    (170) instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .
+
+    #               reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    [               reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    CLASS           reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    $end            reduce using rule 170 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+
+
+state 273
+
+    (176) valueInitializer -> identifier defaultValue ; .
+
+    }               reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    IDENTIFIER      reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    ANY             reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    AS              reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    CLASS           reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    FLAVOR          reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    INSTANCE        reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    METHOD          reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    OF              reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    PARAMETER       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    PRAGMA          reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    PROPERTY        reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    QUALIFIER       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    REFERENCE       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    RESTRICTED      reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    SCHEMA          reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    SCOPE           reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    TOSUBCLASS      reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    TOINSTANCE      reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    TRANSLATABLE    reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    [               reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT8        reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT8        reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT16       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT16       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT32       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT32       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT64       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT64       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_REAL32       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_REAL64       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_CHAR16       reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_STR          reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_BOOL         reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+    DT_DATETIME     reduce using rule 176 (valueInitializer -> identifier defaultValue ; .)
+
+
+state 274
+
+    (177) valueInitializer -> qualifierList identifier defaultValue . ;
+
+    ;               shift and go to state 315
+
+
+state 275
+
+    (171) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } . ;
+
+    ;               shift and go to state 316
+
+
+state 276
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList . } ;
+    (37) associationFeatureList -> associationFeatureList . associationFeature
+    (45) associationFeature -> . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 317
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    associationFeature             shift and go to state 318
+    classFeature                   shift and go to state 319
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 277
+
+    (36) associationFeatureList -> empty .
+
+    }               reduce using rule 36 (associationFeatureList -> empty .)
+    DT_UINT8        reduce using rule 36 (associationFeatureList -> empty .)
+    DT_SINT8        reduce using rule 36 (associationFeatureList -> empty .)
+    DT_UINT16       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_SINT16       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_UINT32       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_SINT32       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_UINT64       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_SINT64       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_REAL32       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_REAL64       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_CHAR16       reduce using rule 36 (associationFeatureList -> empty .)
+    DT_STR          reduce using rule 36 (associationFeatureList -> empty .)
+    DT_BOOL         reduce using rule 36 (associationFeatureList -> empty .)
+    DT_DATETIME     reduce using rule 36 (associationFeatureList -> empty .)
+    [               reduce using rule 36 (associationFeatureList -> empty .)
+    IDENTIFIER      reduce using rule 36 (associationFeatureList -> empty .)
+    ANY             reduce using rule 36 (associationFeatureList -> empty .)
+    AS              reduce using rule 36 (associationFeatureList -> empty .)
+    CLASS           reduce using rule 36 (associationFeatureList -> empty .)
+    DISABLEOVERRIDE reduce using rule 36 (associationFeatureList -> empty .)
+    ENABLEOVERRIDE  reduce using rule 36 (associationFeatureList -> empty .)
+    FLAVOR          reduce using rule 36 (associationFeatureList -> empty .)
+    INSTANCE        reduce using rule 36 (associationFeatureList -> empty .)
+    METHOD          reduce using rule 36 (associationFeatureList -> empty .)
+    OF              reduce using rule 36 (associationFeatureList -> empty .)
+    PARAMETER       reduce using rule 36 (associationFeatureList -> empty .)
+    PRAGMA          reduce using rule 36 (associationFeatureList -> empty .)
+    PROPERTY        reduce using rule 36 (associationFeatureList -> empty .)
+    QUALIFIER       reduce using rule 36 (associationFeatureList -> empty .)
+    REFERENCE       reduce using rule 36 (associationFeatureList -> empty .)
+    RESTRICTED      reduce using rule 36 (associationFeatureList -> empty .)
+    SCHEMA          reduce using rule 36 (associationFeatureList -> empty .)
+    SCOPE           reduce using rule 36 (associationFeatureList -> empty .)
+    TOSUBCLASS      reduce using rule 36 (associationFeatureList -> empty .)
+    TOINSTANCE      reduce using rule 36 (associationFeatureList -> empty .)
+    TRANSLATABLE    reduce using rule 36 (associationFeatureList -> empty .)
+
+
+state 278
+
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { . associationFeatureList } ;
+    (36) associationFeatureList -> . empty
+    (37) associationFeatureList -> . associationFeatureList associationFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    associationFeatureList         shift and go to state 320
+    empty                          shift and go to state 277
+
+state 279
+
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { . associationFeatureList } ;
+    (36) associationFeatureList -> . empty
+    (37) associationFeatureList -> . associationFeatureList associationFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    associationFeatureList         shift and go to state 321
+    empty                          shift and go to state 277
+
+state 280
+
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass . { associationFeatureList } ;
+
+    {               shift and go to state 322
+
+
+state 281
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 323
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 282
+
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 324
+    empty                          shift and go to state 126
+
+state 283
+
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 325
+    empty                          shift and go to state 126
+
+state 284
+
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass . { classFeatureList } ;
+
+    {               shift and go to state 326
+
+
+state 285
+
+    (109) parameter_1 -> dataType . parameterName
+    (110) parameter_1 -> dataType . parameterName array
+    (186) identifier -> dataType .
+    (117) parameterName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 186 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    dataType                       shift and go to state 31
+    parameterName                  shift and go to state 327
+    identifier                     shift and go to state 328
+
+state 286
+
+    (81) methodDeclaration -> dataType methodName ( ) . ;
+
+    ;               shift and go to state 329
+
+
+state 287
+
+    (82) methodDeclaration -> dataType methodName ( parameterList . ) ;
+    (104) parameterList -> parameterList . , parameter
+
+    )               shift and go to state 330
+    ,               shift and go to state 331
+
+
+state 288
+
+    (103) parameterList -> parameter .
+
+    )               reduce using rule 103 (parameterList -> parameter .)
+    ,               reduce using rule 103 (parameterList -> parameter .)
+
+
+state 289
+
+    (105) parameter -> parameter_1 .
+
+    )               reduce using rule 105 (parameter -> parameter_1 .)
+    ,               reduce using rule 105 (parameter -> parameter_1 .)
+
+
+state 290
+
+    (106) parameter -> parameter_2 .
+
+    )               reduce using rule 106 (parameter -> parameter_2 .)
+    ,               reduce using rule 106 (parameter -> parameter_2 .)
+
+
+state 291
+
+    (107) parameter -> parameter_3 .
+
+    )               reduce using rule 107 (parameter -> parameter_3 .)
+    ,               reduce using rule 107 (parameter -> parameter_3 .)
+
+
+state 292
+
+    (108) parameter -> parameter_4 .
+
+    )               reduce using rule 108 (parameter -> parameter_4 .)
+    ,               reduce using rule 108 (parameter -> parameter_4 .)
+
+
+state 293
+
+    (111) parameter_2 -> qualifierList . dataType parameterName
+    (112) parameter_2 -> qualifierList . dataType parameterName array
+    (115) parameter_4 -> qualifierList . objectRef parameterName
+    (116) parameter_4 -> qualifierList . objectRef parameterName array
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    dataType                       shift and go to state 332
+    objectRef                      shift and go to state 333
+    className                      shift and go to state 153
+    identifier                     shift and go to state 63
+
+state 294
+
+    (113) parameter_3 -> objectRef . parameterName
+    (114) parameter_3 -> objectRef . parameterName array
+    (117) parameterName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    parameterName                  shift and go to state 334
+    identifier                     shift and go to state 328
+    dataType                       shift and go to state 31
+
+state 295
+
+    (70) propertyDeclaration_2 -> dataType propertyName defaultValue ; .
+
+    }               reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT8        reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT8        reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT16       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT16       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT32       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT32       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT64       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT64       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_REAL32       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_REAL64       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_CHAR16       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_STR          reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_BOOL         reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_DATETIME     reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    [               reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    IDENTIFIER      reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    ANY             reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    AS              reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    CLASS           reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    FLAVOR          reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    INSTANCE        reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    METHOD          reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    OF              reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PARAMETER       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PRAGMA          reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PROPERTY        reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    QUALIFIER       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    REFERENCE       reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    RESTRICTED      reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    SCHEMA          reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    SCOPE           reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TOINSTANCE      reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 70 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+
+
+state 296
+
+    (71) propertyDeclaration_3 -> dataType propertyName array ; .
+
+    }               reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT8        reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT8        reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT16       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT16       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT32       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT32       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT64       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT64       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_REAL32       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_REAL64       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_CHAR16       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_STR          reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_BOOL         reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_DATETIME     reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    [               reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    IDENTIFIER      reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    ANY             reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    AS              reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    CLASS           reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DISABLEOVERRIDE reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    ENABLEOVERRIDE  reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    FLAVOR          reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    INSTANCE        reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    METHOD          reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    OF              reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PARAMETER       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PRAGMA          reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PROPERTY        reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    QUALIFIER       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    REFERENCE       reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    RESTRICTED      reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    SCHEMA          reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    SCOPE           reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TOSUBCLASS      reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TOINSTANCE      reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TRANSLATABLE    reduce using rule 71 (propertyDeclaration_3 -> dataType propertyName array ; .)
+
+
+state 297
+
+    (72) propertyDeclaration_4 -> dataType propertyName array defaultValue . ;
+
+    ;               shift and go to state 335
+
+
+state 298
+
+    (83) methodDeclaration -> qualifierList dataType methodName ( . ) ;
+    (84) methodDeclaration -> qualifierList dataType methodName ( . parameterList ) ;
+    (103) parameterList -> . parameter
+    (104) parameterList -> . parameterList , parameter
+    (105) parameter -> . parameter_1
+    (106) parameter -> . parameter_2
+    (107) parameter -> . parameter_3
+    (108) parameter -> . parameter_4
+    (109) parameter_1 -> . dataType parameterName
+    (110) parameter_1 -> . dataType parameterName array
+    (111) parameter_2 -> . qualifierList dataType parameterName
+    (112) parameter_2 -> . qualifierList dataType parameterName array
+    (113) parameter_3 -> . objectRef parameterName
+    (114) parameter_3 -> . objectRef parameterName array
+    (115) parameter_4 -> . qualifierList objectRef parameterName
+    (116) parameter_4 -> . qualifierList objectRef parameterName array
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    )               shift and go to state 336
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    qualifierList                  shift and go to state 293
+    dataType                       shift and go to state 285
+    parameterList                  shift and go to state 337
+    parameter                      shift and go to state 288
+    parameter_1                    shift and go to state 289
+    parameter_2                    shift and go to state 290
+    parameter_3                    shift and go to state 291
+    parameter_4                    shift and go to state 292
+    objectRef                      shift and go to state 294
+    className                      shift and go to state 153
+    identifier                     shift and go to state 63
+
+state 299
+
+    (73) propertyDeclaration_5 -> qualifierList dataType propertyName ; .
+
+    }               reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT8        reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT8        reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT16       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT16       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT32       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT32       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT64       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT64       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_REAL32       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_REAL64       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_CHAR16       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_STR          reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_BOOL         reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_DATETIME     reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    [               reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    IDENTIFIER      reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    ANY             reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    AS              reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    CLASS           reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DISABLEOVERRIDE reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    ENABLEOVERRIDE  reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    FLAVOR          reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    INSTANCE        reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    METHOD          reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    OF              reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PARAMETER       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PRAGMA          reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PROPERTY        reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    QUALIFIER       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    REFERENCE       reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    RESTRICTED      reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    SCHEMA          reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    SCOPE           reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TOSUBCLASS      reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TOINSTANCE      reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TRANSLATABLE    reduce using rule 73 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+
+
+state 300
+
+    (74) propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue . ;
+
+    ;               shift and go to state 338
+
+
+state 301
+
+    (75) propertyDeclaration_7 -> qualifierList dataType propertyName array . ;
+    (76) propertyDeclaration_8 -> qualifierList dataType propertyName array . defaultValue ;
+    (120) defaultValue -> . = initializer
+
+    ;               shift and go to state 339
+    =               shift and go to state 188
+
+    defaultValue                   shift and go to state 340
+
+state 302
+
+    (79) referenceDeclaration -> qualifierList objectRef referenceName ; .
+
+    }               reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT8        reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT8        reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT16       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT16       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT32       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT32       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT64       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT64       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_REAL32       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_REAL64       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_CHAR16       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_STR          reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_BOOL         reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_DATETIME     reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    [               reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    IDENTIFIER      reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    ANY             reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    AS              reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    CLASS           reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DISABLEOVERRIDE reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    ENABLEOVERRIDE  reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    FLAVOR          reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    INSTANCE        reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    METHOD          reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    OF              reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PARAMETER       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PRAGMA          reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PROPERTY        reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    QUALIFIER       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    REFERENCE       reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    RESTRICTED      reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    SCHEMA          reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    SCOPE           reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TOSUBCLASS      reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TOINSTANCE      reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TRANSLATABLE    reduce using rule 79 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+
+
+state 303
+
+    (80) referenceDeclaration -> qualifierList objectRef referenceName defaultValue . ;
+
+    ;               shift and go to state 341
+
+
+state 304
+
+    (78) referenceDeclaration -> objectRef referenceName defaultValue ; .
+
+    }               reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT8        reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT8        reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT16       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT16       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT32       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT32       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT64       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT64       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_REAL32       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_REAL64       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_CHAR16       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_STR          reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_BOOL         reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_DATETIME     reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    [               reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    IDENTIFIER      reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    ANY             reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    AS              reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    CLASS           reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    FLAVOR          reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    INSTANCE        reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    METHOD          reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    OF              reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PARAMETER       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PRAGMA          reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PROPERTY        reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    QUALIFIER       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    REFERENCE       reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    RESTRICTED      reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    SCHEMA          reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    SCOPE           reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TOINSTANCE      reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 78 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+
+
+state 305
+
+    (19) classDeclaration -> CLASS className alias superClass { classFeatureList } ; .
+
+    #               reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    [               reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    $end            reduce using rule 19 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+
+
+state 306
+
+    (21) classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .
+
+    #               reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    [               reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    $end            reduce using rule 21 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+
+
+state 307
+
+    (22) classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .
+
+    #               reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    [               reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    CLASS           reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    INSTANCE        reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    $end            reduce using rule 22 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+
+
+state 308
+
+    (23) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } . ;
+
+    ;               shift and go to state 342
+
+
+state 309
+
+    (172) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .
+
+    #               reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    [               reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    CLASS           reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    $end            reduce using rule 172 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+
+
+state 310
+
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } . ;
+
+    ;               shift and go to state 343
+
+
+state 311
+
+    (167) defaultFlavor -> , FLAVOR ( flavorListWithComma . )
+    (169) flavorListWithComma -> flavorListWithComma . , flavor
+
+    )               shift and go to state 345
+    ,               shift and go to state 344
+
+
+state 312
+
+    (168) flavorListWithComma -> flavor .
+
+    )               reduce using rule 168 (flavorListWithComma -> flavor .)
+    ,               reduce using rule 168 (flavorListWithComma -> flavor .)
+
+
+state 313
+
+    (156) metaElementList -> metaElementList , . metaElement
+    (157) metaElement -> . SCHEMA
+    (158) metaElement -> . CLASS
+    (159) metaElement -> . ASSOCIATION
+    (160) metaElement -> . INDICATION
+    (161) metaElement -> . QUALIFIER
+    (162) metaElement -> . PROPERTY
+    (163) metaElement -> . REFERENCE
+    (164) metaElement -> . METHOD
+    (165) metaElement -> . PARAMETER
+    (166) metaElement -> . ANY
+
+    SCHEMA          shift and go to state 261
+    CLASS           shift and go to state 262
+    ASSOCIATION     shift and go to state 263
+    INDICATION      shift and go to state 264
+    QUALIFIER       shift and go to state 265
+    PROPERTY        shift and go to state 266
+    REFERENCE       shift and go to state 267
+    METHOD          shift and go to state 268
+    PARAMETER       shift and go to state 269
+    ANY             shift and go to state 270
+
+    metaElement                    shift and go to state 346
+
+state 314
+
+    (154) scope -> , SCOPE ( metaElementList ) .
+
+    ;               reduce using rule 154 (scope -> , SCOPE ( metaElementList ) .)
+    ,               reduce using rule 154 (scope -> , SCOPE ( metaElementList ) .)
+
+
+state 315
+
+    (177) valueInitializer -> qualifierList identifier defaultValue ; .
+
+    }               reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    IDENTIFIER      reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    ANY             reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    AS              reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    CLASS           reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    FLAVOR          reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    INSTANCE        reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    METHOD          reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    OF              reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PARAMETER       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PRAGMA          reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PROPERTY        reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    QUALIFIER       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    REFERENCE       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    RESTRICTED      reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    SCHEMA          reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    SCOPE           reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TOSUBCLASS      reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TOINSTANCE      reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TRANSLATABLE    reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    [               reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT8        reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT8        reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT16       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT16       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT32       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT32       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT64       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT64       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_REAL32       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_REAL64       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_CHAR16       reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_STR          reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_BOOL         reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_DATETIME     reduce using rule 177 (valueInitializer -> qualifierList identifier defaultValue ; .)
+
+
+state 316
+
+    (171) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .
+
+    #               reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    [               reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    CLASS           reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    $end            reduce using rule 171 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+
+
+state 317
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } . ;
+
+    ;               shift and go to state 347
+
+
+state 318
+
+    (37) associationFeatureList -> associationFeatureList associationFeature .
+
+    }               reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_UINT8        reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_SINT8        reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_UINT16       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_SINT16       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_UINT32       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_SINT32       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_UINT64       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_SINT64       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_REAL32       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_REAL64       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_CHAR16       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_STR          reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_BOOL         reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DT_DATETIME     reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    [               reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    IDENTIFIER      reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    ANY             reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    AS              reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    CLASS           reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    DISABLEOVERRIDE reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    ENABLEOVERRIDE  reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    FLAVOR          reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    INSTANCE        reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    METHOD          reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    OF              reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    PARAMETER       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    PRAGMA          reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    PROPERTY        reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    QUALIFIER       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    REFERENCE       reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    RESTRICTED      reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    SCHEMA          reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    SCOPE           reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    TOSUBCLASS      reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    TOINSTANCE      reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+    TRANSLATABLE    reduce using rule 37 (associationFeatureList -> associationFeatureList associationFeature .)
+
+
+state 319
+
+    (45) associationFeature -> classFeature .
+
+    }               reduce using rule 45 (associationFeature -> classFeature .)
+    DT_UINT8        reduce using rule 45 (associationFeature -> classFeature .)
+    DT_SINT8        reduce using rule 45 (associationFeature -> classFeature .)
+    DT_UINT16       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_SINT16       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_UINT32       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_SINT32       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_UINT64       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_SINT64       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_REAL32       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_REAL64       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_CHAR16       reduce using rule 45 (associationFeature -> classFeature .)
+    DT_STR          reduce using rule 45 (associationFeature -> classFeature .)
+    DT_BOOL         reduce using rule 45 (associationFeature -> classFeature .)
+    DT_DATETIME     reduce using rule 45 (associationFeature -> classFeature .)
+    [               reduce using rule 45 (associationFeature -> classFeature .)
+    IDENTIFIER      reduce using rule 45 (associationFeature -> classFeature .)
+    ANY             reduce using rule 45 (associationFeature -> classFeature .)
+    AS              reduce using rule 45 (associationFeature -> classFeature .)
+    CLASS           reduce using rule 45 (associationFeature -> classFeature .)
+    DISABLEOVERRIDE reduce using rule 45 (associationFeature -> classFeature .)
+    ENABLEOVERRIDE  reduce using rule 45 (associationFeature -> classFeature .)
+    FLAVOR          reduce using rule 45 (associationFeature -> classFeature .)
+    INSTANCE        reduce using rule 45 (associationFeature -> classFeature .)
+    METHOD          reduce using rule 45 (associationFeature -> classFeature .)
+    OF              reduce using rule 45 (associationFeature -> classFeature .)
+    PARAMETER       reduce using rule 45 (associationFeature -> classFeature .)
+    PRAGMA          reduce using rule 45 (associationFeature -> classFeature .)
+    PROPERTY        reduce using rule 45 (associationFeature -> classFeature .)
+    QUALIFIER       reduce using rule 45 (associationFeature -> classFeature .)
+    REFERENCE       reduce using rule 45 (associationFeature -> classFeature .)
+    RESTRICTED      reduce using rule 45 (associationFeature -> classFeature .)
+    SCHEMA          reduce using rule 45 (associationFeature -> classFeature .)
+    SCOPE           reduce using rule 45 (associationFeature -> classFeature .)
+    TOSUBCLASS      reduce using rule 45 (associationFeature -> classFeature .)
+    TOINSTANCE      reduce using rule 45 (associationFeature -> classFeature .)
+    TRANSLATABLE    reduce using rule 45 (associationFeature -> classFeature .)
+
+
+state 320
+
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList . } ;
+    (37) associationFeatureList -> associationFeatureList . associationFeature
+    (45) associationFeature -> . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 348
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    associationFeature             shift and go to state 318
+    classFeature                   shift and go to state 319
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 321
+
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList . } ;
+    (37) associationFeatureList -> associationFeatureList . associationFeature
+    (45) associationFeature -> . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 349
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    associationFeature             shift and go to state 318
+    classFeature                   shift and go to state 319
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 322
+
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { . associationFeatureList } ;
+    (36) associationFeatureList -> . empty
+    (37) associationFeatureList -> . associationFeatureList associationFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    associationFeatureList         shift and go to state 350
+    empty                          shift and go to state 277
+
+state 323
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } . ;
+
+    ;               shift and go to state 351
+
+
+state 324
+
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 352
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 325
+
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 353
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 326
+
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { . classFeatureList } ;
+    (24) classFeatureList -> . empty
+    (25) classFeatureList -> . classFeatureList classFeature
+    (203) empty -> .
+
+    }               reduce using rule 203 (empty -> .)
+    DT_UINT8        reduce using rule 203 (empty -> .)
+    DT_SINT8        reduce using rule 203 (empty -> .)
+    DT_UINT16       reduce using rule 203 (empty -> .)
+    DT_SINT16       reduce using rule 203 (empty -> .)
+    DT_UINT32       reduce using rule 203 (empty -> .)
+    DT_SINT32       reduce using rule 203 (empty -> .)
+    DT_UINT64       reduce using rule 203 (empty -> .)
+    DT_SINT64       reduce using rule 203 (empty -> .)
+    DT_REAL32       reduce using rule 203 (empty -> .)
+    DT_REAL64       reduce using rule 203 (empty -> .)
+    DT_CHAR16       reduce using rule 203 (empty -> .)
+    DT_STR          reduce using rule 203 (empty -> .)
+    DT_BOOL         reduce using rule 203 (empty -> .)
+    DT_DATETIME     reduce using rule 203 (empty -> .)
+    [               reduce using rule 203 (empty -> .)
+    IDENTIFIER      reduce using rule 203 (empty -> .)
+    ANY             reduce using rule 203 (empty -> .)
+    AS              reduce using rule 203 (empty -> .)
+    CLASS           reduce using rule 203 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 203 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 203 (empty -> .)
+    FLAVOR          reduce using rule 203 (empty -> .)
+    INSTANCE        reduce using rule 203 (empty -> .)
+    METHOD          reduce using rule 203 (empty -> .)
+    OF              reduce using rule 203 (empty -> .)
+    PARAMETER       reduce using rule 203 (empty -> .)
+    PRAGMA          reduce using rule 203 (empty -> .)
+    PROPERTY        reduce using rule 203 (empty -> .)
+    QUALIFIER       reduce using rule 203 (empty -> .)
+    REFERENCE       reduce using rule 203 (empty -> .)
+    RESTRICTED      reduce using rule 203 (empty -> .)
+    SCHEMA          reduce using rule 203 (empty -> .)
+    SCOPE           reduce using rule 203 (empty -> .)
+    TOSUBCLASS      reduce using rule 203 (empty -> .)
+    TOINSTANCE      reduce using rule 203 (empty -> .)
+    TRANSLATABLE    reduce using rule 203 (empty -> .)
+
+    classFeatureList               shift and go to state 354
+    empty                          shift and go to state 126
+
+state 327
+
+    (109) parameter_1 -> dataType parameterName .
+    (110) parameter_1 -> dataType parameterName . array
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    )               reduce using rule 109 (parameter_1 -> dataType parameterName .)
+    ,               reduce using rule 109 (parameter_1 -> dataType parameterName .)
+    [               shift and go to state 187
+
+    array                          shift and go to state 355
+
+state 328
+
+    (117) parameterName -> identifier .
+
+    [               reduce using rule 117 (parameterName -> identifier .)
+    )               reduce using rule 117 (parameterName -> identifier .)
+    ,               reduce using rule 117 (parameterName -> identifier .)
+
+
+state 329
+
+    (81) methodDeclaration -> dataType methodName ( ) ; .
+
+    }               reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT8        reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT8        reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT16       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT16       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT32       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT32       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT64       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT64       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_REAL32       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_REAL64       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_CHAR16       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_STR          reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_BOOL         reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_DATETIME     reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    [               reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    IDENTIFIER      reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    ANY             reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    AS              reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    CLASS           reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    DISABLEOVERRIDE reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    ENABLEOVERRIDE  reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    FLAVOR          reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    INSTANCE        reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    METHOD          reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    OF              reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    PARAMETER       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    PRAGMA          reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    PROPERTY        reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    QUALIFIER       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    REFERENCE       reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    RESTRICTED      reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    SCHEMA          reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    SCOPE           reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    TOSUBCLASS      reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    TOINSTANCE      reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+    TRANSLATABLE    reduce using rule 81 (methodDeclaration -> dataType methodName ( ) ; .)
+
+
+state 330
+
+    (82) methodDeclaration -> dataType methodName ( parameterList ) . ;
+
+    ;               shift and go to state 356
+
+
+state 331
+
+    (104) parameterList -> parameterList , . parameter
+    (105) parameter -> . parameter_1
+    (106) parameter -> . parameter_2
+    (107) parameter -> . parameter_3
+    (108) parameter -> . parameter_4
+    (109) parameter_1 -> . dataType parameterName
+    (110) parameter_1 -> . dataType parameterName array
+    (111) parameter_2 -> . qualifierList dataType parameterName
+    (112) parameter_2 -> . qualifierList dataType parameterName array
+    (113) parameter_3 -> . objectRef parameterName
+    (114) parameter_3 -> . objectRef parameterName array
+    (115) parameter_4 -> . qualifierList objectRef parameterName
+    (116) parameter_4 -> . qualifierList objectRef parameterName array
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    parameter                      shift and go to state 357
+    parameter_1                    shift and go to state 289
+    parameter_2                    shift and go to state 290
+    parameter_3                    shift and go to state 291
+    parameter_4                    shift and go to state 292
+    dataType                       shift and go to state 285
+    qualifierList                  shift and go to state 293
+    objectRef                      shift and go to state 294
+    className                      shift and go to state 153
+    identifier                     shift and go to state 63
+
+state 332
+
+    (111) parameter_2 -> qualifierList dataType . parameterName
+    (112) parameter_2 -> qualifierList dataType . parameterName array
+    (186) identifier -> dataType .
+    (117) parameterName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 186 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    dataType                       shift and go to state 31
+    parameterName                  shift and go to state 358
+    identifier                     shift and go to state 328
+
+state 333
+
+    (115) parameter_4 -> qualifierList objectRef . parameterName
+    (116) parameter_4 -> qualifierList objectRef . parameterName array
+    (117) parameterName -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+
+    parameterName                  shift and go to state 359
+    identifier                     shift and go to state 328
+    dataType                       shift and go to state 31
+
+state 334
+
+    (113) parameter_3 -> objectRef parameterName .
+    (114) parameter_3 -> objectRef parameterName . array
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    )               reduce using rule 113 (parameter_3 -> objectRef parameterName .)
+    ,               reduce using rule 113 (parameter_3 -> objectRef parameterName .)
+    [               shift and go to state 187
+
+    array                          shift and go to state 360
+
+state 335
+
+    (72) propertyDeclaration_4 -> dataType propertyName array defaultValue ; .
+
+    }               reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT8        reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT8        reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT16       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT16       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT32       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT32       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT64       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT64       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_REAL32       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_REAL64       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_CHAR16       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_STR          reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_BOOL         reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_DATETIME     reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    [               reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    IDENTIFIER      reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    ANY             reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    AS              reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    CLASS           reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    FLAVOR          reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    INSTANCE        reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    METHOD          reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    OF              reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PARAMETER       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PRAGMA          reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PROPERTY        reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    QUALIFIER       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    REFERENCE       reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    RESTRICTED      reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    SCHEMA          reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    SCOPE           reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TOSUBCLASS      reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TOINSTANCE      reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TRANSLATABLE    reduce using rule 72 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+
+
+state 336
+
+    (83) methodDeclaration -> qualifierList dataType methodName ( ) . ;
+
+    ;               shift and go to state 361
+
+
+state 337
+
+    (84) methodDeclaration -> qualifierList dataType methodName ( parameterList . ) ;
+    (104) parameterList -> parameterList . , parameter
+
+    )               shift and go to state 362
+    ,               shift and go to state 331
+
+
+state 338
+
+    (74) propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .
+
+    }               reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT8        reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT8        reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT16       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT16       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT32       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT32       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT64       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT64       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_REAL32       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_REAL64       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_CHAR16       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_STR          reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_BOOL         reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_DATETIME     reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    [               reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    IDENTIFIER      reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    ANY             reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    AS              reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    CLASS           reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    FLAVOR          reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    INSTANCE        reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    METHOD          reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    OF              reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PARAMETER       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PRAGMA          reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PROPERTY        reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    QUALIFIER       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    REFERENCE       reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    RESTRICTED      reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    SCHEMA          reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    SCOPE           reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TOINSTANCE      reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 74 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+
+
+state 339
+
+    (75) propertyDeclaration_7 -> qualifierList dataType propertyName array ; .
+
+    }               reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT8        reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT8        reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT16       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT16       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT32       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT32       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT64       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT64       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_REAL32       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_REAL64       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_CHAR16       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_STR          reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_BOOL         reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_DATETIME     reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    [               reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    IDENTIFIER      reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    ANY             reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    AS              reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    CLASS           reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DISABLEOVERRIDE reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    ENABLEOVERRIDE  reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    FLAVOR          reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    INSTANCE        reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    METHOD          reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    OF              reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PARAMETER       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PRAGMA          reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PROPERTY        reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    QUALIFIER       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    REFERENCE       reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    RESTRICTED      reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    SCHEMA          reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    SCOPE           reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TOSUBCLASS      reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TOINSTANCE      reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TRANSLATABLE    reduce using rule 75 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+
+
+state 340
+
+    (76) propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue . ;
+
+    ;               shift and go to state 363
+
+
+state 341
+
+    (80) referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .
+
+    }               reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT8        reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT8        reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT16       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT16       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT32       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT32       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT64       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT64       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_REAL32       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_REAL64       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_CHAR16       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_STR          reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_BOOL         reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_DATETIME     reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    [               reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    IDENTIFIER      reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    ANY             reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    AS              reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    CLASS           reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    FLAVOR          reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    INSTANCE        reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    METHOD          reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    OF              reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PARAMETER       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PRAGMA          reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PROPERTY        reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    QUALIFIER       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    REFERENCE       reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    RESTRICTED      reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    SCHEMA          reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    SCOPE           reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TOINSTANCE      reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 80 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+
+
+state 342
+
+    (23) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .
+
+    #               reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    [               reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    $end            reduce using rule 23 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+
+
+state 343
+
+    (173) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .
+
+    #               reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    [               reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    CLASS           reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    $end            reduce using rule 173 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+
+
+state 344
+
+    (169) flavorListWithComma -> flavorListWithComma , . flavor
+    (55) flavor -> . ENABLEOVERRIDE
+    (56) flavor -> . DISABLEOVERRIDE
+    (57) flavor -> . RESTRICTED
+    (58) flavor -> . TOSUBCLASS
+    (59) flavor -> . TOINSTANCE
+    (60) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 100
+    DISABLEOVERRIDE shift and go to state 101
+    RESTRICTED      shift and go to state 102
+    TOSUBCLASS      shift and go to state 103
+    TOINSTANCE      shift and go to state 104
+    TRANSLATABLE    shift and go to state 105
+
+    flavor                         shift and go to state 364
+
+state 345
+
+    (167) defaultFlavor -> , FLAVOR ( flavorListWithComma ) .
+
+    ;               reduce using rule 167 (defaultFlavor -> , FLAVOR ( flavorListWithComma ) .)
+
+
+state 346
+
+    (156) metaElementList -> metaElementList , metaElement .
+
+    )               reduce using rule 156 (metaElementList -> metaElementList , metaElement .)
+    ,               reduce using rule 156 (metaElementList -> metaElementList , metaElement .)
+
+
+state 347
+
+    (26) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .
+
+    #               reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+    [               reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+    CLASS           reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+    QUALIFIER       reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+    INSTANCE        reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+    $end            reduce using rule 26 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className { associationFeatureList } ; .)
+
+
+state 348
+
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } . ;
+
+    ;               shift and go to state 365
+
+
+state 349
+
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } . ;
+
+    ;               shift and go to state 366
+
+
+state 350
+
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList . } ;
+    (37) associationFeatureList -> associationFeatureList . associationFeature
+    (45) associationFeature -> . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 367
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    associationFeature             shift and go to state 318
+    classFeature                   shift and go to state 319
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 351
+
+    (30) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .
+
+    #               reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+    [               reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+    CLASS           reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+    INSTANCE        reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+    $end            reduce using rule 30 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className { classFeatureList } ; .)
+
+
+state 352
+
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } . ;
+
+    ;               shift and go to state 368
+
+
+state 353
+
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } . ;
+
+    ;               shift and go to state 369
+
+
+state 354
+
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList . } ;
+    (25) classFeatureList -> classFeatureList . classFeature
+    (42) classFeature -> . propertyDeclaration
+    (43) classFeature -> . methodDeclaration
+    (44) classFeature -> . referenceDeclaration
+    (61) propertyDeclaration -> . propertyDeclaration_1
+    (62) propertyDeclaration -> . propertyDeclaration_2
+    (63) propertyDeclaration -> . propertyDeclaration_3
+    (64) propertyDeclaration -> . propertyDeclaration_4
+    (65) propertyDeclaration -> . propertyDeclaration_5
+    (66) propertyDeclaration -> . propertyDeclaration_6
+    (67) propertyDeclaration -> . propertyDeclaration_7
+    (68) propertyDeclaration -> . propertyDeclaration_8
+    (81) methodDeclaration -> . dataType methodName ( ) ;
+    (82) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (83) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (84) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (77) referenceDeclaration -> . objectRef referenceName ;
+    (78) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (79) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (80) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (69) propertyDeclaration_1 -> . dataType propertyName ;
+    (70) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (71) propertyDeclaration_3 -> . dataType propertyName array ;
+    (72) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (73) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (74) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (75) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (76) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (88) dataType -> . DT_UINT8
+    (89) dataType -> . DT_SINT8
+    (90) dataType -> . DT_UINT16
+    (91) dataType -> . DT_SINT16
+    (92) dataType -> . DT_UINT32
+    (93) dataType -> . DT_SINT32
+    (94) dataType -> . DT_UINT64
+    (95) dataType -> . DT_SINT64
+    (96) dataType -> . DT_REAL32
+    (97) dataType -> . DT_REAL64
+    (98) dataType -> . DT_CHAR16
+    (99) dataType -> . DT_STR
+    (100) dataType -> . DT_BOOL
+    (101) dataType -> . DT_DATETIME
+    (46) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (102) objectRef -> . className REF
+    (38) className -> . identifier
+    (181) identifier -> . IDENTIFIER
+    (182) identifier -> . ANY
+    (183) identifier -> . AS
+    (184) identifier -> . CLASS
+    (185) identifier -> . DISABLEOVERRIDE
+    (186) identifier -> . dataType
+    (187) identifier -> . ENABLEOVERRIDE
+    (188) identifier -> . FLAVOR
+    (189) identifier -> . INSTANCE
+    (190) identifier -> . METHOD
+    (191) identifier -> . OF
+    (192) identifier -> . PARAMETER
+    (193) identifier -> . PRAGMA
+    (194) identifier -> . PROPERTY
+    (195) identifier -> . QUALIFIER
+    (196) identifier -> . REFERENCE
+    (197) identifier -> . RESTRICTED
+    (198) identifier -> . SCHEMA
+    (199) identifier -> . SCOPE
+    (200) identifier -> . TOSUBCLASS
+    (201) identifier -> . TOINSTANCE
+    (202) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 370
+    DT_UINT8        shift and go to state 48
+    DT_SINT8        shift and go to state 49
+    DT_UINT16       shift and go to state 50
+    DT_SINT16       shift and go to state 51
+    DT_UINT32       shift and go to state 52
+    DT_SINT32       shift and go to state 53
+    DT_UINT64       shift and go to state 54
+    DT_SINT64       shift and go to state 55
+    DT_REAL32       shift and go to state 56
+    DT_REAL64       shift and go to state 57
+    DT_CHAR16       shift and go to state 58
+    DT_STR          shift and go to state 59
+    DT_BOOL         shift and go to state 60
+    DT_DATETIME     shift and go to state 61
+    [               shift and go to state 170
+    IDENTIFIER      shift and go to state 27
+    ANY             shift and go to state 28
+    AS              shift and go to state 29
+    CLASS           shift and go to state 22
+    DISABLEOVERRIDE shift and go to state 30
+    ENABLEOVERRIDE  shift and go to state 32
+    FLAVOR          shift and go to state 33
+    INSTANCE        shift and go to state 34
+    METHOD          shift and go to state 35
+    OF              shift and go to state 36
+    PARAMETER       shift and go to state 37
+    PRAGMA          shift and go to state 38
+    PROPERTY        shift and go to state 39
+    QUALIFIER       shift and go to state 40
+    REFERENCE       shift and go to state 41
+    RESTRICTED      shift and go to state 42
+    SCHEMA          shift and go to state 43
+    SCOPE           shift and go to state 44
+    TOSUBCLASS      shift and go to state 45
+    TOINSTANCE      shift and go to state 46
+    TRANSLATABLE    shift and go to state 47
+
+    className                      shift and go to state 153
+    classFeature                   shift and go to state 155
+    propertyDeclaration            shift and go to state 156
+    methodDeclaration              shift and go to state 157
+    referenceDeclaration           shift and go to state 158
+    propertyDeclaration_1          shift and go to state 159
+    propertyDeclaration_2          shift and go to state 160
+    propertyDeclaration_3          shift and go to state 161
+    propertyDeclaration_4          shift and go to state 162
+    propertyDeclaration_5          shift and go to state 163
+    propertyDeclaration_6          shift and go to state 164
+    propertyDeclaration_7          shift and go to state 165
+    propertyDeclaration_8          shift and go to state 166
+    dataType                       shift and go to state 167
+    qualifierList                  shift and go to state 168
+    objectRef                      shift and go to state 169
+    identifier                     shift and go to state 63
+
+state 355
+
+    (110) parameter_1 -> dataType parameterName array .
+
+    )               reduce using rule 110 (parameter_1 -> dataType parameterName array .)
+    ,               reduce using rule 110 (parameter_1 -> dataType parameterName array .)
+
+
+state 356
+
+    (82) methodDeclaration -> dataType methodName ( parameterList ) ; .
+
+    }               reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT8        reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT8        reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT16       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT16       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT32       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT32       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT64       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT64       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_REAL32       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_REAL64       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_CHAR16       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_STR          reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_BOOL         reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_DATETIME     reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    [               reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    IDENTIFIER      reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    ANY             reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    AS              reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    CLASS           reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DISABLEOVERRIDE reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    ENABLEOVERRIDE  reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    FLAVOR          reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    INSTANCE        reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    METHOD          reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    OF              reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PARAMETER       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PRAGMA          reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PROPERTY        reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    QUALIFIER       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    REFERENCE       reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    RESTRICTED      reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    SCHEMA          reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    SCOPE           reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TOSUBCLASS      reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TOINSTANCE      reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TRANSLATABLE    reduce using rule 82 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+
+
+state 357
+
+    (104) parameterList -> parameterList , parameter .
+
+    )               reduce using rule 104 (parameterList -> parameterList , parameter .)
+    ,               reduce using rule 104 (parameterList -> parameterList , parameter .)
+
+
+state 358
+
+    (111) parameter_2 -> qualifierList dataType parameterName .
+    (112) parameter_2 -> qualifierList dataType parameterName . array
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    )               reduce using rule 111 (parameter_2 -> qualifierList dataType parameterName .)
+    ,               reduce using rule 111 (parameter_2 -> qualifierList dataType parameterName .)
+    [               shift and go to state 187
+
+    array                          shift and go to state 371
+
+state 359
+
+    (115) parameter_4 -> qualifierList objectRef parameterName .
+    (116) parameter_4 -> qualifierList objectRef parameterName . array
+    (118) array -> . [ ]
+    (119) array -> . [ integerValue ]
+
+    )               reduce using rule 115 (parameter_4 -> qualifierList objectRef parameterName .)
+    ,               reduce using rule 115 (parameter_4 -> qualifierList objectRef parameterName .)
+    [               shift and go to state 187
+
+    array                          shift and go to state 372
+
+state 360
+
+    (114) parameter_3 -> objectRef parameterName array .
+
+    )               reduce using rule 114 (parameter_3 -> objectRef parameterName array .)
+    ,               reduce using rule 114 (parameter_3 -> objectRef parameterName array .)
+
+
+state 361
+
+    (83) methodDeclaration -> qualifierList dataType methodName ( ) ; .
+
+    }               reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT8        reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT8        reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT16       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT16       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT32       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT32       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT64       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT64       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_REAL32       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_REAL64       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_CHAR16       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_STR          reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_BOOL         reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_DATETIME     reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    [               reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    IDENTIFIER      reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    ANY             reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    AS              reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    CLASS           reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DISABLEOVERRIDE reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    ENABLEOVERRIDE  reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    FLAVOR          reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    INSTANCE        reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    METHOD          reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    OF              reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PARAMETER       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PRAGMA          reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PROPERTY        reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    QUALIFIER       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    REFERENCE       reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    RESTRICTED      reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    SCHEMA          reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    SCOPE           reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TOSUBCLASS      reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TOINSTANCE      reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TRANSLATABLE    reduce using rule 83 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+
+
+state 362
+
+    (84) methodDeclaration -> qualifierList dataType methodName ( parameterList ) . ;
+
+    ;               shift and go to state 373
+
+
+state 363
+
+    (76) propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .
+
+    }               reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT8        reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT8        reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT16       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT16       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT32       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT32       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT64       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT64       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_REAL32       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_REAL64       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_CHAR16       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_STR          reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_BOOL         reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_DATETIME     reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    [               reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    IDENTIFIER      reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    ANY             reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    AS              reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    CLASS           reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    FLAVOR          reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    INSTANCE        reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    METHOD          reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    OF              reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PARAMETER       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PRAGMA          reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PROPERTY        reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    QUALIFIER       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    REFERENCE       reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    RESTRICTED      reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    SCHEMA          reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    SCOPE           reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TOSUBCLASS      reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TOINSTANCE      reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TRANSLATABLE    reduce using rule 76 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+
+
+state 364
+
+    (169) flavorListWithComma -> flavorListWithComma , flavor .
+
+    )               reduce using rule 169 (flavorListWithComma -> flavorListWithComma , flavor .)
+    ,               reduce using rule 169 (flavorListWithComma -> flavorListWithComma , flavor .)
+
+
+state 365
+
+    (27) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .
+
+    #               reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+    [               reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+    CLASS           reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+    QUALIFIER       reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+    INSTANCE        reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+    $end            reduce using rule 27 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className superClass { associationFeatureList } ; .)
+
+
+state 366
+
+    (28) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .
+
+    #               reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+    [               reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+    CLASS           reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+    QUALIFIER       reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+    INSTANCE        reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+    $end            reduce using rule 28 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias { associationFeatureList } ; .)
+
+
+state 367
+
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } . ;
+
+    ;               shift and go to state 374
+
+
+state 368
+
+    (31) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .
+
+    #               reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+    [               reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+    $end            reduce using rule 31 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className superClass { classFeatureList } ; .)
+
+
+state 369
+
+    (32) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .
+
+    #               reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+    [               reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+    CLASS           reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+    INSTANCE        reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+    $end            reduce using rule 32 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias { classFeatureList } ; .)
+
+
+state 370
+
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } . ;
+
+    ;               shift and go to state 375
+
+
+state 371
+
+    (112) parameter_2 -> qualifierList dataType parameterName array .
+
+    )               reduce using rule 112 (parameter_2 -> qualifierList dataType parameterName array .)
+    ,               reduce using rule 112 (parameter_2 -> qualifierList dataType parameterName array .)
+
+
+state 372
+
+    (116) parameter_4 -> qualifierList objectRef parameterName array .
+
+    )               reduce using rule 116 (parameter_4 -> qualifierList objectRef parameterName array .)
+    ,               reduce using rule 116 (parameter_4 -> qualifierList objectRef parameterName array .)
+
+
+state 373
+
+    (84) methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .
+
+    }               reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT8        reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT8        reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT16       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT16       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT32       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT32       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT64       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT64       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_REAL32       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_REAL64       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_CHAR16       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_STR          reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_BOOL         reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_DATETIME     reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    [               reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    IDENTIFIER      reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    ANY             reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    AS              reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    CLASS           reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DISABLEOVERRIDE reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    ENABLEOVERRIDE  reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    FLAVOR          reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    INSTANCE        reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    METHOD          reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    OF              reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    PARAMETER       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)

--- a/alttestmofout2.txt
+++ b/alttestmofout2.txt
@@ -1,0 +1,1105 @@
+
+INFO:root:PLY: PARSE DEBUG START
+DEBUG:root:
+DEBUG:root:State  : 0
+DEBUG:root:Stack  : . LexToken(QUALIFIER,'Qualifier',1,0)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 3
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 3
+DEBUG:root:Stack  : empty . LexToken(QUALIFIER,'Qualifier',1,0)
+INFO:root:Action : Reduce rule [mofProductionList -> empty] with [None] and goto state 2
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+============================
+DEBUG:root:
+DEBUG:root:State  : 2
+DEBUG:root:Stack  : mofProductionList . LexToken(QUALIFIER,'Qualifier',1,0)
+DEBUG:root:Action : Shift and goto state 18
+DEBUG:root:
+DEBUG:root:State  : 18
+DEBUG:root:Stack  : mofProductionList QUALIFIER . LexToken(ASSOCIATION,'Association',1,10)
+DEBUG:root:Action : Shift and goto state 67
+DEBUG:root:
+DEBUG:root:State  : 67
+DEBUG:root:Stack  : mofProductionList QUALIFIER ASSOCIATION . LexToken(:,':',1,22)
+INFO:root:Action : Reduce rule [qualifierName -> ASSOCIATION] with ['Association'] and goto state 66
+INFO:root:Result : <str @ 0x7f9563a7b130> ('Association')
+DEBUG:root:
+DEBUG:root:State  : 66
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName . LexToken(:,':',1,22)
+DEBUG:root:Action : Shift and goto state 91
+DEBUG:root:
+DEBUG:root:State  : 91
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : . LexToken(DT_BOOL,'boolean',1,24)
+DEBUG:root:Action : Shift and goto state 60
+DEBUG:root:
+DEBUG:root:State  : 60
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : DT_BOOL . LexToken(=,'=',1,32)
+INFO:root:Action : Reduce rule [dataType -> DT_BOOL] with ['boolean'] and goto state 139
+INFO:root:Result : <str @ 0x7f95623a6848> ('boolean')
+DEBUG:root:
+DEBUG:root:State  : 139
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType . LexToken(=,'=',1,32)
+DEBUG:root:Action : Shift and goto state 188
+DEBUG:root:
+DEBUG:root:State  : 188
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = . LexToken(FALSE,'false',1,34)
+DEBUG:root:Action : Shift and goto state 119
+DEBUG:root:
+DEBUG:root:State  : 119
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = FALSE . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [booleanValue -> FALSE] with ['false'] and goto state 112
+INFO:root:Result : <bool @ 0x9d1cc0> (False)
+DEBUG:root:
+DEBUG:root:State  : 112
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = booleanValue . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [constantValue -> booleanValue] with [False] and goto state 223
+INFO:root:Result : <bool @ 0x9d1cc0> (False)
+DEBUG:root:
+DEBUG:root:State  : 223
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = constantValue . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [initializer -> constantValue] with [False] and goto state 222
+INFO:root:Result : <bool @ 0x9d1cc0> (False)
+DEBUG:root:
+DEBUG:root:State  : 222
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = initializer . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [defaultValue -> = initializer] with ['=',False] and goto state 186
+INFO:root:Result : <bool @ 0x9d1cc0> (False)
+DEBUG:root:
+DEBUG:root:State  : 186
+DEBUG:root:Defaulted state 186: Reduce using 153
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType defaultValue . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [qualifierType_2 -> : dataType defaultValue] with [':','boolean',False] and goto state 90
+INFO:root:Result : <tuple @ 0x7f956245b228> (('boolean', False, None, False))
+DEBUG:root:
+DEBUG:root:State  : 90
+DEBUG:root:Defaulted state 90: Reduce using 149
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType_2 . LexToken(,,',',1,39)
+INFO:root:Action : Reduce rule [qualifierType -> qualifierType_2] with [<tuple @ 0x7f956245b228>] and goto state 88
+INFO:root:Result : <tuple @ 0x7f956245b228> (('boolean', False, None, False))
+DEBUG:root:
+DEBUG:root:State  : 88
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType . LexToken(,,',',1,39)
+DEBUG:root:Action : Shift and goto state 138
+DEBUG:root:
+DEBUG:root:State  : 138
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , . LexToken(SCOPE,'Scope',2,45)
+DEBUG:root:Action : Shift and goto state 184
+DEBUG:root:
+DEBUG:root:State  : 184
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE . LexToken((,'(',2,50)
+DEBUG:root:Action : Shift and goto state 218
+DEBUG:root:
+DEBUG:root:State  : 218
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( . LexToken(ASSOCIATION,'association',2,51)
+DEBUG:root:Action : Shift and goto state 263
+DEBUG:root:
+DEBUG:root:State  : 263
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( ASSOCIATION . LexToken(),')',2,62)
+INFO:root:Action : Reduce rule [metaElement -> ASSOCIATION] with ['association'] and goto state 260
+INFO:root:Result : <str @ 0x7f9563a7b630> ('ASSOCIATION')
+DEBUG:root:
+DEBUG:root:State  : 260
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElement . LexToken(),')',2,62)
+INFO:root:Action : Reduce rule [metaElementList -> metaElement] with ['ASSOCIATION'] and goto state 259
+INFO:root:Result : <list @ 0x7f95623c3f88> (['ASSOCIATION'])
+DEBUG:root:
+DEBUG:root:State  : 259
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElementList . LexToken(),')',2,62)
+DEBUG:root:Action : Shift and goto state 314
+DEBUG:root:
+DEBUG:root:State  : 314
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElementList ) . LexToken(,,',',2,63)
+INFO:root:Action : Reduce rule [scope -> , SCOPE ( metaElementList )] with [',','Scope','(',['ASSOCIATION'],')'] and goto state 137
+INFO:root:Result : <OrderedDict @ 0x7f956665a9d8> (OrderedDict([('CLASS', False), ('ASSOCIA ...)
+DEBUG:root:
+DEBUG:root:State  : 137
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope . LexToken(,,',',2,63)
+DEBUG:root:Action : Shift and goto state 183
+DEBUG:root:
+DEBUG:root:State  : 183
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , . LexToken(FLAVOR,'Flavor',2,65)
+DEBUG:root:Action : Shift and goto state 217
+DEBUG:root:
+DEBUG:root:State  : 217
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR . LexToken((,'(',2,71)
+DEBUG:root:Action : Shift and goto state 258
+DEBUG:root:
+DEBUG:root:State  : 258
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( . LexToken(DISABLEOVERRIDE,'DisableOverride',2,72)
+DEBUG:root:Action : Shift and goto state 101
+DEBUG:root:
+DEBUG:root:State  : 101
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( DISABLEOVERRIDE . LexToken(,,',',2,87)
+INFO:root:Action : Reduce rule [flavor -> DISABLEOVERRIDE] with [<str @ 0x7f9563a7b7b0>] and goto state 312
+INFO:root:Result : <str @ 0x7f9563a7b630> ('disableoverride')
+DEBUG:root:
+DEBUG:root:State  : 312
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavor . LexToken(,,',',2,87)
+INFO:root:Action : Reduce rule [flavorListWithComma -> flavor] with [<str @ 0x7f9563a7b630>] and goto state 311
+INFO:root:Result : <list @ 0x7f95623c3f08> (['disableoverride'])
+DEBUG:root:
+DEBUG:root:State  : 311
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma . LexToken(,,',',2,87)
+DEBUG:root:Action : Shift and goto state 344
+DEBUG:root:
+DEBUG:root:State  : 344
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , . LexToken(TOSUBCLASS,'ToSubclass',2,89)
+DEBUG:root:Action : Shift and goto state 103
+DEBUG:root:
+DEBUG:root:State  : 103
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , TOSUBCLASS . LexToken(),')',2,99)
+INFO:root:Action : Reduce rule [flavor -> TOSUBCLASS] with ['ToSubclass'] and goto state 364
+INFO:root:Result : <str @ 0x7f9563a7b1f0> ('tosubclass')
+DEBUG:root:
+DEBUG:root:State  : 364
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , flavor . LexToken(),')',2,99)
+INFO:root:Action : Reduce rule [flavorListWithComma -> flavorListWithComma , flavor] with [<list @ 0x7f95623c3f08>,',','tosubclass'] and goto state 311
+INFO:root:Result : <list @ 0x7f95623c3ac8> (['disableoverride', 'tosubclass'])
+DEBUG:root:
+DEBUG:root:State  : 311
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma . LexToken(),')',2,99)
+DEBUG:root:Action : Shift and goto state 345
+DEBUG:root:
+DEBUG:root:State  : 345
+DEBUG:root:Defaulted state 345: Reduce using 167
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma ) . None
+INFO:root:Action : Reduce rule [defaultFlavor -> , FLAVOR ( flavorListWithComma )] with [',','Flavor','(',<list @ 0x7f95623c3ac8>,')'] and goto state 182
+INFO:root:Result : <dict @ 0x7f95623bb558> ({'ENABLEOVERRIDE': True, 'TOSUBCLASS': T ...)
+DEBUG:root:
+DEBUG:root:State  : 182
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope defaultFlavor . LexToken(;,';',2,100)
+DEBUG:root:Action : Shift and goto state 216
+DEBUG:root:
+DEBUG:root:State  : 216
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope defaultFlavor ; . LexToken(QUALIFIER,'Qualifier',4,103)
+INFO:root:Action : Reduce rule [qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ;] with ['Qualifier','Association',<tuple @ 0x7f956245b228>,<OrderedDict @ 0x7f956665a9d8>,<dict @ 0x7f95623bb558>,';'] and goto state 13
+INFO:root:Result : <CIMQualifierDeclaration @ 0x7f95623a6898> (CIMQualifierDeclaration(name='Associatio ...)
+DEBUG:root:
+DEBUG:root:State  : 13
+DEBUG:root:Stack  : mofProductionList qualifierDeclaration . LexToken(QUALIFIER,'Qualifier',4,103)
+INFO:root:Action : Reduce rule [mp_setQualifier -> qualifierDeclaration] with [<CIMQualifierDeclaration @ 0x7f95623a6898>] and goto state 7
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 7
+DEBUG:root:Stack  : mofProductionList mp_setQualifier . LexToken(QUALIFIER,'Qualifier',4,103)
+INFO:root:Action : Reduce rule [mofProduction -> mp_setQualifier] with [None] and goto state 4
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 4
+DEBUG:root:Stack  : mofProductionList mofProduction . LexToken(QUALIFIER,'Qualifier',4,103)
+INFO:root:Action : Reduce rule [mofProductionList -> mofProductionList mofProduction] with [None,None] and goto state 2
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+=============================================
+DEBUG:root:
+DEBUG:root:State  : 2
+DEBUG:root:Stack  : mofProductionList . LexToken(QUALIFIER,'Qualifier',4,103)
+DEBUG:root:Action : Shift and goto state 18
+DEBUG:root:
+DEBUG:root:State  : 18
+DEBUG:root:Stack  : mofProductionList QUALIFIER . LexToken(IDENTIFIER,'Description',4,113)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList QUALIFIER IDENTIFIER . LexToken(:,':',4,125)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['Description'] and goto state 26
+INFO:root:Result : <str @ 0x7f95623cd470> ('Description')
+DEBUG:root:
+DEBUG:root:State  : 26
+DEBUG:root:Stack  : mofProductionList QUALIFIER identifier . LexToken(:,':',4,125)
+INFO:root:Action : Reduce rule [qualifierName -> identifier] with ['Description'] and goto state 66
+INFO:root:Result : <str @ 0x7f95623cd470> ('Description')
+DEBUG:root:
+DEBUG:root:State  : 66
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName . LexToken(:,':',4,125)
+DEBUG:root:Action : Shift and goto state 91
+DEBUG:root:
+DEBUG:root:State  : 91
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : . LexToken(DT_STR,'string',4,127)
+DEBUG:root:Action : Shift and goto state 59
+DEBUG:root:
+DEBUG:root:State  : 59
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : DT_STR . LexToken(=,'=',4,134)
+INFO:root:Action : Reduce rule [dataType -> DT_STR] with ['string'] and goto state 139
+INFO:root:Result : <str @ 0x7f95623a6768> ('string')
+DEBUG:root:
+DEBUG:root:State  : 139
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType . LexToken(=,'=',4,134)
+DEBUG:root:Action : Shift and goto state 188
+DEBUG:root:
+DEBUG:root:State  : 188
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = . LexToken(NULL,'null',4,136)
+DEBUG:root:Action : Shift and goto state 121
+DEBUG:root:
+DEBUG:root:State  : 121
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = NULL . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [nullValue -> NULL] with ['null'] and goto state 113
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 113
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = nullValue . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [constantValue -> nullValue] with [None] and goto state 223
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 223
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = constantValue . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [initializer -> constantValue] with [None] and goto state 222
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 222
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType = initializer . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [defaultValue -> = initializer] with ['=',None] and goto state 186
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 186
+DEBUG:root:Defaulted state 186: Reduce using 153
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName : dataType defaultValue . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [qualifierType_2 -> : dataType defaultValue] with [':','string',None] and goto state 90
+INFO:root:Result : <tuple @ 0x7f956245b228> (('string', False, None, None))
+DEBUG:root:
+DEBUG:root:State  : 90
+DEBUG:root:Defaulted state 90: Reduce using 149
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType_2 . LexToken(,,',',4,140)
+INFO:root:Action : Reduce rule [qualifierType -> qualifierType_2] with [<tuple @ 0x7f956245b228>] and goto state 88
+INFO:root:Result : <tuple @ 0x7f956245b228> (('string', False, None, None))
+DEBUG:root:
+DEBUG:root:State  : 88
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType . LexToken(,,',',4,140)
+DEBUG:root:Action : Shift and goto state 138
+DEBUG:root:
+DEBUG:root:State  : 138
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , . LexToken(SCOPE,'Scope',5,146)
+DEBUG:root:Action : Shift and goto state 184
+DEBUG:root:
+DEBUG:root:State  : 184
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE . LexToken((,'(',5,151)
+DEBUG:root:Action : Shift and goto state 218
+DEBUG:root:
+DEBUG:root:State  : 218
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( . LexToken(ANY,'any',5,152)
+DEBUG:root:Action : Shift and goto state 270
+DEBUG:root:
+DEBUG:root:State  : 270
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( ANY . LexToken(),')',5,155)
+INFO:root:Action : Reduce rule [metaElement -> ANY] with ['any'] and goto state 260
+INFO:root:Result : <str @ 0x7f95623a6928> ('ANY')
+DEBUG:root:
+DEBUG:root:State  : 260
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElement . LexToken(),')',5,155)
+INFO:root:Action : Reduce rule [metaElementList -> metaElement] with ['ANY'] and goto state 259
+INFO:root:Result : <list @ 0x7f95623c3ac8> (['ANY'])
+DEBUG:root:
+DEBUG:root:State  : 259
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElementList . LexToken(),')',5,155)
+DEBUG:root:Action : Shift and goto state 314
+DEBUG:root:
+DEBUG:root:State  : 314
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType , SCOPE ( metaElementList ) . LexToken(,,',',5,156)
+INFO:root:Action : Reduce rule [scope -> , SCOPE ( metaElementList )] with [',','Scope','(',['ANY'],')'] and goto state 137
+INFO:root:Result : <OrderedDict @ 0x7f9565092620> (OrderedDict([('CLASS', False), ('ASSOCIA ...)
+DEBUG:root:
+DEBUG:root:State  : 137
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope . LexToken(,,',',5,156)
+DEBUG:root:Action : Shift and goto state 183
+DEBUG:root:
+DEBUG:root:State  : 183
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , . LexToken(FLAVOR,'Flavor',5,158)
+DEBUG:root:Action : Shift and goto state 217
+DEBUG:root:
+DEBUG:root:State  : 217
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR . LexToken((,'(',5,164)
+DEBUG:root:Action : Shift and goto state 258
+DEBUG:root:
+DEBUG:root:State  : 258
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( . LexToken(ENABLEOVERRIDE,'EnableOverride',5,165)
+DEBUG:root:Action : Shift and goto state 100
+DEBUG:root:
+DEBUG:root:State  : 100
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( ENABLEOVERRIDE . LexToken(,,',',5,179)
+INFO:root:Action : Reduce rule [flavor -> ENABLEOVERRIDE] with [<str @ 0x7f95623cd770>] and goto state 312
+INFO:root:Result : <str @ 0x7f95623aa230> ('enableoverride')
+DEBUG:root:
+DEBUG:root:State  : 312
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavor . LexToken(,,',',5,179)
+INFO:root:Action : Reduce rule [flavorListWithComma -> flavor] with [<str @ 0x7f95623aa230>] and goto state 311
+INFO:root:Result : <list @ 0x7f95623c3d48> (['enableoverride'])
+DEBUG:root:
+DEBUG:root:State  : 311
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma . LexToken(,,',',5,179)
+DEBUG:root:Action : Shift and goto state 344
+DEBUG:root:
+DEBUG:root:State  : 344
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , . LexToken(TOSUBCLASS,'ToSubclass',5,181)
+DEBUG:root:Action : Shift and goto state 103
+DEBUG:root:
+DEBUG:root:State  : 103
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , TOSUBCLASS . LexToken(,,',',5,191)
+INFO:root:Action : Reduce rule [flavor -> TOSUBCLASS] with ['ToSubclass'] and goto state 364
+INFO:root:Result : <str @ 0x7f95623aa330> ('tosubclass')
+DEBUG:root:
+DEBUG:root:State  : 364
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , flavor . LexToken(,,',',5,191)
+INFO:root:Action : Reduce rule [flavorListWithComma -> flavorListWithComma , flavor] with [<list @ 0x7f95623c3d48>,',','tosubclass'] and goto state 311
+INFO:root:Result : <list @ 0x7f95623c3f08> (['enableoverride', 'tosubclass'])
+DEBUG:root:
+DEBUG:root:State  : 311
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma . LexToken(,,',',5,191)
+DEBUG:root:Action : Shift and goto state 344
+DEBUG:root:
+DEBUG:root:State  : 344
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , . LexToken(TRANSLATABLE,'Translatable',5,193)
+DEBUG:root:Action : Shift and goto state 105
+DEBUG:root:
+DEBUG:root:State  : 105
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , TRANSLATABLE . LexToken(),')',5,205)
+INFO:root:Action : Reduce rule [flavor -> TRANSLATABLE] with ['Translatable'] and goto state 364
+INFO:root:Result : <str @ 0x7f95623aa2b0> ('translatable')
+DEBUG:root:
+DEBUG:root:State  : 364
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma , flavor . LexToken(),')',5,205)
+INFO:root:Action : Reduce rule [flavorListWithComma -> flavorListWithComma , flavor] with [<list @ 0x7f95623c3f08>,',','translatable'] and goto state 311
+INFO:root:Result : <list @ 0x7f95623c3d48> (['enableoverride', 'tosubclass', 'transl ...)
+DEBUG:root:
+DEBUG:root:State  : 311
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma . LexToken(),')',5,205)
+DEBUG:root:Action : Shift and goto state 345
+DEBUG:root:
+DEBUG:root:State  : 345
+DEBUG:root:Defaulted state 345: Reduce using 167
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope , FLAVOR ( flavorListWithComma ) . None
+INFO:root:Action : Reduce rule [defaultFlavor -> , FLAVOR ( flavorListWithComma )] with [',','Flavor','(',<list @ 0x7f95623c3d48>,')'] and goto state 182
+INFO:root:Result : <dict @ 0x7f956226e4c8> ({'ENABLEOVERRIDE': True, 'TOSUBCLASS': T ...)
+DEBUG:root:
+DEBUG:root:State  : 182
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope defaultFlavor . LexToken(;,';',5,206)
+DEBUG:root:Action : Shift and goto state 216
+DEBUG:root:
+DEBUG:root:State  : 216
+DEBUG:root:Stack  : mofProductionList QUALIFIER qualifierName qualifierType scope defaultFlavor ; . LexToken(CLASS,'class',7,209)
+INFO:root:Action : Reduce rule [qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ;] with ['Qualifier','Description',<tuple @ 0x7f956245b228>,<OrderedDict @ 0x7f9565092620>,<dict @ 0x7f956226e4c8>,';'] and goto state 13
+INFO:root:Result : <CIMQualifierDeclaration @ 0x7f9565084b38> (CIMQualifierDeclaration(name='Descriptio ...)
+DEBUG:root:
+DEBUG:root:State  : 13
+DEBUG:root:Stack  : mofProductionList qualifierDeclaration . LexToken(CLASS,'class',7,209)
+INFO:root:Action : Reduce rule [mp_setQualifier -> qualifierDeclaration] with [<CIMQualifierDeclaration @ 0x7f9565084b38>] and goto state 7
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 7
+DEBUG:root:Stack  : mofProductionList mp_setQualifier . LexToken(CLASS,'class',7,209)
+INFO:root:Action : Reduce rule [mofProduction -> mp_setQualifier] with [None] and goto state 4
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 4
+DEBUG:root:Stack  : mofProductionList mofProduction . LexToken(CLASS,'class',7,209)
+INFO:root:Action : Reduce rule [mofProductionList -> mofProductionList mofProduction] with [None,None] and goto state 2
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+================================================ class TST_Person
+DEBUG:root:
+DEBUG:root:State  : 2
+DEBUG:root:Stack  : mofProductionList . LexToken(CLASS,'class',7,209)
+DEBUG:root:Action : Shift and goto state 16
+DEBUG:root:
+DEBUG:root:State  : 16
+DEBUG:root:Stack  : mofProductionList CLASS . LexToken(IDENTIFIER,'TST_Person',7,215)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList CLASS IDENTIFIER . LexToken({,'{',7,225)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['TST_Person'] and goto state 63
+INFO:root:Result : <str @ 0x7f95623aa030> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 63
+DEBUG:root:Stack  : mofProductionList CLASS identifier . LexToken({,'{',7,225)
+INFO:root:Action : Reduce rule [className -> identifier] with ['TST_Person'] and goto state 62
+INFO:root:Result : <str @ 0x7f95623aa030> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 62
+DEBUG:root:Stack  : mofProductionList CLASS className . LexToken({,'{',7,225)
+DEBUG:root:Action : Shift and goto state 81
+DEBUG:root:
+DEBUG:root:State  : 81
+DEBUG:root:Stack  : mofProductionList CLASS className { . LexToken([,'[',8,235)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 126
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 126
+DEBUG:root:Stack  : mofProductionList CLASS className { empty . LexToken([,'[',8,235)
+INFO:root:Action : Reduce rule [classFeatureList -> empty] with [None] and goto state 125
+INFO:root:Result : <list @ 0x7f95623c3fc8> ([])
+DEBUG:root:
+DEBUG:root:State  : 125
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList . LexToken([,'[',8,235)
+DEBUG:root:Action : Shift and goto state 170
+DEBUG:root:
+DEBUG:root:State  : 170
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ . LexToken(IDENTIFIER,'Key',8,236)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ IDENTIFIER . LexToken(,,',',8,239)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['Key'] and goto state 26
+INFO:root:Result : <str @ 0x7f95623a67a0> ('Key')
+DEBUG:root:
+DEBUG:root:State  : 26
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ identifier . LexToken(,,',',8,239)
+INFO:root:Action : Reduce rule [qualifierName -> identifier] with ['Key'] and goto state 25
+INFO:root:Result : <str @ 0x7f95623a67a0> ('Key')
+DEBUG:root:
+DEBUG:root:State  : 25
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifierName . LexToken(,,',',8,239)
+INFO:root:Action : Reduce rule [qualifier -> qualifierName] with ['Key'] and goto state 24
+INFO:root:Result : <CIMQualifier @ 0x7f95622df518> (CIMQualifier(name='Key', value=True, typ ...)
+DEBUG:root:
+DEBUG:root:State  : 24
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier . LexToken(,,',',8,239)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 73
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 73
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier empty . LexToken(,,',',8,239)
+INFO:root:Action : Reduce rule [qualifierListEmpty -> empty] with [None] and goto state 75
+INFO:root:Result : <list @ 0x7f9565086c88> ([])
+DEBUG:root:
+DEBUG:root:State  : 75
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty . LexToken(,,',',8,239)
+DEBUG:root:Action : Shift and goto state 95
+DEBUG:root:
+DEBUG:root:State  : 95
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , . LexToken(IDENTIFIER,'Description',8,241)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , IDENTIFIER . LexToken((,'(',8,253)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['Description'] and goto state 26
+INFO:root:Result : <str @ 0x7f9562452bb0> ('Description')
+DEBUG:root:
+DEBUG:root:State  : 26
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , identifier . LexToken((,'(',8,253)
+INFO:root:Action : Reduce rule [qualifierName -> identifier] with ['Description'] and goto state 25
+INFO:root:Result : <str @ 0x7f9562452bb0> ('Description')
+NOTE: ================state 25 is CLASS Classname, etc. Seems to be same as assocDecl
+DEBUG:root:
+DEBUG:root:State  : 25
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName . LexToken((,'(',8,253)
+DEBUG:root:Action : Shift and goto state 78
+DEBUG:root:
+DEBUG:root:State  : 78
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName ( . LexToken(stringValue,'"This is key prop"',8,254)
+DEBUG:root:Action : Shift and goto state 118
+DEBUG:root:
+DEBUG:root:State  : 118
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName ( stringValue . LexToken(),')',8,272)
+INFO:root:Action : Reduce rule [stringValueList -> stringValue] with [<str @ 0x7f9562369108>] and goto state 111
+INFO:root:Result : <str @ 0x7f95623aea98> ('This is key prop')
+DEBUG:root:
+DEBUG:root:State  : 111
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName ( stringValueList . LexToken(),')',8,272)
+INFO:root:Action : Reduce rule [constantValue -> stringValueList] with [<str @ 0x7f95623aea98>] and goto state 107
+INFO:root:Result : <str @ 0x7f95623aea98> ('This is key prop')
+DEBUG:root:
+DEBUG:root:State  : 107
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName ( constantValue . LexToken(),')',8,272)
+DEBUG:root:Action : Shift and goto state 149
+DEBUG:root:
+DEBUG:root:State  : 149
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName ( constantValue ) . LexToken(],']',8,273)
+INFO:root:Action : Reduce rule [qualifierParameter -> ( constantValue )] with ['(',<str @ 0x7f95623aea98>,')'] and goto state 77
+INFO:root:Result : <str @ 0x7f95623aea98> ('This is key prop')
+DEBUG:root:
+DEBUG:root:State  : 77
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifierName qualifierParameter . LexToken(],']',8,273)
+INFO:root:Action : Reduce rule [qualifier -> qualifierName qualifierParameter] with ['Description',<str @ 0x7f95623aea98>] and goto state 145
+INFO:root:Result : <CIMQualifier @ 0x7f956234c438> (CIMQualifier(name='Description', value=' ...)
+DEBUG:root:
+DEBUG:root:State  : 145
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty , qualifier . LexToken(],']',8,273)
+INFO:root:Action : Reduce rule [qualifierListEmpty -> qualifierListEmpty , qualifier] with [[],',',<CIMQualifier @ 0x7f956234c438>] and goto state 75
+INFO:root:Result : <list @ 0x7f95623c3f08> ([CIMQualifier(name='Description', value= ...)
+DEBUG:root:
+DEBUG:root:State  : 75
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty . LexToken(],']',8,273)
+DEBUG:root:Action : Shift and goto state 97
+DEBUG:root:
+DEBUG:root:State  : 97
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList [ qualifier qualifierListEmpty ] . LexToken(DT_STR,'string',9,279)
+INFO:root:Action : Reduce rule [qualifierList -> [ qualifier qualifierListEmpty ]] with ['[',<CIMQualifier @ 0x7f95622df518>,<list @ 0x7f95623c3f08>,']'] and goto state 168
+INFO:root:Result : <list @ 0x7f9565086c88> ([CIMQualifier(name='Key', value=True, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 168
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList . LexToken(DT_STR,'string',9,279)
+DEBUG:root:Action : Shift and goto state 59
+DEBUG:root:
+DEBUG:root:State  : 59
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList DT_STR . LexToken(IDENTIFIER,'name',9,286)
+INFO:root:Action : Reduce rule [dataType -> DT_STR] with ['string'] and goto state 203
+INFO:root:Result : <str @ 0x7f956234c650> ('string')
+DEBUG:root:
+DEBUG:root:State  : 203
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList dataType . LexToken(IDENTIFIER,'name',9,286)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList dataType IDENTIFIER . LexToken(;,';',9,290)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['name'] and goto state 202
+INFO:root:Result : <str @ 0x7f956232d7a0> ('name')
+DEBUG:root:
+DEBUG:root:State  : 202
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList dataType identifier . LexToken(;,';',9,290)
+INFO:root:Action : Reduce rule [propertyName -> identifier] with ['name'] and goto state 245
+INFO:root:Result : <str @ 0x7f956232d7a0> ('name')
+DEBUG:root:
+DEBUG:root:State  : 245
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList dataType propertyName . LexToken(;,';',9,290)
+DEBUG:root:Action : Shift and goto state 299
+DEBUG:root:
+DEBUG:root:State  : 299
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList qualifierList dataType propertyName ; . LexToken(DT_STR,'string',10,296)
+INFO:root:Action : Reduce rule [propertyDeclaration_5 -> qualifierList dataType propertyName ;] with [<list @ 0x7f9565086c88>,'string','name',';'] and goto state 163
+INFO:root:Result : <CIMProperty @ 0x7f956232d908> (CIMProperty(name='name', value=None, typ ...)
+DEBUG:root:
+DEBUG:root:State  : 163
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList propertyDeclaration_5 . LexToken(DT_STR,'string',10,296)
+INFO:root:Action : Reduce rule [propertyDeclaration -> propertyDeclaration_5] with [<CIMProperty @ 0x7f956232d908>] and goto state 156
+INFO:root:Result : <CIMProperty @ 0x7f956232d908> (CIMProperty(name='name', value=None, typ ...)
+DEBUG:root:
+DEBUG:root:State  : 156
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList propertyDeclaration . LexToken(DT_STR,'string',10,296)
+INFO:root:Action : Reduce rule [classFeature -> propertyDeclaration] with [<CIMProperty @ 0x7f956232d908>] and goto state 155
+INFO:root:Result : <CIMProperty @ 0x7f956232d908> (CIMProperty(name='name', value=None, typ ...)
+DEBUG:root:
+DEBUG:root:State  : 155
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList classFeature . LexToken(DT_STR,'string',10,296)
+INFO:root:Action : Reduce rule [classFeatureList -> classFeatureList classFeature] with [[],<CIMProperty @ 0x7f956232d908>] and goto state 125
+INFO:root:Result : <list @ 0x7f95623c3f08> ([CIMProperty(name='name', value=None, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 125
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList . LexToken(DT_STR,'string',10,296)
+DEBUG:root:Action : Shift and goto state 59
+DEBUG:root:
+DEBUG:root:State  : 59
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList DT_STR . LexToken(IDENTIFIER,'extraProperty',10,303)
+INFO:root:Action : Reduce rule [dataType -> DT_STR] with ['string'] and goto state 167
+INFO:root:Result : <str @ 0x7f956234c490> ('string')
+DEBUG:root:
+DEBUG:root:State  : 167
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList dataType . LexToken(IDENTIFIER,'extraProperty',10,303)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList dataType IDENTIFIER . LexToken(;,';',10,316)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['extraProperty'] and goto state 202
+INFO:root:Result : <str @ 0x7f95624526f0> ('extraProperty')
+DEBUG:root:
+DEBUG:root:State  : 202
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList dataType identifier . LexToken(;,';',10,316)
+INFO:root:Action : Reduce rule [propertyName -> identifier] with ['extraProperty'] and goto state 201
+INFO:root:Result : <str @ 0x7f95624526f0> ('extraProperty')
+DEBUG:root:
+DEBUG:root:State  : 201
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList dataType propertyName . LexToken(;,';',10,316)
+DEBUG:root:Action : Shift and goto state 241
+DEBUG:root:
+DEBUG:root:State  : 241
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList dataType propertyName ; . LexToken(},'}',11,318)
+INFO:root:Action : Reduce rule [propertyDeclaration_1 -> dataType propertyName ;] with ['string','extraProperty',';'] and goto state 159
+INFO:root:Result : <CIMProperty @ 0x7f956232db70> (CIMProperty(name='extraProperty', value= ...)
+DEBUG:root:
+DEBUG:root:State  : 159
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList propertyDeclaration_1 . LexToken(},'}',11,318)
+INFO:root:Action : Reduce rule [propertyDeclaration -> propertyDeclaration_1] with [<CIMProperty @ 0x7f956232db70>] and goto state 156
+INFO:root:Result : <CIMProperty @ 0x7f956232db70> (CIMProperty(name='extraProperty', value= ...)
+DEBUG:root:
+DEBUG:root:State  : 156
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList propertyDeclaration . LexToken(},'}',11,318)
+INFO:root:Action : Reduce rule [classFeature -> propertyDeclaration] with [<CIMProperty @ 0x7f956232db70>] and goto state 155
+INFO:root:Result : <CIMProperty @ 0x7f956232db70> (CIMProperty(name='extraProperty', value= ...)
+DEBUG:root:
+DEBUG:root:State  : 155
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList classFeature . LexToken(},'}',11,318)
+INFO:root:Action : Reduce rule [classFeatureList -> classFeatureList classFeature] with [<list @ 0x7f95623c3f08>,<CIMProperty @ 0x7f956232db70>] and goto state 125
+INFO:root:Result : <list @ 0x7f95623c3fc8> ([CIMProperty(name='name', value=None, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 125
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList . LexToken(},'}',11,318)
+DEBUG:root:Action : Shift and goto state 154
+DEBUG:root:
+DEBUG:root:State  : 154
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList } . LexToken(;,';',11,319)
+DEBUG:root:Action : Shift and goto state 199
+DEBUG:root:
+DEBUG:root:State  : 199
+DEBUG:root:Stack  : mofProductionList CLASS className { classFeatureList } ; . LexToken([,'[',13,322)
+INFO:root:Action : Reduce rule [classDeclaration -> CLASS className { classFeatureList } ;] with ['class','TST_Person','{',<list @ 0x7f95623c3fc8>,'}',';'] and goto state 12
+INFO:root:Result : <CIMClass @ 0x7f956234c630> (CIMClass(classname='TST_Person', supercl ...)
+DEBUG:root:
+DEBUG:root:State  : 12
+DEBUG:root:Stack  : mofProductionList classDeclaration . LexToken([,'[',13,322)
+INFO:root:Action : Reduce rule [mp_createClass -> classDeclaration] with [<CIMClass @ 0x7f956234c630>] and goto state 6
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 6
+DEBUG:root:Stack  : mofProductionList mp_createClass . LexToken([,'[',13,322)
+INFO:root:Action : Reduce rule [mofProduction -> mp_createClass] with [None] and goto state 4
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 4
+DEBUG:root:Stack  : mofProductionList mofProduction . LexToken([,'[',13,322)
+INFO:root:Action : Reduce rule [mofProductionList -> mofProductionList mofProduction] with [None,None] and goto state 2
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+
+======================================= [ASSOCIATION], class
+DEBUG:root:
+DEBUG:root:State  : 2
+DEBUG:root:Stack  : mofProductionList . LexToken([,'[',13,322)
+DEBUG:root:Action : Shift and goto state 15
+DEBUG:root:
+DEBUG:root:State  : 15
+DEBUG:root:Stack  : mofProductionList [ . LexToken(ASSOCIATION,'Association',13,323)
+DEBUG:root:Action : Shift and goto state 21
+DEBUG:root:
+DEBUG:root:State  : 21
+DEBUG:root:Stack  : mofProductionList [ ASSOCIATION . LexToken(],']',13,334)
+INFO:root:Action : Reduce rule [qualifierName -> ASSOCIATION] with ['Association'] and goto state 25
+INFO:root:Result : <str @ 0x7f9562454430> ('Association')
+DEBUG:root:
+DEBUG:root:State  : 25
+DEBUG:root:Stack  : mofProductionList [ qualifierName . LexToken(],']',13,334)
+INFO:root:Action : Reduce rule [qualifier -> qualifierName] with ['Association'] and goto state 24
+INFO:root:Result : <CIMQualifier @ 0x7f956232da20> (CIMQualifier(name='Association', value=T ...)
+DEBUG:root:
+DEBUG:root:State  : 24
+DEBUG:root:Stack  : mofProductionList [ qualifier . LexToken(],']',13,334)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 73
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 73
+DEBUG:root:Stack  : mofProductionList [ qualifier empty . LexToken(],']',13,334)
+INFO:root:Action : Reduce rule [qualifierListEmpty -> empty] with [None] and goto state 75
+INFO:root:Result : <list @ 0x7f956227b0c8> ([])
+DEBUG:root:
+DEBUG:root:State  : 75
+DEBUG:root:Stack  : mofProductionList [ qualifier qualifierListEmpty . LexToken(],']',13,334)
+DEBUG:root:Action : Shift and goto state 97
+DEBUG:root:
+DEBUG:root:State  : 97
+DEBUG:root:Stack  : mofProductionList [ qualifier qualifierListEmpty ] . LexToken(CLASS,'class',14,336)
+INFO:root:Action : Reduce rule [qualifierList -> [ qualifier qualifierListEmpty ]] with ['[',<CIMQualifier @ 0x7f956232da20>,[],']'] and goto state 17
+INFO:root:Result : <list @ 0x7f9562454608> ([CIMQualifier(name='Association', value= ...)
+
+=============================== here we go back to state 17 (20) classDeclaration -> qualifierList . CLASS className { classFeatureList }
+Looks like while we started in assocDeclaration, the class element took us back to classDeclaration
+This may be tied to rule 146 Rule 146   qualifierName -> ASSOCIATION
+and state 21 conflict reduction
+
+state 21
+
+    (26) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className { associationFeatureList } ;
+    (27) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
+    (28) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
+    (29) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
+    (146) qualifierName -> ASSOCIATION .
+    (34) qualifierListEmpty -> . empty
+    (35) qualifierListEmpty -> . qualifierListEmpty , qualifier
+    (203) empty -> .
+
+  ! reduce/reduce conflict for ] resolved using rule 146 (qualifierName -> ASSOCIATION .)
+  ! reduce/reduce conflict for , resolved using rule 146 (qualifierName -> ASSOCIATION .)
+    :               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    (               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    {               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ]               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+    ,               reduce using rule 146 (qualifierName -> ASSOCIATION .)
+
+  ! ]               [ reduce using rule 203 (empty -> .) ]
+  ! ,               [ reduce using rule 203 (empty -> .) ]
+
+    qualifierListEmpty             shift and go to state 72
+    empty                          shift and go to state 73
+
+yacc invokes two default disambiguating rules:
+
+1. In a shift-reduce conflict, the default is to shift.
+
+2. In a reduce-reduce conflict, the default is to reduce by
+the earlier grammar rule (in the yacc specification). Rule 1 implies that
+reductions are deferred in favor of shifts when there is a choice.
+
+This is the following from line: 1469
+
+def p_qualifierName(p):
+    """qualifierName : identifier
+                     | ASSOCIATION
+                     | INDICATION
+                     """
+    p[0] = p[1]
+
+Rules 146 and 159 are the same so conflict resolution picks the first.
+
+Rule 146   qualifierName -> ASSOCIATION
+Rule 159   metaElement -> ASSOCIATION
+
+========================Next state.
+DEBUG:root:
+DEBUG:root:State  : 17
+DEBUG:root:Stack  : mofProductionList qualifierList . LexToken(CLASS,'class',14,336)
+DEBUG:root:Action : Shift and goto state 64
+
+=============================================But here is wierd part. After
+the conflict, it goes to state 17 which is class declaration.
+
+
+state 17
+
+    (20) classDeclaration -> qualifierList . CLASS className { classFeatureList } ;
+    (21) classDeclaration -> qualifierList . CLASS className superClass { classFeatureList } ;
+    (22) classDeclaration -> qualifierList . CLASS className alias { classFeatureList } ;
+    (23) classDeclaration -> qualifierList . CLASS className alias superClass { classFeatureList } ;
+    (172) instanceDeclaration -> qualifierList . INSTANCE OF className { valueInitializerList } ;
+    (173) instanceDeclaration -> qualifierList . INSTANCE OF className alias { valueInitializerList } ;
+
+    CLASS           shift and go to state 64
+    INSTANCE        shift and go to state 65
+
+DEBUG:root:
+DEBUG:root:State  : 64
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS . LexToken(IDENTIFIER,'TST_Lineage',14,342)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS IDENTIFIER . LexToken({,'{',14,354)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['TST_Lineage'] and goto state 63
+INFO:root:Result : <str @ 0x7f9562454c30> ('TST_Lineage')
+DEBUG:root:
+DEBUG:root:State  : 63
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS identifier . LexToken({,'{',14,354)
+INFO:root:Action : Reduce rule [className -> identifier] with ['TST_Lineage'] and goto state 86
+INFO:root:Result : <str @ 0x7f9562454c30> ('TST_Lineage')
+DEBUG:root:
+DEBUG:root:State  : 86
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className . LexToken({,'{',14,354)
+DEBUG:root:Action : Shift and goto state 133
+DEBUG:root:
+DEBUG:root:State  : 133
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { . LexToken([,'[',15,360)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 126
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 126
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { empty . LexToken([,'[',15,360)
+INFO:root:Action : Reduce rule [classFeatureList -> empty] with [None] and goto state 175
+INFO:root:Result : <list @ 0x7f956227b188> ([])
+DEBUG:root:
+DEBUG:root:State  : 175
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList . LexToken([,'[',15,360)
+DEBUG:root:Action : Shift and goto state 170
+DEBUG:root:
+DEBUG:root:State  : 170
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ . LexToken(IDENTIFIER,'key',15,361)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ IDENTIFIER . LexToken(],']',15,364)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['key'] and goto state 26
+INFO:root:Result : <str @ 0x7f956232ddf8> ('key')
+DEBUG:root:
+DEBUG:root:State  : 26
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ identifier . LexToken(],']',15,364)
+INFO:root:Action : Reduce rule [qualifierName -> identifier] with ['key'] and goto state 25
+INFO:root:Result : <str @ 0x7f956232ddf8> ('key')
+DEBUG:root:
+DEBUG:root:State  : 25
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifierName . LexToken(],']',15,364)
+INFO:root:Action : Reduce rule [qualifier -> qualifierName] with ['key'] and goto state 24
+INFO:root:Result : <CIMQualifier @ 0x7f956232df60> (CIMQualifier(name='key', value=True, typ ...)
+DEBUG:root:
+DEBUG:root:State  : 24
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier . LexToken(],']',15,364)
+INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 73
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 73
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier empty . LexToken(],']',15,364)
+INFO:root:Action : Reduce rule [qualifierListEmpty -> empty] with [None] and goto state 75
+INFO:root:Result : <list @ 0x7f956227b8c8> ([])
+DEBUG:root:
+DEBUG:root:State  : 75
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier qualifierListEmpty . LexToken(],']',15,364)
+DEBUG:root:Action : Shift and goto state 97
+DEBUG:root:
+DEBUG:root:State  : 97
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier qualifierListEmpty ] . LexToken(DT_STR,'string',15,366)
+INFO:root:Action : Reduce rule [qualifierList -> [ qualifier qualifierListEmpty ]] with ['[',<CIMQualifier @ 0x7f956232df60>,[],']'] and goto state 168
+INFO:root:Result : <list @ 0x7f95623c3f08> ([CIMQualifier(name='key', value=True, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 168
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList . LexToken(DT_STR,'string',15,366)
+DEBUG:root:Action : Shift and goto state 59
+DEBUG:root:
+DEBUG:root:State  : 59
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList DT_STR . LexToken(IDENTIFIER,'InstanceID',15,373)
+INFO:root:Action : Reduce rule [dataType -> DT_STR] with ['string'] and goto state 203
+INFO:root:Result : <str @ 0x7f956232dbc8> ('string')
+DEBUG:root:
+DEBUG:root:State  : 203
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList dataType . LexToken(IDENTIFIER,'InstanceID',15,373)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList dataType IDENTIFIER . LexToken(;,';',15,383)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['InstanceID'] and goto state 202
+INFO:root:Result : <str @ 0x7f95624549f0> ('InstanceID')
+DEBUG:root:
+DEBUG:root:State  : 202
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList dataType identifier . LexToken(;,';',15,383)
+INFO:root:Action : Reduce rule [propertyName -> identifier] with ['InstanceID'] and goto state 245
+INFO:root:Result : <str @ 0x7f95624549f0> ('InstanceID')
+DEBUG:root:
+DEBUG:root:State  : 245
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList dataType propertyName . LexToken(;,';',15,383)
+DEBUG:root:Action : Shift and goto state 299
+DEBUG:root:
+DEBUG:root:State  : 299
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList dataType propertyName ; . LexToken(IDENTIFIER,'TST_Person',16,389)
+INFO:root:Action : Reduce rule [propertyDeclaration_5 -> qualifierList dataType propertyName ;] with [<list @ 0x7f95623c3f08>,'string','InstanceID',';'] and goto state 163
+INFO:root:Result : <CIMProperty @ 0x7f956232dc88> (CIMProperty(name='InstanceID', value=Non ...)
+DEBUG:root:
+DEBUG:root:State  : 163
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList propertyDeclaration_5 . LexToken(IDENTIFIER,'TST_Person',16,389)
+INFO:root:Action : Reduce rule [propertyDeclaration -> propertyDeclaration_5] with [<CIMProperty @ 0x7f956232dc88>] and goto state 156
+INFO:root:Result : <CIMProperty @ 0x7f956232dc88> (CIMProperty(name='InstanceID', value=Non ...)
+DEBUG:root:
+DEBUG:root:State  : 156
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList propertyDeclaration . LexToken(IDENTIFIER,'TST_Person',16,389)
+INFO:root:Action : Reduce rule [classFeature -> propertyDeclaration] with [<CIMProperty @ 0x7f956232dc88>] and goto state 155
+INFO:root:Result : <CIMProperty @ 0x7f956232dc88> (CIMProperty(name='InstanceID', value=Non ...)
+DEBUG:root:
+DEBUG:root:State  : 155
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList classFeature . LexToken(IDENTIFIER,'TST_Person',16,389)
+INFO:root:Action : Reduce rule [classFeatureList -> classFeatureList classFeature] with [[],<CIMProperty @ 0x7f956232dc88>] and goto state 175
+INFO:root:Result : <list @ 0x7f956227b8c8> ([CIMProperty(name='InstanceID', value=No ...)
+DEBUG:root:
+DEBUG:root:State  : 175
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList . LexToken(IDENTIFIER,'TST_Person',16,389)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList IDENTIFIER . LexToken(REF,'ref',16,400)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['TST_Person'] and goto state 63
+INFO:root:Result : <str @ 0x7f95624556f0> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 63
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList identifier . LexToken(REF,'ref',16,400)
+INFO:root:Action : Reduce rule [className -> identifier] with ['TST_Person'] and goto state 153
+INFO:root:Result : <str @ 0x7f95624556f0> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 153
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList className . LexToken(REF,'ref',16,400)
+DEBUG:root:Action : Shift and goto state 198
+DEBUG:root:
+DEBUG:root:State  : 198
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList className REF . LexToken(IDENTIFIER,'parent',16,404)
+INFO:root:Action : Reduce rule [objectRef -> className REF] with ['TST_Person','ref'] and goto state 169
+INFO:root:Result : <str @ 0x7f95624556f0> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 169
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef . LexToken(IDENTIFIER,'parent',16,404)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef IDENTIFIER . LexToken(;,';',16,410)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['parent'] and goto state 206
+INFO:root:Result : <str @ 0x7f95623620d8> ('parent')
+DEBUG:root:
+DEBUG:root:State  : 206
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef identifier . LexToken(;,';',16,410)
+INFO:root:Action : Reduce rule [referenceName -> identifier] with ['parent'] and goto state 205
+INFO:root:Result : <str @ 0x7f95623620d8> ('parent')
+DEBUG:root:
+DEBUG:root:State  : 205
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef referenceName . LexToken(;,';',16,410)
+DEBUG:root:Action : Shift and goto state 247
+DEBUG:root:
+DEBUG:root:State  : 247
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef referenceName ; . LexToken(IDENTIFIER,'TST_Person',17,416)
+INFO:root:Action : Reduce rule [referenceDeclaration -> objectRef referenceName ;] with ['TST_Person','parent',';'] and goto state 158
+INFO:root:Result : <CIMProperty @ 0x7f956232dc50> (CIMProperty(name='parent', value=None, t ...)
+DEBUG:root:
+DEBUG:root:State  : 158
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList referenceDeclaration . LexToken(IDENTIFIER,'TST_Person',17,416)
+INFO:root:Action : Reduce rule [classFeature -> referenceDeclaration] with [<CIMProperty @ 0x7f956232dc50>] and goto state 155
+INFO:root:Result : <CIMProperty @ 0x7f956232dc50> (CIMProperty(name='parent', value=None, t ...)
+DEBUG:root:
+DEBUG:root:State  : 155
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList classFeature . LexToken(IDENTIFIER,'TST_Person',17,416)
+INFO:root:Action : Reduce rule [classFeatureList -> classFeatureList classFeature] with [<list @ 0x7f956227b8c8>,<CIMProperty @ 0x7f956232dc50>] and goto state 175
+INFO:root:Result : <list @ 0x7f956227b248> ([CIMProperty(name='InstanceID', value=No ...)
+DEBUG:root:
+DEBUG:root:State  : 175
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList . LexToken(IDENTIFIER,'TST_Person',17,416)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList IDENTIFIER . LexToken(REF,'ref',17,427)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['TST_Person'] and goto state 63
+INFO:root:Result : <str @ 0x7f9562454470> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 63
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList identifier . LexToken(REF,'ref',17,427)
+INFO:root:Action : Reduce rule [className -> identifier] with ['TST_Person'] and goto state 153
+INFO:root:Result : <str @ 0x7f9562454470> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 153
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList className . LexToken(REF,'ref',17,427)
+DEBUG:root:Action : Shift and goto state 198
+DEBUG:root:
+DEBUG:root:State  : 198
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList className REF . LexToken(IDENTIFIER,'child',17,431)
+INFO:root:Action : Reduce rule [objectRef -> className REF] with ['TST_Person','ref'] and goto state 169
+INFO:root:Result : <str @ 0x7f9562454470> ('TST_Person')
+DEBUG:root:
+DEBUG:root:State  : 169
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef . LexToken(IDENTIFIER,'child',17,431)
+DEBUG:root:Action : Shift and goto state 27
+DEBUG:root:
+DEBUG:root:State  : 27
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef IDENTIFIER . LexToken(;,';',17,436)
+INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['child'] and goto state 206
+INFO:root:Result : <str @ 0x7f95623620a0> ('child')
+DEBUG:root:
+DEBUG:root:State  : 206
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef identifier . LexToken(;,';',17,436)
+INFO:root:Action : Reduce rule [referenceName -> identifier] with ['child'] and goto state 205
+INFO:root:Result : <str @ 0x7f95623620a0> ('child')
+DEBUG:root:
+DEBUG:root:State  : 205
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef referenceName . LexToken(;,';',17,436)
+DEBUG:root:Action : Shift and goto state 247
+DEBUG:root:
+DEBUG:root:State  : 247
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList objectRef referenceName ; . LexToken(},'}',18,438)
+INFO:root:Action : Reduce rule [referenceDeclaration -> objectRef referenceName ;] with ['TST_Person','child',';'] and goto state 158
+INFO:root:Result : <CIMProperty @ 0x7f9562362f98> (CIMProperty(name='child', value=None, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 158
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList referenceDeclaration . LexToken(},'}',18,438)
+INFO:root:Action : Reduce rule [classFeature -> referenceDeclaration] with [<CIMProperty @ 0x7f9562362f98>] and goto state 155
+INFO:root:Result : <CIMProperty @ 0x7f9562362f98> (CIMProperty(name='child', value=None, ty ...)
+DEBUG:root:
+DEBUG:root:State  : 155
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList classFeature . LexToken(},'}',18,438)
+INFO:root:Action : Reduce rule [classFeatureList -> classFeatureList classFeature] with [<list @ 0x7f956227b248>,<CIMProperty @ 0x7f9562362f98>] and goto state 175
+INFO:root:Result : <list @ 0x7f956227b188> ([CIMProperty(name='InstanceID', value=No ...)
+DEBUG:root:
+DEBUG:root:State  : 175
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList . LexToken(},'}',18,438)
+DEBUG:root:Action : Shift and goto state 210
+DEBUG:root:
+DEBUG:root:State  : 210
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList } . LexToken(;,';',18,439)
+DEBUG:root:Action : Shift and goto state 252
+DEBUG:root:
+DEBUG:root:State  : 252
+DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList } ; . $end
+INFO:root:Action : Reduce rule [classDeclaration -> qualifierList CLASS className { classFeatureList } ;] with [<list @ 0x7f9562454608>,'class','TST_Lineage','{',<list @ 0x7f956227b188>,'}',';'] and goto state 12
+INFO:root:Result : <CIMClass @ 0x7f956232dcf8> (CIMClass(classname='TST_Lineage', superc ...)
+DEBUG:root:
+DEBUG:root:State  : 12
+DEBUG:root:Stack  : mofProductionList classDeclaration . $end
+INFO:root:Action : Reduce rule [mp_createClass -> classDeclaration] with [<CIMClass @ 0x7f956232dcf8>] and goto state 6
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 6
+DEBUG:root:Stack  : mofProductionList mp_createClass . $end
+INFO:root:Action : Reduce rule [mofProduction -> mp_createClass] with [None] and goto state 4
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 4
+DEBUG:root:Stack  : mofProductionList mofProduction . $end
+INFO:root:Action : Reduce rule [mofProductionList -> mofProductionList mofProduction] with [None,None] and goto state 2
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 2
+DEBUG:root:Stack  : mofProductionList . $end
+INFO:root:Action : Reduce rule [mofSpecification -> mofProductionList] with [None] and goto state 1
+INFO:root:Result : <NoneType @ 0x9d34e0> (None)
+DEBUG:root:
+DEBUG:root:State  : 1
+DEBUG:root:Stack  : mofSpecification . $end
+INFO:root:Done   : Returning <NoneType @ 0x9d34e0> (None)
+INFO:root:PLY: PARSE DEBUG END
+    PRAGMA          reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    PROPERTY        reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    QUALIFIER       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    REFERENCE       reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    RESTRICTED      reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    SCHEMA          reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    SCOPE           reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TOSUBCLASS      reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TOINSTANCE      reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TRANSLATABLE    reduce using rule 84 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+
+
+state 374
+
+    (29) assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .
+
+    #               reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+    [               reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+    CLASS           reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+    QUALIFIER       reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+    INSTANCE        reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+    $end            reduce using rule 29 (assocDeclaration -> [ ASSOCIATION qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ; .)
+
+
+state 375
+
+    (33) indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .
+
+    #               reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+    [               reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+    $end            reduce using rule 33 (indicDeclaration -> [ INDICATION qualifierListEmpty ] CLASS className alias superClass { classFeatureList } ; .)
+
+WARNING: 4 reduce/reduce conflicts
+WARNING:
+WARNING: Conflicts:
+WARNING:
+WARNING: reduce/reduce conflict in state 21 resolved using rule (qualifierName -> ASSOCIATION)
+WARNING: rejected rule (empty -> <empty>) in state 21
+WARNING: reduce/reduce conflict in state 21 resolved using rule (qualifierName -> ASSOCIATION)
+WARNING: rejected rule (empty -> <empty>) in state 21
+WARNING: reduce/reduce conflict in state 23 resolved using rule (qualifierName -> INDICATION)
+WARNING: rejected rule (empty -> <empty>) in state 23
+WARNING: reduce/reduce conflict in state 23 resolved using rule (qualifierName -> INDICATION)
+WARNING: rejected rule (empty -> <empty>) in state 23
+lex: tokens   = ['ANY', 'AS', 'ASSOCIATION', 'CLASS', 'DISABLEOVERRIDE', 'DT_BOOL', 'DT_CHAR16', 'DT_DATETIME', 'PRAGMA', 'DT_REAL32', 'DT_REAL64', 'DT_SINT16', 'DT_SINT32', 'DT_SINT64', 'DT_SINT8', 'DT_STR', 'DT_UINT16', 'DT_UINT32', 'DT_UINT64', 'DT_UINT8', 'ENABLEOVERRIDE', 'FALSE', 'FLAVOR', 'INDICATION', 'INSTANCE', 'METHOD', 'NULL', 'OF', 'PARAMETER', 'PROPERTY', 'QUALIFIER', 'REF', 'REFERENCE', 'RESTRICTED', 'SCHEMA', 'SCOPE', 'TOSUBCLASS', 'TOINSTANCE', 'TRANSLATABLE', 'TRUE', 'IDENTIFIER', 'stringValue', 'floatValue', 'charValue', 'binaryValue', 'octalValue', 'decimalValue', 'hexValue']
+lex: literals = '#(){};[],$:='
+lex: states   = {'INITIAL': 'inclusive'}
+lex: Adding rule t_COMMENT -> '//.*' (state 'INITIAL')
+lex: Adding rule t_MCOMMENT -> '/\*(.|\n)*?\*/' (state 'INITIAL')
+lex: Adding rule t_floatValue -> '[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?' (state 'INITIAL')
+lex: Adding rule t_hexValue -> '[+-]?0[xX][0-9a-fA-F]+' (state 'INITIAL')
+lex: Adding rule t_binaryValue -> '[+-]?[0-9]+[bB]' (state 'INITIAL')
+lex: Adding rule t_octalValue -> '[+-]?0[0-9]+' (state 'INITIAL')
+lex: Adding rule t_decimalValue -> '[+-]?([1-9][0-9]*|0)' (state 'INITIAL')
+lex: Adding rule t_charValue -> ''([^'\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))'' (state 'INITIAL')
+lex: Adding rule t_stringValue -> '"([^"\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))*"' (state 'INITIAL')
+lex: Adding rule t_IDENTIFIER -> '([a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))([0-9a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))*' (state 'INITIAL')
+lex: Adding rule t_newline -> '\n+' (state 'INITIAL')
+lex: ==== MASTER REGEXS FOLLOW ====
+lex: state 'INITIAL' : regex[0] = '(?P<t_COMMENT>//.*)|(?P<t_MCOMMENT>/\*(.|\n)*?\*/)|(?P<t_floatValue>[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)|(?P<t_hexValue>[+-]?0[xX][0-9a-fA-F]+)|(?P<t_binaryValue>[+-]?[0-9]+[bB])|(?P<t_octalValue>[+-]?0[0-9]+)|(?P<t_decimalValue>[+-]?([1-9][0-9]*|0))|(?P<t_charValue>'([^'\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))')|(?P<t_stringValue>"([^"\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))*")|(?P<t_IDENTIFIER>([a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))([0-9a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))*)|(?P<t_newline>\n+)'
+Compiling file './test.mof'
+Setting qualifier 'Association'
+Setting qualifier 'Description'
+qualifierListEmpty p=<ply.yacc.YaccProduction object at 0x7f95623a6710>
+qualifierListEmpty p1=[] p3=CIMQualifier(name='Description', value='This is key prop', type='string', ...)
+Creating class p1 CIMClass(classname='TST_Person', ...)
+Creating class 'root/cimv2':'TST_Person'
+Created class 'root/cimv2':'TST_Person'
+qualifierListEmpty p=<ply.yacc.YaccProduction object at 0x7f95623a6710>
+qualifierListEmpty p=<ply.yacc.YaccProduction object at 0x7f95623a6710>
+Creating class p1 CIMClass(classname='TST_Lineage', ...)
+Creating class 'root/cimv2':'TST_Lineage'
+Created class 'root/cimv2':'TST_Lineage'

--- a/fix_mofout2.txt
+++ b/fix_mofout2.txt
@@ -1,0 +1,9480 @@
+MOF repository: Namespace root/cimv2 in WBEM server http://192.168.3.135
+Executing in dry-run mode
+Created by PLY version 3.11 (http://www.dabeaz.com/ply)
+
+Grammar
+
+Rule 0     S' -> mofSpecification
+Rule 1     mofSpecification -> mofProductionList
+Rule 2     mofProductionList -> empty
+Rule 3     mofProductionList -> mofProductionList mofProduction
+Rule 4     mofProduction -> compilerDirective
+Rule 5     mofProduction -> mp_createClass
+Rule 6     mofProduction -> mp_setQualifier
+Rule 7     mofProduction -> mp_createInstance
+Rule 8     mp_createClass -> classDeclaration
+Rule 9     mp_createInstance -> instanceDeclaration
+Rule 10    mp_setQualifier -> qualifierDeclaration
+Rule 11    compilerDirective -> # PRAGMA pragmaName ( pragmaParameter )
+Rule 12    pragmaName -> identifier
+Rule 13    pragmaParameter -> stringValue
+Rule 14    classDeclaration -> CLASS className { classFeatureList } ;
+Rule 15    classDeclaration -> CLASS className superClass { classFeatureList } ;
+Rule 16    classDeclaration -> CLASS className alias { classFeatureList } ;
+Rule 17    classDeclaration -> CLASS className alias superClass { classFeatureList } ;
+Rule 18    classDeclaration -> qualifierList CLASS className { classFeatureList } ;
+Rule 19    classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ;
+Rule 20    classDeclaration -> qualifierList CLASS className alias { classFeatureList } ;
+Rule 21    classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ;
+Rule 22    classFeatureList -> empty
+Rule 23    classFeatureList -> classFeatureList classFeature
+Rule 24    qualifierListEmpty -> empty
+Rule 25    qualifierListEmpty -> qualifierListEmpty , qualifier
+Rule 26    className -> identifier
+Rule 27    alias -> AS aliasIdentifier
+Rule 28    aliasIdentifier -> $ identifier
+Rule 29    superClass -> : className
+Rule 30    classFeature -> propertyDeclaration
+Rule 31    classFeature -> methodDeclaration
+Rule 32    classFeature -> referenceDeclaration
+Rule 33    qualifierList -> [ qualifier qualifierListEmpty ]
+Rule 34    qualifier -> qualifierName
+Rule 35    qualifier -> qualifierName : flavorList
+Rule 36    qualifier -> qualifierName qualifierParameter
+Rule 37    qualifier -> qualifierName qualifierParameter : flavorList
+Rule 38    flavorList -> flavor
+Rule 39    flavorList -> flavorList flavor
+Rule 40    qualifierParameter -> ( constantValue )
+Rule 41    qualifierParameter -> arrayInitializer
+Rule 42    flavor -> ENABLEOVERRIDE
+Rule 43    flavor -> DISABLEOVERRIDE
+Rule 44    flavor -> RESTRICTED
+Rule 45    flavor -> TOSUBCLASS
+Rule 46    flavor -> TOINSTANCE
+Rule 47    flavor -> TRANSLATABLE
+Rule 48    propertyDeclaration -> propertyDeclaration_1
+Rule 49    propertyDeclaration -> propertyDeclaration_2
+Rule 50    propertyDeclaration -> propertyDeclaration_3
+Rule 51    propertyDeclaration -> propertyDeclaration_4
+Rule 52    propertyDeclaration -> propertyDeclaration_5
+Rule 53    propertyDeclaration -> propertyDeclaration_6
+Rule 54    propertyDeclaration -> propertyDeclaration_7
+Rule 55    propertyDeclaration -> propertyDeclaration_8
+Rule 56    propertyDeclaration_1 -> dataType propertyName ;
+Rule 57    propertyDeclaration_2 -> dataType propertyName defaultValue ;
+Rule 58    propertyDeclaration_3 -> dataType propertyName array ;
+Rule 59    propertyDeclaration_4 -> dataType propertyName array defaultValue ;
+Rule 60    propertyDeclaration_5 -> qualifierList dataType propertyName ;
+Rule 61    propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ;
+Rule 62    propertyDeclaration_7 -> qualifierList dataType propertyName array ;
+Rule 63    propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ;
+Rule 64    referenceDeclaration -> objectRef referenceName ;
+Rule 65    referenceDeclaration -> objectRef referenceName defaultValue ;
+Rule 66    referenceDeclaration -> qualifierList objectRef referenceName ;
+Rule 67    referenceDeclaration -> qualifierList objectRef referenceName defaultValue ;
+Rule 68    methodDeclaration -> dataType methodName ( ) ;
+Rule 69    methodDeclaration -> dataType methodName ( parameterList ) ;
+Rule 70    methodDeclaration -> qualifierList dataType methodName ( ) ;
+Rule 71    methodDeclaration -> qualifierList dataType methodName ( parameterList ) ;
+Rule 72    propertyName -> identifier
+Rule 73    referenceName -> identifier
+Rule 74    methodName -> identifier
+Rule 75    dataType -> DT_UINT8
+Rule 76    dataType -> DT_SINT8
+Rule 77    dataType -> DT_UINT16
+Rule 78    dataType -> DT_SINT16
+Rule 79    dataType -> DT_UINT32
+Rule 80    dataType -> DT_SINT32
+Rule 81    dataType -> DT_UINT64
+Rule 82    dataType -> DT_SINT64
+Rule 83    dataType -> DT_REAL32
+Rule 84    dataType -> DT_REAL64
+Rule 85    dataType -> DT_CHAR16
+Rule 86    dataType -> DT_STR
+Rule 87    dataType -> DT_BOOL
+Rule 88    dataType -> DT_DATETIME
+Rule 89    objectRef -> className REF
+Rule 90    parameterList -> parameter
+Rule 91    parameterList -> parameterList , parameter
+Rule 92    parameter -> parameter_1
+Rule 93    parameter -> parameter_2
+Rule 94    parameter -> parameter_3
+Rule 95    parameter -> parameter_4
+Rule 96    parameter_1 -> dataType parameterName
+Rule 97    parameter_1 -> dataType parameterName array
+Rule 98    parameter_2 -> qualifierList dataType parameterName
+Rule 99    parameter_2 -> qualifierList dataType parameterName array
+Rule 100   parameter_3 -> objectRef parameterName
+Rule 101   parameter_3 -> objectRef parameterName array
+Rule 102   parameter_4 -> qualifierList objectRef parameterName
+Rule 103   parameter_4 -> qualifierList objectRef parameterName array
+Rule 104   parameterName -> identifier
+Rule 105   array -> [ ]
+Rule 106   array -> [ integerValue ]
+Rule 107   defaultValue -> = initializer
+Rule 108   initializer -> constantValue
+Rule 109   initializer -> arrayInitializer
+Rule 110   initializer -> referenceInitializer
+Rule 111   arrayInitializer -> { constantValueList }
+Rule 112   arrayInitializer -> { }
+Rule 113   constantValueList -> constantValue
+Rule 114   constantValueList -> constantValueList , constantValue
+Rule 115   stringValueList -> stringValue
+Rule 116   stringValueList -> stringValueList stringValue
+Rule 117   constantValue -> integerValue
+Rule 118   constantValue -> floatValue
+Rule 119   constantValue -> charValue
+Rule 120   constantValue -> stringValueList
+Rule 121   constantValue -> booleanValue
+Rule 122   constantValue -> nullValue
+Rule 123   integerValue -> binaryValue
+Rule 124   integerValue -> octalValue
+Rule 125   integerValue -> decimalValue
+Rule 126   integerValue -> hexValue
+Rule 127   referenceInitializer -> objectHandle
+Rule 128   referenceInitializer -> aliasIdentifier
+Rule 129   objectHandle -> identifier
+Rule 130   qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ;
+Rule 131   qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ;
+Rule 132   qualifierName -> identifier
+Rule 133   qualifierName -> ASSOCIATION
+Rule 134   qualifierName -> INDICATION
+Rule 135   qualifierType -> qualifierType_1
+Rule 136   qualifierType -> qualifierType_2
+Rule 137   qualifierType_1 -> : dataType array
+Rule 138   qualifierType_1 -> : dataType array defaultValue
+Rule 139   qualifierType_2 -> : dataType
+Rule 140   qualifierType_2 -> : dataType defaultValue
+Rule 141   scope -> , SCOPE ( metaElementList )
+Rule 142   metaElementList -> metaElement
+Rule 143   metaElementList -> metaElementList , metaElement
+Rule 144   metaElement -> SCHEMA
+Rule 145   metaElement -> CLASS
+Rule 146   metaElement -> ASSOCIATION
+Rule 147   metaElement -> INDICATION
+Rule 148   metaElement -> QUALIFIER
+Rule 149   metaElement -> PROPERTY
+Rule 150   metaElement -> REFERENCE
+Rule 151   metaElement -> METHOD
+Rule 152   metaElement -> PARAMETER
+Rule 153   metaElement -> ANY
+Rule 154   defaultFlavor -> , FLAVOR ( flavorListWithComma )
+Rule 155   flavorListWithComma -> flavor
+Rule 156   flavorListWithComma -> flavorListWithComma , flavor
+Rule 157   instanceDeclaration -> INSTANCE OF className { valueInitializerList } ;
+Rule 158   instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ;
+Rule 159   instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ;
+Rule 160   instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ;
+Rule 161   valueInitializerList -> valueInitializer
+Rule 162   valueInitializerList -> valueInitializerList valueInitializer
+Rule 163   valueInitializer -> identifier defaultValue ;
+Rule 164   valueInitializer -> qualifierList identifier defaultValue ;
+Rule 165   booleanValue -> FALSE
+Rule 166   booleanValue -> TRUE
+Rule 167   nullValue -> NULL
+Rule 168   identifier -> IDENTIFIER
+Rule 169   identifier -> ANY
+Rule 170   identifier -> AS
+Rule 171   identifier -> CLASS
+Rule 172   identifier -> DISABLEOVERRIDE
+Rule 173   identifier -> dataType
+Rule 174   identifier -> ENABLEOVERRIDE
+Rule 175   identifier -> FLAVOR
+Rule 176   identifier -> INSTANCE
+Rule 177   identifier -> METHOD
+Rule 178   identifier -> OF
+Rule 179   identifier -> PARAMETER
+Rule 180   identifier -> PRAGMA
+Rule 181   identifier -> PROPERTY
+Rule 182   identifier -> QUALIFIER
+Rule 183   identifier -> REFERENCE
+Rule 184   identifier -> RESTRICTED
+Rule 185   identifier -> SCHEMA
+Rule 186   identifier -> SCOPE
+Rule 187   identifier -> TOSUBCLASS
+Rule 188   identifier -> TOINSTANCE
+Rule 189   identifier -> TRANSLATABLE
+Rule 190   empty -> <empty>
+
+Terminals, with rules where they appear
+
+#                    : 11
+$                    : 28
+(                    : 11 40 68 69 70 71 141 154
+)                    : 11 40 68 69 70 71 141 154
+,                    : 25 91 114 141 143 154 156
+:                    : 29 35 37 137 138 139 140
+;                    : 14 15 16 17 18 19 20 21 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 130 131 157 158 159 160 163 164
+=                    : 107
+ANY                  : 153 169
+AS                   : 27 170
+ASSOCIATION          : 133 146
+CLASS                : 14 15 16 17 18 19 20 21 145 171
+DISABLEOVERRIDE      : 43 172
+DT_BOOL              : 87
+DT_CHAR16            : 85
+DT_DATETIME          : 88
+DT_REAL32            : 83
+DT_REAL64            : 84
+DT_SINT16            : 78
+DT_SINT32            : 80
+DT_SINT64            : 82
+DT_SINT8             : 76
+DT_STR               : 86
+DT_UINT16            : 77
+DT_UINT32            : 79
+DT_UINT64            : 81
+DT_UINT8             : 75
+ENABLEOVERRIDE       : 42 174
+FALSE                : 165
+FLAVOR               : 154 175
+IDENTIFIER           : 168
+INDICATION           : 134 147
+INSTANCE             : 157 158 159 160 176
+METHOD               : 151 177
+NULL                 : 167
+OF                   : 157 158 159 160 178
+PARAMETER            : 152 179
+PRAGMA               : 11 180
+PROPERTY             : 149 181
+QUALIFIER            : 130 131 148 182
+REF                  : 89
+REFERENCE            : 150 183
+RESTRICTED           : 44 184
+SCHEMA               : 144 185
+SCOPE                : 141 186
+TOINSTANCE           : 46 188
+TOSUBCLASS           : 45 187
+TRANSLATABLE         : 47 189
+TRUE                 : 166
+[                    : 33 105 106
+]                    : 33 105 106
+binaryValue          : 123
+charValue            : 119
+decimalValue         : 125
+error                : 
+floatValue           : 118
+hexValue             : 126
+octalValue           : 124
+stringValue          : 13 115 116
+{                    : 14 15 16 17 18 19 20 21 111 112 157 158 159 160
+}                    : 14 15 16 17 18 19 20 21 111 112 157 158 159 160
+
+Nonterminals, with rules where they appear
+
+alias                : 16 17 20 21 158 160
+aliasIdentifier      : 27 128
+array                : 58 59 62 63 97 99 101 103 137 138
+arrayInitializer     : 41 109
+booleanValue         : 121
+classDeclaration     : 8
+classFeature         : 23
+classFeatureList     : 14 15 16 17 18 19 20 21 23
+className            : 14 15 16 17 18 19 20 21 29 89 157 158 159 160
+compilerDirective    : 4
+constantValue        : 40 108 113 114
+constantValueList    : 111 114
+dataType             : 56 57 58 59 60 61 62 63 68 69 70 71 96 97 98 99 137 138 139 140 173
+defaultFlavor        : 131
+defaultValue         : 57 59 61 63 65 67 138 140 163 164
+empty                : 2 22 24
+flavor               : 38 39 155 156
+flavorList           : 35 37 39
+flavorListWithComma  : 154 156
+identifier           : 12 26 28 72 73 74 104 129 132 163 164
+initializer          : 107
+instanceDeclaration  : 9
+integerValue         : 106 117
+metaElement          : 142 143
+metaElementList      : 141 143
+methodDeclaration    : 31
+methodName           : 68 69 70 71
+mofProduction        : 3
+mofProductionList    : 1 3
+mofSpecification     : 0
+mp_createClass       : 5
+mp_createInstance    : 7
+mp_setQualifier      : 6
+nullValue            : 122
+objectHandle         : 127
+objectRef            : 64 65 66 67 100 101 102 103
+parameter            : 90 91
+parameterList        : 69 71 91
+parameterName        : 96 97 98 99 100 101 102 103
+parameter_1          : 92
+parameter_2          : 93
+parameter_3          : 94
+parameter_4          : 95
+pragmaName           : 11
+pragmaParameter      : 11
+propertyDeclaration  : 30
+propertyDeclaration_1 : 48
+propertyDeclaration_2 : 49
+propertyDeclaration_3 : 50
+propertyDeclaration_4 : 51
+propertyDeclaration_5 : 52
+propertyDeclaration_6 : 53
+propertyDeclaration_7 : 54
+propertyDeclaration_8 : 55
+propertyName         : 56 57 58 59 60 61 62 63
+qualifier            : 25 33
+qualifierDeclaration : 10
+qualifierList        : 18 19 20 21 60 61 62 63 66 67 70 71 98 99 102 103 159 160 164
+qualifierListEmpty   : 25 33
+qualifierName        : 34 35 36 37 130 131
+qualifierParameter   : 36 37
+qualifierType        : 130 131
+qualifierType_1      : 135
+qualifierType_2      : 136
+referenceDeclaration : 32
+referenceInitializer : 110
+referenceName        : 64 65 66 67
+scope                : 130 131
+stringValueList      : 116 120
+superClass           : 15 17 19 21
+valueInitializer     : 161 162
+valueInitializerList : 157 158 159 160 162
+
+Generating LALR tables
+Parsing method: LALR
+
+state 0
+
+    (0) S' -> . mofSpecification
+    (1) mofSpecification -> . mofProductionList
+    (2) mofProductionList -> . empty
+    (3) mofProductionList -> . mofProductionList mofProduction
+    (190) empty -> .
+
+    #               reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    $end            reduce using rule 190 (empty -> .)
+
+    mofSpecification               shift and go to state 1
+    mofProductionList              shift and go to state 2
+    empty                          shift and go to state 3
+
+state 1
+
+    (0) S' -> mofSpecification .
+
+
+
+state 2
+
+    (1) mofSpecification -> mofProductionList .
+    (3) mofProductionList -> mofProductionList . mofProduction
+    (4) mofProduction -> . compilerDirective
+    (5) mofProduction -> . mp_createClass
+    (6) mofProduction -> . mp_setQualifier
+    (7) mofProduction -> . mp_createInstance
+    (11) compilerDirective -> . # PRAGMA pragmaName ( pragmaParameter )
+    (8) mp_createClass -> . classDeclaration
+    (10) mp_setQualifier -> . qualifierDeclaration
+    (9) mp_createInstance -> . instanceDeclaration
+    (14) classDeclaration -> . CLASS className { classFeatureList } ;
+    (15) classDeclaration -> . CLASS className superClass { classFeatureList } ;
+    (16) classDeclaration -> . CLASS className alias { classFeatureList } ;
+    (17) classDeclaration -> . CLASS className alias superClass { classFeatureList } ;
+    (18) classDeclaration -> . qualifierList CLASS className { classFeatureList } ;
+    (19) classDeclaration -> . qualifierList CLASS className superClass { classFeatureList } ;
+    (20) classDeclaration -> . qualifierList CLASS className alias { classFeatureList } ;
+    (21) classDeclaration -> . qualifierList CLASS className alias superClass { classFeatureList } ;
+    (130) qualifierDeclaration -> . QUALIFIER qualifierName qualifierType scope ;
+    (131) qualifierDeclaration -> . QUALIFIER qualifierName qualifierType scope defaultFlavor ;
+    (157) instanceDeclaration -> . INSTANCE OF className { valueInitializerList } ;
+    (158) instanceDeclaration -> . INSTANCE OF className alias { valueInitializerList } ;
+    (159) instanceDeclaration -> . qualifierList INSTANCE OF className { valueInitializerList } ;
+    (160) instanceDeclaration -> . qualifierList INSTANCE OF className alias { valueInitializerList } ;
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+
+    $end            reduce using rule 1 (mofSpecification -> mofProductionList .)
+    #               shift and go to state 9
+    CLASS           shift and go to state 13
+    QUALIFIER       shift and go to state 15
+    INSTANCE        shift and go to state 16
+    [               shift and go to state 17
+
+    mofProduction                  shift and go to state 4
+    compilerDirective              shift and go to state 5
+    mp_createClass                 shift and go to state 6
+    mp_setQualifier                shift and go to state 7
+    mp_createInstance              shift and go to state 8
+    classDeclaration               shift and go to state 10
+    qualifierDeclaration           shift and go to state 11
+    instanceDeclaration            shift and go to state 12
+    qualifierList                  shift and go to state 14
+
+state 3
+
+    (2) mofProductionList -> empty .
+
+    #               reduce using rule 2 (mofProductionList -> empty .)
+    CLASS           reduce using rule 2 (mofProductionList -> empty .)
+    QUALIFIER       reduce using rule 2 (mofProductionList -> empty .)
+    INSTANCE        reduce using rule 2 (mofProductionList -> empty .)
+    [               reduce using rule 2 (mofProductionList -> empty .)
+    $end            reduce using rule 2 (mofProductionList -> empty .)
+
+
+state 4
+
+    (3) mofProductionList -> mofProductionList mofProduction .
+
+    #               reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    CLASS           reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    QUALIFIER       reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    INSTANCE        reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    [               reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+    $end            reduce using rule 3 (mofProductionList -> mofProductionList mofProduction .)
+
+
+state 5
+
+    (4) mofProduction -> compilerDirective .
+
+    #               reduce using rule 4 (mofProduction -> compilerDirective .)
+    CLASS           reduce using rule 4 (mofProduction -> compilerDirective .)
+    QUALIFIER       reduce using rule 4 (mofProduction -> compilerDirective .)
+    INSTANCE        reduce using rule 4 (mofProduction -> compilerDirective .)
+    [               reduce using rule 4 (mofProduction -> compilerDirective .)
+    $end            reduce using rule 4 (mofProduction -> compilerDirective .)
+
+
+state 6
+
+    (5) mofProduction -> mp_createClass .
+
+    #               reduce using rule 5 (mofProduction -> mp_createClass .)
+    CLASS           reduce using rule 5 (mofProduction -> mp_createClass .)
+    QUALIFIER       reduce using rule 5 (mofProduction -> mp_createClass .)
+    INSTANCE        reduce using rule 5 (mofProduction -> mp_createClass .)
+    [               reduce using rule 5 (mofProduction -> mp_createClass .)
+    $end            reduce using rule 5 (mofProduction -> mp_createClass .)
+
+
+state 7
+
+    (6) mofProduction -> mp_setQualifier .
+
+    #               reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    CLASS           reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    QUALIFIER       reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    INSTANCE        reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    [               reduce using rule 6 (mofProduction -> mp_setQualifier .)
+    $end            reduce using rule 6 (mofProduction -> mp_setQualifier .)
+
+
+state 8
+
+    (7) mofProduction -> mp_createInstance .
+
+    #               reduce using rule 7 (mofProduction -> mp_createInstance .)
+    CLASS           reduce using rule 7 (mofProduction -> mp_createInstance .)
+    QUALIFIER       reduce using rule 7 (mofProduction -> mp_createInstance .)
+    INSTANCE        reduce using rule 7 (mofProduction -> mp_createInstance .)
+    [               reduce using rule 7 (mofProduction -> mp_createInstance .)
+    $end            reduce using rule 7 (mofProduction -> mp_createInstance .)
+
+
+state 9
+
+    (11) compilerDirective -> # . PRAGMA pragmaName ( pragmaParameter )
+
+    PRAGMA          shift and go to state 18
+
+
+state 10
+
+    (8) mp_createClass -> classDeclaration .
+
+    #               reduce using rule 8 (mp_createClass -> classDeclaration .)
+    CLASS           reduce using rule 8 (mp_createClass -> classDeclaration .)
+    QUALIFIER       reduce using rule 8 (mp_createClass -> classDeclaration .)
+    INSTANCE        reduce using rule 8 (mp_createClass -> classDeclaration .)
+    [               reduce using rule 8 (mp_createClass -> classDeclaration .)
+    $end            reduce using rule 8 (mp_createClass -> classDeclaration .)
+
+
+state 11
+
+    (10) mp_setQualifier -> qualifierDeclaration .
+
+    #               reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+    CLASS           reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+    QUALIFIER       reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+    INSTANCE        reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+    [               reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+    $end            reduce using rule 10 (mp_setQualifier -> qualifierDeclaration .)
+
+
+state 12
+
+    (9) mp_createInstance -> instanceDeclaration .
+
+    #               reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+    CLASS           reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+    QUALIFIER       reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+    INSTANCE        reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+    [               reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+    $end            reduce using rule 9 (mp_createInstance -> instanceDeclaration .)
+
+
+state 13
+
+    (14) classDeclaration -> CLASS . className { classFeatureList } ;
+    (15) classDeclaration -> CLASS . className superClass { classFeatureList } ;
+    (16) classDeclaration -> CLASS . className alias { classFeatureList } ;
+    (17) classDeclaration -> CLASS . className alias superClass { classFeatureList } ;
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    className                      shift and go to state 20
+    identifier                     shift and go to state 21
+    dataType                       shift and go to state 26
+
+state 14
+
+    (18) classDeclaration -> qualifierList . CLASS className { classFeatureList } ;
+    (19) classDeclaration -> qualifierList . CLASS className superClass { classFeatureList } ;
+    (20) classDeclaration -> qualifierList . CLASS className alias { classFeatureList } ;
+    (21) classDeclaration -> qualifierList . CLASS className alias superClass { classFeatureList } ;
+    (159) instanceDeclaration -> qualifierList . INSTANCE OF className { valueInitializerList } ;
+    (160) instanceDeclaration -> qualifierList . INSTANCE OF className alias { valueInitializerList } ;
+
+    CLASS           shift and go to state 57
+    INSTANCE        shift and go to state 58
+
+
+state 15
+
+    (130) qualifierDeclaration -> QUALIFIER . qualifierName qualifierType scope ;
+    (131) qualifierDeclaration -> QUALIFIER . qualifierName qualifierType scope defaultFlavor ;
+    (132) qualifierName -> . identifier
+    (133) qualifierName -> . ASSOCIATION
+    (134) qualifierName -> . INDICATION
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 61
+    INDICATION      shift and go to state 62
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifierName                  shift and go to state 59
+    identifier                     shift and go to state 60
+    dataType                       shift and go to state 26
+
+state 16
+
+    (157) instanceDeclaration -> INSTANCE . OF className { valueInitializerList } ;
+    (158) instanceDeclaration -> INSTANCE . OF className alias { valueInitializerList } ;
+
+    OF              shift and go to state 63
+
+
+state 17
+
+    (33) qualifierList -> [ . qualifier qualifierListEmpty ]
+    (34) qualifier -> . qualifierName
+    (35) qualifier -> . qualifierName : flavorList
+    (36) qualifier -> . qualifierName qualifierParameter
+    (37) qualifier -> . qualifierName qualifierParameter : flavorList
+    (132) qualifierName -> . identifier
+    (133) qualifierName -> . ASSOCIATION
+    (134) qualifierName -> . INDICATION
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 61
+    INDICATION      shift and go to state 62
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifier                      shift and go to state 64
+    qualifierName                  shift and go to state 65
+    identifier                     shift and go to state 60
+    dataType                       shift and go to state 26
+
+state 18
+
+    (11) compilerDirective -> # PRAGMA . pragmaName ( pragmaParameter )
+    (12) pragmaName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    pragmaName                     shift and go to state 66
+    identifier                     shift and go to state 67
+    dataType                       shift and go to state 26
+
+state 19
+
+    (171) identifier -> CLASS .
+
+    {               reduce using rule 171 (identifier -> CLASS .)
+    :               reduce using rule 171 (identifier -> CLASS .)
+    AS              reduce using rule 171 (identifier -> CLASS .)
+    (               reduce using rule 171 (identifier -> CLASS .)
+    ]               reduce using rule 171 (identifier -> CLASS .)
+    ,               reduce using rule 171 (identifier -> CLASS .)
+    REF             reduce using rule 171 (identifier -> CLASS .)
+    ;               reduce using rule 171 (identifier -> CLASS .)
+    =               reduce using rule 171 (identifier -> CLASS .)
+    [               reduce using rule 171 (identifier -> CLASS .)
+    )               reduce using rule 171 (identifier -> CLASS .)
+
+
+state 20
+
+    (14) classDeclaration -> CLASS className . { classFeatureList } ;
+    (15) classDeclaration -> CLASS className . superClass { classFeatureList } ;
+    (16) classDeclaration -> CLASS className . alias { classFeatureList } ;
+    (17) classDeclaration -> CLASS className . alias superClass { classFeatureList } ;
+    (29) superClass -> . : className
+    (27) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 68
+    :               shift and go to state 71
+    AS              shift and go to state 72
+
+    superClass                     shift and go to state 69
+    alias                          shift and go to state 70
+
+state 21
+
+    (26) className -> identifier .
+
+    {               reduce using rule 26 (className -> identifier .)
+    :               reduce using rule 26 (className -> identifier .)
+    AS              reduce using rule 26 (className -> identifier .)
+    REF             reduce using rule 26 (className -> identifier .)
+
+
+state 22
+
+    (168) identifier -> IDENTIFIER .
+
+    {               reduce using rule 168 (identifier -> IDENTIFIER .)
+    :               reduce using rule 168 (identifier -> IDENTIFIER .)
+    AS              reduce using rule 168 (identifier -> IDENTIFIER .)
+    (               reduce using rule 168 (identifier -> IDENTIFIER .)
+    ]               reduce using rule 168 (identifier -> IDENTIFIER .)
+    ,               reduce using rule 168 (identifier -> IDENTIFIER .)
+    REF             reduce using rule 168 (identifier -> IDENTIFIER .)
+    ;               reduce using rule 168 (identifier -> IDENTIFIER .)
+    =               reduce using rule 168 (identifier -> IDENTIFIER .)
+    [               reduce using rule 168 (identifier -> IDENTIFIER .)
+    )               reduce using rule 168 (identifier -> IDENTIFIER .)
+
+
+state 23
+
+    (169) identifier -> ANY .
+
+    {               reduce using rule 169 (identifier -> ANY .)
+    :               reduce using rule 169 (identifier -> ANY .)
+    AS              reduce using rule 169 (identifier -> ANY .)
+    (               reduce using rule 169 (identifier -> ANY .)
+    ]               reduce using rule 169 (identifier -> ANY .)
+    ,               reduce using rule 169 (identifier -> ANY .)
+    REF             reduce using rule 169 (identifier -> ANY .)
+    ;               reduce using rule 169 (identifier -> ANY .)
+    =               reduce using rule 169 (identifier -> ANY .)
+    [               reduce using rule 169 (identifier -> ANY .)
+    )               reduce using rule 169 (identifier -> ANY .)
+
+
+state 24
+
+    (170) identifier -> AS .
+
+    {               reduce using rule 170 (identifier -> AS .)
+    :               reduce using rule 170 (identifier -> AS .)
+    AS              reduce using rule 170 (identifier -> AS .)
+    (               reduce using rule 170 (identifier -> AS .)
+    ]               reduce using rule 170 (identifier -> AS .)
+    ,               reduce using rule 170 (identifier -> AS .)
+    REF             reduce using rule 170 (identifier -> AS .)
+    ;               reduce using rule 170 (identifier -> AS .)
+    =               reduce using rule 170 (identifier -> AS .)
+    [               reduce using rule 170 (identifier -> AS .)
+    )               reduce using rule 170 (identifier -> AS .)
+
+
+state 25
+
+    (172) identifier -> DISABLEOVERRIDE .
+
+    {               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    :               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    AS              reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    (               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    ]               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    ,               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    REF             reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    ;               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    =               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    [               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+    )               reduce using rule 172 (identifier -> DISABLEOVERRIDE .)
+
+
+state 26
+
+    (173) identifier -> dataType .
+
+    {               reduce using rule 173 (identifier -> dataType .)
+    :               reduce using rule 173 (identifier -> dataType .)
+    AS              reduce using rule 173 (identifier -> dataType .)
+    (               reduce using rule 173 (identifier -> dataType .)
+    ]               reduce using rule 173 (identifier -> dataType .)
+    ,               reduce using rule 173 (identifier -> dataType .)
+    ;               reduce using rule 173 (identifier -> dataType .)
+    =               reduce using rule 173 (identifier -> dataType .)
+    [               reduce using rule 173 (identifier -> dataType .)
+    )               reduce using rule 173 (identifier -> dataType .)
+
+
+state 27
+
+    (174) identifier -> ENABLEOVERRIDE .
+
+    {               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    :               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    AS              reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    (               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    ]               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    ,               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    REF             reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    ;               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    =               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    [               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+    )               reduce using rule 174 (identifier -> ENABLEOVERRIDE .)
+
+
+state 28
+
+    (175) identifier -> FLAVOR .
+
+    {               reduce using rule 175 (identifier -> FLAVOR .)
+    :               reduce using rule 175 (identifier -> FLAVOR .)
+    AS              reduce using rule 175 (identifier -> FLAVOR .)
+    (               reduce using rule 175 (identifier -> FLAVOR .)
+    ]               reduce using rule 175 (identifier -> FLAVOR .)
+    ,               reduce using rule 175 (identifier -> FLAVOR .)
+    REF             reduce using rule 175 (identifier -> FLAVOR .)
+    ;               reduce using rule 175 (identifier -> FLAVOR .)
+    =               reduce using rule 175 (identifier -> FLAVOR .)
+    [               reduce using rule 175 (identifier -> FLAVOR .)
+    )               reduce using rule 175 (identifier -> FLAVOR .)
+
+
+state 29
+
+    (176) identifier -> INSTANCE .
+
+    {               reduce using rule 176 (identifier -> INSTANCE .)
+    :               reduce using rule 176 (identifier -> INSTANCE .)
+    AS              reduce using rule 176 (identifier -> INSTANCE .)
+    (               reduce using rule 176 (identifier -> INSTANCE .)
+    ]               reduce using rule 176 (identifier -> INSTANCE .)
+    ,               reduce using rule 176 (identifier -> INSTANCE .)
+    REF             reduce using rule 176 (identifier -> INSTANCE .)
+    ;               reduce using rule 176 (identifier -> INSTANCE .)
+    =               reduce using rule 176 (identifier -> INSTANCE .)
+    [               reduce using rule 176 (identifier -> INSTANCE .)
+    )               reduce using rule 176 (identifier -> INSTANCE .)
+
+
+state 30
+
+    (177) identifier -> METHOD .
+
+    {               reduce using rule 177 (identifier -> METHOD .)
+    :               reduce using rule 177 (identifier -> METHOD .)
+    AS              reduce using rule 177 (identifier -> METHOD .)
+    (               reduce using rule 177 (identifier -> METHOD .)
+    ]               reduce using rule 177 (identifier -> METHOD .)
+    ,               reduce using rule 177 (identifier -> METHOD .)
+    REF             reduce using rule 177 (identifier -> METHOD .)
+    ;               reduce using rule 177 (identifier -> METHOD .)
+    =               reduce using rule 177 (identifier -> METHOD .)
+    [               reduce using rule 177 (identifier -> METHOD .)
+    )               reduce using rule 177 (identifier -> METHOD .)
+
+
+state 31
+
+    (178) identifier -> OF .
+
+    {               reduce using rule 178 (identifier -> OF .)
+    :               reduce using rule 178 (identifier -> OF .)
+    AS              reduce using rule 178 (identifier -> OF .)
+    (               reduce using rule 178 (identifier -> OF .)
+    ]               reduce using rule 178 (identifier -> OF .)
+    ,               reduce using rule 178 (identifier -> OF .)
+    REF             reduce using rule 178 (identifier -> OF .)
+    ;               reduce using rule 178 (identifier -> OF .)
+    =               reduce using rule 178 (identifier -> OF .)
+    [               reduce using rule 178 (identifier -> OF .)
+    )               reduce using rule 178 (identifier -> OF .)
+
+
+state 32
+
+    (179) identifier -> PARAMETER .
+
+    {               reduce using rule 179 (identifier -> PARAMETER .)
+    :               reduce using rule 179 (identifier -> PARAMETER .)
+    AS              reduce using rule 179 (identifier -> PARAMETER .)
+    (               reduce using rule 179 (identifier -> PARAMETER .)
+    ]               reduce using rule 179 (identifier -> PARAMETER .)
+    ,               reduce using rule 179 (identifier -> PARAMETER .)
+    REF             reduce using rule 179 (identifier -> PARAMETER .)
+    ;               reduce using rule 179 (identifier -> PARAMETER .)
+    =               reduce using rule 179 (identifier -> PARAMETER .)
+    [               reduce using rule 179 (identifier -> PARAMETER .)
+    )               reduce using rule 179 (identifier -> PARAMETER .)
+
+
+state 33
+
+    (180) identifier -> PRAGMA .
+
+    {               reduce using rule 180 (identifier -> PRAGMA .)
+    :               reduce using rule 180 (identifier -> PRAGMA .)
+    AS              reduce using rule 180 (identifier -> PRAGMA .)
+    (               reduce using rule 180 (identifier -> PRAGMA .)
+    ]               reduce using rule 180 (identifier -> PRAGMA .)
+    ,               reduce using rule 180 (identifier -> PRAGMA .)
+    REF             reduce using rule 180 (identifier -> PRAGMA .)
+    ;               reduce using rule 180 (identifier -> PRAGMA .)
+    =               reduce using rule 180 (identifier -> PRAGMA .)
+    [               reduce using rule 180 (identifier -> PRAGMA .)
+    )               reduce using rule 180 (identifier -> PRAGMA .)
+
+
+state 34
+
+    (181) identifier -> PROPERTY .
+
+    {               reduce using rule 181 (identifier -> PROPERTY .)
+    :               reduce using rule 181 (identifier -> PROPERTY .)
+    AS              reduce using rule 181 (identifier -> PROPERTY .)
+    (               reduce using rule 181 (identifier -> PROPERTY .)
+    ]               reduce using rule 181 (identifier -> PROPERTY .)
+    ,               reduce using rule 181 (identifier -> PROPERTY .)
+    REF             reduce using rule 181 (identifier -> PROPERTY .)
+    ;               reduce using rule 181 (identifier -> PROPERTY .)
+    =               reduce using rule 181 (identifier -> PROPERTY .)
+    [               reduce using rule 181 (identifier -> PROPERTY .)
+    )               reduce using rule 181 (identifier -> PROPERTY .)
+
+
+state 35
+
+    (182) identifier -> QUALIFIER .
+
+    {               reduce using rule 182 (identifier -> QUALIFIER .)
+    :               reduce using rule 182 (identifier -> QUALIFIER .)
+    AS              reduce using rule 182 (identifier -> QUALIFIER .)
+    (               reduce using rule 182 (identifier -> QUALIFIER .)
+    ]               reduce using rule 182 (identifier -> QUALIFIER .)
+    ,               reduce using rule 182 (identifier -> QUALIFIER .)
+    REF             reduce using rule 182 (identifier -> QUALIFIER .)
+    ;               reduce using rule 182 (identifier -> QUALIFIER .)
+    =               reduce using rule 182 (identifier -> QUALIFIER .)
+    [               reduce using rule 182 (identifier -> QUALIFIER .)
+    )               reduce using rule 182 (identifier -> QUALIFIER .)
+
+
+state 36
+
+    (183) identifier -> REFERENCE .
+
+    {               reduce using rule 183 (identifier -> REFERENCE .)
+    :               reduce using rule 183 (identifier -> REFERENCE .)
+    AS              reduce using rule 183 (identifier -> REFERENCE .)
+    (               reduce using rule 183 (identifier -> REFERENCE .)
+    ]               reduce using rule 183 (identifier -> REFERENCE .)
+    ,               reduce using rule 183 (identifier -> REFERENCE .)
+    REF             reduce using rule 183 (identifier -> REFERENCE .)
+    ;               reduce using rule 183 (identifier -> REFERENCE .)
+    =               reduce using rule 183 (identifier -> REFERENCE .)
+    [               reduce using rule 183 (identifier -> REFERENCE .)
+    )               reduce using rule 183 (identifier -> REFERENCE .)
+
+
+state 37
+
+    (184) identifier -> RESTRICTED .
+
+    {               reduce using rule 184 (identifier -> RESTRICTED .)
+    :               reduce using rule 184 (identifier -> RESTRICTED .)
+    AS              reduce using rule 184 (identifier -> RESTRICTED .)
+    (               reduce using rule 184 (identifier -> RESTRICTED .)
+    ]               reduce using rule 184 (identifier -> RESTRICTED .)
+    ,               reduce using rule 184 (identifier -> RESTRICTED .)
+    REF             reduce using rule 184 (identifier -> RESTRICTED .)
+    ;               reduce using rule 184 (identifier -> RESTRICTED .)
+    =               reduce using rule 184 (identifier -> RESTRICTED .)
+    [               reduce using rule 184 (identifier -> RESTRICTED .)
+    )               reduce using rule 184 (identifier -> RESTRICTED .)
+
+
+state 38
+
+    (185) identifier -> SCHEMA .
+
+    {               reduce using rule 185 (identifier -> SCHEMA .)
+    :               reduce using rule 185 (identifier -> SCHEMA .)
+    AS              reduce using rule 185 (identifier -> SCHEMA .)
+    (               reduce using rule 185 (identifier -> SCHEMA .)
+    ]               reduce using rule 185 (identifier -> SCHEMA .)
+    ,               reduce using rule 185 (identifier -> SCHEMA .)
+    REF             reduce using rule 185 (identifier -> SCHEMA .)
+    ;               reduce using rule 185 (identifier -> SCHEMA .)
+    =               reduce using rule 185 (identifier -> SCHEMA .)
+    [               reduce using rule 185 (identifier -> SCHEMA .)
+    )               reduce using rule 185 (identifier -> SCHEMA .)
+
+
+state 39
+
+    (186) identifier -> SCOPE .
+
+    {               reduce using rule 186 (identifier -> SCOPE .)
+    :               reduce using rule 186 (identifier -> SCOPE .)
+    AS              reduce using rule 186 (identifier -> SCOPE .)
+    (               reduce using rule 186 (identifier -> SCOPE .)
+    ]               reduce using rule 186 (identifier -> SCOPE .)
+    ,               reduce using rule 186 (identifier -> SCOPE .)
+    REF             reduce using rule 186 (identifier -> SCOPE .)
+    ;               reduce using rule 186 (identifier -> SCOPE .)
+    =               reduce using rule 186 (identifier -> SCOPE .)
+    [               reduce using rule 186 (identifier -> SCOPE .)
+    )               reduce using rule 186 (identifier -> SCOPE .)
+
+
+state 40
+
+    (187) identifier -> TOSUBCLASS .
+
+    {               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    :               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    AS              reduce using rule 187 (identifier -> TOSUBCLASS .)
+    (               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    ]               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    ,               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    REF             reduce using rule 187 (identifier -> TOSUBCLASS .)
+    ;               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    =               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    [               reduce using rule 187 (identifier -> TOSUBCLASS .)
+    )               reduce using rule 187 (identifier -> TOSUBCLASS .)
+
+
+state 41
+
+    (188) identifier -> TOINSTANCE .
+
+    {               reduce using rule 188 (identifier -> TOINSTANCE .)
+    :               reduce using rule 188 (identifier -> TOINSTANCE .)
+    AS              reduce using rule 188 (identifier -> TOINSTANCE .)
+    (               reduce using rule 188 (identifier -> TOINSTANCE .)
+    ]               reduce using rule 188 (identifier -> TOINSTANCE .)
+    ,               reduce using rule 188 (identifier -> TOINSTANCE .)
+    REF             reduce using rule 188 (identifier -> TOINSTANCE .)
+    ;               reduce using rule 188 (identifier -> TOINSTANCE .)
+    =               reduce using rule 188 (identifier -> TOINSTANCE .)
+    [               reduce using rule 188 (identifier -> TOINSTANCE .)
+    )               reduce using rule 188 (identifier -> TOINSTANCE .)
+
+
+state 42
+
+    (189) identifier -> TRANSLATABLE .
+
+    {               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    :               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    AS              reduce using rule 189 (identifier -> TRANSLATABLE .)
+    (               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    ]               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    ,               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    REF             reduce using rule 189 (identifier -> TRANSLATABLE .)
+    ;               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    =               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    [               reduce using rule 189 (identifier -> TRANSLATABLE .)
+    )               reduce using rule 189 (identifier -> TRANSLATABLE .)
+
+
+state 43
+
+    (75) dataType -> DT_UINT8 .
+
+    {               reduce using rule 75 (dataType -> DT_UINT8 .)
+    :               reduce using rule 75 (dataType -> DT_UINT8 .)
+    AS              reduce using rule 75 (dataType -> DT_UINT8 .)
+    (               reduce using rule 75 (dataType -> DT_UINT8 .)
+    ]               reduce using rule 75 (dataType -> DT_UINT8 .)
+    ,               reduce using rule 75 (dataType -> DT_UINT8 .)
+    [               reduce using rule 75 (dataType -> DT_UINT8 .)
+    =               reduce using rule 75 (dataType -> DT_UINT8 .)
+    IDENTIFIER      reduce using rule 75 (dataType -> DT_UINT8 .)
+    ANY             reduce using rule 75 (dataType -> DT_UINT8 .)
+    CLASS           reduce using rule 75 (dataType -> DT_UINT8 .)
+    DISABLEOVERRIDE reduce using rule 75 (dataType -> DT_UINT8 .)
+    ENABLEOVERRIDE  reduce using rule 75 (dataType -> DT_UINT8 .)
+    FLAVOR          reduce using rule 75 (dataType -> DT_UINT8 .)
+    INSTANCE        reduce using rule 75 (dataType -> DT_UINT8 .)
+    METHOD          reduce using rule 75 (dataType -> DT_UINT8 .)
+    OF              reduce using rule 75 (dataType -> DT_UINT8 .)
+    PARAMETER       reduce using rule 75 (dataType -> DT_UINT8 .)
+    PRAGMA          reduce using rule 75 (dataType -> DT_UINT8 .)
+    PROPERTY        reduce using rule 75 (dataType -> DT_UINT8 .)
+    QUALIFIER       reduce using rule 75 (dataType -> DT_UINT8 .)
+    REFERENCE       reduce using rule 75 (dataType -> DT_UINT8 .)
+    RESTRICTED      reduce using rule 75 (dataType -> DT_UINT8 .)
+    SCHEMA          reduce using rule 75 (dataType -> DT_UINT8 .)
+    SCOPE           reduce using rule 75 (dataType -> DT_UINT8 .)
+    TOSUBCLASS      reduce using rule 75 (dataType -> DT_UINT8 .)
+    TOINSTANCE      reduce using rule 75 (dataType -> DT_UINT8 .)
+    TRANSLATABLE    reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_UINT8        reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_SINT8        reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_UINT16       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_SINT16       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_UINT32       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_SINT32       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_UINT64       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_SINT64       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_REAL32       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_REAL64       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_CHAR16       reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_STR          reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_BOOL         reduce using rule 75 (dataType -> DT_UINT8 .)
+    DT_DATETIME     reduce using rule 75 (dataType -> DT_UINT8 .)
+    REF             reduce using rule 75 (dataType -> DT_UINT8 .)
+    ;               reduce using rule 75 (dataType -> DT_UINT8 .)
+    )               reduce using rule 75 (dataType -> DT_UINT8 .)
+
+
+state 44
+
+    (76) dataType -> DT_SINT8 .
+
+    {               reduce using rule 76 (dataType -> DT_SINT8 .)
+    :               reduce using rule 76 (dataType -> DT_SINT8 .)
+    AS              reduce using rule 76 (dataType -> DT_SINT8 .)
+    (               reduce using rule 76 (dataType -> DT_SINT8 .)
+    ]               reduce using rule 76 (dataType -> DT_SINT8 .)
+    ,               reduce using rule 76 (dataType -> DT_SINT8 .)
+    [               reduce using rule 76 (dataType -> DT_SINT8 .)
+    =               reduce using rule 76 (dataType -> DT_SINT8 .)
+    IDENTIFIER      reduce using rule 76 (dataType -> DT_SINT8 .)
+    ANY             reduce using rule 76 (dataType -> DT_SINT8 .)
+    CLASS           reduce using rule 76 (dataType -> DT_SINT8 .)
+    DISABLEOVERRIDE reduce using rule 76 (dataType -> DT_SINT8 .)
+    ENABLEOVERRIDE  reduce using rule 76 (dataType -> DT_SINT8 .)
+    FLAVOR          reduce using rule 76 (dataType -> DT_SINT8 .)
+    INSTANCE        reduce using rule 76 (dataType -> DT_SINT8 .)
+    METHOD          reduce using rule 76 (dataType -> DT_SINT8 .)
+    OF              reduce using rule 76 (dataType -> DT_SINT8 .)
+    PARAMETER       reduce using rule 76 (dataType -> DT_SINT8 .)
+    PRAGMA          reduce using rule 76 (dataType -> DT_SINT8 .)
+    PROPERTY        reduce using rule 76 (dataType -> DT_SINT8 .)
+    QUALIFIER       reduce using rule 76 (dataType -> DT_SINT8 .)
+    REFERENCE       reduce using rule 76 (dataType -> DT_SINT8 .)
+    RESTRICTED      reduce using rule 76 (dataType -> DT_SINT8 .)
+    SCHEMA          reduce using rule 76 (dataType -> DT_SINT8 .)
+    SCOPE           reduce using rule 76 (dataType -> DT_SINT8 .)
+    TOSUBCLASS      reduce using rule 76 (dataType -> DT_SINT8 .)
+    TOINSTANCE      reduce using rule 76 (dataType -> DT_SINT8 .)
+    TRANSLATABLE    reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_UINT8        reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_SINT8        reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_UINT16       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_SINT16       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_UINT32       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_SINT32       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_UINT64       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_SINT64       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_REAL32       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_REAL64       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_CHAR16       reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_STR          reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_BOOL         reduce using rule 76 (dataType -> DT_SINT8 .)
+    DT_DATETIME     reduce using rule 76 (dataType -> DT_SINT8 .)
+    REF             reduce using rule 76 (dataType -> DT_SINT8 .)
+    ;               reduce using rule 76 (dataType -> DT_SINT8 .)
+    )               reduce using rule 76 (dataType -> DT_SINT8 .)
+
+
+state 45
+
+    (77) dataType -> DT_UINT16 .
+
+    {               reduce using rule 77 (dataType -> DT_UINT16 .)
+    :               reduce using rule 77 (dataType -> DT_UINT16 .)
+    AS              reduce using rule 77 (dataType -> DT_UINT16 .)
+    (               reduce using rule 77 (dataType -> DT_UINT16 .)
+    ]               reduce using rule 77 (dataType -> DT_UINT16 .)
+    ,               reduce using rule 77 (dataType -> DT_UINT16 .)
+    [               reduce using rule 77 (dataType -> DT_UINT16 .)
+    =               reduce using rule 77 (dataType -> DT_UINT16 .)
+    IDENTIFIER      reduce using rule 77 (dataType -> DT_UINT16 .)
+    ANY             reduce using rule 77 (dataType -> DT_UINT16 .)
+    CLASS           reduce using rule 77 (dataType -> DT_UINT16 .)
+    DISABLEOVERRIDE reduce using rule 77 (dataType -> DT_UINT16 .)
+    ENABLEOVERRIDE  reduce using rule 77 (dataType -> DT_UINT16 .)
+    FLAVOR          reduce using rule 77 (dataType -> DT_UINT16 .)
+    INSTANCE        reduce using rule 77 (dataType -> DT_UINT16 .)
+    METHOD          reduce using rule 77 (dataType -> DT_UINT16 .)
+    OF              reduce using rule 77 (dataType -> DT_UINT16 .)
+    PARAMETER       reduce using rule 77 (dataType -> DT_UINT16 .)
+    PRAGMA          reduce using rule 77 (dataType -> DT_UINT16 .)
+    PROPERTY        reduce using rule 77 (dataType -> DT_UINT16 .)
+    QUALIFIER       reduce using rule 77 (dataType -> DT_UINT16 .)
+    REFERENCE       reduce using rule 77 (dataType -> DT_UINT16 .)
+    RESTRICTED      reduce using rule 77 (dataType -> DT_UINT16 .)
+    SCHEMA          reduce using rule 77 (dataType -> DT_UINT16 .)
+    SCOPE           reduce using rule 77 (dataType -> DT_UINT16 .)
+    TOSUBCLASS      reduce using rule 77 (dataType -> DT_UINT16 .)
+    TOINSTANCE      reduce using rule 77 (dataType -> DT_UINT16 .)
+    TRANSLATABLE    reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_UINT8        reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_SINT8        reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_UINT16       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_SINT16       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_UINT32       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_SINT32       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_UINT64       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_SINT64       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_REAL32       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_REAL64       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_CHAR16       reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_STR          reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_BOOL         reduce using rule 77 (dataType -> DT_UINT16 .)
+    DT_DATETIME     reduce using rule 77 (dataType -> DT_UINT16 .)
+    REF             reduce using rule 77 (dataType -> DT_UINT16 .)
+    ;               reduce using rule 77 (dataType -> DT_UINT16 .)
+    )               reduce using rule 77 (dataType -> DT_UINT16 .)
+
+
+state 46
+
+    (78) dataType -> DT_SINT16 .
+
+    {               reduce using rule 78 (dataType -> DT_SINT16 .)
+    :               reduce using rule 78 (dataType -> DT_SINT16 .)
+    AS              reduce using rule 78 (dataType -> DT_SINT16 .)
+    (               reduce using rule 78 (dataType -> DT_SINT16 .)
+    ]               reduce using rule 78 (dataType -> DT_SINT16 .)
+    ,               reduce using rule 78 (dataType -> DT_SINT16 .)
+    [               reduce using rule 78 (dataType -> DT_SINT16 .)
+    =               reduce using rule 78 (dataType -> DT_SINT16 .)
+    IDENTIFIER      reduce using rule 78 (dataType -> DT_SINT16 .)
+    ANY             reduce using rule 78 (dataType -> DT_SINT16 .)
+    CLASS           reduce using rule 78 (dataType -> DT_SINT16 .)
+    DISABLEOVERRIDE reduce using rule 78 (dataType -> DT_SINT16 .)
+    ENABLEOVERRIDE  reduce using rule 78 (dataType -> DT_SINT16 .)
+    FLAVOR          reduce using rule 78 (dataType -> DT_SINT16 .)
+    INSTANCE        reduce using rule 78 (dataType -> DT_SINT16 .)
+    METHOD          reduce using rule 78 (dataType -> DT_SINT16 .)
+    OF              reduce using rule 78 (dataType -> DT_SINT16 .)
+    PARAMETER       reduce using rule 78 (dataType -> DT_SINT16 .)
+    PRAGMA          reduce using rule 78 (dataType -> DT_SINT16 .)
+    PROPERTY        reduce using rule 78 (dataType -> DT_SINT16 .)
+    QUALIFIER       reduce using rule 78 (dataType -> DT_SINT16 .)
+    REFERENCE       reduce using rule 78 (dataType -> DT_SINT16 .)
+    RESTRICTED      reduce using rule 78 (dataType -> DT_SINT16 .)
+    SCHEMA          reduce using rule 78 (dataType -> DT_SINT16 .)
+    SCOPE           reduce using rule 78 (dataType -> DT_SINT16 .)
+    TOSUBCLASS      reduce using rule 78 (dataType -> DT_SINT16 .)
+    TOINSTANCE      reduce using rule 78 (dataType -> DT_SINT16 .)
+    TRANSLATABLE    reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_UINT8        reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_SINT8        reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_UINT16       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_SINT16       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_UINT32       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_SINT32       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_UINT64       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_SINT64       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_REAL32       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_REAL64       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_CHAR16       reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_STR          reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_BOOL         reduce using rule 78 (dataType -> DT_SINT16 .)
+    DT_DATETIME     reduce using rule 78 (dataType -> DT_SINT16 .)
+    REF             reduce using rule 78 (dataType -> DT_SINT16 .)
+    ;               reduce using rule 78 (dataType -> DT_SINT16 .)
+    )               reduce using rule 78 (dataType -> DT_SINT16 .)
+
+
+state 47
+
+    (79) dataType -> DT_UINT32 .
+
+    {               reduce using rule 79 (dataType -> DT_UINT32 .)
+    :               reduce using rule 79 (dataType -> DT_UINT32 .)
+    AS              reduce using rule 79 (dataType -> DT_UINT32 .)
+    (               reduce using rule 79 (dataType -> DT_UINT32 .)
+    ]               reduce using rule 79 (dataType -> DT_UINT32 .)
+    ,               reduce using rule 79 (dataType -> DT_UINT32 .)
+    [               reduce using rule 79 (dataType -> DT_UINT32 .)
+    =               reduce using rule 79 (dataType -> DT_UINT32 .)
+    IDENTIFIER      reduce using rule 79 (dataType -> DT_UINT32 .)
+    ANY             reduce using rule 79 (dataType -> DT_UINT32 .)
+    CLASS           reduce using rule 79 (dataType -> DT_UINT32 .)
+    DISABLEOVERRIDE reduce using rule 79 (dataType -> DT_UINT32 .)
+    ENABLEOVERRIDE  reduce using rule 79 (dataType -> DT_UINT32 .)
+    FLAVOR          reduce using rule 79 (dataType -> DT_UINT32 .)
+    INSTANCE        reduce using rule 79 (dataType -> DT_UINT32 .)
+    METHOD          reduce using rule 79 (dataType -> DT_UINT32 .)
+    OF              reduce using rule 79 (dataType -> DT_UINT32 .)
+    PARAMETER       reduce using rule 79 (dataType -> DT_UINT32 .)
+    PRAGMA          reduce using rule 79 (dataType -> DT_UINT32 .)
+    PROPERTY        reduce using rule 79 (dataType -> DT_UINT32 .)
+    QUALIFIER       reduce using rule 79 (dataType -> DT_UINT32 .)
+    REFERENCE       reduce using rule 79 (dataType -> DT_UINT32 .)
+    RESTRICTED      reduce using rule 79 (dataType -> DT_UINT32 .)
+    SCHEMA          reduce using rule 79 (dataType -> DT_UINT32 .)
+    SCOPE           reduce using rule 79 (dataType -> DT_UINT32 .)
+    TOSUBCLASS      reduce using rule 79 (dataType -> DT_UINT32 .)
+    TOINSTANCE      reduce using rule 79 (dataType -> DT_UINT32 .)
+    TRANSLATABLE    reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_UINT8        reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_SINT8        reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_UINT16       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_SINT16       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_UINT32       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_SINT32       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_UINT64       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_SINT64       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_REAL32       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_REAL64       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_CHAR16       reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_STR          reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_BOOL         reduce using rule 79 (dataType -> DT_UINT32 .)
+    DT_DATETIME     reduce using rule 79 (dataType -> DT_UINT32 .)
+    REF             reduce using rule 79 (dataType -> DT_UINT32 .)
+    ;               reduce using rule 79 (dataType -> DT_UINT32 .)
+    )               reduce using rule 79 (dataType -> DT_UINT32 .)
+
+
+state 48
+
+    (80) dataType -> DT_SINT32 .
+
+    {               reduce using rule 80 (dataType -> DT_SINT32 .)
+    :               reduce using rule 80 (dataType -> DT_SINT32 .)
+    AS              reduce using rule 80 (dataType -> DT_SINT32 .)
+    (               reduce using rule 80 (dataType -> DT_SINT32 .)
+    ]               reduce using rule 80 (dataType -> DT_SINT32 .)
+    ,               reduce using rule 80 (dataType -> DT_SINT32 .)
+    [               reduce using rule 80 (dataType -> DT_SINT32 .)
+    =               reduce using rule 80 (dataType -> DT_SINT32 .)
+    IDENTIFIER      reduce using rule 80 (dataType -> DT_SINT32 .)
+    ANY             reduce using rule 80 (dataType -> DT_SINT32 .)
+    CLASS           reduce using rule 80 (dataType -> DT_SINT32 .)
+    DISABLEOVERRIDE reduce using rule 80 (dataType -> DT_SINT32 .)
+    ENABLEOVERRIDE  reduce using rule 80 (dataType -> DT_SINT32 .)
+    FLAVOR          reduce using rule 80 (dataType -> DT_SINT32 .)
+    INSTANCE        reduce using rule 80 (dataType -> DT_SINT32 .)
+    METHOD          reduce using rule 80 (dataType -> DT_SINT32 .)
+    OF              reduce using rule 80 (dataType -> DT_SINT32 .)
+    PARAMETER       reduce using rule 80 (dataType -> DT_SINT32 .)
+    PRAGMA          reduce using rule 80 (dataType -> DT_SINT32 .)
+    PROPERTY        reduce using rule 80 (dataType -> DT_SINT32 .)
+    QUALIFIER       reduce using rule 80 (dataType -> DT_SINT32 .)
+    REFERENCE       reduce using rule 80 (dataType -> DT_SINT32 .)
+    RESTRICTED      reduce using rule 80 (dataType -> DT_SINT32 .)
+    SCHEMA          reduce using rule 80 (dataType -> DT_SINT32 .)
+    SCOPE           reduce using rule 80 (dataType -> DT_SINT32 .)
+    TOSUBCLASS      reduce using rule 80 (dataType -> DT_SINT32 .)
+    TOINSTANCE      reduce using rule 80 (dataType -> DT_SINT32 .)
+    TRANSLATABLE    reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_UINT8        reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_SINT8        reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_UINT16       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_SINT16       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_UINT32       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_SINT32       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_UINT64       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_SINT64       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_REAL32       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_REAL64       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_CHAR16       reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_STR          reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_BOOL         reduce using rule 80 (dataType -> DT_SINT32 .)
+    DT_DATETIME     reduce using rule 80 (dataType -> DT_SINT32 .)
+    REF             reduce using rule 80 (dataType -> DT_SINT32 .)
+    ;               reduce using rule 80 (dataType -> DT_SINT32 .)
+    )               reduce using rule 80 (dataType -> DT_SINT32 .)
+
+
+state 49
+
+    (81) dataType -> DT_UINT64 .
+
+    {               reduce using rule 81 (dataType -> DT_UINT64 .)
+    :               reduce using rule 81 (dataType -> DT_UINT64 .)
+    AS              reduce using rule 81 (dataType -> DT_UINT64 .)
+    (               reduce using rule 81 (dataType -> DT_UINT64 .)
+    ]               reduce using rule 81 (dataType -> DT_UINT64 .)
+    ,               reduce using rule 81 (dataType -> DT_UINT64 .)
+    [               reduce using rule 81 (dataType -> DT_UINT64 .)
+    =               reduce using rule 81 (dataType -> DT_UINT64 .)
+    IDENTIFIER      reduce using rule 81 (dataType -> DT_UINT64 .)
+    ANY             reduce using rule 81 (dataType -> DT_UINT64 .)
+    CLASS           reduce using rule 81 (dataType -> DT_UINT64 .)
+    DISABLEOVERRIDE reduce using rule 81 (dataType -> DT_UINT64 .)
+    ENABLEOVERRIDE  reduce using rule 81 (dataType -> DT_UINT64 .)
+    FLAVOR          reduce using rule 81 (dataType -> DT_UINT64 .)
+    INSTANCE        reduce using rule 81 (dataType -> DT_UINT64 .)
+    METHOD          reduce using rule 81 (dataType -> DT_UINT64 .)
+    OF              reduce using rule 81 (dataType -> DT_UINT64 .)
+    PARAMETER       reduce using rule 81 (dataType -> DT_UINT64 .)
+    PRAGMA          reduce using rule 81 (dataType -> DT_UINT64 .)
+    PROPERTY        reduce using rule 81 (dataType -> DT_UINT64 .)
+    QUALIFIER       reduce using rule 81 (dataType -> DT_UINT64 .)
+    REFERENCE       reduce using rule 81 (dataType -> DT_UINT64 .)
+    RESTRICTED      reduce using rule 81 (dataType -> DT_UINT64 .)
+    SCHEMA          reduce using rule 81 (dataType -> DT_UINT64 .)
+    SCOPE           reduce using rule 81 (dataType -> DT_UINT64 .)
+    TOSUBCLASS      reduce using rule 81 (dataType -> DT_UINT64 .)
+    TOINSTANCE      reduce using rule 81 (dataType -> DT_UINT64 .)
+    TRANSLATABLE    reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_UINT8        reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_SINT8        reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_UINT16       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_SINT16       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_UINT32       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_SINT32       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_UINT64       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_SINT64       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_REAL32       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_REAL64       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_CHAR16       reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_STR          reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_BOOL         reduce using rule 81 (dataType -> DT_UINT64 .)
+    DT_DATETIME     reduce using rule 81 (dataType -> DT_UINT64 .)
+    REF             reduce using rule 81 (dataType -> DT_UINT64 .)
+    ;               reduce using rule 81 (dataType -> DT_UINT64 .)
+    )               reduce using rule 81 (dataType -> DT_UINT64 .)
+
+
+state 50
+
+    (82) dataType -> DT_SINT64 .
+
+    {               reduce using rule 82 (dataType -> DT_SINT64 .)
+    :               reduce using rule 82 (dataType -> DT_SINT64 .)
+    AS              reduce using rule 82 (dataType -> DT_SINT64 .)
+    (               reduce using rule 82 (dataType -> DT_SINT64 .)
+    ]               reduce using rule 82 (dataType -> DT_SINT64 .)
+    ,               reduce using rule 82 (dataType -> DT_SINT64 .)
+    [               reduce using rule 82 (dataType -> DT_SINT64 .)
+    =               reduce using rule 82 (dataType -> DT_SINT64 .)
+    IDENTIFIER      reduce using rule 82 (dataType -> DT_SINT64 .)
+    ANY             reduce using rule 82 (dataType -> DT_SINT64 .)
+    CLASS           reduce using rule 82 (dataType -> DT_SINT64 .)
+    DISABLEOVERRIDE reduce using rule 82 (dataType -> DT_SINT64 .)
+    ENABLEOVERRIDE  reduce using rule 82 (dataType -> DT_SINT64 .)
+    FLAVOR          reduce using rule 82 (dataType -> DT_SINT64 .)
+    INSTANCE        reduce using rule 82 (dataType -> DT_SINT64 .)
+    METHOD          reduce using rule 82 (dataType -> DT_SINT64 .)
+    OF              reduce using rule 82 (dataType -> DT_SINT64 .)
+    PARAMETER       reduce using rule 82 (dataType -> DT_SINT64 .)
+    PRAGMA          reduce using rule 82 (dataType -> DT_SINT64 .)
+    PROPERTY        reduce using rule 82 (dataType -> DT_SINT64 .)
+    QUALIFIER       reduce using rule 82 (dataType -> DT_SINT64 .)
+    REFERENCE       reduce using rule 82 (dataType -> DT_SINT64 .)
+    RESTRICTED      reduce using rule 82 (dataType -> DT_SINT64 .)
+    SCHEMA          reduce using rule 82 (dataType -> DT_SINT64 .)
+    SCOPE           reduce using rule 82 (dataType -> DT_SINT64 .)
+    TOSUBCLASS      reduce using rule 82 (dataType -> DT_SINT64 .)
+    TOINSTANCE      reduce using rule 82 (dataType -> DT_SINT64 .)
+    TRANSLATABLE    reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_UINT8        reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_SINT8        reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_UINT16       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_SINT16       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_UINT32       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_SINT32       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_UINT64       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_SINT64       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_REAL32       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_REAL64       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_CHAR16       reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_STR          reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_BOOL         reduce using rule 82 (dataType -> DT_SINT64 .)
+    DT_DATETIME     reduce using rule 82 (dataType -> DT_SINT64 .)
+    REF             reduce using rule 82 (dataType -> DT_SINT64 .)
+    ;               reduce using rule 82 (dataType -> DT_SINT64 .)
+    )               reduce using rule 82 (dataType -> DT_SINT64 .)
+
+
+state 51
+
+    (83) dataType -> DT_REAL32 .
+
+    {               reduce using rule 83 (dataType -> DT_REAL32 .)
+    :               reduce using rule 83 (dataType -> DT_REAL32 .)
+    AS              reduce using rule 83 (dataType -> DT_REAL32 .)
+    (               reduce using rule 83 (dataType -> DT_REAL32 .)
+    ]               reduce using rule 83 (dataType -> DT_REAL32 .)
+    ,               reduce using rule 83 (dataType -> DT_REAL32 .)
+    [               reduce using rule 83 (dataType -> DT_REAL32 .)
+    =               reduce using rule 83 (dataType -> DT_REAL32 .)
+    IDENTIFIER      reduce using rule 83 (dataType -> DT_REAL32 .)
+    ANY             reduce using rule 83 (dataType -> DT_REAL32 .)
+    CLASS           reduce using rule 83 (dataType -> DT_REAL32 .)
+    DISABLEOVERRIDE reduce using rule 83 (dataType -> DT_REAL32 .)
+    ENABLEOVERRIDE  reduce using rule 83 (dataType -> DT_REAL32 .)
+    FLAVOR          reduce using rule 83 (dataType -> DT_REAL32 .)
+    INSTANCE        reduce using rule 83 (dataType -> DT_REAL32 .)
+    METHOD          reduce using rule 83 (dataType -> DT_REAL32 .)
+    OF              reduce using rule 83 (dataType -> DT_REAL32 .)
+    PARAMETER       reduce using rule 83 (dataType -> DT_REAL32 .)
+    PRAGMA          reduce using rule 83 (dataType -> DT_REAL32 .)
+    PROPERTY        reduce using rule 83 (dataType -> DT_REAL32 .)
+    QUALIFIER       reduce using rule 83 (dataType -> DT_REAL32 .)
+    REFERENCE       reduce using rule 83 (dataType -> DT_REAL32 .)
+    RESTRICTED      reduce using rule 83 (dataType -> DT_REAL32 .)
+    SCHEMA          reduce using rule 83 (dataType -> DT_REAL32 .)
+    SCOPE           reduce using rule 83 (dataType -> DT_REAL32 .)
+    TOSUBCLASS      reduce using rule 83 (dataType -> DT_REAL32 .)
+    TOINSTANCE      reduce using rule 83 (dataType -> DT_REAL32 .)
+    TRANSLATABLE    reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_UINT8        reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_SINT8        reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_UINT16       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_SINT16       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_UINT32       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_SINT32       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_UINT64       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_SINT64       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_REAL32       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_REAL64       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_CHAR16       reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_STR          reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_BOOL         reduce using rule 83 (dataType -> DT_REAL32 .)
+    DT_DATETIME     reduce using rule 83 (dataType -> DT_REAL32 .)
+    REF             reduce using rule 83 (dataType -> DT_REAL32 .)
+    ;               reduce using rule 83 (dataType -> DT_REAL32 .)
+    )               reduce using rule 83 (dataType -> DT_REAL32 .)
+
+
+state 52
+
+    (84) dataType -> DT_REAL64 .
+
+    {               reduce using rule 84 (dataType -> DT_REAL64 .)
+    :               reduce using rule 84 (dataType -> DT_REAL64 .)
+    AS              reduce using rule 84 (dataType -> DT_REAL64 .)
+    (               reduce using rule 84 (dataType -> DT_REAL64 .)
+    ]               reduce using rule 84 (dataType -> DT_REAL64 .)
+    ,               reduce using rule 84 (dataType -> DT_REAL64 .)
+    [               reduce using rule 84 (dataType -> DT_REAL64 .)
+    =               reduce using rule 84 (dataType -> DT_REAL64 .)
+    IDENTIFIER      reduce using rule 84 (dataType -> DT_REAL64 .)
+    ANY             reduce using rule 84 (dataType -> DT_REAL64 .)
+    CLASS           reduce using rule 84 (dataType -> DT_REAL64 .)
+    DISABLEOVERRIDE reduce using rule 84 (dataType -> DT_REAL64 .)
+    ENABLEOVERRIDE  reduce using rule 84 (dataType -> DT_REAL64 .)
+    FLAVOR          reduce using rule 84 (dataType -> DT_REAL64 .)
+    INSTANCE        reduce using rule 84 (dataType -> DT_REAL64 .)
+    METHOD          reduce using rule 84 (dataType -> DT_REAL64 .)
+    OF              reduce using rule 84 (dataType -> DT_REAL64 .)
+    PARAMETER       reduce using rule 84 (dataType -> DT_REAL64 .)
+    PRAGMA          reduce using rule 84 (dataType -> DT_REAL64 .)
+    PROPERTY        reduce using rule 84 (dataType -> DT_REAL64 .)
+    QUALIFIER       reduce using rule 84 (dataType -> DT_REAL64 .)
+    REFERENCE       reduce using rule 84 (dataType -> DT_REAL64 .)
+    RESTRICTED      reduce using rule 84 (dataType -> DT_REAL64 .)
+    SCHEMA          reduce using rule 84 (dataType -> DT_REAL64 .)
+    SCOPE           reduce using rule 84 (dataType -> DT_REAL64 .)
+    TOSUBCLASS      reduce using rule 84 (dataType -> DT_REAL64 .)
+    TOINSTANCE      reduce using rule 84 (dataType -> DT_REAL64 .)
+    TRANSLATABLE    reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_UINT8        reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_SINT8        reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_UINT16       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_SINT16       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_UINT32       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_SINT32       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_UINT64       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_SINT64       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_REAL32       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_REAL64       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_CHAR16       reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_STR          reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_BOOL         reduce using rule 84 (dataType -> DT_REAL64 .)
+    DT_DATETIME     reduce using rule 84 (dataType -> DT_REAL64 .)
+    REF             reduce using rule 84 (dataType -> DT_REAL64 .)
+    ;               reduce using rule 84 (dataType -> DT_REAL64 .)
+    )               reduce using rule 84 (dataType -> DT_REAL64 .)
+
+
+state 53
+
+    (85) dataType -> DT_CHAR16 .
+
+    {               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    :               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    AS              reduce using rule 85 (dataType -> DT_CHAR16 .)
+    (               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    ]               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    ,               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    [               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    =               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    IDENTIFIER      reduce using rule 85 (dataType -> DT_CHAR16 .)
+    ANY             reduce using rule 85 (dataType -> DT_CHAR16 .)
+    CLASS           reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DISABLEOVERRIDE reduce using rule 85 (dataType -> DT_CHAR16 .)
+    ENABLEOVERRIDE  reduce using rule 85 (dataType -> DT_CHAR16 .)
+    FLAVOR          reduce using rule 85 (dataType -> DT_CHAR16 .)
+    INSTANCE        reduce using rule 85 (dataType -> DT_CHAR16 .)
+    METHOD          reduce using rule 85 (dataType -> DT_CHAR16 .)
+    OF              reduce using rule 85 (dataType -> DT_CHAR16 .)
+    PARAMETER       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    PRAGMA          reduce using rule 85 (dataType -> DT_CHAR16 .)
+    PROPERTY        reduce using rule 85 (dataType -> DT_CHAR16 .)
+    QUALIFIER       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    REFERENCE       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    RESTRICTED      reduce using rule 85 (dataType -> DT_CHAR16 .)
+    SCHEMA          reduce using rule 85 (dataType -> DT_CHAR16 .)
+    SCOPE           reduce using rule 85 (dataType -> DT_CHAR16 .)
+    TOSUBCLASS      reduce using rule 85 (dataType -> DT_CHAR16 .)
+    TOINSTANCE      reduce using rule 85 (dataType -> DT_CHAR16 .)
+    TRANSLATABLE    reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_UINT8        reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_SINT8        reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_UINT16       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_SINT16       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_UINT32       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_SINT32       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_UINT64       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_SINT64       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_REAL32       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_REAL64       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_CHAR16       reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_STR          reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_BOOL         reduce using rule 85 (dataType -> DT_CHAR16 .)
+    DT_DATETIME     reduce using rule 85 (dataType -> DT_CHAR16 .)
+    REF             reduce using rule 85 (dataType -> DT_CHAR16 .)
+    ;               reduce using rule 85 (dataType -> DT_CHAR16 .)
+    )               reduce using rule 85 (dataType -> DT_CHAR16 .)
+
+
+state 54
+
+    (86) dataType -> DT_STR .
+
+    {               reduce using rule 86 (dataType -> DT_STR .)
+    :               reduce using rule 86 (dataType -> DT_STR .)
+    AS              reduce using rule 86 (dataType -> DT_STR .)
+    (               reduce using rule 86 (dataType -> DT_STR .)
+    ]               reduce using rule 86 (dataType -> DT_STR .)
+    ,               reduce using rule 86 (dataType -> DT_STR .)
+    [               reduce using rule 86 (dataType -> DT_STR .)
+    =               reduce using rule 86 (dataType -> DT_STR .)
+    IDENTIFIER      reduce using rule 86 (dataType -> DT_STR .)
+    ANY             reduce using rule 86 (dataType -> DT_STR .)
+    CLASS           reduce using rule 86 (dataType -> DT_STR .)
+    DISABLEOVERRIDE reduce using rule 86 (dataType -> DT_STR .)
+    ENABLEOVERRIDE  reduce using rule 86 (dataType -> DT_STR .)
+    FLAVOR          reduce using rule 86 (dataType -> DT_STR .)
+    INSTANCE        reduce using rule 86 (dataType -> DT_STR .)
+    METHOD          reduce using rule 86 (dataType -> DT_STR .)
+    OF              reduce using rule 86 (dataType -> DT_STR .)
+    PARAMETER       reduce using rule 86 (dataType -> DT_STR .)
+    PRAGMA          reduce using rule 86 (dataType -> DT_STR .)
+    PROPERTY        reduce using rule 86 (dataType -> DT_STR .)
+    QUALIFIER       reduce using rule 86 (dataType -> DT_STR .)
+    REFERENCE       reduce using rule 86 (dataType -> DT_STR .)
+    RESTRICTED      reduce using rule 86 (dataType -> DT_STR .)
+    SCHEMA          reduce using rule 86 (dataType -> DT_STR .)
+    SCOPE           reduce using rule 86 (dataType -> DT_STR .)
+    TOSUBCLASS      reduce using rule 86 (dataType -> DT_STR .)
+    TOINSTANCE      reduce using rule 86 (dataType -> DT_STR .)
+    TRANSLATABLE    reduce using rule 86 (dataType -> DT_STR .)
+    DT_UINT8        reduce using rule 86 (dataType -> DT_STR .)
+    DT_SINT8        reduce using rule 86 (dataType -> DT_STR .)
+    DT_UINT16       reduce using rule 86 (dataType -> DT_STR .)
+    DT_SINT16       reduce using rule 86 (dataType -> DT_STR .)
+    DT_UINT32       reduce using rule 86 (dataType -> DT_STR .)
+    DT_SINT32       reduce using rule 86 (dataType -> DT_STR .)
+    DT_UINT64       reduce using rule 86 (dataType -> DT_STR .)
+    DT_SINT64       reduce using rule 86 (dataType -> DT_STR .)
+    DT_REAL32       reduce using rule 86 (dataType -> DT_STR .)
+    DT_REAL64       reduce using rule 86 (dataType -> DT_STR .)
+    DT_CHAR16       reduce using rule 86 (dataType -> DT_STR .)
+    DT_STR          reduce using rule 86 (dataType -> DT_STR .)
+    DT_BOOL         reduce using rule 86 (dataType -> DT_STR .)
+    DT_DATETIME     reduce using rule 86 (dataType -> DT_STR .)
+    REF             reduce using rule 86 (dataType -> DT_STR .)
+    ;               reduce using rule 86 (dataType -> DT_STR .)
+    )               reduce using rule 86 (dataType -> DT_STR .)
+
+
+state 55
+
+    (87) dataType -> DT_BOOL .
+
+    {               reduce using rule 87 (dataType -> DT_BOOL .)
+    :               reduce using rule 87 (dataType -> DT_BOOL .)
+    AS              reduce using rule 87 (dataType -> DT_BOOL .)
+    (               reduce using rule 87 (dataType -> DT_BOOL .)
+    ]               reduce using rule 87 (dataType -> DT_BOOL .)
+    ,               reduce using rule 87 (dataType -> DT_BOOL .)
+    [               reduce using rule 87 (dataType -> DT_BOOL .)
+    =               reduce using rule 87 (dataType -> DT_BOOL .)
+    IDENTIFIER      reduce using rule 87 (dataType -> DT_BOOL .)
+    ANY             reduce using rule 87 (dataType -> DT_BOOL .)
+    CLASS           reduce using rule 87 (dataType -> DT_BOOL .)
+    DISABLEOVERRIDE reduce using rule 87 (dataType -> DT_BOOL .)
+    ENABLEOVERRIDE  reduce using rule 87 (dataType -> DT_BOOL .)
+    FLAVOR          reduce using rule 87 (dataType -> DT_BOOL .)
+    INSTANCE        reduce using rule 87 (dataType -> DT_BOOL .)
+    METHOD          reduce using rule 87 (dataType -> DT_BOOL .)
+    OF              reduce using rule 87 (dataType -> DT_BOOL .)
+    PARAMETER       reduce using rule 87 (dataType -> DT_BOOL .)
+    PRAGMA          reduce using rule 87 (dataType -> DT_BOOL .)
+    PROPERTY        reduce using rule 87 (dataType -> DT_BOOL .)
+    QUALIFIER       reduce using rule 87 (dataType -> DT_BOOL .)
+    REFERENCE       reduce using rule 87 (dataType -> DT_BOOL .)
+    RESTRICTED      reduce using rule 87 (dataType -> DT_BOOL .)
+    SCHEMA          reduce using rule 87 (dataType -> DT_BOOL .)
+    SCOPE           reduce using rule 87 (dataType -> DT_BOOL .)
+    TOSUBCLASS      reduce using rule 87 (dataType -> DT_BOOL .)
+    TOINSTANCE      reduce using rule 87 (dataType -> DT_BOOL .)
+    TRANSLATABLE    reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_UINT8        reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_SINT8        reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_UINT16       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_SINT16       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_UINT32       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_SINT32       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_UINT64       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_SINT64       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_REAL32       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_REAL64       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_CHAR16       reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_STR          reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_BOOL         reduce using rule 87 (dataType -> DT_BOOL .)
+    DT_DATETIME     reduce using rule 87 (dataType -> DT_BOOL .)
+    REF             reduce using rule 87 (dataType -> DT_BOOL .)
+    ;               reduce using rule 87 (dataType -> DT_BOOL .)
+    )               reduce using rule 87 (dataType -> DT_BOOL .)
+
+
+state 56
+
+    (88) dataType -> DT_DATETIME .
+
+    {               reduce using rule 88 (dataType -> DT_DATETIME .)
+    :               reduce using rule 88 (dataType -> DT_DATETIME .)
+    AS              reduce using rule 88 (dataType -> DT_DATETIME .)
+    (               reduce using rule 88 (dataType -> DT_DATETIME .)
+    ]               reduce using rule 88 (dataType -> DT_DATETIME .)
+    ,               reduce using rule 88 (dataType -> DT_DATETIME .)
+    [               reduce using rule 88 (dataType -> DT_DATETIME .)
+    =               reduce using rule 88 (dataType -> DT_DATETIME .)
+    IDENTIFIER      reduce using rule 88 (dataType -> DT_DATETIME .)
+    ANY             reduce using rule 88 (dataType -> DT_DATETIME .)
+    CLASS           reduce using rule 88 (dataType -> DT_DATETIME .)
+    DISABLEOVERRIDE reduce using rule 88 (dataType -> DT_DATETIME .)
+    ENABLEOVERRIDE  reduce using rule 88 (dataType -> DT_DATETIME .)
+    FLAVOR          reduce using rule 88 (dataType -> DT_DATETIME .)
+    INSTANCE        reduce using rule 88 (dataType -> DT_DATETIME .)
+    METHOD          reduce using rule 88 (dataType -> DT_DATETIME .)
+    OF              reduce using rule 88 (dataType -> DT_DATETIME .)
+    PARAMETER       reduce using rule 88 (dataType -> DT_DATETIME .)
+    PRAGMA          reduce using rule 88 (dataType -> DT_DATETIME .)
+    PROPERTY        reduce using rule 88 (dataType -> DT_DATETIME .)
+    QUALIFIER       reduce using rule 88 (dataType -> DT_DATETIME .)
+    REFERENCE       reduce using rule 88 (dataType -> DT_DATETIME .)
+    RESTRICTED      reduce using rule 88 (dataType -> DT_DATETIME .)
+    SCHEMA          reduce using rule 88 (dataType -> DT_DATETIME .)
+    SCOPE           reduce using rule 88 (dataType -> DT_DATETIME .)
+    TOSUBCLASS      reduce using rule 88 (dataType -> DT_DATETIME .)
+    TOINSTANCE      reduce using rule 88 (dataType -> DT_DATETIME .)
+    TRANSLATABLE    reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_UINT8        reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_SINT8        reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_UINT16       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_SINT16       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_UINT32       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_SINT32       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_UINT64       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_SINT64       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_REAL32       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_REAL64       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_CHAR16       reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_STR          reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_BOOL         reduce using rule 88 (dataType -> DT_DATETIME .)
+    DT_DATETIME     reduce using rule 88 (dataType -> DT_DATETIME .)
+    REF             reduce using rule 88 (dataType -> DT_DATETIME .)
+    ;               reduce using rule 88 (dataType -> DT_DATETIME .)
+    )               reduce using rule 88 (dataType -> DT_DATETIME .)
+
+
+state 57
+
+    (18) classDeclaration -> qualifierList CLASS . className { classFeatureList } ;
+    (19) classDeclaration -> qualifierList CLASS . className superClass { classFeatureList } ;
+    (20) classDeclaration -> qualifierList CLASS . className alias { classFeatureList } ;
+    (21) classDeclaration -> qualifierList CLASS . className alias superClass { classFeatureList } ;
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    className                      shift and go to state 73
+    identifier                     shift and go to state 21
+    dataType                       shift and go to state 26
+
+state 58
+
+    (159) instanceDeclaration -> qualifierList INSTANCE . OF className { valueInitializerList } ;
+    (160) instanceDeclaration -> qualifierList INSTANCE . OF className alias { valueInitializerList } ;
+
+    OF              shift and go to state 74
+
+
+state 59
+
+    (130) qualifierDeclaration -> QUALIFIER qualifierName . qualifierType scope ;
+    (131) qualifierDeclaration -> QUALIFIER qualifierName . qualifierType scope defaultFlavor ;
+    (135) qualifierType -> . qualifierType_1
+    (136) qualifierType -> . qualifierType_2
+    (137) qualifierType_1 -> . : dataType array
+    (138) qualifierType_1 -> . : dataType array defaultValue
+    (139) qualifierType_2 -> . : dataType
+    (140) qualifierType_2 -> . : dataType defaultValue
+
+    :               shift and go to state 78
+
+    qualifierType                  shift and go to state 75
+    qualifierType_1                shift and go to state 76
+    qualifierType_2                shift and go to state 77
+
+state 60
+
+    (132) qualifierName -> identifier .
+
+    :               reduce using rule 132 (qualifierName -> identifier .)
+    (               reduce using rule 132 (qualifierName -> identifier .)
+    {               reduce using rule 132 (qualifierName -> identifier .)
+    ]               reduce using rule 132 (qualifierName -> identifier .)
+    ,               reduce using rule 132 (qualifierName -> identifier .)
+
+
+state 61
+
+    (133) qualifierName -> ASSOCIATION .
+
+    :               reduce using rule 133 (qualifierName -> ASSOCIATION .)
+    (               reduce using rule 133 (qualifierName -> ASSOCIATION .)
+    {               reduce using rule 133 (qualifierName -> ASSOCIATION .)
+    ]               reduce using rule 133 (qualifierName -> ASSOCIATION .)
+    ,               reduce using rule 133 (qualifierName -> ASSOCIATION .)
+
+
+state 62
+
+    (134) qualifierName -> INDICATION .
+
+    :               reduce using rule 134 (qualifierName -> INDICATION .)
+    (               reduce using rule 134 (qualifierName -> INDICATION .)
+    {               reduce using rule 134 (qualifierName -> INDICATION .)
+    ]               reduce using rule 134 (qualifierName -> INDICATION .)
+    ,               reduce using rule 134 (qualifierName -> INDICATION .)
+
+
+state 63
+
+    (157) instanceDeclaration -> INSTANCE OF . className { valueInitializerList } ;
+    (158) instanceDeclaration -> INSTANCE OF . className alias { valueInitializerList } ;
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    className                      shift and go to state 79
+    identifier                     shift and go to state 21
+    dataType                       shift and go to state 26
+
+state 64
+
+    (33) qualifierList -> [ qualifier . qualifierListEmpty ]
+    (24) qualifierListEmpty -> . empty
+    (25) qualifierListEmpty -> . qualifierListEmpty , qualifier
+    (190) empty -> .
+
+    ]               reduce using rule 190 (empty -> .)
+    ,               reduce using rule 190 (empty -> .)
+
+    qualifierListEmpty             shift and go to state 80
+    empty                          shift and go to state 81
+
+state 65
+
+    (34) qualifier -> qualifierName .
+    (35) qualifier -> qualifierName . : flavorList
+    (36) qualifier -> qualifierName . qualifierParameter
+    (37) qualifier -> qualifierName . qualifierParameter : flavorList
+    (40) qualifierParameter -> . ( constantValue )
+    (41) qualifierParameter -> . arrayInitializer
+    (111) arrayInitializer -> . { constantValueList }
+    (112) arrayInitializer -> . { }
+
+    ]               reduce using rule 34 (qualifier -> qualifierName .)
+    ,               reduce using rule 34 (qualifier -> qualifierName .)
+    :               shift and go to state 82
+    (               shift and go to state 84
+    {               shift and go to state 86
+
+    qualifierParameter             shift and go to state 83
+    arrayInitializer               shift and go to state 85
+
+state 66
+
+    (11) compilerDirective -> # PRAGMA pragmaName . ( pragmaParameter )
+
+    (               shift and go to state 87
+
+
+state 67
+
+    (12) pragmaName -> identifier .
+
+    (               reduce using rule 12 (pragmaName -> identifier .)
+
+
+state 68
+
+    (14) classDeclaration -> CLASS className { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 88
+    empty                          shift and go to state 89
+
+state 69
+
+    (15) classDeclaration -> CLASS className superClass . { classFeatureList } ;
+
+    {               shift and go to state 90
+
+
+state 70
+
+    (16) classDeclaration -> CLASS className alias . { classFeatureList } ;
+    (17) classDeclaration -> CLASS className alias . superClass { classFeatureList } ;
+    (29) superClass -> . : className
+
+    {               shift and go to state 91
+    :               shift and go to state 71
+
+    superClass                     shift and go to state 92
+
+state 71
+
+    (29) superClass -> : . className
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    className                      shift and go to state 93
+    identifier                     shift and go to state 21
+    dataType                       shift and go to state 26
+
+state 72
+
+    (27) alias -> AS . aliasIdentifier
+    (28) aliasIdentifier -> . $ identifier
+
+    $               shift and go to state 95
+
+    aliasIdentifier                shift and go to state 94
+
+state 73
+
+    (18) classDeclaration -> qualifierList CLASS className . { classFeatureList } ;
+    (19) classDeclaration -> qualifierList CLASS className . superClass { classFeatureList } ;
+    (20) classDeclaration -> qualifierList CLASS className . alias { classFeatureList } ;
+    (21) classDeclaration -> qualifierList CLASS className . alias superClass { classFeatureList } ;
+    (29) superClass -> . : className
+    (27) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 96
+    :               shift and go to state 71
+    AS              shift and go to state 72
+
+    superClass                     shift and go to state 97
+    alias                          shift and go to state 98
+
+state 74
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF . className { valueInitializerList } ;
+    (160) instanceDeclaration -> qualifierList INSTANCE OF . className alias { valueInitializerList } ;
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    className                      shift and go to state 99
+    identifier                     shift and go to state 21
+    dataType                       shift and go to state 26
+
+state 75
+
+    (130) qualifierDeclaration -> QUALIFIER qualifierName qualifierType . scope ;
+    (131) qualifierDeclaration -> QUALIFIER qualifierName qualifierType . scope defaultFlavor ;
+    (141) scope -> . , SCOPE ( metaElementList )
+
+    ,               shift and go to state 101
+
+    scope                          shift and go to state 100
+
+state 76
+
+    (135) qualifierType -> qualifierType_1 .
+
+    ,               reduce using rule 135 (qualifierType -> qualifierType_1 .)
+
+
+state 77
+
+    (136) qualifierType -> qualifierType_2 .
+
+    ,               reduce using rule 136 (qualifierType -> qualifierType_2 .)
+
+
+state 78
+
+    (137) qualifierType_1 -> : . dataType array
+    (138) qualifierType_1 -> : . dataType array defaultValue
+    (139) qualifierType_2 -> : . dataType
+    (140) qualifierType_2 -> : . dataType defaultValue
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    dataType                       shift and go to state 102
+
+state 79
+
+    (157) instanceDeclaration -> INSTANCE OF className . { valueInitializerList } ;
+    (158) instanceDeclaration -> INSTANCE OF className . alias { valueInitializerList } ;
+    (27) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 103
+    AS              shift and go to state 72
+
+    alias                          shift and go to state 104
+
+state 80
+
+    (33) qualifierList -> [ qualifier qualifierListEmpty . ]
+    (25) qualifierListEmpty -> qualifierListEmpty . , qualifier
+
+    ]               shift and go to state 105
+    ,               shift and go to state 106
+
+
+state 81
+
+    (24) qualifierListEmpty -> empty .
+
+    ]               reduce using rule 24 (qualifierListEmpty -> empty .)
+    ,               reduce using rule 24 (qualifierListEmpty -> empty .)
+
+
+state 82
+
+    (35) qualifier -> qualifierName : . flavorList
+    (38) flavorList -> . flavor
+    (39) flavorList -> . flavorList flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavorList                     shift and go to state 107
+    flavor                         shift and go to state 108
+
+state 83
+
+    (36) qualifier -> qualifierName qualifierParameter .
+    (37) qualifier -> qualifierName qualifierParameter . : flavorList
+
+    ]               reduce using rule 36 (qualifier -> qualifierName qualifierParameter .)
+    ,               reduce using rule 36 (qualifier -> qualifierName qualifierParameter .)
+    :               shift and go to state 115
+
+
+state 84
+
+    (40) qualifierParameter -> ( . constantValue )
+    (117) constantValue -> . integerValue
+    (118) constantValue -> . floatValue
+    (119) constantValue -> . charValue
+    (120) constantValue -> . stringValueList
+    (121) constantValue -> . booleanValue
+    (122) constantValue -> . nullValue
+    (123) integerValue -> . binaryValue
+    (124) integerValue -> . octalValue
+    (125) integerValue -> . decimalValue
+    (126) integerValue -> . hexValue
+    (115) stringValueList -> . stringValue
+    (116) stringValueList -> . stringValueList stringValue
+    (165) booleanValue -> . FALSE
+    (166) booleanValue -> . TRUE
+    (167) nullValue -> . NULL
+
+    floatValue      shift and go to state 118
+    charValue       shift and go to state 119
+    binaryValue     shift and go to state 123
+    octalValue      shift and go to state 124
+    decimalValue    shift and go to state 125
+    hexValue        shift and go to state 126
+    stringValue     shift and go to state 127
+    FALSE           shift and go to state 128
+    TRUE            shift and go to state 129
+    NULL            shift and go to state 130
+
+    constantValue                  shift and go to state 116
+    integerValue                   shift and go to state 117
+    stringValueList                shift and go to state 120
+    booleanValue                   shift and go to state 121
+    nullValue                      shift and go to state 122
+
+state 85
+
+    (41) qualifierParameter -> arrayInitializer .
+
+    :               reduce using rule 41 (qualifierParameter -> arrayInitializer .)
+    ]               reduce using rule 41 (qualifierParameter -> arrayInitializer .)
+    ,               reduce using rule 41 (qualifierParameter -> arrayInitializer .)
+
+
+state 86
+
+    (111) arrayInitializer -> { . constantValueList }
+    (112) arrayInitializer -> { . }
+    (113) constantValueList -> . constantValue
+    (114) constantValueList -> . constantValueList , constantValue
+    (117) constantValue -> . integerValue
+    (118) constantValue -> . floatValue
+    (119) constantValue -> . charValue
+    (120) constantValue -> . stringValueList
+    (121) constantValue -> . booleanValue
+    (122) constantValue -> . nullValue
+    (123) integerValue -> . binaryValue
+    (124) integerValue -> . octalValue
+    (125) integerValue -> . decimalValue
+    (126) integerValue -> . hexValue
+    (115) stringValueList -> . stringValue
+    (116) stringValueList -> . stringValueList stringValue
+    (165) booleanValue -> . FALSE
+    (166) booleanValue -> . TRUE
+    (167) nullValue -> . NULL
+
+    }               shift and go to state 132
+    floatValue      shift and go to state 118
+    charValue       shift and go to state 119
+    binaryValue     shift and go to state 123
+    octalValue      shift and go to state 124
+    decimalValue    shift and go to state 125
+    hexValue        shift and go to state 126
+    stringValue     shift and go to state 127
+    FALSE           shift and go to state 128
+    TRUE            shift and go to state 129
+    NULL            shift and go to state 130
+
+    constantValueList              shift and go to state 131
+    constantValue                  shift and go to state 133
+    integerValue                   shift and go to state 117
+    stringValueList                shift and go to state 120
+    booleanValue                   shift and go to state 121
+    nullValue                      shift and go to state 122
+
+state 87
+
+    (11) compilerDirective -> # PRAGMA pragmaName ( . pragmaParameter )
+    (13) pragmaParameter -> . stringValue
+
+    stringValue     shift and go to state 135
+
+    pragmaParameter                shift and go to state 134
+
+state 88
+
+    (14) classDeclaration -> CLASS className { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 137
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    qualifierList                  shift and go to state 151
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 89
+
+    (22) classFeatureList -> empty .
+
+    }               reduce using rule 22 (classFeatureList -> empty .)
+    DT_UINT8        reduce using rule 22 (classFeatureList -> empty .)
+    DT_SINT8        reduce using rule 22 (classFeatureList -> empty .)
+    DT_UINT16       reduce using rule 22 (classFeatureList -> empty .)
+    DT_SINT16       reduce using rule 22 (classFeatureList -> empty .)
+    DT_UINT32       reduce using rule 22 (classFeatureList -> empty .)
+    DT_SINT32       reduce using rule 22 (classFeatureList -> empty .)
+    DT_UINT64       reduce using rule 22 (classFeatureList -> empty .)
+    DT_SINT64       reduce using rule 22 (classFeatureList -> empty .)
+    DT_REAL32       reduce using rule 22 (classFeatureList -> empty .)
+    DT_REAL64       reduce using rule 22 (classFeatureList -> empty .)
+    DT_CHAR16       reduce using rule 22 (classFeatureList -> empty .)
+    DT_STR          reduce using rule 22 (classFeatureList -> empty .)
+    DT_BOOL         reduce using rule 22 (classFeatureList -> empty .)
+    DT_DATETIME     reduce using rule 22 (classFeatureList -> empty .)
+    [               reduce using rule 22 (classFeatureList -> empty .)
+    IDENTIFIER      reduce using rule 22 (classFeatureList -> empty .)
+    ANY             reduce using rule 22 (classFeatureList -> empty .)
+    AS              reduce using rule 22 (classFeatureList -> empty .)
+    CLASS           reduce using rule 22 (classFeatureList -> empty .)
+    DISABLEOVERRIDE reduce using rule 22 (classFeatureList -> empty .)
+    ENABLEOVERRIDE  reduce using rule 22 (classFeatureList -> empty .)
+    FLAVOR          reduce using rule 22 (classFeatureList -> empty .)
+    INSTANCE        reduce using rule 22 (classFeatureList -> empty .)
+    METHOD          reduce using rule 22 (classFeatureList -> empty .)
+    OF              reduce using rule 22 (classFeatureList -> empty .)
+    PARAMETER       reduce using rule 22 (classFeatureList -> empty .)
+    PRAGMA          reduce using rule 22 (classFeatureList -> empty .)
+    PROPERTY        reduce using rule 22 (classFeatureList -> empty .)
+    QUALIFIER       reduce using rule 22 (classFeatureList -> empty .)
+    REFERENCE       reduce using rule 22 (classFeatureList -> empty .)
+    RESTRICTED      reduce using rule 22 (classFeatureList -> empty .)
+    SCHEMA          reduce using rule 22 (classFeatureList -> empty .)
+    SCOPE           reduce using rule 22 (classFeatureList -> empty .)
+    TOSUBCLASS      reduce using rule 22 (classFeatureList -> empty .)
+    TOINSTANCE      reduce using rule 22 (classFeatureList -> empty .)
+    TRANSLATABLE    reduce using rule 22 (classFeatureList -> empty .)
+
+
+state 90
+
+    (15) classDeclaration -> CLASS className superClass { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 153
+    empty                          shift and go to state 89
+
+state 91
+
+    (16) classDeclaration -> CLASS className alias { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 154
+    empty                          shift and go to state 89
+
+state 92
+
+    (17) classDeclaration -> CLASS className alias superClass . { classFeatureList } ;
+
+    {               shift and go to state 155
+
+
+state 93
+
+    (29) superClass -> : className .
+
+    {               reduce using rule 29 (superClass -> : className .)
+
+
+state 94
+
+    (27) alias -> AS aliasIdentifier .
+
+    {               reduce using rule 27 (alias -> AS aliasIdentifier .)
+    :               reduce using rule 27 (alias -> AS aliasIdentifier .)
+
+
+state 95
+
+    (28) aliasIdentifier -> $ . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    identifier                     shift and go to state 156
+    dataType                       shift and go to state 26
+
+state 96
+
+    (18) classDeclaration -> qualifierList CLASS className { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 157
+    empty                          shift and go to state 89
+
+state 97
+
+    (19) classDeclaration -> qualifierList CLASS className superClass . { classFeatureList } ;
+
+    {               shift and go to state 158
+
+
+state 98
+
+    (20) classDeclaration -> qualifierList CLASS className alias . { classFeatureList } ;
+    (21) classDeclaration -> qualifierList CLASS className alias . superClass { classFeatureList } ;
+    (29) superClass -> . : className
+
+    {               shift and go to state 159
+    :               shift and go to state 71
+
+    superClass                     shift and go to state 160
+
+state 99
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF className . { valueInitializerList } ;
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className . alias { valueInitializerList } ;
+    (27) alias -> . AS aliasIdentifier
+
+    {               shift and go to state 161
+    AS              shift and go to state 72
+
+    alias                          shift and go to state 162
+
+state 100
+
+    (130) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope . ;
+    (131) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope . defaultFlavor ;
+    (154) defaultFlavor -> . , FLAVOR ( flavorListWithComma )
+
+    ;               shift and go to state 163
+    ,               shift and go to state 165
+
+    defaultFlavor                  shift and go to state 164
+
+state 101
+
+    (141) scope -> , . SCOPE ( metaElementList )
+
+    SCOPE           shift and go to state 166
+
+
+state 102
+
+    (137) qualifierType_1 -> : dataType . array
+    (138) qualifierType_1 -> : dataType . array defaultValue
+    (139) qualifierType_2 -> : dataType .
+    (140) qualifierType_2 -> : dataType . defaultValue
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+    (107) defaultValue -> . = initializer
+
+    ,               reduce using rule 139 (qualifierType_2 -> : dataType .)
+    [               shift and go to state 169
+    =               shift and go to state 170
+
+    array                          shift and go to state 167
+    defaultValue                   shift and go to state 168
+
+state 103
+
+    (157) instanceDeclaration -> INSTANCE OF className { . valueInitializerList } ;
+    (161) valueInitializerList -> . valueInitializer
+    (162) valueInitializerList -> . valueInitializerList valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    valueInitializerList           shift and go to state 171
+    valueInitializer               shift and go to state 172
+    identifier                     shift and go to state 173
+    qualifierList                  shift and go to state 174
+    dataType                       shift and go to state 26
+
+state 104
+
+    (158) instanceDeclaration -> INSTANCE OF className alias . { valueInitializerList } ;
+
+    {               shift and go to state 175
+
+
+state 105
+
+    (33) qualifierList -> [ qualifier qualifierListEmpty ] .
+
+    CLASS           reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    INSTANCE        reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT8        reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT8        reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT16       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT16       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT32       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT32       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_UINT64       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_SINT64       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_REAL32       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_REAL64       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_CHAR16       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_STR          reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_BOOL         reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DT_DATETIME     reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    IDENTIFIER      reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    ANY             reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    AS              reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    DISABLEOVERRIDE reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    ENABLEOVERRIDE  reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    FLAVOR          reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    METHOD          reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    OF              reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PARAMETER       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PRAGMA          reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    PROPERTY        reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    QUALIFIER       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    REFERENCE       reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    RESTRICTED      reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    SCHEMA          reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    SCOPE           reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TOSUBCLASS      reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TOINSTANCE      reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+    TRANSLATABLE    reduce using rule 33 (qualifierList -> [ qualifier qualifierListEmpty ] .)
+
+
+state 106
+
+    (25) qualifierListEmpty -> qualifierListEmpty , . qualifier
+    (34) qualifier -> . qualifierName
+    (35) qualifier -> . qualifierName : flavorList
+    (36) qualifier -> . qualifierName qualifierParameter
+    (37) qualifier -> . qualifierName qualifierParameter : flavorList
+    (132) qualifierName -> . identifier
+    (133) qualifierName -> . ASSOCIATION
+    (134) qualifierName -> . INDICATION
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    ASSOCIATION     shift and go to state 61
+    INDICATION      shift and go to state 62
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifier                      shift and go to state 176
+    qualifierName                  shift and go to state 65
+    identifier                     shift and go to state 60
+    dataType                       shift and go to state 26
+
+state 107
+
+    (35) qualifier -> qualifierName : flavorList .
+    (39) flavorList -> flavorList . flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ]               reduce using rule 35 (qualifier -> qualifierName : flavorList .)
+    ,               reduce using rule 35 (qualifier -> qualifierName : flavorList .)
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavor                         shift and go to state 177
+
+state 108
+
+    (38) flavorList -> flavor .
+
+    ENABLEOVERRIDE  reduce using rule 38 (flavorList -> flavor .)
+    DISABLEOVERRIDE reduce using rule 38 (flavorList -> flavor .)
+    RESTRICTED      reduce using rule 38 (flavorList -> flavor .)
+    TOSUBCLASS      reduce using rule 38 (flavorList -> flavor .)
+    TOINSTANCE      reduce using rule 38 (flavorList -> flavor .)
+    TRANSLATABLE    reduce using rule 38 (flavorList -> flavor .)
+    ]               reduce using rule 38 (flavorList -> flavor .)
+    ,               reduce using rule 38 (flavorList -> flavor .)
+
+
+state 109
+
+    (42) flavor -> ENABLEOVERRIDE .
+
+    ENABLEOVERRIDE  reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    DISABLEOVERRIDE reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    RESTRICTED      reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    TOSUBCLASS      reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    TOINSTANCE      reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    TRANSLATABLE    reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    ]               reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    ,               reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+    )               reduce using rule 42 (flavor -> ENABLEOVERRIDE .)
+
+
+state 110
+
+    (43) flavor -> DISABLEOVERRIDE .
+
+    ENABLEOVERRIDE  reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    DISABLEOVERRIDE reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    RESTRICTED      reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    TOSUBCLASS      reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    TOINSTANCE      reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    TRANSLATABLE    reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    ]               reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    ,               reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+    )               reduce using rule 43 (flavor -> DISABLEOVERRIDE .)
+
+
+state 111
+
+    (44) flavor -> RESTRICTED .
+
+    ENABLEOVERRIDE  reduce using rule 44 (flavor -> RESTRICTED .)
+    DISABLEOVERRIDE reduce using rule 44 (flavor -> RESTRICTED .)
+    RESTRICTED      reduce using rule 44 (flavor -> RESTRICTED .)
+    TOSUBCLASS      reduce using rule 44 (flavor -> RESTRICTED .)
+    TOINSTANCE      reduce using rule 44 (flavor -> RESTRICTED .)
+    TRANSLATABLE    reduce using rule 44 (flavor -> RESTRICTED .)
+    ]               reduce using rule 44 (flavor -> RESTRICTED .)
+    ,               reduce using rule 44 (flavor -> RESTRICTED .)
+    )               reduce using rule 44 (flavor -> RESTRICTED .)
+
+
+state 112
+
+    (45) flavor -> TOSUBCLASS .
+
+    ENABLEOVERRIDE  reduce using rule 45 (flavor -> TOSUBCLASS .)
+    DISABLEOVERRIDE reduce using rule 45 (flavor -> TOSUBCLASS .)
+    RESTRICTED      reduce using rule 45 (flavor -> TOSUBCLASS .)
+    TOSUBCLASS      reduce using rule 45 (flavor -> TOSUBCLASS .)
+    TOINSTANCE      reduce using rule 45 (flavor -> TOSUBCLASS .)
+    TRANSLATABLE    reduce using rule 45 (flavor -> TOSUBCLASS .)
+    ]               reduce using rule 45 (flavor -> TOSUBCLASS .)
+    ,               reduce using rule 45 (flavor -> TOSUBCLASS .)
+    )               reduce using rule 45 (flavor -> TOSUBCLASS .)
+
+
+state 113
+
+    (46) flavor -> TOINSTANCE .
+
+    ENABLEOVERRIDE  reduce using rule 46 (flavor -> TOINSTANCE .)
+    DISABLEOVERRIDE reduce using rule 46 (flavor -> TOINSTANCE .)
+    RESTRICTED      reduce using rule 46 (flavor -> TOINSTANCE .)
+    TOSUBCLASS      reduce using rule 46 (flavor -> TOINSTANCE .)
+    TOINSTANCE      reduce using rule 46 (flavor -> TOINSTANCE .)
+    TRANSLATABLE    reduce using rule 46 (flavor -> TOINSTANCE .)
+    ]               reduce using rule 46 (flavor -> TOINSTANCE .)
+    ,               reduce using rule 46 (flavor -> TOINSTANCE .)
+    )               reduce using rule 46 (flavor -> TOINSTANCE .)
+
+
+state 114
+
+    (47) flavor -> TRANSLATABLE .
+
+    ENABLEOVERRIDE  reduce using rule 47 (flavor -> TRANSLATABLE .)
+    DISABLEOVERRIDE reduce using rule 47 (flavor -> TRANSLATABLE .)
+    RESTRICTED      reduce using rule 47 (flavor -> TRANSLATABLE .)
+    TOSUBCLASS      reduce using rule 47 (flavor -> TRANSLATABLE .)
+    TOINSTANCE      reduce using rule 47 (flavor -> TRANSLATABLE .)
+    TRANSLATABLE    reduce using rule 47 (flavor -> TRANSLATABLE .)
+    ]               reduce using rule 47 (flavor -> TRANSLATABLE .)
+    ,               reduce using rule 47 (flavor -> TRANSLATABLE .)
+    )               reduce using rule 47 (flavor -> TRANSLATABLE .)
+
+
+state 115
+
+    (37) qualifier -> qualifierName qualifierParameter : . flavorList
+    (38) flavorList -> . flavor
+    (39) flavorList -> . flavorList flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavorList                     shift and go to state 178
+    flavor                         shift and go to state 108
+
+state 116
+
+    (40) qualifierParameter -> ( constantValue . )
+
+    )               shift and go to state 179
+
+
+state 117
+
+    (117) constantValue -> integerValue .
+
+    )               reduce using rule 117 (constantValue -> integerValue .)
+    }               reduce using rule 117 (constantValue -> integerValue .)
+    ,               reduce using rule 117 (constantValue -> integerValue .)
+    ;               reduce using rule 117 (constantValue -> integerValue .)
+
+
+state 118
+
+    (118) constantValue -> floatValue .
+
+    )               reduce using rule 118 (constantValue -> floatValue .)
+    }               reduce using rule 118 (constantValue -> floatValue .)
+    ,               reduce using rule 118 (constantValue -> floatValue .)
+    ;               reduce using rule 118 (constantValue -> floatValue .)
+
+
+state 119
+
+    (119) constantValue -> charValue .
+
+    )               reduce using rule 119 (constantValue -> charValue .)
+    }               reduce using rule 119 (constantValue -> charValue .)
+    ,               reduce using rule 119 (constantValue -> charValue .)
+    ;               reduce using rule 119 (constantValue -> charValue .)
+
+
+state 120
+
+    (120) constantValue -> stringValueList .
+    (116) stringValueList -> stringValueList . stringValue
+
+    )               reduce using rule 120 (constantValue -> stringValueList .)
+    }               reduce using rule 120 (constantValue -> stringValueList .)
+    ,               reduce using rule 120 (constantValue -> stringValueList .)
+    ;               reduce using rule 120 (constantValue -> stringValueList .)
+    stringValue     shift and go to state 180
+
+
+state 121
+
+    (121) constantValue -> booleanValue .
+
+    )               reduce using rule 121 (constantValue -> booleanValue .)
+    }               reduce using rule 121 (constantValue -> booleanValue .)
+    ,               reduce using rule 121 (constantValue -> booleanValue .)
+    ;               reduce using rule 121 (constantValue -> booleanValue .)
+
+
+state 122
+
+    (122) constantValue -> nullValue .
+
+    )               reduce using rule 122 (constantValue -> nullValue .)
+    }               reduce using rule 122 (constantValue -> nullValue .)
+    ,               reduce using rule 122 (constantValue -> nullValue .)
+    ;               reduce using rule 122 (constantValue -> nullValue .)
+
+
+state 123
+
+    (123) integerValue -> binaryValue .
+
+    )               reduce using rule 123 (integerValue -> binaryValue .)
+    }               reduce using rule 123 (integerValue -> binaryValue .)
+    ,               reduce using rule 123 (integerValue -> binaryValue .)
+    ]               reduce using rule 123 (integerValue -> binaryValue .)
+    ;               reduce using rule 123 (integerValue -> binaryValue .)
+
+
+state 124
+
+    (124) integerValue -> octalValue .
+
+    )               reduce using rule 124 (integerValue -> octalValue .)
+    }               reduce using rule 124 (integerValue -> octalValue .)
+    ,               reduce using rule 124 (integerValue -> octalValue .)
+    ]               reduce using rule 124 (integerValue -> octalValue .)
+    ;               reduce using rule 124 (integerValue -> octalValue .)
+
+
+state 125
+
+    (125) integerValue -> decimalValue .
+
+    )               reduce using rule 125 (integerValue -> decimalValue .)
+    }               reduce using rule 125 (integerValue -> decimalValue .)
+    ,               reduce using rule 125 (integerValue -> decimalValue .)
+    ]               reduce using rule 125 (integerValue -> decimalValue .)
+    ;               reduce using rule 125 (integerValue -> decimalValue .)
+
+
+state 126
+
+    (126) integerValue -> hexValue .
+
+    )               reduce using rule 126 (integerValue -> hexValue .)
+    }               reduce using rule 126 (integerValue -> hexValue .)
+    ,               reduce using rule 126 (integerValue -> hexValue .)
+    ]               reduce using rule 126 (integerValue -> hexValue .)
+    ;               reduce using rule 126 (integerValue -> hexValue .)
+
+
+state 127
+
+    (115) stringValueList -> stringValue .
+
+    stringValue     reduce using rule 115 (stringValueList -> stringValue .)
+    )               reduce using rule 115 (stringValueList -> stringValue .)
+    }               reduce using rule 115 (stringValueList -> stringValue .)
+    ,               reduce using rule 115 (stringValueList -> stringValue .)
+    ;               reduce using rule 115 (stringValueList -> stringValue .)
+
+
+state 128
+
+    (165) booleanValue -> FALSE .
+
+    )               reduce using rule 165 (booleanValue -> FALSE .)
+    }               reduce using rule 165 (booleanValue -> FALSE .)
+    ,               reduce using rule 165 (booleanValue -> FALSE .)
+    ;               reduce using rule 165 (booleanValue -> FALSE .)
+
+
+state 129
+
+    (166) booleanValue -> TRUE .
+
+    )               reduce using rule 166 (booleanValue -> TRUE .)
+    }               reduce using rule 166 (booleanValue -> TRUE .)
+    ,               reduce using rule 166 (booleanValue -> TRUE .)
+    ;               reduce using rule 166 (booleanValue -> TRUE .)
+
+
+state 130
+
+    (167) nullValue -> NULL .
+
+    )               reduce using rule 167 (nullValue -> NULL .)
+    }               reduce using rule 167 (nullValue -> NULL .)
+    ,               reduce using rule 167 (nullValue -> NULL .)
+    ;               reduce using rule 167 (nullValue -> NULL .)
+
+
+state 131
+
+    (111) arrayInitializer -> { constantValueList . }
+    (114) constantValueList -> constantValueList . , constantValue
+
+    }               shift and go to state 181
+    ,               shift and go to state 182
+
+
+state 132
+
+    (112) arrayInitializer -> { } .
+
+    :               reduce using rule 112 (arrayInitializer -> { } .)
+    ]               reduce using rule 112 (arrayInitializer -> { } .)
+    ,               reduce using rule 112 (arrayInitializer -> { } .)
+    ;               reduce using rule 112 (arrayInitializer -> { } .)
+
+
+state 133
+
+    (113) constantValueList -> constantValue .
+
+    }               reduce using rule 113 (constantValueList -> constantValue .)
+    ,               reduce using rule 113 (constantValueList -> constantValue .)
+
+
+state 134
+
+    (11) compilerDirective -> # PRAGMA pragmaName ( pragmaParameter . )
+
+    )               shift and go to state 183
+
+
+state 135
+
+    (13) pragmaParameter -> stringValue .
+
+    )               reduce using rule 13 (pragmaParameter -> stringValue .)
+
+
+state 136
+
+    (89) objectRef -> className . REF
+
+    REF             shift and go to state 184
+
+
+state 137
+
+    (14) classDeclaration -> CLASS className { classFeatureList } . ;
+
+    ;               shift and go to state 185
+
+
+state 138
+
+    (23) classFeatureList -> classFeatureList classFeature .
+
+    }               reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT8        reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT8        reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT16       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT16       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT32       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT32       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_UINT64       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_SINT64       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_REAL32       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_REAL64       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_CHAR16       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_STR          reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_BOOL         reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DT_DATETIME     reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    [               reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    IDENTIFIER      reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    ANY             reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    AS              reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    CLASS           reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    DISABLEOVERRIDE reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    ENABLEOVERRIDE  reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    FLAVOR          reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    INSTANCE        reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    METHOD          reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    OF              reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    PARAMETER       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    PRAGMA          reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    PROPERTY        reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    QUALIFIER       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    REFERENCE       reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    RESTRICTED      reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    SCHEMA          reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    SCOPE           reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    TOSUBCLASS      reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    TOINSTANCE      reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+    TRANSLATABLE    reduce using rule 23 (classFeatureList -> classFeatureList classFeature .)
+
+
+state 139
+
+    (30) classFeature -> propertyDeclaration .
+
+    }               reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_UINT8        reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_SINT8        reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_UINT16       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_SINT16       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_UINT32       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_SINT32       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_UINT64       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_SINT64       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_REAL32       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_REAL64       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_CHAR16       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_STR          reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_BOOL         reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DT_DATETIME     reduce using rule 30 (classFeature -> propertyDeclaration .)
+    [               reduce using rule 30 (classFeature -> propertyDeclaration .)
+    IDENTIFIER      reduce using rule 30 (classFeature -> propertyDeclaration .)
+    ANY             reduce using rule 30 (classFeature -> propertyDeclaration .)
+    AS              reduce using rule 30 (classFeature -> propertyDeclaration .)
+    CLASS           reduce using rule 30 (classFeature -> propertyDeclaration .)
+    DISABLEOVERRIDE reduce using rule 30 (classFeature -> propertyDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 30 (classFeature -> propertyDeclaration .)
+    FLAVOR          reduce using rule 30 (classFeature -> propertyDeclaration .)
+    INSTANCE        reduce using rule 30 (classFeature -> propertyDeclaration .)
+    METHOD          reduce using rule 30 (classFeature -> propertyDeclaration .)
+    OF              reduce using rule 30 (classFeature -> propertyDeclaration .)
+    PARAMETER       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    PRAGMA          reduce using rule 30 (classFeature -> propertyDeclaration .)
+    PROPERTY        reduce using rule 30 (classFeature -> propertyDeclaration .)
+    QUALIFIER       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    REFERENCE       reduce using rule 30 (classFeature -> propertyDeclaration .)
+    RESTRICTED      reduce using rule 30 (classFeature -> propertyDeclaration .)
+    SCHEMA          reduce using rule 30 (classFeature -> propertyDeclaration .)
+    SCOPE           reduce using rule 30 (classFeature -> propertyDeclaration .)
+    TOSUBCLASS      reduce using rule 30 (classFeature -> propertyDeclaration .)
+    TOINSTANCE      reduce using rule 30 (classFeature -> propertyDeclaration .)
+    TRANSLATABLE    reduce using rule 30 (classFeature -> propertyDeclaration .)
+
+
+state 140
+
+    (31) classFeature -> methodDeclaration .
+
+    }               reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_UINT8        reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_SINT8        reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_UINT16       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_SINT16       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_UINT32       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_SINT32       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_UINT64       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_SINT64       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_REAL32       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_REAL64       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_CHAR16       reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_STR          reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_BOOL         reduce using rule 31 (classFeature -> methodDeclaration .)
+    DT_DATETIME     reduce using rule 31 (classFeature -> methodDeclaration .)
+    [               reduce using rule 31 (classFeature -> methodDeclaration .)
+    IDENTIFIER      reduce using rule 31 (classFeature -> methodDeclaration .)
+    ANY             reduce using rule 31 (classFeature -> methodDeclaration .)
+    AS              reduce using rule 31 (classFeature -> methodDeclaration .)
+    CLASS           reduce using rule 31 (classFeature -> methodDeclaration .)
+    DISABLEOVERRIDE reduce using rule 31 (classFeature -> methodDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 31 (classFeature -> methodDeclaration .)
+    FLAVOR          reduce using rule 31 (classFeature -> methodDeclaration .)
+    INSTANCE        reduce using rule 31 (classFeature -> methodDeclaration .)
+    METHOD          reduce using rule 31 (classFeature -> methodDeclaration .)
+    OF              reduce using rule 31 (classFeature -> methodDeclaration .)
+    PARAMETER       reduce using rule 31 (classFeature -> methodDeclaration .)
+    PRAGMA          reduce using rule 31 (classFeature -> methodDeclaration .)
+    PROPERTY        reduce using rule 31 (classFeature -> methodDeclaration .)
+    QUALIFIER       reduce using rule 31 (classFeature -> methodDeclaration .)
+    REFERENCE       reduce using rule 31 (classFeature -> methodDeclaration .)
+    RESTRICTED      reduce using rule 31 (classFeature -> methodDeclaration .)
+    SCHEMA          reduce using rule 31 (classFeature -> methodDeclaration .)
+    SCOPE           reduce using rule 31 (classFeature -> methodDeclaration .)
+    TOSUBCLASS      reduce using rule 31 (classFeature -> methodDeclaration .)
+    TOINSTANCE      reduce using rule 31 (classFeature -> methodDeclaration .)
+    TRANSLATABLE    reduce using rule 31 (classFeature -> methodDeclaration .)
+
+
+state 141
+
+    (32) classFeature -> referenceDeclaration .
+
+    }               reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_UINT8        reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_SINT8        reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_UINT16       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_SINT16       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_UINT32       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_SINT32       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_UINT64       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_SINT64       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_REAL32       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_REAL64       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_CHAR16       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_STR          reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_BOOL         reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DT_DATETIME     reduce using rule 32 (classFeature -> referenceDeclaration .)
+    [               reduce using rule 32 (classFeature -> referenceDeclaration .)
+    IDENTIFIER      reduce using rule 32 (classFeature -> referenceDeclaration .)
+    ANY             reduce using rule 32 (classFeature -> referenceDeclaration .)
+    AS              reduce using rule 32 (classFeature -> referenceDeclaration .)
+    CLASS           reduce using rule 32 (classFeature -> referenceDeclaration .)
+    DISABLEOVERRIDE reduce using rule 32 (classFeature -> referenceDeclaration .)
+    ENABLEOVERRIDE  reduce using rule 32 (classFeature -> referenceDeclaration .)
+    FLAVOR          reduce using rule 32 (classFeature -> referenceDeclaration .)
+    INSTANCE        reduce using rule 32 (classFeature -> referenceDeclaration .)
+    METHOD          reduce using rule 32 (classFeature -> referenceDeclaration .)
+    OF              reduce using rule 32 (classFeature -> referenceDeclaration .)
+    PARAMETER       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    PRAGMA          reduce using rule 32 (classFeature -> referenceDeclaration .)
+    PROPERTY        reduce using rule 32 (classFeature -> referenceDeclaration .)
+    QUALIFIER       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    REFERENCE       reduce using rule 32 (classFeature -> referenceDeclaration .)
+    RESTRICTED      reduce using rule 32 (classFeature -> referenceDeclaration .)
+    SCHEMA          reduce using rule 32 (classFeature -> referenceDeclaration .)
+    SCOPE           reduce using rule 32 (classFeature -> referenceDeclaration .)
+    TOSUBCLASS      reduce using rule 32 (classFeature -> referenceDeclaration .)
+    TOINSTANCE      reduce using rule 32 (classFeature -> referenceDeclaration .)
+    TRANSLATABLE    reduce using rule 32 (classFeature -> referenceDeclaration .)
+
+
+state 142
+
+    (48) propertyDeclaration -> propertyDeclaration_1 .
+
+    }               reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT8        reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT8        reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT16       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT16       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT32       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT32       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_UINT64       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_SINT64       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_REAL32       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_REAL64       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_CHAR16       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_STR          reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_BOOL         reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DT_DATETIME     reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    [               reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    IDENTIFIER      reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    ANY             reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    AS              reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    CLASS           reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    DISABLEOVERRIDE reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    ENABLEOVERRIDE  reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    FLAVOR          reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    INSTANCE        reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    METHOD          reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    OF              reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    PARAMETER       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    PRAGMA          reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    PROPERTY        reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    QUALIFIER       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    REFERENCE       reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    RESTRICTED      reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    SCHEMA          reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    SCOPE           reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    TOSUBCLASS      reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    TOINSTANCE      reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+    TRANSLATABLE    reduce using rule 48 (propertyDeclaration -> propertyDeclaration_1 .)
+
+
+state 143
+
+    (49) propertyDeclaration -> propertyDeclaration_2 .
+
+    }               reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT8        reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT8        reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT16       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT16       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT32       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT32       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_UINT64       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_SINT64       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_REAL32       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_REAL64       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_CHAR16       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_STR          reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_BOOL         reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DT_DATETIME     reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    [               reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    IDENTIFIER      reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    ANY             reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    AS              reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    CLASS           reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    DISABLEOVERRIDE reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    ENABLEOVERRIDE  reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    FLAVOR          reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    INSTANCE        reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    METHOD          reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    OF              reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    PARAMETER       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    PRAGMA          reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    PROPERTY        reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    QUALIFIER       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    REFERENCE       reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    RESTRICTED      reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    SCHEMA          reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    SCOPE           reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    TOSUBCLASS      reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    TOINSTANCE      reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+    TRANSLATABLE    reduce using rule 49 (propertyDeclaration -> propertyDeclaration_2 .)
+
+
+state 144
+
+    (50) propertyDeclaration -> propertyDeclaration_3 .
+
+    }               reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT8        reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT8        reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT16       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT16       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT32       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT32       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_UINT64       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_SINT64       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_REAL32       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_REAL64       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_CHAR16       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_STR          reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_BOOL         reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DT_DATETIME     reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    [               reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    IDENTIFIER      reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    ANY             reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    AS              reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    CLASS           reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    DISABLEOVERRIDE reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    ENABLEOVERRIDE  reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    FLAVOR          reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    INSTANCE        reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    METHOD          reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    OF              reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    PARAMETER       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    PRAGMA          reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    PROPERTY        reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    QUALIFIER       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    REFERENCE       reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    RESTRICTED      reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    SCHEMA          reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    SCOPE           reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    TOSUBCLASS      reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    TOINSTANCE      reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+    TRANSLATABLE    reduce using rule 50 (propertyDeclaration -> propertyDeclaration_3 .)
+
+
+state 145
+
+    (51) propertyDeclaration -> propertyDeclaration_4 .
+
+    }               reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT8        reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT8        reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT16       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT16       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT32       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT32       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_UINT64       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_SINT64       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_REAL32       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_REAL64       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_CHAR16       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_STR          reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_BOOL         reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DT_DATETIME     reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    [               reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    IDENTIFIER      reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    ANY             reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    AS              reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    CLASS           reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    DISABLEOVERRIDE reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    ENABLEOVERRIDE  reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    FLAVOR          reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    INSTANCE        reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    METHOD          reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    OF              reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    PARAMETER       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    PRAGMA          reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    PROPERTY        reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    QUALIFIER       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    REFERENCE       reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    RESTRICTED      reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    SCHEMA          reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    SCOPE           reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    TOSUBCLASS      reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    TOINSTANCE      reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+    TRANSLATABLE    reduce using rule 51 (propertyDeclaration -> propertyDeclaration_4 .)
+
+
+state 146
+
+    (52) propertyDeclaration -> propertyDeclaration_5 .
+
+    }               reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT8        reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT8        reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT16       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT16       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT32       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT32       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_UINT64       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_SINT64       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_REAL32       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_REAL64       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_CHAR16       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_STR          reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_BOOL         reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DT_DATETIME     reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    [               reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    IDENTIFIER      reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    ANY             reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    AS              reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    CLASS           reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    DISABLEOVERRIDE reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    ENABLEOVERRIDE  reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    FLAVOR          reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    INSTANCE        reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    METHOD          reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    OF              reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    PARAMETER       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    PRAGMA          reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    PROPERTY        reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    QUALIFIER       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    REFERENCE       reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    RESTRICTED      reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    SCHEMA          reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    SCOPE           reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    TOSUBCLASS      reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    TOINSTANCE      reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+    TRANSLATABLE    reduce using rule 52 (propertyDeclaration -> propertyDeclaration_5 .)
+
+
+state 147
+
+    (53) propertyDeclaration -> propertyDeclaration_6 .
+
+    }               reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT8        reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT8        reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT16       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT16       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT32       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT32       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_UINT64       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_SINT64       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_REAL32       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_REAL64       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_CHAR16       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_STR          reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_BOOL         reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DT_DATETIME     reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    [               reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    IDENTIFIER      reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    ANY             reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    AS              reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    CLASS           reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    DISABLEOVERRIDE reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    ENABLEOVERRIDE  reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    FLAVOR          reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    INSTANCE        reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    METHOD          reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    OF              reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    PARAMETER       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    PRAGMA          reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    PROPERTY        reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    QUALIFIER       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    REFERENCE       reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    RESTRICTED      reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    SCHEMA          reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    SCOPE           reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    TOSUBCLASS      reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    TOINSTANCE      reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+    TRANSLATABLE    reduce using rule 53 (propertyDeclaration -> propertyDeclaration_6 .)
+
+
+state 148
+
+    (54) propertyDeclaration -> propertyDeclaration_7 .
+
+    }               reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT8        reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT8        reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT16       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT16       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT32       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT32       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_UINT64       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_SINT64       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_REAL32       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_REAL64       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_CHAR16       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_STR          reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_BOOL         reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DT_DATETIME     reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    [               reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    IDENTIFIER      reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    ANY             reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    AS              reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    CLASS           reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    DISABLEOVERRIDE reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    ENABLEOVERRIDE  reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    FLAVOR          reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    INSTANCE        reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    METHOD          reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    OF              reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    PARAMETER       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    PRAGMA          reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    PROPERTY        reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    QUALIFIER       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    REFERENCE       reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    RESTRICTED      reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    SCHEMA          reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    SCOPE           reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    TOSUBCLASS      reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    TOINSTANCE      reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+    TRANSLATABLE    reduce using rule 54 (propertyDeclaration -> propertyDeclaration_7 .)
+
+
+state 149
+
+    (55) propertyDeclaration -> propertyDeclaration_8 .
+
+    }               reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT8        reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT8        reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT16       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT16       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT32       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT32       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_UINT64       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_SINT64       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_REAL32       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_REAL64       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_CHAR16       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_STR          reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_BOOL         reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DT_DATETIME     reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    [               reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    IDENTIFIER      reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    ANY             reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    AS              reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    CLASS           reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    DISABLEOVERRIDE reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    ENABLEOVERRIDE  reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    FLAVOR          reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    INSTANCE        reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    METHOD          reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    OF              reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    PARAMETER       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    PRAGMA          reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    PROPERTY        reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    QUALIFIER       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    REFERENCE       reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    RESTRICTED      reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    SCHEMA          reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    SCOPE           reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    TOSUBCLASS      reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    TOINSTANCE      reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+    TRANSLATABLE    reduce using rule 55 (propertyDeclaration -> propertyDeclaration_8 .)
+
+
+state 150
+
+    (68) methodDeclaration -> dataType . methodName ( ) ;
+    (69) methodDeclaration -> dataType . methodName ( parameterList ) ;
+    (56) propertyDeclaration_1 -> dataType . propertyName ;
+    (57) propertyDeclaration_2 -> dataType . propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> dataType . propertyName array ;
+    (59) propertyDeclaration_4 -> dataType . propertyName array defaultValue ;
+    (173) identifier -> dataType .
+    (74) methodName -> . identifier
+    (72) propertyName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 173 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    dataType                       shift and go to state 26
+    methodName                     shift and go to state 186
+    propertyName                   shift and go to state 187
+    identifier                     shift and go to state 188
+
+state 151
+
+    (70) methodDeclaration -> qualifierList . dataType methodName ( ) ;
+    (71) methodDeclaration -> qualifierList . dataType methodName ( parameterList ) ;
+    (66) referenceDeclaration -> qualifierList . objectRef referenceName ;
+    (67) referenceDeclaration -> qualifierList . objectRef referenceName defaultValue ;
+    (60) propertyDeclaration_5 -> qualifierList . dataType propertyName ;
+    (61) propertyDeclaration_6 -> qualifierList . dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> qualifierList . dataType propertyName array ;
+    (63) propertyDeclaration_8 -> qualifierList . dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    dataType                       shift and go to state 189
+    objectRef                      shift and go to state 190
+    className                      shift and go to state 136
+    identifier                     shift and go to state 21
+
+state 152
+
+    (64) referenceDeclaration -> objectRef . referenceName ;
+    (65) referenceDeclaration -> objectRef . referenceName defaultValue ;
+    (73) referenceName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    referenceName                  shift and go to state 191
+    identifier                     shift and go to state 192
+    dataType                       shift and go to state 26
+
+state 153
+
+    (15) classDeclaration -> CLASS className superClass { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 193
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    qualifierList                  shift and go to state 151
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 154
+
+    (16) classDeclaration -> CLASS className alias { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 194
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    qualifierList                  shift and go to state 151
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 155
+
+    (17) classDeclaration -> CLASS className alias superClass { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 195
+    empty                          shift and go to state 89
+
+state 156
+
+    (28) aliasIdentifier -> $ identifier .
+
+    {               reduce using rule 28 (aliasIdentifier -> $ identifier .)
+    :               reduce using rule 28 (aliasIdentifier -> $ identifier .)
+    ,               reduce using rule 28 (aliasIdentifier -> $ identifier .)
+    ;               reduce using rule 28 (aliasIdentifier -> $ identifier .)
+
+
+state 157
+
+    (18) classDeclaration -> qualifierList CLASS className { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 196
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    qualifierList                  shift and go to state 151
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 158
+
+    (19) classDeclaration -> qualifierList CLASS className superClass { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 197
+    empty                          shift and go to state 89
+
+state 159
+
+    (20) classDeclaration -> qualifierList CLASS className alias { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 198
+    empty                          shift and go to state 89
+
+state 160
+
+    (21) classDeclaration -> qualifierList CLASS className alias superClass . { classFeatureList } ;
+
+    {               shift and go to state 199
+
+
+state 161
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF className { . valueInitializerList } ;
+    (161) valueInitializerList -> . valueInitializer
+    (162) valueInitializerList -> . valueInitializerList valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifierList                  shift and go to state 174
+    valueInitializerList           shift and go to state 200
+    valueInitializer               shift and go to state 172
+    identifier                     shift and go to state 173
+    dataType                       shift and go to state 26
+
+state 162
+
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className alias . { valueInitializerList } ;
+
+    {               shift and go to state 201
+
+
+state 163
+
+    (130) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .
+
+    #               reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    CLASS           reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    QUALIFIER       reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    INSTANCE        reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    [               reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+    $end            reduce using rule 130 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope ; .)
+
+
+state 164
+
+    (131) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor . ;
+
+    ;               shift and go to state 202
+
+
+state 165
+
+    (154) defaultFlavor -> , . FLAVOR ( flavorListWithComma )
+
+    FLAVOR          shift and go to state 203
+
+
+state 166
+
+    (141) scope -> , SCOPE . ( metaElementList )
+
+    (               shift and go to state 204
+
+
+state 167
+
+    (137) qualifierType_1 -> : dataType array .
+    (138) qualifierType_1 -> : dataType array . defaultValue
+    (107) defaultValue -> . = initializer
+
+    ,               reduce using rule 137 (qualifierType_1 -> : dataType array .)
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 205
+
+state 168
+
+    (140) qualifierType_2 -> : dataType defaultValue .
+
+    ,               reduce using rule 140 (qualifierType_2 -> : dataType defaultValue .)
+
+
+state 169
+
+    (105) array -> [ . ]
+    (106) array -> [ . integerValue ]
+    (123) integerValue -> . binaryValue
+    (124) integerValue -> . octalValue
+    (125) integerValue -> . decimalValue
+    (126) integerValue -> . hexValue
+
+    ]               shift and go to state 206
+    binaryValue     shift and go to state 123
+    octalValue      shift and go to state 124
+    decimalValue    shift and go to state 125
+    hexValue        shift and go to state 126
+
+    integerValue                   shift and go to state 207
+
+state 170
+
+    (107) defaultValue -> = . initializer
+    (108) initializer -> . constantValue
+    (109) initializer -> . arrayInitializer
+    (110) initializer -> . referenceInitializer
+    (117) constantValue -> . integerValue
+    (118) constantValue -> . floatValue
+    (119) constantValue -> . charValue
+    (120) constantValue -> . stringValueList
+    (121) constantValue -> . booleanValue
+    (122) constantValue -> . nullValue
+    (111) arrayInitializer -> . { constantValueList }
+    (112) arrayInitializer -> . { }
+    (127) referenceInitializer -> . objectHandle
+    (128) referenceInitializer -> . aliasIdentifier
+    (123) integerValue -> . binaryValue
+    (124) integerValue -> . octalValue
+    (125) integerValue -> . decimalValue
+    (126) integerValue -> . hexValue
+    (115) stringValueList -> . stringValue
+    (116) stringValueList -> . stringValueList stringValue
+    (165) booleanValue -> . FALSE
+    (166) booleanValue -> . TRUE
+    (167) nullValue -> . NULL
+    (129) objectHandle -> . identifier
+    (28) aliasIdentifier -> . $ identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    floatValue      shift and go to state 118
+    charValue       shift and go to state 119
+    {               shift and go to state 86
+    binaryValue     shift and go to state 123
+    octalValue      shift and go to state 124
+    decimalValue    shift and go to state 125
+    hexValue        shift and go to state 126
+    stringValue     shift and go to state 127
+    FALSE           shift and go to state 128
+    TRUE            shift and go to state 129
+    NULL            shift and go to state 130
+    $               shift and go to state 95
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    initializer                    shift and go to state 208
+    constantValue                  shift and go to state 209
+    arrayInitializer               shift and go to state 210
+    referenceInitializer           shift and go to state 211
+    integerValue                   shift and go to state 117
+    stringValueList                shift and go to state 120
+    booleanValue                   shift and go to state 121
+    nullValue                      shift and go to state 122
+    objectHandle                   shift and go to state 212
+    aliasIdentifier                shift and go to state 213
+    identifier                     shift and go to state 214
+    dataType                       shift and go to state 26
+
+state 171
+
+    (157) instanceDeclaration -> INSTANCE OF className { valueInitializerList . } ;
+    (162) valueInitializerList -> valueInitializerList . valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    }               shift and go to state 215
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    valueInitializer               shift and go to state 216
+    identifier                     shift and go to state 173
+    qualifierList                  shift and go to state 174
+    dataType                       shift and go to state 26
+
+state 172
+
+    (161) valueInitializerList -> valueInitializer .
+
+    }               reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    IDENTIFIER      reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    ANY             reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    AS              reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    CLASS           reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DISABLEOVERRIDE reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    ENABLEOVERRIDE  reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    FLAVOR          reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    INSTANCE        reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    METHOD          reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    OF              reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    PARAMETER       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    PRAGMA          reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    PROPERTY        reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    QUALIFIER       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    REFERENCE       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    RESTRICTED      reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    SCHEMA          reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    SCOPE           reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    TOSUBCLASS      reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    TOINSTANCE      reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    TRANSLATABLE    reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    [               reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_UINT8        reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_SINT8        reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_UINT16       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_SINT16       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_UINT32       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_SINT32       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_UINT64       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_SINT64       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_REAL32       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_REAL64       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_CHAR16       reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_STR          reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_BOOL         reduce using rule 161 (valueInitializerList -> valueInitializer .)
+    DT_DATETIME     reduce using rule 161 (valueInitializerList -> valueInitializer .)
+
+
+state 173
+
+    (163) valueInitializer -> identifier . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 217
+
+state 174
+
+    (164) valueInitializer -> qualifierList . identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    identifier                     shift and go to state 218
+    dataType                       shift and go to state 26
+
+state 175
+
+    (158) instanceDeclaration -> INSTANCE OF className alias { . valueInitializerList } ;
+    (161) valueInitializerList -> . valueInitializer
+    (162) valueInitializerList -> . valueInitializerList valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    valueInitializerList           shift and go to state 219
+    valueInitializer               shift and go to state 172
+    identifier                     shift and go to state 173
+    qualifierList                  shift and go to state 174
+    dataType                       shift and go to state 26
+
+state 176
+
+    (25) qualifierListEmpty -> qualifierListEmpty , qualifier .
+
+    ]               reduce using rule 25 (qualifierListEmpty -> qualifierListEmpty , qualifier .)
+    ,               reduce using rule 25 (qualifierListEmpty -> qualifierListEmpty , qualifier .)
+
+
+state 177
+
+    (39) flavorList -> flavorList flavor .
+
+    ENABLEOVERRIDE  reduce using rule 39 (flavorList -> flavorList flavor .)
+    DISABLEOVERRIDE reduce using rule 39 (flavorList -> flavorList flavor .)
+    RESTRICTED      reduce using rule 39 (flavorList -> flavorList flavor .)
+    TOSUBCLASS      reduce using rule 39 (flavorList -> flavorList flavor .)
+    TOINSTANCE      reduce using rule 39 (flavorList -> flavorList flavor .)
+    TRANSLATABLE    reduce using rule 39 (flavorList -> flavorList flavor .)
+    ]               reduce using rule 39 (flavorList -> flavorList flavor .)
+    ,               reduce using rule 39 (flavorList -> flavorList flavor .)
+
+
+state 178
+
+    (37) qualifier -> qualifierName qualifierParameter : flavorList .
+    (39) flavorList -> flavorList . flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ]               reduce using rule 37 (qualifier -> qualifierName qualifierParameter : flavorList .)
+    ,               reduce using rule 37 (qualifier -> qualifierName qualifierParameter : flavorList .)
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavor                         shift and go to state 177
+
+state 179
+
+    (40) qualifierParameter -> ( constantValue ) .
+
+    :               reduce using rule 40 (qualifierParameter -> ( constantValue ) .)
+    ]               reduce using rule 40 (qualifierParameter -> ( constantValue ) .)
+    ,               reduce using rule 40 (qualifierParameter -> ( constantValue ) .)
+
+
+state 180
+
+    (116) stringValueList -> stringValueList stringValue .
+
+    stringValue     reduce using rule 116 (stringValueList -> stringValueList stringValue .)
+    )               reduce using rule 116 (stringValueList -> stringValueList stringValue .)
+    }               reduce using rule 116 (stringValueList -> stringValueList stringValue .)
+    ,               reduce using rule 116 (stringValueList -> stringValueList stringValue .)
+    ;               reduce using rule 116 (stringValueList -> stringValueList stringValue .)
+
+
+state 181
+
+    (111) arrayInitializer -> { constantValueList } .
+
+    :               reduce using rule 111 (arrayInitializer -> { constantValueList } .)
+    ]               reduce using rule 111 (arrayInitializer -> { constantValueList } .)
+    ,               reduce using rule 111 (arrayInitializer -> { constantValueList } .)
+    ;               reduce using rule 111 (arrayInitializer -> { constantValueList } .)
+
+
+state 182
+
+    (114) constantValueList -> constantValueList , . constantValue
+    (117) constantValue -> . integerValue
+    (118) constantValue -> . floatValue
+    (119) constantValue -> . charValue
+    (120) constantValue -> . stringValueList
+    (121) constantValue -> . booleanValue
+    (122) constantValue -> . nullValue
+    (123) integerValue -> . binaryValue
+    (124) integerValue -> . octalValue
+    (125) integerValue -> . decimalValue
+    (126) integerValue -> . hexValue
+    (115) stringValueList -> . stringValue
+    (116) stringValueList -> . stringValueList stringValue
+    (165) booleanValue -> . FALSE
+    (166) booleanValue -> . TRUE
+    (167) nullValue -> . NULL
+
+    floatValue      shift and go to state 118
+    charValue       shift and go to state 119
+    binaryValue     shift and go to state 123
+    octalValue      shift and go to state 124
+    decimalValue    shift and go to state 125
+    hexValue        shift and go to state 126
+    stringValue     shift and go to state 127
+    FALSE           shift and go to state 128
+    TRUE            shift and go to state 129
+    NULL            shift and go to state 130
+
+    constantValue                  shift and go to state 220
+    integerValue                   shift and go to state 117
+    stringValueList                shift and go to state 120
+    booleanValue                   shift and go to state 121
+    nullValue                      shift and go to state 122
+
+state 183
+
+    (11) compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .
+
+    #               reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    CLASS           reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    QUALIFIER       reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    INSTANCE        reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    [               reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+    $end            reduce using rule 11 (compilerDirective -> # PRAGMA pragmaName ( pragmaParameter ) .)
+
+
+state 184
+
+    (89) objectRef -> className REF .
+
+    IDENTIFIER      reduce using rule 89 (objectRef -> className REF .)
+    ANY             reduce using rule 89 (objectRef -> className REF .)
+    AS              reduce using rule 89 (objectRef -> className REF .)
+    CLASS           reduce using rule 89 (objectRef -> className REF .)
+    DISABLEOVERRIDE reduce using rule 89 (objectRef -> className REF .)
+    ENABLEOVERRIDE  reduce using rule 89 (objectRef -> className REF .)
+    FLAVOR          reduce using rule 89 (objectRef -> className REF .)
+    INSTANCE        reduce using rule 89 (objectRef -> className REF .)
+    METHOD          reduce using rule 89 (objectRef -> className REF .)
+    OF              reduce using rule 89 (objectRef -> className REF .)
+    PARAMETER       reduce using rule 89 (objectRef -> className REF .)
+    PRAGMA          reduce using rule 89 (objectRef -> className REF .)
+    PROPERTY        reduce using rule 89 (objectRef -> className REF .)
+    QUALIFIER       reduce using rule 89 (objectRef -> className REF .)
+    REFERENCE       reduce using rule 89 (objectRef -> className REF .)
+    RESTRICTED      reduce using rule 89 (objectRef -> className REF .)
+    SCHEMA          reduce using rule 89 (objectRef -> className REF .)
+    SCOPE           reduce using rule 89 (objectRef -> className REF .)
+    TOSUBCLASS      reduce using rule 89 (objectRef -> className REF .)
+    TOINSTANCE      reduce using rule 89 (objectRef -> className REF .)
+    TRANSLATABLE    reduce using rule 89 (objectRef -> className REF .)
+    DT_UINT8        reduce using rule 89 (objectRef -> className REF .)
+    DT_SINT8        reduce using rule 89 (objectRef -> className REF .)
+    DT_UINT16       reduce using rule 89 (objectRef -> className REF .)
+    DT_SINT16       reduce using rule 89 (objectRef -> className REF .)
+    DT_UINT32       reduce using rule 89 (objectRef -> className REF .)
+    DT_SINT32       reduce using rule 89 (objectRef -> className REF .)
+    DT_UINT64       reduce using rule 89 (objectRef -> className REF .)
+    DT_SINT64       reduce using rule 89 (objectRef -> className REF .)
+    DT_REAL32       reduce using rule 89 (objectRef -> className REF .)
+    DT_REAL64       reduce using rule 89 (objectRef -> className REF .)
+    DT_CHAR16       reduce using rule 89 (objectRef -> className REF .)
+    DT_STR          reduce using rule 89 (objectRef -> className REF .)
+    DT_BOOL         reduce using rule 89 (objectRef -> className REF .)
+    DT_DATETIME     reduce using rule 89 (objectRef -> className REF .)
+
+
+state 185
+
+    (14) classDeclaration -> CLASS className { classFeatureList } ; .
+
+    #               reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    CLASS           reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    INSTANCE        reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    [               reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+    $end            reduce using rule 14 (classDeclaration -> CLASS className { classFeatureList } ; .)
+
+
+state 186
+
+    (68) methodDeclaration -> dataType methodName . ( ) ;
+    (69) methodDeclaration -> dataType methodName . ( parameterList ) ;
+
+    (               shift and go to state 221
+
+
+state 187
+
+    (56) propertyDeclaration_1 -> dataType propertyName . ;
+    (57) propertyDeclaration_2 -> dataType propertyName . defaultValue ;
+    (58) propertyDeclaration_3 -> dataType propertyName . array ;
+    (59) propertyDeclaration_4 -> dataType propertyName . array defaultValue ;
+    (107) defaultValue -> . = initializer
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    ;               shift and go to state 222
+    =               shift and go to state 170
+    [               shift and go to state 169
+
+    defaultValue                   shift and go to state 223
+    array                          shift and go to state 224
+
+state 188
+
+    (74) methodName -> identifier .
+    (72) propertyName -> identifier .
+
+    (               reduce using rule 74 (methodName -> identifier .)
+    ;               reduce using rule 72 (propertyName -> identifier .)
+    =               reduce using rule 72 (propertyName -> identifier .)
+    [               reduce using rule 72 (propertyName -> identifier .)
+
+
+state 189
+
+    (70) methodDeclaration -> qualifierList dataType . methodName ( ) ;
+    (71) methodDeclaration -> qualifierList dataType . methodName ( parameterList ) ;
+    (60) propertyDeclaration_5 -> qualifierList dataType . propertyName ;
+    (61) propertyDeclaration_6 -> qualifierList dataType . propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> qualifierList dataType . propertyName array ;
+    (63) propertyDeclaration_8 -> qualifierList dataType . propertyName array defaultValue ;
+    (173) identifier -> dataType .
+    (74) methodName -> . identifier
+    (72) propertyName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 173 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    dataType                       shift and go to state 26
+    methodName                     shift and go to state 225
+    propertyName                   shift and go to state 226
+    identifier                     shift and go to state 188
+
+state 190
+
+    (66) referenceDeclaration -> qualifierList objectRef . referenceName ;
+    (67) referenceDeclaration -> qualifierList objectRef . referenceName defaultValue ;
+    (73) referenceName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    referenceName                  shift and go to state 227
+    identifier                     shift and go to state 192
+    dataType                       shift and go to state 26
+
+state 191
+
+    (64) referenceDeclaration -> objectRef referenceName . ;
+    (65) referenceDeclaration -> objectRef referenceName . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    ;               shift and go to state 228
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 229
+
+state 192
+
+    (73) referenceName -> identifier .
+
+    ;               reduce using rule 73 (referenceName -> identifier .)
+    =               reduce using rule 73 (referenceName -> identifier .)
+
+
+state 193
+
+    (15) classDeclaration -> CLASS className superClass { classFeatureList } . ;
+
+    ;               shift and go to state 230
+
+
+state 194
+
+    (16) classDeclaration -> CLASS className alias { classFeatureList } . ;
+
+    ;               shift and go to state 231
+
+
+state 195
+
+    (17) classDeclaration -> CLASS className alias superClass { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 232
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    qualifierList                  shift and go to state 151
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 196
+
+    (18) classDeclaration -> qualifierList CLASS className { classFeatureList } . ;
+
+    ;               shift and go to state 233
+
+
+state 197
+
+    (19) classDeclaration -> qualifierList CLASS className superClass { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 234
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    qualifierList                  shift and go to state 151
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 198
+
+    (20) classDeclaration -> qualifierList CLASS className alias { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 235
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    qualifierList                  shift and go to state 151
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 199
+
+    (21) classDeclaration -> qualifierList CLASS className alias superClass { . classFeatureList } ;
+    (22) classFeatureList -> . empty
+    (23) classFeatureList -> . classFeatureList classFeature
+    (190) empty -> .
+
+    }               reduce using rule 190 (empty -> .)
+    DT_UINT8        reduce using rule 190 (empty -> .)
+    DT_SINT8        reduce using rule 190 (empty -> .)
+    DT_UINT16       reduce using rule 190 (empty -> .)
+    DT_SINT16       reduce using rule 190 (empty -> .)
+    DT_UINT32       reduce using rule 190 (empty -> .)
+    DT_SINT32       reduce using rule 190 (empty -> .)
+    DT_UINT64       reduce using rule 190 (empty -> .)
+    DT_SINT64       reduce using rule 190 (empty -> .)
+    DT_REAL32       reduce using rule 190 (empty -> .)
+    DT_REAL64       reduce using rule 190 (empty -> .)
+    DT_CHAR16       reduce using rule 190 (empty -> .)
+    DT_STR          reduce using rule 190 (empty -> .)
+    DT_BOOL         reduce using rule 190 (empty -> .)
+    DT_DATETIME     reduce using rule 190 (empty -> .)
+    [               reduce using rule 190 (empty -> .)
+    IDENTIFIER      reduce using rule 190 (empty -> .)
+    ANY             reduce using rule 190 (empty -> .)
+    AS              reduce using rule 190 (empty -> .)
+    CLASS           reduce using rule 190 (empty -> .)
+    DISABLEOVERRIDE reduce using rule 190 (empty -> .)
+    ENABLEOVERRIDE  reduce using rule 190 (empty -> .)
+    FLAVOR          reduce using rule 190 (empty -> .)
+    INSTANCE        reduce using rule 190 (empty -> .)
+    METHOD          reduce using rule 190 (empty -> .)
+    OF              reduce using rule 190 (empty -> .)
+    PARAMETER       reduce using rule 190 (empty -> .)
+    PRAGMA          reduce using rule 190 (empty -> .)
+    PROPERTY        reduce using rule 190 (empty -> .)
+    QUALIFIER       reduce using rule 190 (empty -> .)
+    REFERENCE       reduce using rule 190 (empty -> .)
+    RESTRICTED      reduce using rule 190 (empty -> .)
+    SCHEMA          reduce using rule 190 (empty -> .)
+    SCOPE           reduce using rule 190 (empty -> .)
+    TOSUBCLASS      reduce using rule 190 (empty -> .)
+    TOINSTANCE      reduce using rule 190 (empty -> .)
+    TRANSLATABLE    reduce using rule 190 (empty -> .)
+
+    classFeatureList               shift and go to state 236
+    empty                          shift and go to state 89
+
+state 200
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList . } ;
+    (162) valueInitializerList -> valueInitializerList . valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    }               shift and go to state 237
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifierList                  shift and go to state 174
+    valueInitializer               shift and go to state 216
+    identifier                     shift and go to state 173
+    dataType                       shift and go to state 26
+
+state 201
+
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className alias { . valueInitializerList } ;
+    (161) valueInitializerList -> . valueInitializer
+    (162) valueInitializerList -> . valueInitializerList valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifierList                  shift and go to state 174
+    valueInitializerList           shift and go to state 238
+    valueInitializer               shift and go to state 172
+    identifier                     shift and go to state 173
+    dataType                       shift and go to state 26
+
+state 202
+
+    (131) qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .
+
+    #               reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    CLASS           reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    QUALIFIER       reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    INSTANCE        reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    [               reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+    $end            reduce using rule 131 (qualifierDeclaration -> QUALIFIER qualifierName qualifierType scope defaultFlavor ; .)
+
+
+state 203
+
+    (154) defaultFlavor -> , FLAVOR . ( flavorListWithComma )
+
+    (               shift and go to state 239
+
+
+state 204
+
+    (141) scope -> , SCOPE ( . metaElementList )
+    (142) metaElementList -> . metaElement
+    (143) metaElementList -> . metaElementList , metaElement
+    (144) metaElement -> . SCHEMA
+    (145) metaElement -> . CLASS
+    (146) metaElement -> . ASSOCIATION
+    (147) metaElement -> . INDICATION
+    (148) metaElement -> . QUALIFIER
+    (149) metaElement -> . PROPERTY
+    (150) metaElement -> . REFERENCE
+    (151) metaElement -> . METHOD
+    (152) metaElement -> . PARAMETER
+    (153) metaElement -> . ANY
+
+    SCHEMA          shift and go to state 242
+    CLASS           shift and go to state 243
+    ASSOCIATION     shift and go to state 244
+    INDICATION      shift and go to state 245
+    QUALIFIER       shift and go to state 246
+    PROPERTY        shift and go to state 247
+    REFERENCE       shift and go to state 248
+    METHOD          shift and go to state 249
+    PARAMETER       shift and go to state 250
+    ANY             shift and go to state 251
+
+    metaElementList                shift and go to state 240
+    metaElement                    shift and go to state 241
+
+state 205
+
+    (138) qualifierType_1 -> : dataType array defaultValue .
+
+    ,               reduce using rule 138 (qualifierType_1 -> : dataType array defaultValue .)
+
+
+state 206
+
+    (105) array -> [ ] .
+
+    =               reduce using rule 105 (array -> [ ] .)
+    ,               reduce using rule 105 (array -> [ ] .)
+    ;               reduce using rule 105 (array -> [ ] .)
+    )               reduce using rule 105 (array -> [ ] .)
+
+
+state 207
+
+    (106) array -> [ integerValue . ]
+
+    ]               shift and go to state 252
+
+
+state 208
+
+    (107) defaultValue -> = initializer .
+
+    ,               reduce using rule 107 (defaultValue -> = initializer .)
+    ;               reduce using rule 107 (defaultValue -> = initializer .)
+
+
+state 209
+
+    (108) initializer -> constantValue .
+
+    ,               reduce using rule 108 (initializer -> constantValue .)
+    ;               reduce using rule 108 (initializer -> constantValue .)
+
+
+state 210
+
+    (109) initializer -> arrayInitializer .
+
+    ,               reduce using rule 109 (initializer -> arrayInitializer .)
+    ;               reduce using rule 109 (initializer -> arrayInitializer .)
+
+
+state 211
+
+    (110) initializer -> referenceInitializer .
+
+    ,               reduce using rule 110 (initializer -> referenceInitializer .)
+    ;               reduce using rule 110 (initializer -> referenceInitializer .)
+
+
+state 212
+
+    (127) referenceInitializer -> objectHandle .
+
+    ,               reduce using rule 127 (referenceInitializer -> objectHandle .)
+    ;               reduce using rule 127 (referenceInitializer -> objectHandle .)
+
+
+state 213
+
+    (128) referenceInitializer -> aliasIdentifier .
+
+    ,               reduce using rule 128 (referenceInitializer -> aliasIdentifier .)
+    ;               reduce using rule 128 (referenceInitializer -> aliasIdentifier .)
+
+
+state 214
+
+    (129) objectHandle -> identifier .
+
+    ,               reduce using rule 129 (objectHandle -> identifier .)
+    ;               reduce using rule 129 (objectHandle -> identifier .)
+
+
+state 215
+
+    (157) instanceDeclaration -> INSTANCE OF className { valueInitializerList } . ;
+
+    ;               shift and go to state 253
+
+
+state 216
+
+    (162) valueInitializerList -> valueInitializerList valueInitializer .
+
+    }               reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    IDENTIFIER      reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    ANY             reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    AS              reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    CLASS           reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DISABLEOVERRIDE reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    ENABLEOVERRIDE  reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    FLAVOR          reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    INSTANCE        reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    METHOD          reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    OF              reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PARAMETER       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PRAGMA          reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    PROPERTY        reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    QUALIFIER       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    REFERENCE       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    RESTRICTED      reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    SCHEMA          reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    SCOPE           reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TOSUBCLASS      reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TOINSTANCE      reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    TRANSLATABLE    reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    [               reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT8        reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT8        reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT16       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT16       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT32       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT32       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_UINT64       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_SINT64       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_REAL32       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_REAL64       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_CHAR16       reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_STR          reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_BOOL         reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+    DT_DATETIME     reduce using rule 162 (valueInitializerList -> valueInitializerList valueInitializer .)
+
+
+state 217
+
+    (163) valueInitializer -> identifier defaultValue . ;
+
+    ;               shift and go to state 254
+
+
+state 218
+
+    (164) valueInitializer -> qualifierList identifier . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 255
+
+state 219
+
+    (158) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList . } ;
+    (162) valueInitializerList -> valueInitializerList . valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    }               shift and go to state 256
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    valueInitializer               shift and go to state 216
+    identifier                     shift and go to state 173
+    qualifierList                  shift and go to state 174
+    dataType                       shift and go to state 26
+
+state 220
+
+    (114) constantValueList -> constantValueList , constantValue .
+
+    }               reduce using rule 114 (constantValueList -> constantValueList , constantValue .)
+    ,               reduce using rule 114 (constantValueList -> constantValueList , constantValue .)
+
+
+state 221
+
+    (68) methodDeclaration -> dataType methodName ( . ) ;
+    (69) methodDeclaration -> dataType methodName ( . parameterList ) ;
+    (90) parameterList -> . parameter
+    (91) parameterList -> . parameterList , parameter
+    (92) parameter -> . parameter_1
+    (93) parameter -> . parameter_2
+    (94) parameter -> . parameter_3
+    (95) parameter -> . parameter_4
+    (96) parameter_1 -> . dataType parameterName
+    (97) parameter_1 -> . dataType parameterName array
+    (98) parameter_2 -> . qualifierList dataType parameterName
+    (99) parameter_2 -> . qualifierList dataType parameterName array
+    (100) parameter_3 -> . objectRef parameterName
+    (101) parameter_3 -> . objectRef parameterName array
+    (102) parameter_4 -> . qualifierList objectRef parameterName
+    (103) parameter_4 -> . qualifierList objectRef parameterName array
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    )               shift and go to state 258
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    dataType                       shift and go to state 257
+    parameterList                  shift and go to state 259
+    parameter                      shift and go to state 260
+    parameter_1                    shift and go to state 261
+    parameter_2                    shift and go to state 262
+    parameter_3                    shift and go to state 263
+    parameter_4                    shift and go to state 264
+    qualifierList                  shift and go to state 265
+    objectRef                      shift and go to state 266
+    className                      shift and go to state 136
+    identifier                     shift and go to state 21
+
+state 222
+
+    (56) propertyDeclaration_1 -> dataType propertyName ; .
+
+    }               reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT8        reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT8        reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT16       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT16       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT32       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT32       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_UINT64       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_SINT64       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_REAL32       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_REAL64       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_CHAR16       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_STR          reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_BOOL         reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DT_DATETIME     reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    [               reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    IDENTIFIER      reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    ANY             reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    AS              reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    CLASS           reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    DISABLEOVERRIDE reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    ENABLEOVERRIDE  reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    FLAVOR          reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    INSTANCE        reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    METHOD          reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    OF              reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PARAMETER       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PRAGMA          reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    PROPERTY        reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    QUALIFIER       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    REFERENCE       reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    RESTRICTED      reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    SCHEMA          reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    SCOPE           reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TOSUBCLASS      reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TOINSTANCE      reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+    TRANSLATABLE    reduce using rule 56 (propertyDeclaration_1 -> dataType propertyName ; .)
+
+
+state 223
+
+    (57) propertyDeclaration_2 -> dataType propertyName defaultValue . ;
+
+    ;               shift and go to state 267
+
+
+state 224
+
+    (58) propertyDeclaration_3 -> dataType propertyName array . ;
+    (59) propertyDeclaration_4 -> dataType propertyName array . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    ;               shift and go to state 268
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 269
+
+state 225
+
+    (70) methodDeclaration -> qualifierList dataType methodName . ( ) ;
+    (71) methodDeclaration -> qualifierList dataType methodName . ( parameterList ) ;
+
+    (               shift and go to state 270
+
+
+state 226
+
+    (60) propertyDeclaration_5 -> qualifierList dataType propertyName . ;
+    (61) propertyDeclaration_6 -> qualifierList dataType propertyName . defaultValue ;
+    (62) propertyDeclaration_7 -> qualifierList dataType propertyName . array ;
+    (63) propertyDeclaration_8 -> qualifierList dataType propertyName . array defaultValue ;
+    (107) defaultValue -> . = initializer
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    ;               shift and go to state 271
+    =               shift and go to state 170
+    [               shift and go to state 169
+
+    defaultValue                   shift and go to state 272
+    array                          shift and go to state 273
+
+state 227
+
+    (66) referenceDeclaration -> qualifierList objectRef referenceName . ;
+    (67) referenceDeclaration -> qualifierList objectRef referenceName . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    ;               shift and go to state 274
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 275
+
+state 228
+
+    (64) referenceDeclaration -> objectRef referenceName ; .
+
+    }               reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT8        reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT8        reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT16       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT16       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT32       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT32       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_UINT64       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_SINT64       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_REAL32       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_REAL64       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_CHAR16       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_STR          reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_BOOL         reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DT_DATETIME     reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    [               reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    IDENTIFIER      reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    ANY             reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    AS              reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    CLASS           reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    DISABLEOVERRIDE reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    ENABLEOVERRIDE  reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    FLAVOR          reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    INSTANCE        reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    METHOD          reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    OF              reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    PARAMETER       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    PRAGMA          reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    PROPERTY        reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    QUALIFIER       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    REFERENCE       reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    RESTRICTED      reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    SCHEMA          reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    SCOPE           reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    TOSUBCLASS      reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    TOINSTANCE      reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+    TRANSLATABLE    reduce using rule 64 (referenceDeclaration -> objectRef referenceName ; .)
+
+
+state 229
+
+    (65) referenceDeclaration -> objectRef referenceName defaultValue . ;
+
+    ;               shift and go to state 276
+
+
+state 230
+
+    (15) classDeclaration -> CLASS className superClass { classFeatureList } ; .
+
+    #               reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    [               reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+    $end            reduce using rule 15 (classDeclaration -> CLASS className superClass { classFeatureList } ; .)
+
+
+state 231
+
+    (16) classDeclaration -> CLASS className alias { classFeatureList } ; .
+
+    #               reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    CLASS           reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    INSTANCE        reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    [               reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+    $end            reduce using rule 16 (classDeclaration -> CLASS className alias { classFeatureList } ; .)
+
+
+state 232
+
+    (17) classDeclaration -> CLASS className alias superClass { classFeatureList } . ;
+
+    ;               shift and go to state 277
+
+
+state 233
+
+    (18) classDeclaration -> qualifierList CLASS className { classFeatureList } ; .
+
+    #               reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    CLASS           reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    INSTANCE        reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    [               reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+    $end            reduce using rule 18 (classDeclaration -> qualifierList CLASS className { classFeatureList } ; .)
+
+
+state 234
+
+    (19) classDeclaration -> qualifierList CLASS className superClass { classFeatureList } . ;
+
+    ;               shift and go to state 278
+
+
+state 235
+
+    (20) classDeclaration -> qualifierList CLASS className alias { classFeatureList } . ;
+
+    ;               shift and go to state 279
+
+
+state 236
+
+    (21) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList . } ;
+    (23) classFeatureList -> classFeatureList . classFeature
+    (30) classFeature -> . propertyDeclaration
+    (31) classFeature -> . methodDeclaration
+    (32) classFeature -> . referenceDeclaration
+    (48) propertyDeclaration -> . propertyDeclaration_1
+    (49) propertyDeclaration -> . propertyDeclaration_2
+    (50) propertyDeclaration -> . propertyDeclaration_3
+    (51) propertyDeclaration -> . propertyDeclaration_4
+    (52) propertyDeclaration -> . propertyDeclaration_5
+    (53) propertyDeclaration -> . propertyDeclaration_6
+    (54) propertyDeclaration -> . propertyDeclaration_7
+    (55) propertyDeclaration -> . propertyDeclaration_8
+    (68) methodDeclaration -> . dataType methodName ( ) ;
+    (69) methodDeclaration -> . dataType methodName ( parameterList ) ;
+    (70) methodDeclaration -> . qualifierList dataType methodName ( ) ;
+    (71) methodDeclaration -> . qualifierList dataType methodName ( parameterList ) ;
+    (64) referenceDeclaration -> . objectRef referenceName ;
+    (65) referenceDeclaration -> . objectRef referenceName defaultValue ;
+    (66) referenceDeclaration -> . qualifierList objectRef referenceName ;
+    (67) referenceDeclaration -> . qualifierList objectRef referenceName defaultValue ;
+    (56) propertyDeclaration_1 -> . dataType propertyName ;
+    (57) propertyDeclaration_2 -> . dataType propertyName defaultValue ;
+    (58) propertyDeclaration_3 -> . dataType propertyName array ;
+    (59) propertyDeclaration_4 -> . dataType propertyName array defaultValue ;
+    (60) propertyDeclaration_5 -> . qualifierList dataType propertyName ;
+    (61) propertyDeclaration_6 -> . qualifierList dataType propertyName defaultValue ;
+    (62) propertyDeclaration_7 -> . qualifierList dataType propertyName array ;
+    (63) propertyDeclaration_8 -> . qualifierList dataType propertyName array defaultValue ;
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    }               shift and go to state 280
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    qualifierList                  shift and go to state 151
+    className                      shift and go to state 136
+    classFeature                   shift and go to state 138
+    propertyDeclaration            shift and go to state 139
+    methodDeclaration              shift and go to state 140
+    referenceDeclaration           shift and go to state 141
+    propertyDeclaration_1          shift and go to state 142
+    propertyDeclaration_2          shift and go to state 143
+    propertyDeclaration_3          shift and go to state 144
+    propertyDeclaration_4          shift and go to state 145
+    propertyDeclaration_5          shift and go to state 146
+    propertyDeclaration_6          shift and go to state 147
+    propertyDeclaration_7          shift and go to state 148
+    propertyDeclaration_8          shift and go to state 149
+    dataType                       shift and go to state 150
+    objectRef                      shift and go to state 152
+    identifier                     shift and go to state 21
+
+state 237
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } . ;
+
+    ;               shift and go to state 281
+
+
+state 238
+
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList . } ;
+    (162) valueInitializerList -> valueInitializerList . valueInitializer
+    (163) valueInitializer -> . identifier defaultValue ;
+    (164) valueInitializer -> . qualifierList identifier defaultValue ;
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    }               shift and go to state 282
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    [               shift and go to state 17
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    qualifierList                  shift and go to state 174
+    valueInitializer               shift and go to state 216
+    identifier                     shift and go to state 173
+    dataType                       shift and go to state 26
+
+state 239
+
+    (154) defaultFlavor -> , FLAVOR ( . flavorListWithComma )
+    (155) flavorListWithComma -> . flavor
+    (156) flavorListWithComma -> . flavorListWithComma , flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavorListWithComma            shift and go to state 283
+    flavor                         shift and go to state 284
+
+state 240
+
+    (141) scope -> , SCOPE ( metaElementList . )
+    (143) metaElementList -> metaElementList . , metaElement
+
+    )               shift and go to state 286
+    ,               shift and go to state 285
+
+
+state 241
+
+    (142) metaElementList -> metaElement .
+
+    )               reduce using rule 142 (metaElementList -> metaElement .)
+    ,               reduce using rule 142 (metaElementList -> metaElement .)
+
+
+state 242
+
+    (144) metaElement -> SCHEMA .
+
+    )               reduce using rule 144 (metaElement -> SCHEMA .)
+    ,               reduce using rule 144 (metaElement -> SCHEMA .)
+
+
+state 243
+
+    (145) metaElement -> CLASS .
+
+    )               reduce using rule 145 (metaElement -> CLASS .)
+    ,               reduce using rule 145 (metaElement -> CLASS .)
+
+
+state 244
+
+    (146) metaElement -> ASSOCIATION .
+
+    )               reduce using rule 146 (metaElement -> ASSOCIATION .)
+    ,               reduce using rule 146 (metaElement -> ASSOCIATION .)
+
+
+state 245
+
+    (147) metaElement -> INDICATION .
+
+    )               reduce using rule 147 (metaElement -> INDICATION .)
+    ,               reduce using rule 147 (metaElement -> INDICATION .)
+
+
+state 246
+
+    (148) metaElement -> QUALIFIER .
+
+    )               reduce using rule 148 (metaElement -> QUALIFIER .)
+    ,               reduce using rule 148 (metaElement -> QUALIFIER .)
+
+
+state 247
+
+    (149) metaElement -> PROPERTY .
+
+    )               reduce using rule 149 (metaElement -> PROPERTY .)
+    ,               reduce using rule 149 (metaElement -> PROPERTY .)
+
+
+state 248
+
+    (150) metaElement -> REFERENCE .
+
+    )               reduce using rule 150 (metaElement -> REFERENCE .)
+    ,               reduce using rule 150 (metaElement -> REFERENCE .)
+
+
+state 249
+
+    (151) metaElement -> METHOD .
+
+    )               reduce using rule 151 (metaElement -> METHOD .)
+    ,               reduce using rule 151 (metaElement -> METHOD .)
+
+
+state 250
+
+    (152) metaElement -> PARAMETER .
+
+    )               reduce using rule 152 (metaElement -> PARAMETER .)
+    ,               reduce using rule 152 (metaElement -> PARAMETER .)
+
+
+state 251
+
+    (153) metaElement -> ANY .
+
+    )               reduce using rule 153 (metaElement -> ANY .)
+    ,               reduce using rule 153 (metaElement -> ANY .)
+
+
+state 252
+
+    (106) array -> [ integerValue ] .
+
+    =               reduce using rule 106 (array -> [ integerValue ] .)
+    ,               reduce using rule 106 (array -> [ integerValue ] .)
+    ;               reduce using rule 106 (array -> [ integerValue ] .)
+    )               reduce using rule 106 (array -> [ integerValue ] .)
+
+
+state 253
+
+    (157) instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .
+
+    #               reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    CLASS           reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    [               reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+    $end            reduce using rule 157 (instanceDeclaration -> INSTANCE OF className { valueInitializerList } ; .)
+
+
+state 254
+
+    (163) valueInitializer -> identifier defaultValue ; .
+
+    }               reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    IDENTIFIER      reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    ANY             reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    AS              reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    CLASS           reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    FLAVOR          reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    INSTANCE        reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    METHOD          reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    OF              reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    PARAMETER       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    PRAGMA          reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    PROPERTY        reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    QUALIFIER       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    REFERENCE       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    RESTRICTED      reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    SCHEMA          reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    SCOPE           reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    TOSUBCLASS      reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    TOINSTANCE      reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    TRANSLATABLE    reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    [               reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT8        reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT8        reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT16       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT16       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT32       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT32       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_UINT64       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_SINT64       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_REAL32       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_REAL64       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_CHAR16       reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_STR          reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_BOOL         reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+    DT_DATETIME     reduce using rule 163 (valueInitializer -> identifier defaultValue ; .)
+
+
+state 255
+
+    (164) valueInitializer -> qualifierList identifier defaultValue . ;
+
+    ;               shift and go to state 287
+
+
+state 256
+
+    (158) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } . ;
+
+    ;               shift and go to state 288
+
+
+state 257
+
+    (96) parameter_1 -> dataType . parameterName
+    (97) parameter_1 -> dataType . parameterName array
+    (173) identifier -> dataType .
+    (104) parameterName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 173 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    dataType                       shift and go to state 26
+    parameterName                  shift and go to state 289
+    identifier                     shift and go to state 290
+
+state 258
+
+    (68) methodDeclaration -> dataType methodName ( ) . ;
+
+    ;               shift and go to state 291
+
+
+state 259
+
+    (69) methodDeclaration -> dataType methodName ( parameterList . ) ;
+    (91) parameterList -> parameterList . , parameter
+
+    )               shift and go to state 292
+    ,               shift and go to state 293
+
+
+state 260
+
+    (90) parameterList -> parameter .
+
+    )               reduce using rule 90 (parameterList -> parameter .)
+    ,               reduce using rule 90 (parameterList -> parameter .)
+
+
+state 261
+
+    (92) parameter -> parameter_1 .
+
+    )               reduce using rule 92 (parameter -> parameter_1 .)
+    ,               reduce using rule 92 (parameter -> parameter_1 .)
+
+
+state 262
+
+    (93) parameter -> parameter_2 .
+
+    )               reduce using rule 93 (parameter -> parameter_2 .)
+    ,               reduce using rule 93 (parameter -> parameter_2 .)
+
+
+state 263
+
+    (94) parameter -> parameter_3 .
+
+    )               reduce using rule 94 (parameter -> parameter_3 .)
+    ,               reduce using rule 94 (parameter -> parameter_3 .)
+
+
+state 264
+
+    (95) parameter -> parameter_4 .
+
+    )               reduce using rule 95 (parameter -> parameter_4 .)
+    ,               reduce using rule 95 (parameter -> parameter_4 .)
+
+
+state 265
+
+    (98) parameter_2 -> qualifierList . dataType parameterName
+    (99) parameter_2 -> qualifierList . dataType parameterName array
+    (102) parameter_4 -> qualifierList . objectRef parameterName
+    (103) parameter_4 -> qualifierList . objectRef parameterName array
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    dataType                       shift and go to state 294
+    objectRef                      shift and go to state 295
+    className                      shift and go to state 136
+    identifier                     shift and go to state 21
+
+state 266
+
+    (100) parameter_3 -> objectRef . parameterName
+    (101) parameter_3 -> objectRef . parameterName array
+    (104) parameterName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    parameterName                  shift and go to state 296
+    identifier                     shift and go to state 290
+    dataType                       shift and go to state 26
+
+state 267
+
+    (57) propertyDeclaration_2 -> dataType propertyName defaultValue ; .
+
+    }               reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT8        reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT8        reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT16       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT16       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT32       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT32       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_UINT64       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_SINT64       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_REAL32       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_REAL64       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_CHAR16       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_STR          reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_BOOL         reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DT_DATETIME     reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    [               reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    IDENTIFIER      reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    ANY             reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    AS              reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    CLASS           reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    FLAVOR          reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    INSTANCE        reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    METHOD          reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    OF              reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PARAMETER       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PRAGMA          reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    PROPERTY        reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    QUALIFIER       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    REFERENCE       reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    RESTRICTED      reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    SCHEMA          reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    SCOPE           reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TOINSTANCE      reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 57 (propertyDeclaration_2 -> dataType propertyName defaultValue ; .)
+
+
+state 268
+
+    (58) propertyDeclaration_3 -> dataType propertyName array ; .
+
+    }               reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT8        reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT8        reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT16       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT16       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT32       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT32       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_UINT64       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_SINT64       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_REAL32       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_REAL64       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_CHAR16       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_STR          reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_BOOL         reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DT_DATETIME     reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    [               reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    IDENTIFIER      reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    ANY             reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    AS              reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    CLASS           reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    DISABLEOVERRIDE reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    ENABLEOVERRIDE  reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    FLAVOR          reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    INSTANCE        reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    METHOD          reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    OF              reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PARAMETER       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PRAGMA          reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    PROPERTY        reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    QUALIFIER       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    REFERENCE       reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    RESTRICTED      reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    SCHEMA          reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    SCOPE           reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TOSUBCLASS      reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TOINSTANCE      reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+    TRANSLATABLE    reduce using rule 58 (propertyDeclaration_3 -> dataType propertyName array ; .)
+
+
+state 269
+
+    (59) propertyDeclaration_4 -> dataType propertyName array defaultValue . ;
+
+    ;               shift and go to state 297
+
+
+state 270
+
+    (70) methodDeclaration -> qualifierList dataType methodName ( . ) ;
+    (71) methodDeclaration -> qualifierList dataType methodName ( . parameterList ) ;
+    (90) parameterList -> . parameter
+    (91) parameterList -> . parameterList , parameter
+    (92) parameter -> . parameter_1
+    (93) parameter -> . parameter_2
+    (94) parameter -> . parameter_3
+    (95) parameter -> . parameter_4
+    (96) parameter_1 -> . dataType parameterName
+    (97) parameter_1 -> . dataType parameterName array
+    (98) parameter_2 -> . qualifierList dataType parameterName
+    (99) parameter_2 -> . qualifierList dataType parameterName array
+    (100) parameter_3 -> . objectRef parameterName
+    (101) parameter_3 -> . objectRef parameterName array
+    (102) parameter_4 -> . qualifierList objectRef parameterName
+    (103) parameter_4 -> . qualifierList objectRef parameterName array
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    )               shift and go to state 298
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    qualifierList                  shift and go to state 265
+    dataType                       shift and go to state 257
+    parameterList                  shift and go to state 299
+    parameter                      shift and go to state 260
+    parameter_1                    shift and go to state 261
+    parameter_2                    shift and go to state 262
+    parameter_3                    shift and go to state 263
+    parameter_4                    shift and go to state 264
+    objectRef                      shift and go to state 266
+    className                      shift and go to state 136
+    identifier                     shift and go to state 21
+
+state 271
+
+    (60) propertyDeclaration_5 -> qualifierList dataType propertyName ; .
+
+    }               reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT8        reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT8        reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT16       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT16       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT32       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT32       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_UINT64       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_SINT64       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_REAL32       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_REAL64       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_CHAR16       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_STR          reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_BOOL         reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DT_DATETIME     reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    [               reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    IDENTIFIER      reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    ANY             reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    AS              reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    CLASS           reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    DISABLEOVERRIDE reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    ENABLEOVERRIDE  reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    FLAVOR          reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    INSTANCE        reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    METHOD          reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    OF              reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PARAMETER       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PRAGMA          reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    PROPERTY        reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    QUALIFIER       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    REFERENCE       reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    RESTRICTED      reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    SCHEMA          reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    SCOPE           reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TOSUBCLASS      reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TOINSTANCE      reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+    TRANSLATABLE    reduce using rule 60 (propertyDeclaration_5 -> qualifierList dataType propertyName ; .)
+
+
+state 272
+
+    (61) propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue . ;
+
+    ;               shift and go to state 300
+
+
+state 273
+
+    (62) propertyDeclaration_7 -> qualifierList dataType propertyName array . ;
+    (63) propertyDeclaration_8 -> qualifierList dataType propertyName array . defaultValue ;
+    (107) defaultValue -> . = initializer
+
+    ;               shift and go to state 301
+    =               shift and go to state 170
+
+    defaultValue                   shift and go to state 302
+
+state 274
+
+    (66) referenceDeclaration -> qualifierList objectRef referenceName ; .
+
+    }               reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT8        reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT8        reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT16       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT16       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT32       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT32       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_UINT64       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_SINT64       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_REAL32       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_REAL64       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_CHAR16       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_STR          reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_BOOL         reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DT_DATETIME     reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    [               reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    IDENTIFIER      reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    ANY             reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    AS              reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    CLASS           reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    DISABLEOVERRIDE reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    ENABLEOVERRIDE  reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    FLAVOR          reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    INSTANCE        reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    METHOD          reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    OF              reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PARAMETER       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PRAGMA          reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    PROPERTY        reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    QUALIFIER       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    REFERENCE       reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    RESTRICTED      reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    SCHEMA          reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    SCOPE           reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TOSUBCLASS      reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TOINSTANCE      reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+    TRANSLATABLE    reduce using rule 66 (referenceDeclaration -> qualifierList objectRef referenceName ; .)
+
+
+state 275
+
+    (67) referenceDeclaration -> qualifierList objectRef referenceName defaultValue . ;
+
+    ;               shift and go to state 303
+
+
+state 276
+
+    (65) referenceDeclaration -> objectRef referenceName defaultValue ; .
+
+    }               reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT8        reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT8        reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT16       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT16       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT32       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT32       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_UINT64       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_SINT64       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_REAL32       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_REAL64       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_CHAR16       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_STR          reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_BOOL         reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DT_DATETIME     reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    [               reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    IDENTIFIER      reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    ANY             reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    AS              reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    CLASS           reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    FLAVOR          reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    INSTANCE        reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    METHOD          reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    OF              reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PARAMETER       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PRAGMA          reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    PROPERTY        reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    QUALIFIER       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    REFERENCE       reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    RESTRICTED      reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    SCHEMA          reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    SCOPE           reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TOINSTANCE      reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 65 (referenceDeclaration -> objectRef referenceName defaultValue ; .)
+
+
+state 277
+
+    (17) classDeclaration -> CLASS className alias superClass { classFeatureList } ; .
+
+    #               reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    [               reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+    $end            reduce using rule 17 (classDeclaration -> CLASS className alias superClass { classFeatureList } ; .)
+
+
+state 278
+
+    (19) classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .
+
+    #               reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    [               reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+    $end            reduce using rule 19 (classDeclaration -> qualifierList CLASS className superClass { classFeatureList } ; .)
+
+
+state 279
+
+    (20) classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .
+
+    #               reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    CLASS           reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    INSTANCE        reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    [               reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+    $end            reduce using rule 20 (classDeclaration -> qualifierList CLASS className alias { classFeatureList } ; .)
+
+
+state 280
+
+    (21) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } . ;
+
+    ;               shift and go to state 304
+
+
+state 281
+
+    (159) instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .
+
+    #               reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    CLASS           reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    [               reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+    $end            reduce using rule 159 (instanceDeclaration -> qualifierList INSTANCE OF className { valueInitializerList } ; .)
+
+
+state 282
+
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } . ;
+
+    ;               shift and go to state 305
+
+
+state 283
+
+    (154) defaultFlavor -> , FLAVOR ( flavorListWithComma . )
+    (156) flavorListWithComma -> flavorListWithComma . , flavor
+
+    )               shift and go to state 307
+    ,               shift and go to state 306
+
+
+state 284
+
+    (155) flavorListWithComma -> flavor .
+
+    )               reduce using rule 155 (flavorListWithComma -> flavor .)
+    ,               reduce using rule 155 (flavorListWithComma -> flavor .)
+
+
+state 285
+
+    (143) metaElementList -> metaElementList , . metaElement
+    (144) metaElement -> . SCHEMA
+    (145) metaElement -> . CLASS
+    (146) metaElement -> . ASSOCIATION
+    (147) metaElement -> . INDICATION
+    (148) metaElement -> . QUALIFIER
+    (149) metaElement -> . PROPERTY
+    (150) metaElement -> . REFERENCE
+    (151) metaElement -> . METHOD
+    (152) metaElement -> . PARAMETER
+    (153) metaElement -> . ANY
+
+    SCHEMA          shift and go to state 242
+    CLASS           shift and go to state 243
+    ASSOCIATION     shift and go to state 244
+    INDICATION      shift and go to state 245
+    QUALIFIER       shift and go to state 246
+    PROPERTY        shift and go to state 247
+    REFERENCE       shift and go to state 248
+    METHOD          shift and go to state 249
+    PARAMETER       shift and go to state 250
+    ANY             shift and go to state 251
+
+    metaElement                    shift and go to state 308
+
+state 286
+
+    (141) scope -> , SCOPE ( metaElementList ) .
+
+    ;               reduce using rule 141 (scope -> , SCOPE ( metaElementList ) .)
+    ,               reduce using rule 141 (scope -> , SCOPE ( metaElementList ) .)
+
+
+state 287
+
+    (164) valueInitializer -> qualifierList identifier defaultValue ; .
+
+    }               reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    IDENTIFIER      reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    ANY             reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    AS              reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    CLASS           reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    FLAVOR          reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    INSTANCE        reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    METHOD          reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    OF              reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PARAMETER       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PRAGMA          reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    PROPERTY        reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    QUALIFIER       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    REFERENCE       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    RESTRICTED      reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    SCHEMA          reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    SCOPE           reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TOSUBCLASS      reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TOINSTANCE      reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    TRANSLATABLE    reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    [               reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT8        reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT8        reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT16       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT16       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT32       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT32       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_UINT64       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_SINT64       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_REAL32       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_REAL64       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_CHAR16       reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_STR          reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_BOOL         reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+    DT_DATETIME     reduce using rule 164 (valueInitializer -> qualifierList identifier defaultValue ; .)
+
+
+state 288
+
+    (158) instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .
+
+    #               reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    CLASS           reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    [               reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+    $end            reduce using rule 158 (instanceDeclaration -> INSTANCE OF className alias { valueInitializerList } ; .)
+
+
+state 289
+
+    (96) parameter_1 -> dataType parameterName .
+    (97) parameter_1 -> dataType parameterName . array
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    )               reduce using rule 96 (parameter_1 -> dataType parameterName .)
+    ,               reduce using rule 96 (parameter_1 -> dataType parameterName .)
+    [               shift and go to state 169
+
+    array                          shift and go to state 309
+
+state 290
+
+    (104) parameterName -> identifier .
+
+    [               reduce using rule 104 (parameterName -> identifier .)
+    )               reduce using rule 104 (parameterName -> identifier .)
+    ,               reduce using rule 104 (parameterName -> identifier .)
+
+
+state 291
+
+    (68) methodDeclaration -> dataType methodName ( ) ; .
+
+    }               reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT8        reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT8        reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT16       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT16       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT32       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT32       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_UINT64       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_SINT64       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_REAL32       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_REAL64       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_CHAR16       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_STR          reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_BOOL         reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DT_DATETIME     reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    [               reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    IDENTIFIER      reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    ANY             reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    AS              reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    CLASS           reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    DISABLEOVERRIDE reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    ENABLEOVERRIDE  reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    FLAVOR          reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    INSTANCE        reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    METHOD          reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    OF              reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    PARAMETER       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    PRAGMA          reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    PROPERTY        reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    QUALIFIER       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    REFERENCE       reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    RESTRICTED      reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    SCHEMA          reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    SCOPE           reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    TOSUBCLASS      reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    TOINSTANCE      reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+    TRANSLATABLE    reduce using rule 68 (methodDeclaration -> dataType methodName ( ) ; .)
+
+
+state 292
+
+    (69) methodDeclaration -> dataType methodName ( parameterList ) . ;
+
+    ;               shift and go to state 310
+
+
+state 293
+
+    (91) parameterList -> parameterList , . parameter
+    (92) parameter -> . parameter_1
+    (93) parameter -> . parameter_2
+    (94) parameter -> . parameter_3
+    (95) parameter -> . parameter_4
+    (96) parameter_1 -> . dataType parameterName
+    (97) parameter_1 -> . dataType parameterName array
+    (98) parameter_2 -> . qualifierList dataType parameterName
+    (99) parameter_2 -> . qualifierList dataType parameterName array
+    (100) parameter_3 -> . objectRef parameterName
+    (101) parameter_3 -> . objectRef parameterName array
+    (102) parameter_4 -> . qualifierList objectRef parameterName
+    (103) parameter_4 -> . qualifierList objectRef parameterName array
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+    (33) qualifierList -> . [ qualifier qualifierListEmpty ]
+    (89) objectRef -> . className REF
+    (26) className -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+    [               shift and go to state 17
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+
+    parameter                      shift and go to state 311
+    parameter_1                    shift and go to state 261
+    parameter_2                    shift and go to state 262
+    parameter_3                    shift and go to state 263
+    parameter_4                    shift and go to state 264
+    dataType                       shift and go to state 257
+    qualifierList                  shift and go to state 265
+    objectRef                      shift and go to state 266
+    className                      shift and go to state 136
+    identifier                     shift and go to state 21
+
+state 294
+
+    (98) parameter_2 -> qualifierList dataType . parameterName
+    (99) parameter_2 -> qualifierList dataType . parameterName array
+    (173) identifier -> dataType .
+    (104) parameterName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    REF             reduce using rule 173 (identifier -> dataType .)
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    dataType                       shift and go to state 26
+    parameterName                  shift and go to state 312
+    identifier                     shift and go to state 290
+
+state 295
+
+    (102) parameter_4 -> qualifierList objectRef . parameterName
+    (103) parameter_4 -> qualifierList objectRef . parameterName array
+    (104) parameterName -> . identifier
+    (168) identifier -> . IDENTIFIER
+    (169) identifier -> . ANY
+    (170) identifier -> . AS
+    (171) identifier -> . CLASS
+    (172) identifier -> . DISABLEOVERRIDE
+    (173) identifier -> . dataType
+    (174) identifier -> . ENABLEOVERRIDE
+    (175) identifier -> . FLAVOR
+    (176) identifier -> . INSTANCE
+    (177) identifier -> . METHOD
+    (178) identifier -> . OF
+    (179) identifier -> . PARAMETER
+    (180) identifier -> . PRAGMA
+    (181) identifier -> . PROPERTY
+    (182) identifier -> . QUALIFIER
+    (183) identifier -> . REFERENCE
+    (184) identifier -> . RESTRICTED
+    (185) identifier -> . SCHEMA
+    (186) identifier -> . SCOPE
+    (187) identifier -> . TOSUBCLASS
+    (188) identifier -> . TOINSTANCE
+    (189) identifier -> . TRANSLATABLE
+    (75) dataType -> . DT_UINT8
+    (76) dataType -> . DT_SINT8
+    (77) dataType -> . DT_UINT16
+    (78) dataType -> . DT_SINT16
+    (79) dataType -> . DT_UINT32
+    (80) dataType -> . DT_SINT32
+    (81) dataType -> . DT_UINT64
+    (82) dataType -> . DT_SINT64
+    (83) dataType -> . DT_REAL32
+    (84) dataType -> . DT_REAL64
+    (85) dataType -> . DT_CHAR16
+    (86) dataType -> . DT_STR
+    (87) dataType -> . DT_BOOL
+    (88) dataType -> . DT_DATETIME
+
+    IDENTIFIER      shift and go to state 22
+    ANY             shift and go to state 23
+    AS              shift and go to state 24
+    CLASS           shift and go to state 19
+    DISABLEOVERRIDE shift and go to state 25
+    ENABLEOVERRIDE  shift and go to state 27
+    FLAVOR          shift and go to state 28
+    INSTANCE        shift and go to state 29
+    METHOD          shift and go to state 30
+    OF              shift and go to state 31
+    PARAMETER       shift and go to state 32
+    PRAGMA          shift and go to state 33
+    PROPERTY        shift and go to state 34
+    QUALIFIER       shift and go to state 35
+    REFERENCE       shift and go to state 36
+    RESTRICTED      shift and go to state 37
+    SCHEMA          shift and go to state 38
+    SCOPE           shift and go to state 39
+    TOSUBCLASS      shift and go to state 40
+    TOINSTANCE      shift and go to state 41
+    TRANSLATABLE    shift and go to state 42
+    DT_UINT8        shift and go to state 43
+    DT_SINT8        shift and go to state 44
+    DT_UINT16       shift and go to state 45
+    DT_SINT16       shift and go to state 46
+    DT_UINT32       shift and go to state 47
+    DT_SINT32       shift and go to state 48
+    DT_UINT64       shift and go to state 49
+    DT_SINT64       shift and go to state 50
+    DT_REAL32       shift and go to state 51
+    DT_REAL64       shift and go to state 52
+    DT_CHAR16       shift and go to state 53
+    DT_STR          shift and go to state 54
+    DT_BOOL         shift and go to state 55
+    DT_DATETIME     shift and go to state 56
+
+    parameterName                  shift and go to state 313
+    identifier                     shift and go to state 290
+    dataType                       shift and go to state 26
+
+state 296
+
+    (100) parameter_3 -> objectRef parameterName .
+    (101) parameter_3 -> objectRef parameterName . array
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    )               reduce using rule 100 (parameter_3 -> objectRef parameterName .)
+    ,               reduce using rule 100 (parameter_3 -> objectRef parameterName .)
+    [               shift and go to state 169
+
+    array                          shift and go to state 314
+
+state 297
+
+    (59) propertyDeclaration_4 -> dataType propertyName array defaultValue ; .
+
+    }               reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT8        reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT8        reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT16       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT16       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT32       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT32       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_UINT64       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_SINT64       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_REAL32       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_REAL64       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_CHAR16       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_STR          reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_BOOL         reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DT_DATETIME     reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    [               reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    IDENTIFIER      reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    ANY             reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    AS              reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    CLASS           reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    FLAVOR          reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    INSTANCE        reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    METHOD          reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    OF              reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PARAMETER       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PRAGMA          reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    PROPERTY        reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    QUALIFIER       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    REFERENCE       reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    RESTRICTED      reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    SCHEMA          reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    SCOPE           reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TOSUBCLASS      reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TOINSTANCE      reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+    TRANSLATABLE    reduce using rule 59 (propertyDeclaration_4 -> dataType propertyName array defaultValue ; .)
+
+
+state 298
+
+    (70) methodDeclaration -> qualifierList dataType methodName ( ) . ;
+
+    ;               shift and go to state 315
+
+
+state 299
+
+    (71) methodDeclaration -> qualifierList dataType methodName ( parameterList . ) ;
+    (91) parameterList -> parameterList . , parameter
+
+    )               shift and go to state 316
+    ,               shift and go to state 293
+
+
+state 300
+
+    (61) propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .
+
+    }               reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT8        reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT8        reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT16       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT16       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT32       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT32       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_UINT64       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_SINT64       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_REAL32       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_REAL64       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_CHAR16       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_STR          reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_BOOL         reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DT_DATETIME     reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    [               reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    IDENTIFIER      reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    ANY             reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    AS              reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    CLASS           reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    FLAVOR          reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    INSTANCE        reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    METHOD          reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    OF              reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PARAMETER       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PRAGMA          reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    PROPERTY        reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    QUALIFIER       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    REFERENCE       reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    RESTRICTED      reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    SCHEMA          reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    SCOPE           reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TOINSTANCE      reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 61 (propertyDeclaration_6 -> qualifierList dataType propertyName defaultValue ; .)
+
+
+state 301
+
+    (62) propertyDeclaration_7 -> qualifierList dataType propertyName array ; .
+
+    }               reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT8        reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT8        reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT16       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT16       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT32       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT32       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_UINT64       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_SINT64       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_REAL32       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_REAL64       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_CHAR16       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_STR          reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_BOOL         reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DT_DATETIME     reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    [               reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    IDENTIFIER      reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    ANY             reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    AS              reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    CLASS           reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    DISABLEOVERRIDE reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    ENABLEOVERRIDE  reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    FLAVOR          reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    INSTANCE        reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    METHOD          reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    OF              reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PARAMETER       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PRAGMA          reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    PROPERTY        reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    QUALIFIER       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    REFERENCE       reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    RESTRICTED      reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    SCHEMA          reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    SCOPE           reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TOSUBCLASS      reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TOINSTANCE      reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+    TRANSLATABLE    reduce using rule 62 (propertyDeclaration_7 -> qualifierList dataType propertyName array ; .)
+
+
+state 302
+
+    (63) propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue . ;
+
+    ;               shift and go to state 317
+
+
+state 303
+
+    (67) referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .
+
+    }               reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT8        reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT8        reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT16       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT16       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT32       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT32       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_UINT64       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_SINT64       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_REAL32       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_REAL64       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_CHAR16       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_STR          reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_BOOL         reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DT_DATETIME     reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    [               reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    IDENTIFIER      reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    ANY             reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    AS              reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    CLASS           reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    FLAVOR          reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    INSTANCE        reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    METHOD          reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    OF              reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PARAMETER       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PRAGMA          reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    PROPERTY        reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    QUALIFIER       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    REFERENCE       reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    RESTRICTED      reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    SCHEMA          reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    SCOPE           reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TOSUBCLASS      reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TOINSTANCE      reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+    TRANSLATABLE    reduce using rule 67 (referenceDeclaration -> qualifierList objectRef referenceName defaultValue ; .)
+
+
+state 304
+
+    (21) classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .
+
+    #               reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    CLASS           reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    QUALIFIER       reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    INSTANCE        reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    [               reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+    $end            reduce using rule 21 (classDeclaration -> qualifierList CLASS className alias superClass { classFeatureList } ; .)
+
+
+state 305
+
+    (160) instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .
+
+    #               reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    CLASS           reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    QUALIFIER       reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    INSTANCE        reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    [               reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+    $end            reduce using rule 160 (instanceDeclaration -> qualifierList INSTANCE OF className alias { valueInitializerList } ; .)
+
+
+state 306
+
+    (156) flavorListWithComma -> flavorListWithComma , . flavor
+    (42) flavor -> . ENABLEOVERRIDE
+    (43) flavor -> . DISABLEOVERRIDE
+    (44) flavor -> . RESTRICTED
+    (45) flavor -> . TOSUBCLASS
+    (46) flavor -> . TOINSTANCE
+    (47) flavor -> . TRANSLATABLE
+
+    ENABLEOVERRIDE  shift and go to state 109
+    DISABLEOVERRIDE shift and go to state 110
+    RESTRICTED      shift and go to state 111
+    TOSUBCLASS      shift and go to state 112
+    TOINSTANCE      shift and go to state 113
+    TRANSLATABLE    shift and go to state 114
+
+    flavor                         shift and go to state 318
+
+state 307
+
+    (154) defaultFlavor -> , FLAVOR ( flavorListWithComma ) .
+
+    ;               reduce using rule 154 (defaultFlavor -> , FLAVOR ( flavorListWithComma ) .)
+
+
+state 308
+
+    (143) metaElementList -> metaElementList , metaElement .
+
+    )               reduce using rule 143 (metaElementList -> metaElementList , metaElement .)
+    ,               reduce using rule 143 (metaElementList -> metaElementList , metaElement .)
+
+
+state 309
+
+    (97) parameter_1 -> dataType parameterName array .
+
+    )               reduce using rule 97 (parameter_1 -> dataType parameterName array .)
+    ,               reduce using rule 97 (parameter_1 -> dataType parameterName array .)
+
+
+state 310
+
+    (69) methodDeclaration -> dataType methodName ( parameterList ) ; .
+
+    }               reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT8        reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT8        reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT16       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT16       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT32       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT32       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_UINT64       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_SINT64       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_REAL32       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_REAL64       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_CHAR16       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_STR          reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_BOOL         reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DT_DATETIME     reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    [               reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    IDENTIFIER      reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    ANY             reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    AS              reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    CLASS           reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    DISABLEOVERRIDE reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    ENABLEOVERRIDE  reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    FLAVOR          reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    INSTANCE        reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    METHOD          reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    OF              reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PARAMETER       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PRAGMA          reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    PROPERTY        reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    QUALIFIER       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    REFERENCE       reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    RESTRICTED      reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    SCHEMA          reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    SCOPE           reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TOSUBCLASS      reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TOINSTANCE      reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+    TRANSLATABLE    reduce using rule 69 (methodDeclaration -> dataType methodName ( parameterList ) ; .)
+
+
+state 311
+
+    (91) parameterList -> parameterList , parameter .
+
+    )               reduce using rule 91 (parameterList -> parameterList , parameter .)
+    ,               reduce using rule 91 (parameterList -> parameterList , parameter .)
+
+
+state 312
+
+    (98) parameter_2 -> qualifierList dataType parameterName .
+    (99) parameter_2 -> qualifierList dataType parameterName . array
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    )               reduce using rule 98 (parameter_2 -> qualifierList dataType parameterName .)
+    ,               reduce using rule 98 (parameter_2 -> qualifierList dataType parameterName .)
+    [               shift and go to state 169
+
+    array                          shift and go to state 319
+
+state 313
+
+    (102) parameter_4 -> qualifierList objectRef parameterName .
+    (103) parameter_4 -> qualifierList objectRef parameterName . array
+    (105) array -> . [ ]
+    (106) array -> . [ integerValue ]
+
+    )               reduce using rule 102 (parameter_4 -> qualifierList objectRef parameterName .)
+    ,               reduce using rule 102 (parameter_4 -> qualifierList objectRef parameterName .)
+    [               shift and go to state 169
+
+    array                          shift and go to state 320
+
+state 314
+
+    (101) parameter_3 -> objectRef parameterName array .
+
+    )               reduce using rule 101 (parameter_3 -> objectRef parameterName array .)
+    ,               reduce using rule 101 (parameter_3 -> objectRef parameterName array .)
+
+
+state 315
+
+    (70) methodDeclaration -> qualifierList dataType methodName ( ) ; .
+
+    }               reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT8        reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT8        reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT16       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT16       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT32       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT32       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_UINT64       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_SINT64       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_REAL32       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_REAL64       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_CHAR16       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_STR          reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_BOOL         reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DT_DATETIME     reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    [               reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    IDENTIFIER      reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    ANY             reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    AS              reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    CLASS           reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    DISABLEOVERRIDE reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    ENABLEOVERRIDE  reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    FLAVOR          reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    INSTANCE        reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    METHOD          reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    OF              reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PARAMETER       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PRAGMA          reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    PROPERTY        reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    QUALIFIER       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    REFERENCE       reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    RESTRICTED      reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    SCHEMA          reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    SCOPE           reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TOSUBCLASS      reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TOINSTANCE      reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+    TRANSLATABLE    reduce using rule 70 (methodDeclaration -> qualifierList dataType methodName ( ) ; .)
+
+
+state 316
+
+    (71) methodDeclaration -> qualifierList dataType methodName ( parameterList ) . ;
+
+    ;               shift and go to state 321
+
+
+state 317
+
+    (63) propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .
+
+    }               reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT8        reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT8        reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT16       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT16       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT32       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT32       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_UINT64       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_SINT64       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_REAL32       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_REAL64       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_CHAR16       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_STR          reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_BOOL         reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DT_DATETIME     reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    [               reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    IDENTIFIER      reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    ANY             reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    AS              reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    CLASS           reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    DISABLEOVERRIDE reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    ENABLEOVERRIDE  reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    FLAVOR          reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    INSTANCE        reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    METHOD          reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    OF              reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PARAMETER       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PRAGMA          reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    PROPERTY        reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    QUALIFIER       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    REFERENCE       reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    RESTRICTED      reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    SCHEMA          reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    SCOPE           reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TOSUBCLASS      reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TOINSTANCE      reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+    TRANSLATABLE    reduce using rule 63 (propertyDeclaration_8 -> qualifierList dataType propertyName array defaultValue ; .)
+
+
+state 318
+
+    (156) flavorListWithComma -> flavorListWithComma , flavor .
+
+    )               reduce using rule 156 (flavorListWithComma -> flavorListWithComma , flavor .)
+    ,               reduce using rule 156 (flavorListWithComma -> flavorListWithComma , flavor .)
+
+
+state 319
+
+    (99) parameter_2 -> qualifierList dataType parameterName array .
+
+    )               reduce using rule 99 (parameter_2 -> qualifierList dataType parameterName array .)
+    ,               reduce using rule 99 (parameter_2 -> qualifierList dataType parameterName array .)
+
+
+state 320
+
+    (103) parameter_4 -> qualifierList objectRef parameterName array .
+
+    )               reduce using rule 103 (parameter_4 -> qualifierList objectRef parameterName array .)
+    ,               reduce using rule 103 (parameter_4 -> qualifierList objectRef parameterName array .)
+
+
+state 321
+
+    (71) methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .
+
+    }               reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT8        reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT8        reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT16       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT16       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT32       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT32       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_UINT64       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_SINT64       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_REAL32       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_REAL64       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_CHAR16       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_STR          reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_BOOL         reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DT_DATETIME     reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    [               reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    IDENTIFIER      reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    ANY             reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    AS              reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    CLASS           reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    DISABLEOVERRIDE reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    ENABLEOVERRIDE  reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    FLAVOR          reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    INSTANCE        reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    METHOD          reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    OF              reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    PARAMETER       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    PRAGMA          reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    PROPERTY        reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    QUALIFIER       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    REFERENCE       reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    RESTRICTED      reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    SCHEMA          reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    SCOPE           reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TOSUBCLASS      reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TOINSTANCE      reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+    TRANSLATABLE    reduce using rule 71 (methodDeclaration -> qualifierList dataType methodName ( parameterList ) ; .)
+
+lex: tokens   = ['ANY', 'AS', 'ASSOCIATION', 'CLASS', 'DISABLEOVERRIDE', 'DT_BOOL', 'DT_CHAR16', 'DT_DATETIME', 'PRAGMA', 'DT_REAL32', 'DT_REAL64', 'DT_SINT16', 'DT_SINT32', 'DT_SINT64', 'DT_SINT8', 'DT_STR', 'DT_UINT16', 'DT_UINT32', 'DT_UINT64', 'DT_UINT8', 'ENABLEOVERRIDE', 'FALSE', 'FLAVOR', 'INDICATION', 'INSTANCE', 'METHOD', 'NULL', 'OF', 'PARAMETER', 'PROPERTY', 'QUALIFIER', 'REF', 'REFERENCE', 'RESTRICTED', 'SCHEMA', 'SCOPE', 'TOSUBCLASS', 'TOINSTANCE', 'TRANSLATABLE', 'TRUE', 'IDENTIFIER', 'stringValue', 'floatValue', 'charValue', 'binaryValue', 'octalValue', 'decimalValue', 'hexValue']
+lex: literals = '#(){};[],$:='
+lex: states   = {'INITIAL': 'inclusive'}
+lex: Adding rule t_COMMENT -> '//.*' (state 'INITIAL')
+lex: Adding rule t_MCOMMENT -> '/\*(.|\n)*?\*/' (state 'INITIAL')
+lex: Adding rule t_floatValue -> '[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?' (state 'INITIAL')
+lex: Adding rule t_hexValue -> '[+-]?0[xX][0-9a-fA-F]+' (state 'INITIAL')
+lex: Adding rule t_binaryValue -> '[+-]?[0-9]+[bB]' (state 'INITIAL')
+lex: Adding rule t_octalValue -> '[+-]?0[0-9]+' (state 'INITIAL')
+lex: Adding rule t_decimalValue -> '[+-]?([1-9][0-9]*|0)' (state 'INITIAL')
+lex: Adding rule t_charValue -> ''([^'\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))'' (state 'INITIAL')
+lex: Adding rule t_stringValue -> '"([^"\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))*"' (state 'INITIAL')
+lex: Adding rule t_IDENTIFIER -> '([a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))([0-9a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))*' (state 'INITIAL')
+lex: Adding rule t_newline -> '\n+' (state 'INITIAL')
+lex: ==== MASTER REGEXS FOLLOW ====
+lex: state 'INITIAL' : regex[0] = '(?P<t_COMMENT>//.*)|(?P<t_MCOMMENT>/\*(.|\n)*?\*/)|(?P<t_floatValue>[+-]?[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)|(?P<t_hexValue>[+-]?0[xX][0-9a-fA-F]+)|(?P<t_binaryValue>[+-]?[0-9]+[bB])|(?P<t_octalValue>[+-]?0[0-9]+)|(?P<t_decimalValue>[+-]?([1-9][0-9]*|0))|(?P<t_charValue>'([^'\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))')|(?P<t_stringValue>"([^"\\\n\r]|([\\](([bfnrt'"\\])|([xX][0-9a-fA-F]{1,4}))))*")|(?P<t_IDENTIFIER>([a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))([0-9a-zA-Z_]|(([\xC2-\xDF][\x80-\xBF])|(\xE0[\xA0-\xBF][\x80-\xBF])|([\xE1-\xEC][\x80-\xBF][\x80-\xBF])|(\xED[\x80-\x9F][\x80-\xBF])|([\xEE-\xEF][\x80-\xBF][\x80-\xBF])|(\xF0[\x90-\xBF][\x80-\xBF][\x80-\xBF])|([\xF1-\xF3][\x80-\xBF][\x80-\xBF][\x80-\xBF])|(\xF4[\x80-\x8F][\x80-\xBF][\x80-\xBF])))*)|(?P<t_newline>\n+)'
+Compiling file './test.mof'
+Setting qualifier 'Association'
+Setting qualifier 'Description'
+Creating class 'root/cimv2':'TST_Person'
+Created class 'root/cimv2':'TST_Person'
+Creating class 'root/cimv2':'TST_Lineage'
+Created class 'root/cimv2':'TST_Lineage'

--- a/fixmofout2.txt
+++ b/fixmofout2.txt
@@ -1,0 +1,9 @@
+MOF repository: Namespace root/cimv2 in WBEM server vvv
+Executing in dry-run mode
+Compiling file './test.mof'
+Syntax error:./test.mof:1:9
+Qualifier Association : boolean = false,
+         ^^^^^^^^^^^
+mof_compiler: MOFParseError: MOFParseError:
+./test.mof:1:9 msg=None
+['Qualifier Association : boolean = false,', '         ^^^^^^^^^^^']

--- a/mof_compilertests.txt
+++ b/mof_compilertests.txt
@@ -1,0 +1,9 @@
+pp coverage report run mof_compiler -dv -s http://192.168.3.135 test.mof
+followed by
+coverage html
+
+or
+
+pp mof_compiler -dv -s http://192.168.3.135 test.mof -svvv 2>@1 | tee mofout2.txt
+
+

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -79,6 +79,7 @@ from __future__ import print_function, absolute_import
 import sys
 import os
 import re
+import logging
 from abc import ABCMeta, abstractmethod
 try:
     from collections import OrderedDict
@@ -494,6 +495,7 @@ def p_mp_createClass(p):
                       """
 
     # pylint: disable=too-many-branches,too-many-statements,too-many-locals
+    print('Creating class p1 %s' % p[1])
     ns = p.parser.handle.default_namespace
     cc = p[1]
     try:
@@ -792,6 +794,7 @@ def p_assocDeclaration(p):
                         | '[' ASSOCIATION qualifierListEmpty ']' CLASS className alias superClass '{' associationFeatureList '}' ';'
                         """  # noqa: E501
     aqual = CIMQualifier('ASSOCIATION', True, type='boolean')
+    print("assocDecl p2=%s p3=%s" % (p[2], p[3]))
     quals = [aqual] + p[3]
     p[0] = _assoc_or_indic_decl(quals, p)
 
@@ -812,6 +815,7 @@ def _assoc_or_indic_decl(quals, p):
     """(refer to grammer rules on p_assocDeclaration and p_indicDeclaration)"""
     superclass = None
     alias = None
+    print('_assoc_or_indic_decl quals=%s p[6]=%s p[7]=%s' % (quals, p[6], p7))
     cname = p[6]
     if p[7] == '{':
         cfl = p[8]
@@ -846,8 +850,10 @@ def p_qualifierListEmpty(p):
                           | qualifierListEmpty ',' qualifier
                           """
     if len(p) == 2:
+        print("qualifierListEmpty p=%r" % p)
         p[0] = []
     else:
+        print("qualifierListEmpty p1=%s p3=%s" % (p[1], p[3]))
         p[0] = p[1] + [p[3]]
 
 
@@ -856,8 +862,10 @@ def p_associationFeatureList(p):
                               | associationFeatureList associationFeature
                               """
     if len(p) == 2:
+        print('assocfeaturelist len')
         p[0] = []
     else:
+        print("assocfeaturelist p1=%s p3=%s" % (p[1], p[2]))
         p[0] = p[1] + [p[2]]
 
 
@@ -2506,7 +2514,9 @@ class MOFCompiler(object):
         try:
             # Call the parser.  To generate detailed output of states
             # add debug=1 to following line.
-            rv = self.parser.parse(mof, lexer=lexer)
+            log = logging.getLogger()
+            logging.basicConfig(level=logging.DEBUG)
+            rv = self.parser.parse(mof, lexer=lexer, debug=log)
             self.parser.file = oldfile
             self.parser.mof = oldmof
             return rv
@@ -2643,7 +2653,7 @@ def _yacc(verbose=False):
                      tabmodule=_tabmodule,
                      outputdir=_tabdir,
                      debug=True,
-                     debuglog=yacc.NullLogger(),
+                     debuglog=yacc.PlyLogger(sys.stdout),
                      errorlog=yacc.PlyLogger(sys.stdout))
 
 
@@ -2658,5 +2668,6 @@ def _lex(verbose=False):
     return lex.lex(optimize=_optimize,
                    lextab=_lextab,
                    outputdir=_tabdir,
-                   debug=False,
+                   debug=True,
+                   debuglog=lex.PlyLogger(sys.stdout),
                    errorlog=lex.PlyLogger(sys.stdout))

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -488,9 +488,9 @@ def p_mofProduction(p):
 
 
 def p_mp_createClass(p):
-    """mp_createClass : classDeclaration
-                      | assocDeclaration
+    """mp_createClass : assocDeclaration
                       | indicDeclaration
+                      | classDeclaration
                       """
 
     # pylint: disable=too-many-branches,too-many-statements,too-many-locals

--- a/test.mof
+++ b/test.mof
@@ -1,0 +1,20 @@
+Qualifier Association : boolean = false,
+    Scope(association), Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string = null,
+    Scope(any), Flavor(EnableOverride, ToSubclass, Translatable);
+
+class TST_Person{
+        [Key, Description ("This is key prop")]
+    string name;
+    string extraProperty;
+};
+
+[Association]
+class TST_Lineage {
+    [key] string InstanceID;
+    TST_Person ref parent;
+    TST_Person ref child;
+};
+
+


### PR DESCRIPTION
This changes the compiler by simply reordering the createClass produciton to put assocDeclaration is moved to be first.

FOR DISCUSSION ONLY.

This NOT an alternate proposal to proposal #1699. 

I uploaded it only for possible discussion since there is one state change that I have not figured out.  It causes the same conflict as before the change and also never executes the assocDeclaration production action.

It includes a detailed output for the ply output file both for definition of the tables altmofout.txt and for 
the output of a simple compile of the file pywbem/test.mof with pywbem/mof_compiler. This is in the files alttestmofout.txt (the output of ply compiling the tables) and alttestmofout2.txt (the compile)

I have it pretty well explained to myself,  There is a resolve/resolve conflict when the compile of test.mof hits the association class create.  It occurs at the ASSOCIATION item in the compile definition and it detailed in alttestmofout2.txt and shown/explained below.  My only question is right after state 97 below where it seems to go from state 21 (the . is right after ASSOCIATION (which is were the resolve conflict occurs) to state 17.   The only place is should be able to go to state 17 is from state 2 as far as I can tell.  This is really just my own curiosity about YACC and PLY mostly but it does lead me to beleive that there is probably something messy in the whole qualifierlist, qualifierlistempty production set.

execution of the cmd line
```
=======================================
[ASSOCIATION], class
DEBUG:root:
DEBUG:root:State  : 2
DEBUG:root:Stack  : mofProductionList . LexToken([,'[',13,322)
DEBUG:root:Action : Shift and goto state 15
DEBUG:root:
DEBUG:root:State  : 15
DEBUG:root:Stack  : mofProductionList [ . LexToken(ASSOCIATION,'Association',13,323)
DEBUG:root:Action : Shift and goto state 21
DEBUG:root:
DEBUG:root:State  : 21
DEBUG:root:Stack  : mofProductionList [ ASSOCIATION . LexToken(],']',13,334)
INFO:root:Action : Reduce rule [qualifierName -> ASSOCIATION] with ['Association'] and goto state 25
INFO:root:Result : <str @ 0x7f9562454430> ('Association')
DEBUG:root:
DEBUG:root:State  : 25
DEBUG:root:Stack  : mofProductionList [ qualifierName . LexToken(],']',13,334)
INFO:root:Action : Reduce rule [qualifier -> qualifierName] with ['Association'] and goto state 24
INFO:root:Result : <CIMQualifier @ 0x7f956232da20> (CIMQualifier(name='Association', value=T ...)
DEBUG:root:
DEBUG:root:State  : 24
DEBUG:root:Stack  : mofProductionList [ qualifier . LexToken(],']',13,334)
INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 73
INFO:root:Result : <NoneType @ 0x9d34e0> (None)
DEBUG:root:
DEBUG:root:State  : 73
DEBUG:root:Stack  : mofProductionList [ qualifier empty . LexToken(],']',13,334)
INFO:root:Action : Reduce rule [qualifierListEmpty -> empty] with [None] and goto state 75
INFO:root:Result : <list @ 0x7f956227b0c8> ([])
DEBUG:root:
DEBUG:root:State  : 75
DEBUG:root:Stack  : mofProductionList [ qualifier qualifierListEmpty . LexToken(],']',13,334)
DEBUG:root:Action : Shift and goto state 97
DEBUG:root:
DEBUG:root:State  : 97
DEBUG:root:Stack  : mofProductionList [ qualifier qualifierListEmpty ] . LexToken(CLASS,'class',14,336)
INFO:root:Action : Reduce rule [qualifierList -> [ qualifier qualifierListEmpty ]] with ['[',<CIMQualifier @ 0x7f956232da20>,[],']'] and goto state 17
INFO:root:Result : <list @ 0x7f9562454608> ([CIMQualifier(name='Association', value= ...)
===============================
```

here we go back to state 17 (20) classDeclaration -> qualifierList . CLASS className { classFeatureList }
Looks like while we started in assocDeclaration, the class element took us back to classDeclaration
This may be tied to rule 146 Rule 146   qualifierName -> ASSOCIATION
and state 21 conflict reduction

```
state 21

    (26) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className { associationFeatureList } ;
    (27) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className superClass { associationFeatureList } ;
    (28) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias { associationFeatureList } ;
    (29) assocDeclaration -> [ ASSOCIATION . qualifierListEmpty ] CLASS className alias superClass { associationFeatureList } ;
    (146) qualifierName -> ASSOCIATION .
    (34) qualifierListEmpty -> . empty
    (35) qualifierListEmpty -> . qualifierListEmpty , qualifier
    (203) empty -> .

  ! reduce/reduce conflict for ] resolved using rule 146 (qualifierName -> ASSOCIATION .)
  ! reduce/reduce conflict for , resolved using rule 146 (qualifierName -> ASSOCIATION .)
    :               reduce using rule 146 (qualifierName -> ASSOCIATION .)
    (               reduce using rule 146 (qualifierName -> ASSOCIATION .)
    {               reduce using rule 146 (qualifierName -> ASSOCIATION .)
    ]               reduce using rule 146 (qualifierName -> ASSOCIATION .)
    ,               reduce using rule 146 (qualifierName -> ASSOCIATION .)

  ! ]               [ reduce using rule 203 (empty -> .) ]
  ! ,               [ reduce using rule 203 (empty -> .) ]

    qualifierListEmpty             shift and go to state 72
    empty                          shift and go to state 73
```

yacc invokes two default disambiguating rules:

1. In a shift-reduce conflict, the default is to shift.

2. In a reduce-reduce conflict, the default is to reduce by
the earlier grammar rule (in the yacc specification). Rule 1 implies that
reductions are deferred in favor of shifts when there is a choice.

This is the following from line: 1469

```
def p_qualifierName(p):
    """qualifierName : identifier
                     | ASSOCIATION
                     | INDICATION
                     """
    p[0] = p[1]
```

Rules 146 and 159 are the same so conflict resolution picks the first.

Rule 146   qualifierName -> ASSOCIATION
Rule 159   metaElement -> ASSOCIATION

This comes from using the same terminal (ASSOCIATION)

```
========================Next state.
DEBUG:root:
DEBUG:root:State  : 17
DEBUG:root:Stack  : mofProductionList qualifierList . LexToken(CLASS,'class',14,336)
DEBUG:root:Action : Shift and goto state 64
=============================================
```

But here is wierd part. After the conflict, it goes to state 17 which is class declaration.


```
state 17

    (20) classDeclaration -> qualifierList . CLASS className { classFeatureList } ;
    (21) classDeclaration -> qualifierList . CLASS className superClass { classFeatureList } ;
    (22) classDeclaration -> qualifierList . CLASS className alias { classFeatureList } ;
    (23) classDeclaration -> qualifierList . CLASS className alias superClass { classFeatureList } ;
    (172) instanceDeclaration -> qualifierList . INSTANCE OF className { valueInitializerList } ;
    (173) instanceDeclaration -> qualifierList . INSTANCE OF className alias { valueInitializerList } ;

    CLASS           shift and go to state 64
    INSTANCE        shift and go to state 65

DEBUG:root:
DEBUG:root:State  : 64
DEBUG:root:Stack  : mofProductionList qualifierList CLASS . LexToken(IDENTIFIER,'TST_Lineage',14,342)
DEBUG:root:Action : Shift and goto state 27
DEBUG:root:
DEBUG:root:State  : 27
DEBUG:root:Stack  : mofProductionList qualifierList CLASS IDENTIFIER . LexToken({,'{',14,354)
INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['TST_Lineage'] and goto state 63
INFO:root:Result : <str @ 0x7f9562454c30> ('TST_Lineage')
DEBUG:root:
DEBUG:root:State  : 63
DEBUG:root:Stack  : mofProductionList qualifierList CLASS identifier . LexToken({,'{',14,354)
INFO:root:Action : Reduce rule [className -> identifier] with ['TST_Lineage'] and goto state 86
INFO:root:Result : <str @ 0x7f9562454c30> ('TST_Lineage')
DEBUG:root:
DEBUG:root:State  : 86
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className . LexToken({,'{',14,354)
DEBUG:root:Action : Shift and goto state 133
DEBUG:root:
DEBUG:root:State  : 133
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { . LexToken([,'[',15,360)
INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 126
INFO:root:Result : <NoneType @ 0x9d34e0> (None)
DEBUG:root:
DEBUG:root:State  : 126
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { empty . LexToken([,'[',15,360)
INFO:root:Action : Reduce rule [classFeatureList -> empty] with [None] and goto state 175
INFO:root:Result : <list @ 0x7f956227b188> ([])
DEBUG:root:
DEBUG:root:State  : 175
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList . LexToken([,'[',15,360)
DEBUG:root:Action : Shift and goto state 170
DEBUG:root:
DEBUG:root:State  : 170
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ . LexToken(IDENTIFIER,'key',15,361)
DEBUG:root:Action : Shift and goto state 27
DEBUG:root:
DEBUG:root:State  : 27
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ IDENTIFIER . LexToken(],']',15,364)
INFO:root:Action : Reduce rule [identifier -> IDENTIFIER] with ['key'] and goto state 26
INFO:root:Result : <str @ 0x7f956232ddf8> ('key')
DEBUG:root:
DEBUG:root:State  : 26
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ identifier . LexToken(],']',15,364)
INFO:root:Action : Reduce rule [qualifierName -> identifier] with ['key'] and goto state 25
INFO:root:Result : <str @ 0x7f956232ddf8> ('key')
DEBUG:root:
DEBUG:root:State  : 25
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifierName . LexToken(],']',15,364)
INFO:root:Action : Reduce rule [qualifier -> qualifierName] with ['key'] and goto state 24
INFO:root:Result : <CIMQualifier @ 0x7f956232df60> (CIMQualifier(name='key', value=True, typ ...)
DEBUG:root:
DEBUG:root:State  : 24
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier . LexToken(],']',15,364)
INFO:root:Action : Reduce rule [empty -> <empty>] with [] and goto state 73
INFO:root:Result : <NoneType @ 0x9d34e0> (None)
DEBUG:root:
DEBUG:root:State  : 73
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier empty . LexToken(],']',15,364)
INFO:root:Action : Reduce rule [qualifierListEmpty -> empty] with [None] and goto state 75
INFO:root:Result : <list @ 0x7f956227b8c8> ([])
DEBUG:root:
DEBUG:root:State  : 75
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier qualifierListEmpty . LexToken(],']',15,364)
DEBUG:root:Action : Shift and goto state 97
DEBUG:root:
DEBUG:root:State  : 97
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList [ qualifier qualifierListEmpty ] . LexToken(DT_STR,'string',15,366)
INFO:root:Action : Reduce rule [qualifierList -> [ qualifier qualifierListEmpty ]] with ['[',<CIMQualifier @ 0x7f956232df60>,[],']'] and goto state 168
INFO:root:Result : <list @ 0x7f95623c3f08> ([CIMQualifier(name='key', value=True, ty ...)
DEBUG:root:
DEBUG:root:State  : 168
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList . LexToken(DT_STR,'string',15,366)
DEBUG:root:Action : Shift and goto state 59
DEBUG:root:
DEBUG:root:State  : 59
DEBUG:root:Stack  : mofProductionList qualifierList CLASS className { classFeatureList qualifierList DT_STR . LexToken(IDENTIFIER,'InstanceID',15,373)
INFO:root:Action : Reduce rule [dataType -> DT_STR] with ['string'] and goto state 203
INFO:root:Result : <str @ 0x7f956232dbc8> ('string')
```

I do have one open quesiton that I have not resolved based on my knowledge of YACC and PLY