### PR TITLE
Fixes #44: Added function testcases for invalid surrogates in HTTP response body

### DIFF
--- a/pywbem/tupletree.py
+++ b/pywbem/tupletree.py
@@ -343,15 +343,23 @@ def check_invalid_utf8_sequences(utf8_string, meaning, conn_id=None):
     (3) The Python escapes ``\\u`` and ``\\U`` used in literal strings can
         represent the surrogate code points (as well as all other code points,
         regardless of whether they are assigned to Unicode characters).
+        That is the case in both Python 2 and Python 3.
 
-    (4) The Python `encode()` and `decode()` functions successfully
-        translate the surrogate code points back and forth for encoding UTF-8.
+    (4) In Python 2, the `unicode.encode()` and `str.decode()` methods
+        successfully translate surrogate code points back and forth for
+        encoding UTF-8, tolerating invalid surrogate sequences.
 
         For example, ``b'\\xed\\xb0\\x80'.decode("utf-8") = u'\\udc00'``.
 
-    (5) Because Python supports the encoding and decoding of UTF-8 sequences
+        In Python 3, the `str.encode()` and `bytes.decode()` methods raise
+        UnicodeEncodeError / UnicodeDecodeError for invalid surrogate
+        sequences. However, the `codecs.encode()` and `codecs.decode()`
+        methods have an error handler 'surrogatepass' which tolerates
+        invalid surrogate sequences.
+
+    (5) Because Python 2 supports the encoding and decoding of UTF-8 sequences
         also for the surrogate code points, the "narrow" Unicode build of
-        Python can be (mis-)used to transport each surrogate unit separately
+        Python 2 can be (mis-)used to transport each surrogate unit separately
         encoded in (ill-formed) UTF-8.
 
         For example, code point U+10122 can be (illegally) created from a

--- a/tests/functiontest/invalidresponseerror.yaml
+++ b/tests/functiontest/invalidresponseerror.yaml
@@ -2871,3 +2871,228 @@
                 </SIMPLERSP>
               </MESSAGE>
             </CIM>"
+-
+    name: InvalidResponse33
+    description: GetInstance response contains illegal unpaired surrogate U+D800
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: XMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>
+            <CIM CIMVERSION=\"2.0\" DTDVERSION=\"2.0\">
+              <MESSAGE ID=\"1001\" PROTOCOLVERSION=\"1.0\">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME=\"GetInstance\">
+                    <IRETURNVALUE>
+                      <INSTANCE CLASSNAME=\"PyWBEM_Person\">
+                        <PROPERTY NAME=\"Name\" TYPE=\"string\">
+                          <VALUE>Fritz</VALUE>
+                        </PROPERTY>
+                        <PROPERTY NAME=\"Address\" TYPE=\"string\">
+                          <VALUE>Fritz \uD800 Town</VALUE>
+                        </PROPERTY>
+                      </INSTANCE>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>"
+-
+    name: InvalidResponse34
+    description: GetInstance response contains illegal unpaired surrogate U+DC00
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: XMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>
+            <CIM CIMVERSION=\"2.0\" DTDVERSION=\"2.0\">
+              <MESSAGE ID=\"1001\" PROTOCOLVERSION=\"1.0\">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME=\"GetInstance\">
+                    <IRETURNVALUE>
+                      <INSTANCE CLASSNAME=\"PyWBEM_Person\">
+                        <PROPERTY NAME=\"Name\" TYPE=\"string\">
+                          <VALUE>Fritz</VALUE>
+                        </PROPERTY>
+                        <PROPERTY NAME=\"Address\" TYPE=\"string\">
+                          <VALUE>Fritz \uDC00 Town</VALUE>
+                        </PROPERTY>
+                      </INSTANCE>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>"
+-
+    name: InvalidResponse35
+    description: GetInstance response contains illegal swapped surrogate sequence U+DC00, U+D800
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: XMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>
+            <CIM CIMVERSION=\"2.0\" DTDVERSION=\"2.0\">
+              <MESSAGE ID=\"1001\" PROTOCOLVERSION=\"1.0\">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME=\"GetInstance\">
+                    <IRETURNVALUE>
+                      <INSTANCE CLASSNAME=\"PyWBEM_Person\">
+                        <PROPERTY NAME=\"Name\" TYPE=\"string\">
+                          <VALUE>Fritz</VALUE>
+                        </PROPERTY>
+                        <PROPERTY NAME=\"Address\" TYPE=\"string\">
+                          <VALUE>Fritz \uDC00\uD800 Town</VALUE>
+                        </PROPERTY>
+                      </INSTANCE>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>"


### PR DESCRIPTION
For details, see commit message. Ready for review.

Note, I don't think that rollback to 0.15.0 is needed.