### PR TITLE
fixes issue #1741 Jupyter Note book example broken

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,12 @@ Released: not yet
 
 * Test: Added and fixed profile definitions for end2end tests. (Issue #1714)
 
+* Fix issue in the Jupyter notebook iterablecimoperations where the
+  IterQueryInstance example did not correctly processthe return from the
+  operation.  It attempted to itereate the returned object and should have
+  been iterating the generator property in that object.  Documentation of
+  that example and the example were corrected. (see issue #1741)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/docs/notebooks/iterablecimoperations.ipynb
+++ b/docs/notebooks/iterablecimoperations.ipynb
@@ -67,9 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pywbem\n",
@@ -129,9 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -174,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -227,9 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -279,9 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -332,9 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -376,15 +364,17 @@
    "source": [
     "The [`IterQueryInstances()`](https://pywbem.readthedocs.io/en/latest/client.html#pywbem.WBEMConnection.IterQueryInstances) method requests the instances returned by a query from the server. It uses either the [`OpenQueryInstances()`](https://pywbem.readthedocs.io/en/latest/client.html#pywbem.WBEMConnection.OpenQueryInstances) if the server supports it or otherwise [`ExecQuery()`](https://pywbem.readthedocs.io/en/latest/client.html#pywbem.WBEMConnection.ExecQuery).\n",
     "\n",
-    "The operation returns an iterator for instances, that is being processed in a for-loop:"
+    "This operation returns an object with two properties: \n",
+    "\n",
+    "1. `query_result_class` (CIMClass): The query result class, if requested via the `ReturnQueryResultClass` parameter which is only used with the [`OpenQueryInstances()`]​ operation and is not available with the [`ExecQuery()`] operation. None, if a query result class was not requested.\n",
+    "\n",
+    "2. `generator` - A generator object that allows the user to iterate the CIM instances representing the query result. These instances do not have an instance path set.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -397,9 +387,9 @@
     "                             default_namespace=namespace,\n",
     "                             no_verification=True)\n",
     "try:\n",
-    "    inst_iterator = conn.IterQueryInstances(query_language, query,\n",
+    "    inst_result = conn.IterQueryInstances(query_language, query,\n",
     "                                            MaxObjectCount=max_obj_cnt)\n",
-    "    for inst in inst_iterator:\n",
+    "    for inst in inst_result.generator:\n",
     "        print(inst.tomof())\n",
     "    else:\n",
     "        print('query has no result')\n",
@@ -421,9 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -463,9 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -506,9 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Global variables from first example are used\n",
@@ -533,21 +517,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes the example of the use of IterQueryInstances in the Jupyter
notebook iterablecimoperations.ipynb where the example tried to iterate
the returned result rather than the generator property of the returned
result.  This also expanded the documentation for this example.