### PR TITLE
Fixes #1800: Fixed pyzmq install error on Travis with MacOS 10.13 / Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,8 @@ install:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "${PYTHON:0:1}" == "2" ]]; then
-        export PYTHON_CMD=python;
-        export PIP_CMD=pip;
+        export PYTHON_CMD=python2;
+        export PIP_CMD=pip2;
       else
         export PYTHON_CMD=python3;
         export PIP_CMD=pip3;
@@ -151,14 +151,16 @@ install:
       if [[ "${PYTHON:0:1}" == "2" ]]; then
         OSX_PYTHON_PKG=python@2;
       else
-        OSX_PYTHON_PKG=python;
+        OSX_PYTHON_PKG=python@3;
       fi;
       echo "OSX_PYTHON_PKG=$OSX_PYTHON_PKG";
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      echo "travis.yml Updating package metadata";
       brew update;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      echo "travis.yml Installing/upgrading Python";
       brew ls --versions $OSX_PYTHON_PKG;
       rc=$?;
       if [[ $rc == 0 ]]; then
@@ -177,16 +179,20 @@ install:
       which $PYTHON_CMD && which $PIP_CMD;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      echo "travis.yml Installing Python virtualenv";
       $PIP_CMD install virtualenv;
       virtualenv $HOME/venv -p $PYTHON_CMD && source $HOME/venv/bin/activate;
     fi
   - env |sort
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      echo "travis.yml Setting Python development env.vars";
       openssl_dir=$(brew --prefix openssl);
-      echo "Setting LDFLAGS/CFLAGS/SWIG_FEATURES env.vars to $openssl_dir/...";
-      export LDFLAGS="-L$openssl_dir/lib $LDFLAGS";
-      export CFLAGS="-I$openssl_dir/include $CFLAGS";
+      export LDFLAGS="-L$openssl_dir/lib -I/usr/lib $LDFLAGS";
+      echo "LDFLAGS=$LDFLAGS";
+      export CFLAGS="-I$openssl_dir/include -I/usr/include $CFLAGS";
+      echo "CFLAGS=$CFLAGS";
       export SWIG_FEATURES="-I$openssl_dir/include $SWIG_FEATURES";
+      echo "SWIG_FEATURES=$SWIG_FEATURES";
     fi
   - pip list
   - make platform env

--- a/pywbem_os_setup.sh
+++ b/pywbem_os_setup.sh
@@ -246,12 +246,12 @@ elif [[ "$distro_family" == "osx" ]]; then
   brew update
 
   if [[ "$purpose" == "install" ]]; then
+    # Python devel seems to be part of the python package.
     if [[ "$py_m" == "2" ]]; then
       # For M2Crypto:
       install_osx openssl
       install_osx gcc
       install_osx swig
-      # Python devel seems to be there already. Not clear about package name.
     fi
   fi
 


### PR DESCRIPTION
For details, see the commit message.
Ready for review.

Note that the changes are all on OS-X which is not enabled in the standard set of platforms on Travis. So to review how the change runs on OS-X, the manual-ci-run branch in PR #791 has been rebased on this PR here. Look at its Travis runs for details.