### PR TITLE
Fixes #1926: Removed ordering of NocaseDict, CIMInstanceName, CIMInstance, CIMClass

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,11 @@ Released: not yet
   named arguments to these methods. This is only incompatible when the WBEM
   server supports non-standard parameters. (See issue #1415)
 
+* Removed support for ordering NocaseDict, CIMInstanceName, CIMInstance
+  and CIMClass objects. The ordering of such dictionaries is not supported
+  on Python 3, and for Python 2 it had been deprecated since pywbem 0.12.0.
+  (See issue #1926).
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/pywbem/_nocasedict.py
+++ b/pywbem/_nocasedict.py
@@ -45,7 +45,6 @@ from __future__ import print_function, absolute_import
 
 import sys
 import warnings
-import traceback
 try:
     from collections import OrderedDict
 except ImportError:
@@ -54,7 +53,6 @@ except ImportError:
 import six
 
 from ._utils import _stacklevel_above_module, _format
-from .config import DEBUG_WARNING_ORIGIN
 
 __all__ = []
 
@@ -464,50 +462,26 @@ class NocaseDict(object):
         """
         return not self == other
 
-    def __ordering_deprecated(self):
-        """Function to issue deprecation warning for ordered comparisons
+    def __raise_ordering_not_supported(self, other, op):
         """
-        msg = _format("Ordering comparisons involving {0} objects are "
-                      "deprecated.", self.__class__.__name__)
-        if DEBUG_WARNING_ORIGIN:
-            msg += "\nTraceback:\n" + ''.join(traceback.format_stack())
-        warnings.warn(msg, DeprecationWarning,
-                      stacklevel=_stacklevel_above_module(__name__))
+        Function to raise a TypeError indicating that ordering of this class
+        is not supported.
+        """
+        raise TypeError(
+            "'{}' not supported between instances of '{}' and '{}'".
+            format(op, type(self), type(other)))
 
     def __lt__(self, other):
-        self.__ordering_deprecated()
-        # Delegate to the underlying standard dictionary. This will result in
-        # a case sensitive comparison, but that will be better than the faulty
-        # algorithm that was used before. It will raise TypeError "unorderable
-        # types" in Python 3.
-        return self._data < other._data  # pylint: disable=protected-access
+        self.__raise_ordering_not_supported(other, '<')
 
     def __gt__(self, other):
-        """
-        Invoked when two dictionaries are compared with the `>` operator.
-
-        Implemented by delegating to the `<` operator.
-        """
-        self.__ordering_deprecated()
-        return other < self
+        self.__raise_ordering_not_supported(other, '>')
 
     def __ge__(self, other):
-        """
-        Invoked when two dictionaries are compared with the `>=` operator.
-
-        Implemented by delegating to the `>` and `==` operators.
-        """
-        self.__ordering_deprecated()
-        return (self > other) or (self == other)
+        self.__raise_ordering_not_supported(other, '>=')
 
     def __le__(self, other):
-        """
-        Invoked when two dictionaries are compared with the `<=` operator.
-
-        Implemented by delegating to the `<` and `==` operators.
-        """
-        self.__ordering_deprecated()
-        return (self < other) or (self == other)
+        self.__raise_ordering_not_supported(other, '<=')
 
     def __hash__(self):
         """

--- a/pywbem/cim_types.py
+++ b/pywbem/cim_types.py
@@ -75,12 +75,10 @@ from __future__ import absolute_import
 
 from datetime import tzinfo, datetime, timedelta
 import re
-import warnings
 import copy
-import traceback
 import six
 
-from .config import DEBUG_WARNING_ORIGIN, ENFORCE_INTEGER_RANGE
+from .config import ENFORCE_INTEGER_RANGE
 from ._utils import _ensure_unicode, _hash_item, _format, _to_unicode
 
 if six.PY2:
@@ -128,49 +126,26 @@ class _CIMComparisonMixin(object):  # pylint: disable=too-few-public-methods
         """
         return self._cmp(other) != 0
 
-    def __ordering_deprecated(self):
-        """Deprecated warning for pywbem CIM Objects"""
-        msg = _format("Ordering comparisons involving {0} objects are "
-                      "deprecated.", self.__class__.__name__)
-        if DEBUG_WARNING_ORIGIN:
-            msg += "\nTraceback:\n" + ''.join(traceback.format_stack())
-        warnings.warn(msg, DeprecationWarning, stacklevel=3)
+    def __raise_ordering_not_supported(self, other, op):
+        """
+        Function to raise a TypeError indicating that ordering of this class
+        is not supported.
+        """
+        raise TypeError(
+            "'{}' not supported between instances of '{}' and '{}'".
+            format(op, type(self), type(other)))
 
     def __lt__(self, other):
-        """
-        Invoked when two CIM objects are compared with the `<` operator.
-
-        The comparison is delegated to the `_cmp()` method.
-        """
-        self.__ordering_deprecated()
-        return self._cmp(other) < 0
+        self.__raise_ordering_not_supported(other, '<')
 
     def __gt__(self, other):
-        """
-        Invoked when two CIM objects are compared with the `>` operator.
-
-        The comparison is delegated to the `_cmp()` method.
-        """
-        self.__ordering_deprecated()
-        return self._cmp(other) > 0
-
-    def __le__(self, other):
-        """
-        Invoked when two CIM objects are compared with the `<=` operator.
-
-        The comparison is delegated to the `_cmp()` method.
-        """
-        self.__ordering_deprecated()
-        return self._cmp(other) <= 0
+        self.__raise_ordering_not_supported(other, '>')
 
     def __ge__(self, other):
-        """
-        Invoked when two CIM objects are compared with the `>=` operator.
+        self.__raise_ordering_not_supported(other, '>=')
 
-        The comparison is delegated to the `_cmp()` method.
-        """
-        self.__ordering_deprecated()
-        return self._cmp(other) >= 0
+    def __le__(self, other):
+        self.__raise_ordering_not_supported(other, '<=')
 
     def _cmp(self, other):
         """

--- a/tests/unittest/pywbem/test_nocasedict.py
+++ b/tests/unittest/pywbem/test_nocasedict.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 
 import sys
 import re
-import six
 try:
     from collections import OrderedDict
 except ImportError:
@@ -2250,7 +2249,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Empty dicts with >=",
@@ -2260,7 +2259,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Empty dicts with <",
@@ -2270,7 +2269,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Empty dicts with <=",
@@ -2280,7 +2279,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
 
     # Equal dicts
@@ -2292,7 +2291,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Equal dicts with >=",
@@ -2302,7 +2301,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Equal dicts with <",
@@ -2312,7 +2311,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Equal dicts with <=",
@@ -2322,7 +2321,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
 
     # Dicts that compare less (obj1 < obj2)
@@ -2334,7 +2333,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Less-comparing dicts with >=",
@@ -2344,7 +2343,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>=',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Less-comparing dicts with <",
@@ -2354,7 +2353,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Less-comparing dicts with <=",
@@ -2364,7 +2363,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
 
     # Dicts that compare greater (obj1 > obj2)
@@ -2376,7 +2375,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Greater-comparing dicts with >=",
@@ -2386,7 +2385,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='>=',
             exp_result=True,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Greater-comparing dicts with <",
@@ -2396,7 +2395,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
     (
         "Greater-comparing dicts with <=",
@@ -2406,7 +2405,7 @@ TESTCASES_NOCASEDICT_ORDERING = [
             op='<=',
             exp_result=False,
         ),
-        TypeError if six.PY3 else None, DeprecationWarning, True
+        TypeError, None, True
     ),
 
     # Note: More subtle cases of less- or greater-comparing dicts are not


### PR DESCRIPTION
For details, see the commit message.
Ready for review.