### PR TITLE
Fixes #1913 and #1879: Added support for Python 3.8 (Appveyor still commented out)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,14 +66,24 @@ matrix:
 #      python: "3.6"
 #      env:
 #        - PACKAGE_LEVEL=latest
+#    - os: linux
+#      language: python
+#      python: "3.7"
+#      env:
+#        - PACKAGE_LEVEL=minimum
+#    - os: linux
+#      language: python
+#      python: "3.7"
+#      env:
+#        - PACKAGE_LEVEL=latest
     - os: linux
       language: python
-      python: "3.7"
+      python: "3.8"
       env:
         - PACKAGE_LEVEL=minimum
 #    - os: linux
 #      language: python
-#      python: "3.7"
+#      python: "3.8"
 #      env:
 #        - PACKAGE_LEVEL=latest
 # Note: pywbem does not install on pypy, because M2Crypto does not install.

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,11 @@ matrix:
       python: "3.8"
       env:
         - PACKAGE_LEVEL=minimum
-#    - os: linux
-#      language: python
-#      python: "3.8"
-#      env:
-#        - PACKAGE_LEVEL=latest
+    - os: linux
+      language: python
+      python: "3.8"
+      env:
+        - PACKAGE_LEVEL=latest
 # Note: pywbem does not install on pypy, because M2Crypto does not install.
 #    - os: linux
 #      language: python
@@ -221,6 +221,6 @@ after_success:
 #       make sure this project is enabled there.
 # Make sure the Python version matches the one specified for python-coveralls
 # in dev-requirements.txt.
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.4" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.8" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
       coveralls;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,16 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
+## TODO: Enable Python 3.8 once available on Appveyor
+##    - TOX_ENV: win64_py38_32
+##      UNIX_PATH: none
+##      PYTHON_CMD: python
+
+## TODO: Enable Python 3.8 once available on Appveyor
+##    - TOX_ENV: win64_py38_64
+##      UNIX_PATH: none
+##      PYTHON_CMD: python
+
 # TODO: Disabled because python2.7 with cygwin 32-bit fails with:
 #       "virtualenv is not compatible with this system or executable"
 #    - TOX_ENV: cygwin32_py27
@@ -63,6 +73,18 @@ environment:
       UNIX_PATH: C:\cygwin64\bin
       PYTHON_CMD: python3.6m
       PIP_CMD: pip
+
+## TODO: Enable Python 3.7 once available on Appveyor in Cygwin
+##    - TOX_ENV: cygwin64_py37
+##      UNIX_PATH: C:\cygwin64\bin
+##      PYTHON_CMD: python3.7m
+##      PIP_CMD: pip
+
+## TODO: Enable Python 3.8 once available on Appveyor in Cygwin
+##    - TOX_ENV: cygwin64_py38
+##      UNIX_PATH: C:\cygwin64\bin
+##      PYTHON_CMD: python3.8m
+##      PIP_CMD: pip
 
 configuration:
 # These values will become the values of the PACKAGE_LEVEL env.var.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -98,9 +98,13 @@ tabulate >= 0.8.3
 # Performance profiling tools
 pyinstrument >=3.0.1
 
-# Pinning typed-ast to <1.4.0 because it started removing Python 3.4 support
+# Pinning typed-ast to <1.4.0 for Python 3.4 because it started removing
+# Python 3.4 support.
+# Requiring typed-ast>=1.4.0 for Python 3.8 since it addresses compile errors
+# with missing pgenheaders.h and duplicate definition of a struct.
 typed-ast>=1.3.0,<1.4.0; python_version == '3.4'
-typed-ast>=1.3.0; python_version > '3.4'
+typed-ast>=1.3.0; python_version > '3.4' and python_version < '3.8'
+typed-ast>=1.4.0; python_version >= '3.8'
 
 # Used for xml comparisons in unit test
 FormEncode>=1.3.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -26,24 +26,15 @@ funcsigs>=1.0.2
 
 # Coverage reporting (no imports, invoked via coveralls script).
 # Make sure the Python version matches the one used in .travis.yml.
-# Note: python-coveralls 2.9.1 has requirement coverage==4.0.3, and therefore
-# must be stated before pytest-cov, whose 2.5.1 specifies requirement
-# coverage>=3.7.1 and thus would get coverage 4.5 1 if processed first.
-python-coveralls>=2.8.0; python_version == '3.4'
+coverage>=4.5.3; python_version == '3.8'
+python-coveralls>=2.9.2; python_version == '3.8'
 
 # Safety CI by pyup.io
 safety>=1.8.4
 
 # Unit test (no imports, invoked via py.test script):
 
