### PR TITLE
Fixes issue # 1890 - duplicate instance compile loses instance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -149,6 +149,12 @@ Released: not yet
   the case of property names did not match. Fixed the case test error and
   put the class defined proerty name into the modified instance. See issue #1887
 
+* Fix issue in mof compiler where mof instance that duplicates existing instance
+  path can get lost with no warning. NOTE: This does not happen in the
+  standalone compiler because it creates a duplicate instance issue # 1852
+  but depending on the implementation of ModifyInstance for the compiler,
+  it can simply lose the instance. See issue #1890
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -631,8 +631,8 @@ def p_mp_createInstance(p):
                             "Modifying...", inst.classname))
             try:
                 p.parser.handle.ModifyInstance(inst)
-            except CIMError as ce:
-                if ce.status_code == CIM_ERR_NOT_SUPPORTED:
+            except CIMError as ce2:
+                if ce2.status_code == CIM_ERR_NOT_SUPPORTED:
                     if p.parser.verbose:
                         p.parser.log(
                             _format("ModifyInstance not supported. "
@@ -644,6 +644,9 @@ def p_mp_createInstance(p):
                             _format("Creating instance of {0!A}.",
                                     inst.classname))
                     p.parser.handle.CreateInstance(inst)
+                else:  # modify failed unknown error, output original error
+                    ce.file_line = (p.parser.file, p.lexer.lineno)
+                    raise ce
         else:
             ce.file_line = (p.parser.file, p.lexer.lineno)
             raise


### PR DESCRIPTION
The compiler and some server implementations (i.e implementations of BaseWBEMConnection) together could lose a a new instance being created with "instance of" because the compiler is
missing an exception. If the server returns ALREADY_EXISTS on CreateInstance and the subsequent ModifyInstance that is executed within the compiler returns anything but NOT_SUPPORTED, the compiler just drops the instance.

This adds that exception .

Note that this does not test the change because the problem does not
occur with the default MOFWBEMConnection test class in the mof compiler.
It always appends new instances even if their paths are the same.

To test the change we would have to add a new subclass to MOFWBEMConnection that implemented a way for CreateInstance to return ALREADY_EXISTS.  Note that this means that the standalone mof_compiler and mof_compiler.bat also might lose the instance without returning any issue.  However, I propose that be a separate issue.