### PR TITLE
0.14: Pinned pytest to 5.0.0 for Python<3.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,10 @@
 
 # Unit test (imports into testcases):
 unittest2>=1.1.0
+# pytest 5.0.0 has removed support for Python < 3.5
 pytest>=3.0.7,<3.3.0; python_version == '2.6'
-pytest>=3.3.0,!=3.9.2; python_version > '2.6'
+pytest>=3.3.0,!=3.9.2,<5.0.0; python_version > '2.6' and python_version < '3.5'
+pytest>=3.3.0,!=3.9.2; python_version >= '3.5'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
 testfixtures>=4.3.3,<6.0.0
 httpretty>=0.8.14,<0.9.1; python_version == '2.6'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,9 @@ Released: not yet
 * Dev/Test: Pinned lxml to <4.4.0 because that version removed Python 3.4
   support.
 
+* Dev/Test: Pinned pytest to <5.0.0 for Python < 3.5 because that version
+  requires Python >= 3.5.
+
 **Enhancements:**
 
 **Known issues:**


### PR DESCRIPTION
This PR rolls back PR #1813 into 0.14.