-# TODO: Remove the pinning of the pytest-cov version again once issue
-#       https://github.com/z4r/python-coveralls/issues/66
-#       is resolved.
-#       Background: pytest-cov 2.6.0 has increased the version
-#       requirement for the coverage package from >=3.7.1 to
-#       >=4.4, which is in conflict with the version requirement
-#       defined by the python-coveralls package for coverage==4.0.3.
-pytest-cov>=2.4.0,<2.6
+pytest-cov>=2.4.0
 
 # Tox
 tox>=2.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -102,5 +102,8 @@ pyinstrument >=3.0.1
 typed-ast>=1.3.0,<1.4.0; python_version == '3.4'
 typed-ast>=1.3.0; python_version > '3.4'
 
+# Used for xml comparisons in unit test
+FormEncode>=1.3.1
+
 # Indirect dependencies are no longer specified here, but for testing with a
 # minimum version, they are listed in the minimum-constraints.txt file.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -233,6 +233,8 @@ Released: not yet
 * Added support for byte string values in keybindings of CIMInstanceName
   method to_wbem_uri(), consistent with other methods.
 
+* Test: Added Python 3.8 to the tested environments. (See issue #1879)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -60,8 +60,8 @@ funcsigs==1.0.2
 FormEncode==1.3.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
-python-coveralls==2.8.0
-coverage==4.0.3
+python-coveralls==2.9.2
+coverage>=4.5.3
 
 # Safety CI by pyup.io
 safety==1.8.4

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -61,7 +61,7 @@ FormEncode==1.3.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
 python-coveralls==2.9.2
-coverage>=4.5.3
+coverage==4.5.3
 
 # Safety CI by pyup.io
 safety==1.8.4

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -104,7 +104,8 @@ tabulate==0.8.3
 pyinstrument==3.0.1
 pyinstrument-cext==0.2.0  # from pyinstrument
 
-typed-ast==1.3.0
+typed-ast==1.3.0; python_version >= '3.4' and python_version < '3.8'
+typed-ast==1.4.0; python_version >= '3.8'
 
 # Indirect dependencies for develop (not in dev-requirements.txt)
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -57,6 +57,7 @@ requests==2.20.1
 decorator==4.0.11
 yamlordereddictloader==0.4.0
 funcsigs==1.0.2
+FormEncode==1.3.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
 python-coveralls==2.8.0

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -802,7 +802,7 @@ class CIMInt(CIMType, _Longint):
                 raise ValueError(
                     _format("Integer value {0} is out of range for CIM "
                             "datatype {1}", value, cls.cimtype))
-        # The value needs to be processed here, because int/long is unmutable
+        # The value needs to be processed here, because int/long is immutable
         return super(CIMInt, cls).__new__(cls, *args, **kwargs)
 
     # Note: __str__() is added later, for Python 3.

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -249,6 +249,8 @@ class MinutesFromUTC(tzinfo):
         """
         self._offset = offset
 
+    __str__ = tzinfo.__repr__
+
     def __repr__(self):
         return _format(
             "MinutesFromUTC("
@@ -295,6 +297,8 @@ class CIMType(object):  # pylint: disable=too-few-public-methods
     #: The name of the CIM datatype, as a :term:`string`. See
     #: :ref:`CIM data types` for details.
     cimtype = None
+
+    __str__ = object.__repr__
 
     def __repr__(self):
         """Return a string representation suitable for debugging."""
@@ -796,6 +800,8 @@ class CIMInt(CIMType, _Longint):
     #: integer data types.
     maxvalue = None
 
+    __str__ = _Longint.__repr__
+
     def __new__(cls, *args, **kwargs):
 
         # Python 3.7 removed support for passing the value for int() as a
@@ -964,6 +970,8 @@ class CIMFloat(CIMType, float):
     subclasses of this class, or to use them as dictionary keys or as members
     in sets.
     """
+
+    __str__ = float.__repr__
 
 
 class Real32(CIMFloat):

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Systems Administration',
     ]

--- a/tests/unittest/pywbem/test_cim_types.py
+++ b/tests/unittest/pywbem/test_cim_types.py
@@ -6,6 +6,7 @@ Test CIM types.
 
 from __future__ import absolute_import, print_function
 
+import re
 from datetime import timedelta, datetime
 import pytest
 import six
@@ -219,6 +220,50 @@ def test_real_init_str(real_tuple):
     obj_type = real_tuple[0]
     obj = obj_type('42.0')
     assert obj == 42.0
