### PR TITLE
Add tests for LocalOnly & IncludeQualifiers to manual test

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -97,6 +97,10 @@ Released: not yet
   operations are used.
   (See issue #1780)
 
+* Added test to tests/manual/cim_operations.py specifically to test the iter and
+  pull operations for the IncludeQualifier and LocalOnly parameters based on
+  issue #1780.
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()


### PR DESCRIPTION
Extends the tests in the IterEnumInstances class that execute tests to compare traditional, pull, and iter results to add tests for LocalOnly and IncludeQualifier with enum and IncludeQualifier with Associators and References.

NOTE: As of this morning it does catch the LocalOnly issue (only a couple of years to late).

Propose rollback logical since we will make further changes to 1.0.0.