### PR TITLE
Ks/#add log to mof compiler options

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -291,6 +291,9 @@ Released: not yet
   `AssocClass` parameters of association operations are specified using a
   `CIMClassName` object. (See issue #1907)
 
+* Added capability to log calls to WBEM server from mof_compile script. AAdds
+  an option to the cmd line options to enable logging.
+
 * Improved test coverage of function tests by verifying the last_request,
   last_raw_request, last_reply, and last_raw_reply attributes of a connection.
 

--- a/mof_compiler
+++ b/mof_compiler
@@ -39,6 +39,12 @@ from pywbem.mof_compiler import MOFWBEMConnection, MOFCompiler
 from pywbem.cim_http import get_default_ca_cert_paths
 from pywbem import __version__
 
+from pywbem._logging import LOG_DESTINATIONS, \
+    LOG_DETAIL_LEVELS, LOGGER_SIMPLE_NAMES, DEFAULT_LOG_DETAIL_LEVEL, \
+    DEFAULT_LOG_DESTINATION, configure_loggers_from_string
+
+MOFCOMP_LOG_FILENAME = 'mofcompServer.log'
+
 
 def main():
     """
@@ -190,6 +196,26 @@ Example:
         '--search', dest='outdated_search',
         nargs='?', action='store', const=True, default=False,
         help=argparse.SUPPRESS)
+    general_arggroup.add_argument(
+        '--log', dest='log', metavar='log_spec[,logspec]',
+        action='store', default=None,
+        help='R|Log_spec defines characteristics of the various named\n'
+             'loggers. It is the form:\n COMP=[DEST[:DETAIL]] where:\n'
+             '   COMP:   Logger component name:[{c}].\n'
+             '           (Default={cd})\n'
+             '   DEST:   Destination for component:[{d}].\n'
+             '           (Default={dd})\n'
+             '   DETAIL: Detail Level to log: [{dl}] or\n'
+             '           an integer that defines the maximum length of\n'
+             '           of each log record.\n'
+             '           (Default={dll})\n'
+             # pylint: disable=bad-continuation
+             .format(c='|'.join(LOGGER_SIMPLE_NAMES),
+                     cd='all',
+                     d='|'.join(LOG_DESTINATIONS),
+                     dd=DEFAULT_LOG_DESTINATION,
+                     dl='|'.join(LOG_DETAIL_LEVELS),
+                     dll=DEFAULT_LOG_DETAIL_LEVEL))
 
     args = argparser.parse_args()
 
@@ -243,6 +269,9 @@ Example:
                           no_verification=args.no_verify_cert,
                           x509=x509_dict, ca_certs=args.ca_certs)
 
+    if args.log:
+        configure_loggers_from_string(args.log, MOFCOMP_LOG_FILENAME, conn)
+
     if args.remove or args.dry_run:
 
         conn_mof = MOFWBEMConnection(conn=conn)
@@ -276,6 +305,10 @@ Example:
 
     # If removing, we'll be verbose later when we actually remove stuff.
     # We don't want MOFCompiler to be verbose, as that would be confusing.
+
+    # Remove works by recompiling the mof into MOFWBEMConnection and
+    # using the instances and classes defined in that local repository to
+    # drive the removal
     verbose = args.verbose and not args.remove
 
     mofcomp = MOFCompiler(handle=conn, search_paths=include_dirs,
@@ -291,8 +324,6 @@ Example:
         return 1
 
     if args.remove and not args.dry_run:
-        # Removal works by recording the changes but not doing them, and then
-        # rolling back and doing them.
         try:
             conn.rollback(verbose=args.verbose)
         except Error as exc:

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2256,52 +2256,6 @@ class MOFWBEMConnection(BaseRepositoryConnection):
         # Issue #990: Also roll back changes to qualifier declarations
 
 
-class MOFWBEMConnectionRollback(MOFWBEMConnection):
-    """
-    A CIM repository connection to an in-memory repository on top of an
-    underlying repository, adapts MOFWBEMConnection by modifying
-    CreateInstance to set CIMInstanceName on each created instance from
-    the properties in the instance. This is required for rollback
-    because the rollback uses the instance path to tell the server
-    delete each instance.
-
-    This class implements the
-    :class:`~pywbem.BaseRepositoryConnection` interface.
-
-    Raises:
-
-      : The methods of this class may raise any exceptions described for
-        class :class:`~pywbem.WBEMConnection`.
-    """
-    def CreateInstance(self, *args, **kwargs):
-        """
-        Extend CreateInstance to set instancePath on the instance so that
-        there is a path to be used in rollback.
-
-        For a description of the parameters, see
-        :meth:`pywbem.WBEMConnection.CreateInstance`.
-        """
-
-        inst = args[0] if args else kwargs['NewInstance']
-
-        # If the path or keybindings do not exist, create the path from
-        # the class and instance and set it into NewInstance
-        print('CreateInstanceBefore\n%s\n%s' % (inst.path, inst.tomof()))
-        if not inst.path or not inst.path.keybindings:
-
-            cls = self.GetClass(inst.classname,
-                                LocalOnly=False,
-                                IncludeQualifiers=True)
-            inst.path = CIMInstanceName.from_instance(cls, inst)
-            print('CreateInstanceAfter path %s\nInst\n%r' % (inst.path, inst))
-        try:
-            self.instances[self.default_namespace].append(inst)
-        except KeyError:  # default_namespace does not exist. Create it
-            self.instances[self.default_namespace] = [inst]
-
-        return inst.path
-
-
 def _print_logger(msg):
     """Print the `msg` parameter to stdout."""
     print(msg)


### PR DESCRIPTION
See commit message for description

NOTE: I marked this rollback needed only because I was using it to sort out the issues with the issue #1158 problem and that is marked rollback needed.

The only help this provides to to be able to better sort out what a server is really replying when the script tries to delete and the delete fails.