+
+
+#
+# repr() and str() tests for CIMInt/CIMFloat
+#
+
+@pytest.fixture(params=[
+
+    # Each list item is a tuple of:
+    # (obj_type, init_arg, exp_str, exp_repr_pattern)
+    (Uint8, 42, u'42', r'^Uint8\(.*, 42\)'),
+    (Uint16, 42, u'42', r'^Uint16\(.*, 42\)'),
+    (Uint32, 42, u'42', r'^Uint32\(.*, 42\)'),
+    (Uint64, 42, u'42', r'^Uint64\(.*, 42\)'),
+    (Sint8, -42, u'-42', r'^Sint8\(.*, -42\)'),
+    (Sint16, -42, u'-42', r'^Sint16\(.*, -42\)'),
+    (Sint32, -42, u'-42', r'^Sint32\(.*, -42\)'),
+    (Sint64, -42, u'-42', r'^Sint64\(.*, -42\)'),
+    (Real32, -42.1, u'-42.1', r'^Real32\(.*, -42.1\)'),
+    (Real64, -42.1, u'-42.1', r'^Real64\(.*, -42.1\)'),
+], scope='module')
+def number_str_repr_tuple(request):
+    """Utility function to return param from request"""
+    return request.param
+
+
+def test_number_str(number_str_repr_tuple):
+    obj_type, init_arg, exp_str, _ = number_str_repr_tuple
+    obj = obj_type(init_arg)
+
+    # The code to be tested
+    act_str = str(obj)
+
+    assert act_str == exp_str
+
+
+def test_number_repr(number_str_repr_tuple):
+    obj_type, init_arg, _, exp_repr_pattern = number_str_repr_tuple
+    obj = obj_type(init_arg)
+
+    # The code to be tested
+    act_repr = repr(obj)
+
+    assert re.match(exp_repr_pattern, act_repr)
 
 
 #

--- a/tests/unittest/utils/validate.py
+++ b/tests/unittest/utils/validate.py
@@ -62,7 +62,6 @@ Note: Changes in DSP0203 2.4.0, compared to 2.3.1:
 
 from __future__ import print_function, absolute_import
 
-import os
 import os.path
 import re
 from subprocess import Popen, PIPE, STDOUT

--- a/tests/unittest/utils/validate.py
+++ b/tests/unittest/utils/validate.py
@@ -67,6 +67,9 @@ import os.path
 import re
 from subprocess import Popen, PIPE, STDOUT
 
+from formencode import doctest_xml_compare
+import xml.etree.ElementTree as ET
+
 from ...utils import import_installed
 pywbem = import_installed('pywbem')  # noqa: E402
 
@@ -135,6 +138,16 @@ def validate_cim_xml(cim_xml_str, root_elem_name=None):
         raise CIMXMLValidationError(output)
 
 
+def _xml_semantic_compare(l, r):
+    """
+    Compare XML to ensure the content is the same.
+    """
+    left_xml = ET.fromstring(l)
+    right_xml = ET.fromstring(r)
+
+    return doctest_xml_compare.xml_compare(left_xml, right_xml)
+
+
 def validate_cim_xml_obj(obj, obj_xml_str, exp_xml_str):
     """
     Validate a CIM-XML string of a CIM object against an expected CIM-XML
@@ -150,7 +163,7 @@ def validate_cim_xml_obj(obj, obj_xml_str, exp_xml_str):
       exp_xml_str (string): The expected CIM-XML string.
     """
 
-    assert obj_xml_str == exp_xml_str
+    assert _xml_semantic_compare(obj_xml_str, exp_xml_str)
 
     m = re.match(r'^<([^ >]+)', exp_xml_str)
     assert m is not None, \

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     py35
     py36
     py37
+    py38
     win64_py27_32
     win64_py27_64
     win64_py35_32
@@ -22,9 +23,13 @@ envlist =
     win64_py36_64
     win64_py37_32
     win64_py37_64
+    win64_py38_32
+    win64_py38_64
     cygwin32_py27
     cygwin64_py27
     cygwin64_py36
+    cygwin64_py37
+    cygwin64_py38
 skip_missing_interpreters = true
 skipsdist = true
 
@@ -85,6 +90,10 @@ basepython = python3.6
 platform = linux2|darwin
 basepython = python3.7
 
+[testenv:py38]
+platform = linux2|darwin
+basepython = python3.8
+
 # Note: The basepython file paths for the win64* tox environments are set for
 #       Appveyor CI.
 
@@ -120,6 +129,14 @@ basepython = C:\Python37\python.exe
 platform = win32
 basepython = C:\Python37-x64\python.exe
 
+[testenv:win64_py38_32]
+platform = win32
+basepython = C:\Python38\python.exe
+
+[testenv:win64_py38_64]
+platform = win32
+basepython = C:\Python38-x64\python.exe
+
 [testenv:cygwin32_py27]
 platform = cygwin
 basepython = python2.7
@@ -131,3 +148,11 @@ basepython = python2.7
 [testenv:cygwin64_py36]
 platform = cygwin
 basepython = python3.6m
+
+[testenv:cygwin64_py37]
+platform = cygwin
+basepython = python3.7m
+
+[testenv:cygwin64_py38]
+platform = cygwin
+basepython = python3.8m


### PR DESCRIPTION
This PR contains the content of PR #1914 as well as other changes to enable Python 3.8.

At this point, the Python 3.8 tests are enabled only for Travis. For Appveyor, the changes are also in ths PR, but commented out, because Appveyor does not yet have Python 3.8 support. However, I suggest to go forward with this PR, since Appveyor can be easily enabled by another change, once Python 3.8 supports gets added there in the future.