### PR TITLE
Removed pinning of docutils as new variant of 0.15 was released today

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -91,7 +91,3 @@ pyinstrument >=3.0.1
 
 # Indirect dependencies are no longer specified here, but for testing with a
 # minimum version, they are listed in the minimum-constraints.txt file.
-
-# TODO: docutils pinned to 0.14, see https://github.com/pywbem/pywbem/issues/1788. Remove pinning once fixed.
-docutils<=0.14
-

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -97,9 +97,6 @@ Released: not yet
   operations are used.
   (See issue #1780)
 
-* Pinned the docutils package to version 0.14, because its newly released
-  version 0.15 causes a SyntaxError on Python 2.7 (issue #1788).
-
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()


### PR DESCRIPTION
For details, see the commit message.
Ready for review.