### PR TITLE
03 Changed GetCentralInstances methodology to be bypassed by default

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,13 @@ Released: not yet
 
 **Enhancements:**
 
+* Changed GetCentralInstances methodology in WBEMServer.get_central_instances()
+  to be bypassed by default, because (1) WBEM servers do not implement it at
+  this point, and (2) there are WBEM servers that do not behave gracefully
+  when unknown CIM methods are invoked. Because WBEM servers are required to
+  implement one of the other methodologies, this change is not incompatible for
+  pywbem users.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
For details, see the commit message.

This PR has been rolled back to 0.14.2 in PR #1726.