### PR TITLE
Fixes #1907: Clarified namespace/host are ignored when Result/AssocClass are CIMInstanceName

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -239,6 +239,10 @@ Released: not yet
   `tests/profiles/profiles.yml` by the ability to specify the profile version.
   (See issue #1554)
 
+* Clarified that namespace and host will be ignored when the `ResultClass` and
+  `AssocClass` parameters of association operations are specified using a
+  `CIMClassName` object. (See issue #1907)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -3208,6 +3208,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -3215,6 +3217,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -3440,6 +3444,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -3447,6 +3453,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -3609,6 +3617,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -3820,6 +3830,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -4863,6 +4875,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -4870,6 +4884,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -5191,6 +5207,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -5198,6 +5216,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -5461,6 +5481,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -5761,6 +5783,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -6748,6 +6772,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -6755,6 +6781,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -7008,6 +7036,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -7015,6 +7045,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an associated class (case independent),
             to filter the result to include only traversals to that associated
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -7248,6 +7280,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -7491,6 +7525,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             Class name of an association class (case independent),
             to filter the result to include only traversals of that association
             class (or subclasses).
+            If specified as a :class:`~pywbem.CIMClassName` object, its
+            `host` and `namespace` attributes will be ignored.
 
             `None` means that no such filtering is peformed.
 
@@ -8441,7 +8477,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class whose subclasses are to be retrieved
             (case independent).
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
             If `None`, the top-level classes in the namespace will be
@@ -8606,7 +8642,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
           ClassName (:term:`string` or :class:`~pywbem.CIMClassName`):
             Name of the class whose subclasses are to be retrieved
             (case independent).
-            If specified as a :class:`~pywbem.CIMClassName` object, its host
+            If specified as a :class:`~pywbem.CIMClassName` object, its `host`
             attribute will be ignored.
 
             If `None`, the top-level classes in the namespace will be


### PR DESCRIPTION
For details, see commit message. Ready for review.