### PR TITLE
Ks/#1803 mock enum inst propertylist issue

### DIFF
--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -2532,7 +2532,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                     pl = class_pl
                 else:      # reduce pl to properties in class_properties
                     pl_lower = [pc.lower() for pc in pl]
-                    pl = [pc for pc in class_pl if pc.lower in pl_lower]
+                    pl = [pc for pc in class_pl if pc.lower() in pl_lower]
 
         clns_dict = self._get_subclass_list_for_enums(cname, namespace)
         insts = [self._get_instance(inst.path, namespace,

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -2528,7 +2528,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # by the PropertyList
         if not self._repo_lite:
             if not di:
-                if pl is None:
+                if pl is None:  # properties in class form property list
                     pl = class_pl
                 else:      # reduce pl to properties in class_properties
                     pl_lower = [pc.lower() for pc in pl]

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -3280,11 +3280,11 @@ Examples:
         help='Enable gathering of statistics on operations.')
     general_arggroup.add_argument(
         '--mock-server', dest='mock_server', metavar='file name', nargs='*',
-        help='R|Activate pywbem_mock in place of a live WBEMConnection and\n'
-             'compile/build the files defined (".mof" suffix or "py" suffix.\n'
-             'MOF files are compiled and python files are executed assuming\n'
-             'that they include mock_pywbem methods that add objects to the\n'
-             'repository.')
+        help='R|Activate pywbem_mock in place of a live WBEMConnection\n'
+             'and compile/build the files defined (".mof" suffix or\n'
+             '"py" suffix. MOF files are compiled and python files \n'
+             'are executed assuming that they include mock_pywbem\n'
+             'methods that add objects to the repository.')
     general_arggroup.add_argument(
         '-l', '--log', dest='log', metavar='log_spec[,logspec]',
         action='store', default=None,

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -3280,11 +3280,11 @@ Examples:
         help='Enable gathering of statistics on operations.')
     general_arggroup.add_argument(
         '--mock-server', dest='mock_server', metavar='file name', nargs='*',
-        help='R|Activate pywbem_mock in place of a live WBEMConnection\n'
-             'and compile/build the files defined (".mof" suffix or\n'
-             '"py" suffix. MOF files are compiled and python files \n'
-             'are executed assuming that they include mock_pywbem\n'
-             'methods that add objects to the repository.')
+        help='R|Activate pywbem_mock in place of a live WBEMConnection and\n'
+             'compile/build the files defined (".mof" suffix or "py" suffix.\n'
+             'MOF files are compiled and python files are executed assuming\n'
+             'that they include mock_pywbem methods that add objects to the\n'
+             'repository.')
     general_arggroup.add_argument(
         '-l', '--log', dest='log', metavar='log_spec[,logspec]',
         action='store', default=None,


### PR DESCRIPTION
The mock enumerateinstances returns no properties if there is a property list and deep inheritance is False.  This pr fixes the issue and makes the test more complete

See commit for details