### PR TITLE
Fixes #1879: Enabled py38 for native Windows in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,15 +47,13 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
-## TODO: Enable Python 3.8 once available on Appveyor
-##    - TOX_ENV: win64_py38_32
-##      UNIX_PATH: none
-##      PYTHON_CMD: python
+    - TOX_ENV: win64_py38_32
+      UNIX_PATH: none
+      PYTHON_CMD: python
 
-## TODO: Enable Python 3.8 once available on Appveyor
-##    - TOX_ENV: win64_py38_64
-##      UNIX_PATH: none
-##      PYTHON_CMD: python
+    - TOX_ENV: win64_py38_64
+      UNIX_PATH: none
+      PYTHON_CMD: python
 
 # TODO: Disabled because python2.7 with cygwin 32-bit fails with:
 #       "virtualenv is not compatible with this system or executable"

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,11 @@ envlist =
     cygwin64_py36
     cygwin64_py37
     cygwin64_py38
-skip_missing_interpreters = true
+
+# For Appveyor, missing interpreters should fail. For local use, you may
+# want to allow to skip missing interpreters.
+skip_missing_interpreters = false
+
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
This PR enabled Python 3.8 for native Windows to checkout whether it is now supported on Appveyor.

Python 3.7 and 3.8 for CygWin on Appveyor is still commented out.