### PR TITLE
Pinned pytest to 5.0.0 for Python<3.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,9 @@
 # Direct dependencies:
 
 # Unit test (imports into testcases):
-pytest>=3.3.0,!=3.9.2
+# pytest 5.0.0 has removed support for Python < 3.5
+pytest>=3.3.0,!=3.9.2,<5.0.0; python_version < '3.5'
+pytest>=3.3.0,!=3.9.2; python_version >= '3.5'
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.9.5
 # Pinning lxml to <4.4.0 because it started removing Python 3.4 support

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,9 @@ Released: not yet
 * Dev/Test: Pinned lxml to <4.4.0 because that version removed Python 3.4
   support.
 
+* Dev/Test: Pinned pytest to <5.0.0 for Python < 3.5 because that version
+  requires Python >= 3.5.
+
 * Test: Temporary fix for pytest option `--pythonwarnings` in end2end tests
   (issue #1714).
 


### PR DESCRIPTION
For details, see the commit message.
Ready for review and merge.