### PR TITLE
Add changes to gain more performance:

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,11 @@ Released: not yet
   implement one of the other methodologies, this change is not incompatible for
   pywbem users.
 
+* Improved the performance for receiving large CIM-XML responses in the
+  tupleparser by moving type checks for text content in XML into an error
+  handling path, and by replacing some isinstance() calls with type()
+  comparison.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
1. Remove six  usage in tupleparser.py

1. Change from using isinstance() to using type() in tupleparser.
   This change seemed to actually gain  significant performance at least
  for python 3.

3. Change function that created set to create list because
   faster.  This actually seemed to gain some performance.

NOTE: This involves moving from using isinstance() to type() for this performance sensitive code and so we should really be sure that there are no issues.  The reason this was considered at all is that the isinstance had become one of the largest time consumers in the response_performance test as of version 0.14.0

I did not mark this for review since I am still doing testing, ex. against OpenPegasus. but am marking it now..