### PR TITLE
0.14: Added and fixed profile definitions for end2end tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,8 @@ Released: not yet
 
 * Test: Fixed AttributeError in end2end assertion functions (Issue #1714)
 
+* Test: Added and fixed profile definitions for end2end tests. (Issue #1714)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/tests/profiles/profiles.yml
+++ b/tests/profiles/profiles.yml
@@ -143,6 +143,15 @@
   scoping_class: CIM_ComputerSystem
   scoping_path: null
   doc: SMI-S Fabric
+-
+  registered_org: SNIA
+  registered_name: Cascading
+  type: component
+  central_class: CIM_ComputerSystem
+  scoping_class: CIM_ComputerSystem
+  scoping_path: CIM_Dependency
+  doc: SMI-S Common Profiles  # In SMI-S 1.4 only
+
 # Note: History on all SNIA indications related profiles:
 #       * The SNIA 'Indication' profile already existed in SMI.S 1.2 as stable.
 #       * SMI-S 1.5 (or 1.4?) introduced a SNIA 'Experimental Indication'
@@ -161,6 +170,7 @@
 # Note: The profile definitions below do not include the SNIA 'Experimental
 #       Indication' profile and the SNIA 'Indications' profile because they
 #       were removed while still being experimental.
+
 -
   # Note: Special case: Discussion with Mike Walker revealed that the central
   #       class is probably CIM_ListenerDestinationCIMXML, but since it is not
@@ -824,7 +834,7 @@
   doc: SMI-S File Systems
 -
   registered_org: SNIA
-  registered_name: Masking And Mapping
+  registered_name: Masking and Mapping
   type: component
   central_class: CIM_ControllerConfigurationService
   scoping_class: CIM_ComputerSystem


### PR DESCRIPTION
For details, see the commit message.
This PR resolves some of the issues reported in issue #1714.

**Discussion point:** Complete the details for the Cascading profile. Using CIM_ComputerSystem for both central and scoping class, which consistent with what I found in a particular storage array. Asked Mike for clarification.

Update: Mike explained the situation with the Cascading profile, i.e. that in the version it appeared the central and scoping classes were not specified in the profile yet. Updated the PR with his suggestions. It is now ready to go. The end2end tests pass with the storage array I tested against.