### PR TITLE
0.14: Fixed minimum version of testfixtures, pytest and PyYAML

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,11 +12,13 @@
 # Unit test (imports into testcases):
 unittest2>=1.1.0
 # pytest 5.0.0 has removed support for Python < 3.5
+# pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest>=3.0.7,<3.3.0; python_version == '2.6'
-pytest>=3.3.0,!=3.9.2,<5.0.0; python_version > '2.6' and python_version < '3.5'
-pytest>=3.3.0,!=3.9.2; python_version >= '3.5'
+pytest>=4.3.1,<5.0.0; python_version > '2.6' and python_version < '3.5'
+pytest>=4.3.1; python_version >= '3.5'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
-testfixtures>=4.3.3,<6.0.0
+testfixtures>=4.3.3,<6.0.0; python_version == '2.6'
+testfixtures>=6.9.0; python_version > '2.6'
 httpretty>=0.8.14,<0.9.1; python_version == '2.6'
 httpretty>=0.9.5; python_version > '2.6'
 lxml>=4.2.4,<4.3.0; python_version == '2.6'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,9 @@ Released: not yet
   it fixed an issue that surfaced with pywbem minimum package levels
   on Python 3.7.
 
+* Increased minimum version of PyYAML from 3.13 to 5.1 due to deprecation issue
+  announced for Python 3.8.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,14 @@ Released: not yet
   and ResourceWarning (py3 only), and fixed incorrect make variable for that.
   (See issue #1720)
 
+* Test: Removed pinning of testfixtures to <6.0.0 for Python 2.7/3.x due
+  to deprecation issue announced for Python 3.8, and increased its minimum
+  version from 4.3.3 to 6.9.0.
+
+* Test: Increased minimum version of pytest from 3.3.0 to 4.3.1 because
+  it fixed an issue that surfaced with pywbem minimum package levels
+  on Python 3.7.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -41,7 +41,7 @@ ordereddict==1.1
 pbr==1.10.0
 ply==3.10
 PyYAML==3.11; python_version == '2.6'
-PyYAML==3.13; python_version >= '2.7'
+PyYAML==5.1; python_version >= '2.7'
 six==1.10.0
 
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -56,8 +56,9 @@ typing==3.6.1  # from M2Crypto
 # Unit test (imports into testcases):
 unittest2==1.1.0
 pytest==3.0.7; python_version == '2.6'
-pytest==3.3.0; python_version > '2.6'
-testfixtures==4.3.3
+pytest==4.3.1; python_version > '2.6'
+testfixtures==4.3.3; python_version == '2.6'
+testfixtures==6.9.0; python_version > '2.6'
 httpretty==0.8.14; python_version == '2.6'
 httpretty==0.9.5; python_version > '2.6'
 lxml==4.2.4; python_version == '2.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ mock>=2.0.0
 ordereddict>=1.1; python_version == '2.6'
 pbr>=1.10.0
 ply>=3.10
-PyYAML==3.11; python_version == '2.6'  # yaml package
-PyYAML>=3.13; python_version >= '2.7'  # yaml package
+PyYAML>=3.11,<3.12; python_version == '2.6'  # yaml package
+PyYAML>=5.1; python_version >= '2.7'  # yaml package
 six>=1.10.0
 
 


### PR DESCRIPTION
Rolls back PR #1870 into 0.14.6, but is slightly more complex because of py2.6. support. Still, no review needed, IMO.