### PR TITLE
0.14: Upgraded minimum versions of dependent packages: requests, urllib3, bleach

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,7 +19,10 @@ httpretty>=0.8.14,<0.9.1; python_version == '2.6'
 httpretty>=0.9.5; python_version > '2.6'
 lxml>=4.2.4,<4.3.0; python_version == '2.6'
 lxml>=4.2.4; python_version > '2.6'
-requests>=2.19.1
+# Note: requests 2.19.1 has a security issue that is fixed in 2.20.0. However,
+#       requests 2.20.0 has dropped support for Python 2.6.
+requests>=2.19.1; python_version == '2.6'
+requests>=2.20.1; python_version > '2.6'
 decorator>=4.0.11
 yamlordereddictloader>=0.4.0
 funcsigs>=1.0.2

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,18 @@ Released: not yet
   https://slproweb.com/products/Win32OpenSSL.html removes the previous version
   from their web site when a new version is released.
 
+* Increased versions of the following packages to address security
+  vulnerabilities:
+
+  * requests from 2.19.1 to 2.20.1 (when on Python 2.7 or higher)
+  * urllib3 from 1.22 to 1.23
+  * bleach from 2.1.0 to 2.1.4
+
+  These packages are only used for development of pywbem.
+
+  Note that requests 2.19.1 has a security issue that is fixed in 2.20.0.
+  However, requests 2.20.0 has dropped support for Python 2.6. 
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -62,7 +62,8 @@ httpretty==0.8.14; python_version == '2.6'
 httpretty==0.9.5; python_version > '2.6'
 lxml==4.2.4; python_version == '2.6'
 lxml==4.2.4; python_version > '2.6'
-requests==2.19.1
+requests==2.19.1; python_version == '2.6'
+requests==2.20.1; python_version > '2.6'
 decorator==4.0.11
 yamlordereddictloader==0.4.0
 funcsigs==1.0.2
@@ -124,7 +125,7 @@ alabaster==0.7.9
 appnope==0.1.0
 args==0.1.0
 Babel==2.3.4
-bleach==2.1.0
+bleach==2.1.4
 chardet==3.0.2
 clint==0.5.1
 coverage==4.0.3
@@ -175,7 +176,7 @@ toml==0.10.0
 tornado==4.4.2
 traceback2==1.4.0
 traitlets==4.3.1
-urllib3==1.22
+urllib3==1.23
 virtualenv==14.0.0
 wcwidth==0.1.7
 widgetsnbextension==1.2.6


### PR DESCRIPTION
This PR rolls back PR #1757 into 0.14, with the exception that the `requests` package is not being upgraded on Python 2.6.