### PR TITLE
Test: Fixed errors on Python 2.6 about unnamed format replacements

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -104,6 +104,8 @@ Released: not yet
   pull operations for the IncludeQualifier and LocalOnly parameters based on
   issue #1780.
 
+* Test: Fixed errors on Python 2.6 about unnamed format replacements.
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -132,8 +132,8 @@ class ClientTest(unittest.TestCase):
             # pylint: disable=undefined-variable
             warnings.simplefilter("ignore", ResourceWarning)  # noqa: F821
 
-        self.log('setup connection {} ns {}'.format(self.system_url,
-                                                    self.namespace))
+        self.log('setup connection {0} ns {1}'.
+                 format(self.system_url, self.namespace))
 
         self.conn = WBEMConnection(
             self.system_url,
@@ -158,8 +158,8 @@ class ClientTest(unittest.TestCase):
             self.yamlfp = TestClientRecorder.open_file(self.yamlfile, 'a')
             self.conn.add_operation_recorder(TestClientRecorder(self.yamlfp))
 
-        self.log('Connected {}, ns {}'.format(self.system_url,
-                                              CLI_ARGS['namespace']))
+        self.log('Connected {0}, ns {1}'.
+                 format(self.system_url, CLI_ARGS['namespace']))
 
     def tearDown(self):
         """Close the test_client YAML file and display stats."""
@@ -181,7 +181,7 @@ class ClientTest(unittest.TestCase):
            Returns result of request to caller
         """
 
-        self.log('cimcall fn {} args *pargs {} **kwargs {}'.
+        self.log('cimcall fn {0} args *pargs {1} **kwargs {2}'.
                  format(fn, pargs, kwargs))
         try:
             result = fn(*pargs, **kwargs)
@@ -225,7 +225,7 @@ class ClientTest(unittest.TestCase):
         """Display log entry if verbose."""
         # TODO ks aug 17. FUTURE This should be integrated into logging
         if self.verbose:
-            print('{}'.format(data_))
+            print('{0}'.format(data_))
 
     def pywbem_person_class_exists(self):
         """

--- a/tests/manualtest/run_operationtimeouts.py
+++ b/tests/manualtest/run_operationtimeouts.py
@@ -91,7 +91,7 @@ class ClientTest(unittest.TestCase):
 
     def connect(self, url, timeout=None):
 
-        self.log('setup connection {} timeout {}'.format(url, timeout))
+        self.log('setup connection {0} timeout {1}'.format(url, timeout))
         conn = WBEMConnection(
             url,
             (args['username'], args['password']),
@@ -102,13 +102,13 @@ class ClientTest(unittest.TestCase):
 
         # enable saving of xml for display
         conn.debug = args['debug']
-        self.log('Connected {}'.format(url))
+        self.log('Connected {0}'.format(url))
         return conn
 
     def log(self, data_):
         """Display log entry if verbose"""
         if self.debug:
-            print('{}'.format(data_))
+            print('{0}'.format(data_))
 
 
 class ServerTimeoutTest(ClientTest):

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -450,9 +450,10 @@ class TestSchemaError(MOFTest):
                              os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                           'System',
                                           'CIM_ComputerSystem.mof'))
-            if ce.file_line[1] != 2:
-                print('assert {}'.format(ce.file_line))
-            self.assertEqual(ce.file_line[1], 2)
+            self.assertEqual(ce.file_line[1], 2,
+                             msg="Unexpected line number in CIMError: {0!r}: "
+                             "got {1}, expected {2}".
+                             format(ce, ce.file_line[1], 2))
 
         self.mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                                'qualifiers.mof'),
@@ -471,10 +472,10 @@ class TestSchemaError(MOFTest):
                                  'System',
                                  'CIM_ComputerSystem.mof'))
             # TODO The following is cim version dependent.
-            if ce.file_line[1] != 179:
-                print('assertEqual {} line {}'.format(ce,
-                                                      ce.file_line[1]))
-            self.assertEqual(ce.file_line[1], 179)
+            self.assertEqual(ce.file_line[1], 179,
+                             msg="Unexpected line number in CIMError: {0!r}: "
+                             "got {1}, expected {2}".
+                             format(ce, ce.file_line[1], 179))
 
 
 class TestSchemaSearch(MOFTest):


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.