### PR TITLE
Fixes #1887: Mock Modify Instance property case sensitivity

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -138,10 +138,16 @@ Released: not yet
 
 * Test: Fixed args of WBEMOperation methods in mock unit tests & function tests.
 
-* Code: Fixed pywbem_mock issue where CreateInstance was not handling the case 
-  sensitivityof property cases if the instance property name case was different than the
+* Code: Fixed pywbem_mock issue where CreateInstance was not handling the case
+  sensitivity of property cases if the instance property name case was different than the
   class property name case. While not legally incorrect the created instance
   looks bad. See issue #1883
+
+* Code: Fixed pywbem_mock issue where ModifyInstance not handling case
+  sensitivity of property cases if the instance property name case was
+  different than the class property name case. Modify failed if
+  the case of property names did not match. Fixed the case test error and
+  put the class defined proerty name into the modified instance. See issue #1887
 
 **Enhancements:**
 

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -3744,6 +3744,8 @@ class TestInstanceOperations(object):
 
             # change any property that is different
             [0, ['cimfoo_sub', 'newval'], None, True],
+            # change any property that is different with prop case different
+            [0, ['CIMFOO_SUB', 'newval'], None, True],
             # change this property only
             [0, ['cimfoo_sub', 'newval'], ['cimfoo_sub'], True],
             # Duplicate in property list
@@ -3766,11 +3768,10 @@ class TestInstanceOperations(object):
             # change any property that is different, no prop list
             [0, [('cimfoo_sub', 'newval'),
                  ('cimfoo_sub_sub', 'newval2'), ], None, True],
+            # change any property that is different, no prop list, p case diff
+            [0, [('CIMFOO_SUB', 'newvalx'),
+                 ('CIMFOO_SUB_sub', 'newval2x'), ], None, True],
             # Invalid change, Key property
-            # change any property that is different, no prop list
-            [0, ['InstanceID', 'newval'], None, CIMError(CIM_ERR_NOT_FOUND)],
-            # Invalid change, Key property
-            # change any property that is different, no prop list
             [0, ['InstanceID', 'newval'], None, CIMError(CIM_ERR_NOT_FOUND)],
             # Bad namespace. Depends on special code in path
             [2, ['cimfoo_sub', 'newval'], None,
@@ -3838,12 +3839,20 @@ class TestInstanceOperations(object):
             conn.ModifyInstance(modify_instance, PropertyList=pl)
 
             rtn_instance = conn.GetInstance(modify_instance.path)
+            tst_class = conn.GetClass(modify_instance.path.classname,
+                                      LocalOnly=False)
             if exp_resp:
                 for p in rtn_instance:
-                    assert rtn_instance[p] == modify_instance[p]
+                    assert rtn_instance.properties[p] == \
+                        modify_instance.properties[p]
+                    assert rtn_instance.properties[p].name == \
+                        tst_class.properties[p].name
             else:
                 for p in rtn_instance:
-                    assert rtn_instance[p] == orig_instance[p]
+                    assert rtn_instance.properties[p] == \
+                        orig_instance.properties[p]
+                    assert rtn_instance.properties[p].name == \
+                        tst_class.properties[p].name
 
     def test_modifyinstance_lite(self, conn_lite, tst_instances):
         # pylint: disable=no-self-use


### PR DESCRIPTION
Fixes issue with case sensitivity of property names in modify instance.

Note that we refactored code slightly in the method to eliminate an
unnecessary pair of list comprehenshions and make internal var
names clearer.

Adds test for the documented condtion and removes one duplicated
test.