### PR TITLE
0.14: Fixed case sensitive class name in ModifyInstance mock support

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed case sensitive class name check in mock support of ModifyInstance
+  (See issue #1859)
+
 **Enhancements:**
 
 **Known issues:**

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -2249,7 +2249,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         "CIMInstance. Rcvd type={0}", type(modified_instance)))
 
         # Classnames in instance and path must match
-        if modified_instance.classname != modified_instance.path.classname:
+        if modified_instance.classname.lower() != \
+                modified_instance.path.classname.lower():
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
                 _format("ModifyInstance classname in path and instance do "


### PR DESCRIPTION
Rolls back PR #1860 to 0.14.6