### PR TITLE
Upgraded minimum versions of dependent packages: requests, urllib3, bleach

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ pytest>=3.3.0,!=3.9.2
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.9.5
 lxml>=4.2.4
-requests>=2.19.1
+requests>=2.20.1
 decorator>=4.0.11
 yamlordereddictloader>=0.4.0
 funcsigs>=1.0.2

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -100,6 +100,15 @@ Released: not yet
   https://slproweb.com/products/Win32OpenSSL.html removes the previous version
   from their web site when a new version is released.
 
+* Increased versions of the following packages to address security
+  vulnerabilities:
+
+  * requests from 2.19.1 to 2.20.1
+  * urllib3 from 1.22 to 1.23
+  * bleach from 2.1.0 to 2.1.4
+
+  These packages are only used for development of pywbem.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -57,7 +57,7 @@ pytest==3.3.0
 testfixtures==4.3.3
 httpretty==0.9.5
 lxml==4.2.4
-requests==2.19.1
+requests==2.20.1
 decorator==4.0.11
 yamlordereddictloader==0.4.0
 funcsigs==1.0.2
@@ -113,7 +113,7 @@ alabaster==0.7.9
 appnope==0.1.0
 args==0.1.0
 Babel==2.3.4
-bleach==2.1.0
+bleach==2.1.4
 chardet==3.0.2
 clint==0.5.1
 coverage==4.0.3
@@ -162,7 +162,7 @@ toml==0.10.0
 tornado==4.4.2
 traceback2==1.4.0
 traitlets==4.3.1
-urllib3==1.22
+urllib3==1.23
 virtualenv==14.0.0
 wcwidth==0.1.7
 widgetsnbextension==1.2.6


### PR DESCRIPTION
**Note: This PR is on top of #1760. Review only the last commit with the delta.**
For details, see the commit message.

The issues were reported as follows, by the `safety` package:

```
╞══════════════════════════════════════════════════════════════════════════════╡
│ REPORT                                                                       │
│ checked 106 packages, using default DB                                       │
╞════════════════════════════╤═══════════╤══════════════════════════╤══════════╡
│ package                    │ installed │ affected                 │ ID       │
╞════════════════════════════╧═══════════╧══════════════════════════╧══════════╡
│ requests                   │ 2.19.1    │ <=2.19.1                 │ 36546    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ The Requests package before 2.19.1 sends an HTTP Authorization header to an  │
│ http URI upon receiving a same-hostname https-to-http redirect, which makes  │
│ it easier for remote attackers to discover credentials by sniffing the netwo │
│ rk.                                                                          │
╞══════════════════════════════════════════════════════════════════════════════╡
│ bleach                     │ 2.1.0     │ >=2.1,<2.1.3             │ 35792    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ bleach  2.1.3 fixes a security issue.  Attributes that have URI values weren │
│ 't properly sanitized if the values contained character entities. Using char │
│ acter entities, it was possible to construct a URI value with a scheme that  │
│ was not allowed that would slide through unsanitized.                        │
╞══════════════════════════════════════════════════════════════════════════════╡
│ urllib3                    │ 1.22      │ <1.23                    │ 36541    │
╞══════════════════════════════════════════════════════════════════════════════╡
│ urllib3 before 1.23 does not remove the Authorization HTTP header when follo │
│ wing a cross-origin redirect (i.e., a redirect that differs in host, port, o │
│ r scheme). This can allow for credentials in the Authorization header to be  │
│ exposed to unintended hosts or transmitted in cleartext.                     │
╘══════════════════════════════════════════════════════════════════════════════╛
```