### PR TITLE
0.14: Add ref in doc to pywbem_mock Jupyter notebook

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Released: not yet
   (14.04) because the default distro version on Travis changed to xenial
   (16.04) which no longer has Python 2.6.
 
+* Add Jupyter tutorial for pywbem_mock to table of notebooks in documentation.
+
 **Enhancements:**
 
 * Docs: Clarified how the pywbem_os_setup.sh/bat scripts can be downloaded

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -15,6 +15,9 @@ and are shown using the online
 This allows viewing the tutorials without having Jupyter Notebook installed
 locally.
 
+Table of Jupyter tutorials
+--------------------------
+
 In order to view a tutorial, just click on a link in this table:
 
 ===================================== ==========================================
@@ -32,6 +35,7 @@ Tutorial                              Short description
 :nbview:`iterablecimoperations.ipynb` The Iterable Operation Extensions
 :nbview:`wbemserverclass.ipynb`       Pywbem WBEMServer Class
 :nbview:`subscriptionmanager.ipynb`   Subscription Manager
+:nbview:`pywbemmock.ipynb`            Using the pywbem_mock module
 ===================================== ==========================================
 
 For the following topics, tutorials are not yet available:
@@ -41,7 +45,6 @@ For the following topics, tutorials are not yet available:
 * Class Operations
 * Qualifier Operations
 * WBEMListener
-* Iter* Operations
 
 Executing code in the tutorials
 -------------------------------


### PR DESCRIPTION
We had created the Jupyter notebook for this tutorial earlier this year
but I neglected to include it in the table of notebooks in the
tutorial.rst file.

Add a section for the table of notebooks

To make the documentation on tutorials clearer, I added a section "table
of Jupyter notebooks" so that can be clearly seen from the table of
contents from the documentation.