### PR TITLE
0.14: Test: Fixed errors on Python 2.6 about unnamed format replacements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Released: not yet
 * Dev/Test: Pinned pytest to <5.0.0 for Python < 3.5 because that version
   requires Python >= 3.5.
 
+* Test: Fixed errors on Python 2.6 about unnamed format replacements.
+
 **Enhancements:**
 
 **Known issues:**
@@ -83,7 +85,7 @@ Released: 2019-07-20
 
 **Cleanup:**
 
-* Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04) 
+* Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)
   for Python 3.7, because that is now the default distro version, in order to
   pick up a future increase of the default distro version automatically.
 
@@ -123,7 +125,7 @@ Released: 2019-05-30
   These packages are only used for development of pywbem.
 
   Note that requests 2.19.1 has a security issue that is fixed in 2.20.0.
-  However, requests 2.20.0 has dropped support for Python 2.6. 
+  However, requests 2.20.0 has dropped support for Python 2.6.
 
 
 pywbem 0.14.2

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -132,8 +132,8 @@ class ClientTest(unittest.TestCase):
             # pylint: disable=undefined-variable
             warnings.simplefilter("ignore", ResourceWarning)  # noqa: F821
 
-        self.log('setup connection {} ns {}'.format(self.system_url,
-                                                    self.namespace))
+        self.log('setup connection {0} ns {1}'.
+                 format(self.system_url, self.namespace))
 
         self.conn = WBEMConnection(
             self.system_url,
@@ -158,8 +158,8 @@ class ClientTest(unittest.TestCase):
             self.yamlfp = TestClientRecorder.open_file(self.yamlfile, 'a')
             self.conn.add_operation_recorder(TestClientRecorder(self.yamlfp))
 
-        self.log('Connected {}, ns {}'.format(self.system_url,
-                                              CLI_ARGS['namespace']))
+        self.log('Connected {0}, ns {1}'.
+                 format(self.system_url, CLI_ARGS['namespace']))
 
     def tearDown(self):
         """Close the test_client YAML file and display stats."""
@@ -181,7 +181,7 @@ class ClientTest(unittest.TestCase):
            Returns result of request to caller
         """
 
-        self.log('cimcall fn {} args *pargs {} **kwargs {}'.
+        self.log('cimcall fn {0} args *pargs {1} **kwargs {2}'.
                  format(fn, pargs, kwargs))
         try:
             result = fn(*pargs, **kwargs)
@@ -225,7 +225,7 @@ class ClientTest(unittest.TestCase):
         """Display log entry if verbose."""
         # TODO ks aug 17. FUTURE This should be integrated into logging
         if self.verbose:
-            print('{}'.format(data_))
+            print('{0}'.format(data_))
 
     def pywbem_person_class_exists(self):
         """

--- a/tests/manualtest/run_operationtimeouts.py
+++ b/tests/manualtest/run_operationtimeouts.py
@@ -91,7 +91,7 @@ class ClientTest(unittest.TestCase):
 
     def connect(self, url, timeout=None):
 
-        self.log('setup connection {} timeout {}'.format(url, timeout))
+        self.log('setup connection {0} timeout {1}'.format(url, timeout))
         conn = WBEMConnection(
             url,
             (args['username'], args['password']),
@@ -102,13 +102,13 @@ class ClientTest(unittest.TestCase):
 
         # enable saving of xml for display
         conn.debug = args['debug']
-        self.log('Connected {}'.format(url))
+        self.log('Connected {0}'.format(url))
         return conn
 
     def log(self, data_):
         """Display log entry if verbose"""
         if self.debug:
-            print('{}'.format(data_))
+            print('{0}'.format(data_))
 
 
 class ServerTimeoutTest(ClientTest):

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -450,9 +450,10 @@ class TestSchemaError(MOFTest):
                              os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                           'System',
                                           'CIM_ComputerSystem.mof'))
-            if ce.file_line[1] != 2:
-                print('assert {}'.format(ce.file_line))
-            self.assertEqual(ce.file_line[1], 2)
+            self.assertEqual(ce.file_line[1], 2,
+                             msg="Unexpected line number in CIMError: {0!r}: "
+                             "got {1}, expected {2}".
+                             format(ce, ce.file_line[1], 2))
 
         self.mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                                'qualifiers.mof'),
@@ -471,10 +472,10 @@ class TestSchemaError(MOFTest):
                                  'System',
                                  'CIM_ComputerSystem.mof'))
             # TODO The following is cim version dependent.
-            if ce.file_line[1] != 179:
-                print('assertEqual {} line {}'.format(ce,
-                                                      ce.file_line[1]))
-            self.assertEqual(ce.file_line[1], 179)
+            self.assertEqual(ce.file_line[1], 179,
+                             msg="Unexpected line number in CIMError: {0!r}: "
+                             "got {1}, expected {2}".
+                             format(ce, ce.file_line[1], 179))
 
 
 class TestSchemaSearch(MOFTest):


### PR DESCRIPTION
This PR rolls back PR #1812 into 0.14.