### PR TITLE
Fix issue in run_response_performance.py

### DIFF
--- a/tests/manualtest/run_response_performance.py
+++ b/tests/manualtest/run_response_performance.py
@@ -39,7 +39,7 @@ PROFILE_LOG_SUFFIX = 'out'
 # The parser call is dependent on pywbem version. Changed from direct function
 # call in 0.13 to a method in a class.
 ver_tuple = __version__.split('.')
-if ver_tuple[0] == 0 and ver_tuple[1] <= 12:
+if int(ver_tuple[0]) == 0 and int(ver_tuple[1]) <= 12:
     from pywbem.tupleparse import parse_cim
 
     def test_tuple_parse(tt):


### PR DESCRIPTION
Fix issue in this manual test when used with pywbem tests version 0.12
and earlier.  We were comparing a string and integer.

This is an issue in a manual test only but it is a bug.  I propose that if we do another pywbem 14.x release we include this fix backport