### PR TITLE
Fixes #1883: Property case on create instance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -138,6 +138,11 @@ Released: not yet
 
 * Test: Fixed args of WBEMOperation methods in mock unit tests & function tests.
 
+* Code: Fixed pywbem_mock issue where CreateInstance was not handling the case 
+  sensitivityof property cases if the instance property name case was different than the
+  class property name case. While not legally incorrect the created instance
+  looks bad. See issue #1883
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -83,11 +83,11 @@ General options:
   -V, --version         Display pywbem version and exit.
   --statistics          Enable gathering of statistics on operations.
   --mock-server [file name [file name ...]]
-                        Activate pywbem_mock in place of a live WBEMConnection and
-                        compile/build the files defined (".mof" suffix or "py" suffix.
-                        MOF files are compiled and python files are executed assuming
-                        that they include mock_pywbem methods that add objects to the
-                        repository.
+                        Activate pywbem_mock in place of a live WBEMConnection
+                        and compile/build the files defined (".mof" suffix or
+                        "py" suffix. MOF files are compiled and python files
+                        are executed assuming that they include mock_pywbem
+                        methods that add objects to the repository.
   -l log_spec[,logspec], --log log_spec[,logspec]
                         Log_spec defines characteristics of the various named
                         loggers. It is the form:


### PR DESCRIPTION
Fixes issue where the case of properties on CreateInstance keeps the
case of the property in the instance, not the case of the property in
the class.

This is not disallowed in the specs as far as I can tell but it is
unsightly.

We simply modify any property names where the case is different to be
the case as defined in the class.

This is going to be fun.  I marked for rollback assuming that it is rollback to 0.15.0.