### PR TITLE
Fixes #1844: 0.14: Fixed the issue with 'dnf makecache fast' during pywbem_os_setup.sh on Fedora

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -60,6 +60,9 @@ Released: not yet
 
 * Fixed bad formatting on --mock-server option in wbemcli.py.
 
+* Fixed the issue with 'dnf makecache fast' during pywbem_os_setup.sh on Fedora
+  (See issue #1844)
+
 **Enhancements:**
 
 * Improved handling of missing WinOpenSSL on Windows by recommending manual

--- a/pywbem_os_setup.sh
+++ b/pywbem_os_setup.sh
@@ -185,7 +185,11 @@ if [[ "$distro_family" == "redhat" ]]; then
   fi
   echo "$myname: Using installer: $installer"
 
-  sudo $installer makecache fast
+  if [[ "$installer" == "dnf" ]]; then
+    sudo $installer makecache
+  else
+    sudo $installer makecache fast
+  fi
 
   if [[ "$purpose" == "install" ]]; then
     if [[ "$py_m" == "2" ]]; then


### PR DESCRIPTION
No review needed.