### PR TITLE
0.15: Deprecated the wbemcli command.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,23 @@ Released: not yet
 
 **Deprecations:**
 
+* The wbemcli command has been deprecated. Pywbem 1.0.0 will remove the wbemcli
+  command. The recommended replacement is the pywbemcli command from the
+  pywbemtools package on Pypi: https://pypi.org/project/pywbemtools/.
+  Some of the reasons for the intended removal are: (See issue #1932)
+
+  - Wbemcli does not have a command line mode (i.e. a non-interactive mode), but
+    pywbemcli does.
+  - The interactive mode of wbemcli is more of a programming environment than
+    an interactive CLI, and that makes it harder to use than necessary.
+    Pywbemcli has an interactive mode that uses the same commands as in the
+    command line mode. If you need an interactive programming prompt e.g. for
+    demonstrating the pywbem API, use the interactive mode of the python
+    command, or Python's IDLE.
+  - Pywbemcli provides more functionality than wbemcli, e.g. server commands,
+    persistent connections, class find, instance count, or multiple output
+    formats.
+
 **Bug fixes:**
 
 * Fixed that the embedded_object attribute was not copied in CIMProperty.copy().

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -52,6 +52,11 @@ The ``wbemcli`` command is a WBEM client in the form of a shell that provides
 an interactive Python environment for issuing WBEM operations to a WBEM
 server.
 
+**Deprecated:** The ``wbemcli`` command has been deprecated in pywbem 0.15.0.
+Version 1.0.0 of pywbem will remove the ``wbemcli`` command. The recommended
+replacement is to use the ``pywbemcli`` command from the
+`pywbemtools package on Pypi <https://pypi.org/project/pywbemtools/>`_`.
+
 See :ref:`Python functions in wbemcli` for details on the Python functions
 available in that environment.
 

--- a/docs/wbemcli.help.txt
+++ b/docs/wbemcli.help.txt
@@ -7,6 +7,11 @@ input requests as soon as the interactive shell is started.
 
 Use h() in thenteractive shell for help for wbemcli methods and variables.
 
+Deprecated: The wbemcli command has been deprecated in pywbem 0.15.0.
+Version 1.0.0 of pywbem will remove the wbemcli command.
+The recommended replacement is to use the pywbemcli command from the
+pywbemtools package on Pypi.
+
 Positional arguments:
   server                Host name or url of the WBEM server in this format:
                             [{scheme}://]{host}[:{port}]

--- a/tests/unittest/test_wbemcli.py
+++ b/tests/unittest/test_wbemcli.py
@@ -59,6 +59,11 @@ input requests as soon as the interactive shell is started.
 
 Use h() in thenteractive shell for help for wbemcli methods and variables.
 
+Deprecated: The wbemcli command has been deprecated in pywbem 0.15.0.
+Version 1.0.0 of pywbem will remove the wbemcli command.
+The recommended replacement is to use the pywbemcli command from the
+pywbemtools package on Pypi.
+
 Positional arguments:
   server                Host name or url of the WBEM server in this format:
                             [{scheme}://]{host}[:{port}]

--- a/wbemcli.py
+++ b/wbemcli.py
@@ -3121,7 +3121,7 @@ def _get_connection_info():
     return fill(info, 78, subsequent_indent='    ')
 
 
-def _get_banner():
+def _get_banner(prog):
     """Return a banner message for the interactive console."""
 
     result = ''
@@ -3137,7 +3137,12 @@ def _get_banner():
     else:
         result += '\nPress Ctrl-D or enter quit() or exit() to exit'
     result += '\nEnter h() for help'
-
+    result += '\n\n-----------------------------------------------------------'
+    result += '\nThe %s command has been deprecated in pywbem 0.15.0.' % prog
+    result += '\nVersion 1.0.0 of pywbem will remove the %s command.' % prog
+    result += '\nThe recommended replacement is to use the pywbemcli command'
+    result += '\nfrom the pywbemtools package on Pypi.'
+    result += '\n-----------------------------------------------------------\n'
     return result
 
 
@@ -3187,7 +3192,12 @@ wbemcli executes the WBEMConnection as part of initialization so the user can
 input requests as soon as the interactive shell is started.
 
 Use h() in thenteractive shell for help for wbemcli methods and variables.
-"""
+
+Deprecated: The %s command has been deprecated in pywbem 0.15.0.
+Version 1.0.0 of pywbem will remove the %s command.
+The recommended replacement is to use the pywbemcli command from the
+pywbemtools package on Pypi.
+""" % (prog, prog)
     epilog = """
 Examples:
   %s https://localhost:15345 -n vendor -u sheldon -p penny
@@ -3393,7 +3403,7 @@ Examples:
 
     # Interact
     i = _code.InteractiveConsole(globals())
-    i.interact(_get_banner())
+    i.interact(_get_banner(prog))
 
     # Save command line history
     if _HAVE_READLINE:


### PR DESCRIPTION
This PR addresses the deprecation part of issue #1932 for 0.15.0.
For details, see the commit message.
Ready for review.