### PR TITLE
Add ref in doc to pywbem_mock Jupyter notebook

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -112,6 +112,10 @@ Released: not yet
 * Docs: Clarified how the pywbem_os_setup.sh/bat scripts can be downloaded
   using a predictable URL, for automated downloads.
 
+**Bug fixes:**
+
+* Add Jupyter tutorial for pywbem_mock to table of notebooks in documentation.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -15,6 +15,9 @@ and are shown using the online
 This allows viewing the tutorials without having Jupyter Notebook installed
 locally.
 
+Table of Jupyter tutorials
+--------------------------
+
 In order to view a tutorial, just click on a link in this table:
 
 ===================================== ==========================================
@@ -32,6 +35,7 @@ Tutorial                              Short description
 :nbview:`iterablecimoperations.ipynb` The Iterable Operation Extensions
 :nbview:`wbemserverclass.ipynb`       Pywbem WBEMServer Class
 :nbview:`subscriptionmanager.ipynb`   Subscription Manager
+:nbview:`pywbemmock.ipynb`            Using the pywbem_mock module
 ===================================== ==========================================
 
 For the following topics, tutorials are not yet available:
@@ -41,7 +45,6 @@ For the following topics, tutorials are not yet available:
 * Class Operations
 * Qualifier Operations
 * WBEMListener
-* Iter* Operations
 
 Executing code in the tutorials
 -------------------------------


### PR DESCRIPTION
Added a reference in the table of notebooks to the mock notebook.  I thought I had done it for v 0.13.0 but found in a demo that it was missing.

See commit message for details

I also marked this for rollback but I have another but to submit and since this is low priority, I propose we wait for my other bug before any minor revision release.