### PR TITLE
Fixes #1769: AttributeError when using connection certificates on Python 3

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -79,6 +79,10 @@ Released: not yet
 
 * Add Jupyter tutorial for pywbem_mock to table of notebooks in documentation.
 
+* Fix issue with Python 3 and WBEMconnection certificate handling. pywbem
+  was getting AttributeError: 'SSLContext' object has no attribute 'load_cert'
+  because incorrect method called. (See issue # 1769)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()
@@ -116,7 +120,7 @@ Released: not yet
 
 **Cleanup:**
 
-* Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04) 
+* Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)
   for Python 3.7, because that is now the default distro version, in order to
   pick up a future increase of the default distro version automatically.
 

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -614,7 +614,7 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                 ctx = SSL.SSLContext(SSL.PROTOCOL_SSLv23)
 
                 if self.cert_file:
-                    ctx.load_cert(self.cert_file, keyfile=self.key_file)
+                    ctx.load_cert_chain(self.cert_file, keyfile=self.key_file)
                 if self.ca_certs:
                     # We need to use CERT_REQUIRED to require that the server
                     # certificate is being validated by the client (against the


### PR DESCRIPTION
The method load_cert is incorrect for python 3.  The correct method
should be load_cert_chain(...). The load_cert(...) method is from
M2Crypto

NOTE: We need to write a test for OpenPegasus to test certs.  see issue # 1778

Currently there is no test of certs in the unit, client, or openpegasus
tests.