### PR TITLE
0.14: Test: Print pywbem path and version and no longer CHECK_0_12_0

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function
+import os
+from .utils import import_installed
+pywbem = import_installed('pywbem')
+
+print("Testing pywbem version {0} from {1}".
+      format(pywbem.__version__, os.path.dirname(pywbem.__file__)))

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -108,9 +108,6 @@ exp_type_reference = u'reference' if CHECK_0_12_0 else 'reference'
 exp_eo_object = u'object' if CHECK_0_12_0 else 'object'
 exp_eo_instance = u'instance' if CHECK_0_12_0 else 'instance'
 
-print("Debug: CHECK_0_12_0 = %s, __version__ = %s" %
-      (CHECK_0_12_0, __version__))
-
 
 def swapcase2(text):
     """Returns text, where every other character has been changed to swap


### PR DESCRIPTION
No review needed.