### PR TITLE
Fixes #1554: Added profile version to end2end profile definitions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -235,6 +235,10 @@ Released: not yet
 
 * Test: Added Python 3.8 to the tested environments. (See issue #1879)
 
+* For the end2end tests, extended the definitions in
+  `tests/profiles/profiles.yml` by the ability to specify the profile version.
+  (See issue #1554)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/tests/end2endtest/test_profile_snia_server.py
+++ b/tests/end2endtest/test_profile_snia_server.py
@@ -46,16 +46,17 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
         central_inst_paths = server_func_asserted(
             self.server, 'get_central_instances',
-            self.profile_inst.path,
+            profile_path=self.profile_inst.path,
             central_class=self.profile_definition['central_class'],
             scoping_class=self.profile_definition['scoping_class'],
             scoping_path=self.profile_definition['scoping_path'],
             reference_direction=self.profile_definition['reference_direction'])
 
         central_insts_msg = _format(
-            "central instances of profile {0} {1!A}",
+            "central instances of profile {0} {1!A} (version: {2})",
             self.profile_definition['registered_org'],
-            self.profile_definition['registered_name'])
+            self.profile_definition['registered_name'],
+            self.profile_definition['registered_version'] or 'any')
 
         # Check that there is just one central instance for this profile
         assert_number_of_instances_equal(
@@ -109,9 +110,10 @@ class Test_SNIA_Server_Profile(ProfileTest):
         far_insts_msg = _format(
             "CIM_Namespace instances associated via "
             "CIM_NamespaceInManager to "
-            "central instance of profile {0} {1!A}",
+            "central instance of profile {0} {1!A} (version {2})",
             self.profile_definition['registered_org'],
-            self.profile_definition['registered_name'])
+            self.profile_definition['registered_name'],
+            self.profile_definition['registered_version'] or 'any')
 
         for inst in far_insts:
 
@@ -164,9 +166,10 @@ class Test_SNIA_Server_Profile(ProfileTest):
         far_insts_msg = _format(
             "CIM_ObjectManagerCommunicationMechanism instances associated via "
             "CIM_CommMechanismForManager to "
-            "central instance of profile {0} {1!A}",
+            "central instance of profile {0} {1!A} (version {2})",
             self.profile_definition['registered_org'],
-            self.profile_definition['registered_name'])
+            self.profile_definition['registered_name'],
+            self.profile_definition['registered_version'] or 'any')
 
         for inst in far_insts:
 
@@ -237,9 +240,10 @@ class Test_SNIA_Server_Profile(ProfileTest):
 
         far_insts_msg = _format(
             "CIM_System instances associated via CIM_HostedService to "
-            "central instance of profile {0} {1!A}",
+            "central instance of profile {0} {1!A} (version {2})",
             self.profile_definition['registered_org'],
-            self.profile_definition['registered_name'])
+            self.profile_definition['registered_name'],
+            self.profile_definition['registered_version'] or 'any')
 
         for inst in far_insts:
 

--- a/tests/end2endtest/test_profile_snia_smis.py
+++ b/tests/end2endtest/test_profile_snia_smis.py
@@ -35,7 +35,8 @@ def test_snia_smis_to_profile_not_swapped(wbem_connection):  # noqa: F811
 
     spec_insts = server_func_asserted(
         server, 'get_selected_profiles',
-        SPEC_ORG, SPEC_NAME)
+        registered_org=SPEC_ORG,
+        registered_name=SPEC_NAME)
     if not spec_insts:
         pytest.skip("Server {0} at {1}: The {2} {3!r} specification is not "
                     "advertised".
@@ -71,7 +72,8 @@ def test_snia_smis_to_profile_not_reffed(wbem_connection):  # noqa: F811
 
     spec_insts = server_func_asserted(
         server, 'get_selected_profiles',
-        SPEC_ORG, SPEC_NAME)
+        registered_org=SPEC_ORG,
+        registered_name=SPEC_NAME)
     if not spec_insts:
         pytest.skip("Server {0} at {1}: The {2} {3!r} specification is not "
                     "advertised".
@@ -108,7 +110,8 @@ def test_snia_smis_profile_tree_not_circular(wbem_connection):  # noqa: F811
 
     spec_insts = server_func_asserted(
         server, 'get_selected_profiles',
-        SPEC_ORG, SPEC_NAME)
+        registered_org=SPEC_ORG,
+        registered_name=SPEC_NAME)
     if not spec_insts:
         pytest.skip("Server {0} at {1}: The {2} {3!r} specification is not "
                     "advertised".

--- a/tests/profiles/profiles.yml
+++ b/tests/profiles/profiles.yml
@@ -12,6 +12,8 @@
 # * registered_org: Registered organization of the profile or specification
 #   (as a string, e.g. 'SNIA').
 # * registered_name: Registered name of the profile or specification.
+# * registered_version: Registered version of the profile or specification
+#   that this item matches. Optional; defaults to match any version.
 # * type: Type of the profile or specification, as follows:
 #   - specification: Item is a specification (e.g. SNIA SMI-S).
 #   - autonomous: Item is an autonomous profile (e.g. SNIA Array).
@@ -31,8 +33,6 @@
 #   must support the central class methodology.
 #   Optional, defaults to null.
 # * doc: Informal reference to the standards document describing the profile.
-#
-# TODO #1554: Add support for representing profile versions.
 
 -
   # Note: Special case: The 'SMI-S' profile is actually a registered


### PR DESCRIPTION
For details, see the commit message. Ready for review.

I don't think this should to be rolled back to 0.15.