### PR TITLE
Ks/add mock tutorial to table of tutorials

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -112,6 +112,10 @@ Released: not yet
 * Docs: Clarified how the pywbem_os_setup.sh/bat scripts can be downloaded
   using a predictable URL, for automated downloads.
 
+**Bug fixes:**
+
+* Add Jupyter tutorial for pywbem_mock to table of notebooks in documentation.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -32,6 +32,7 @@ Tutorial                              Short description
 :nbview:`iterablecimoperations.ipynb` The Iterable Operation Extensions
 :nbview:`wbemserverclass.ipynb`       Pywbem WBEMServer Class
 :nbview:`subscriptionmanager.ipynb`   Subscription Manager
+:nbview:`pywbemmock.ipynb`            Using the pywbem_mock module
 ===================================== ==========================================
 
 For the following topics, tutorials are not yet available:

--- a/tests/unittest/utils/cmd_line_test_utils.py
+++ b/tests/unittest/utils/cmd_line_test_utils.py
@@ -26,6 +26,7 @@ Without this, wbemcli would drop into the interactive loop after starting.
 from __future__ import absolute_import, print_function
 
 import os
+import sys
 import re
 from subprocess import Popen, PIPE
 import pytest
@@ -366,6 +367,8 @@ def assert_lines(exp_lines, act_lines, meaning):
       meaning (string): A short descriptive text that identifies the meaning
         of the lines that are matched, e.g. 'stderr'.
     """
+    if sys.platform == 'win32':
+        act_lines.replace("\n\n", "\n")
     assert len(act_lines) == len(exp_lines), \
         "Unexpected number of lines in {0}:\n" \
         "Expected lines cnt={1}:\n" \


### PR DESCRIPTION
See commit message for more information.

I propose that we roll this one back since it is a bug but have one more pr to do so we can roll back both at same time.