### PR TITLE
01 Fixed --pythonwarnings option for pytest in end2end tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Test: Temporary fix for pytest option `--pythonwarnings` in end2end tests
+  (issue #1714).
+
 **Enhancements:**
 
 **Known issues:**

--- a/makefile
+++ b/makefile
@@ -269,14 +269,16 @@ pytest_end2end_opts := -v --tb=short $(pytest_opts)
 
 ifeq ($(python_m_version),3)
   pytest_warnings := --pythonwarnings=default
-  pytest_end2end_warnings_opts := --pythonwarnings=default,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ResourceWarning
+  pytest_end2end_warnings_opts := --pythonwarnings=default
+  # TODO: Add "ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ResourceWarning"
 else
   ifeq ($(python_mn_version),2.6)
     pytest_warnings :=
     pytest_end2end_warnings_opts :=
   else
     pytest_warnings := --pythonwarnings=default
-    pytest_end2end_warnings_opts := --pythonwarnings=default,ignore::DeprecationWarning,ignore::PendingDeprecationWarning
+    pytest_end2end_warnings_opts := --pythonwarnings=default
+    # TODO: Add "ignore::DeprecationWarning,ignore::PendingDeprecationWarning"
   endif
 endif
 


### PR DESCRIPTION
For details, see the commit message.
This is a temporary fix for a part of the issues reported in issue #1714.
Issue #1720 has been opened to find a permanent solution.

This PR has been rolled back to 0.14.2 in PR #1723.