### PR TITLE
0.15: Workaround for pywin32 issue on Appveyor python 2.7 32-bit

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,6 +84,10 @@ twine>=1.8.1; python_version >= '2.7'
 # Python 3.4.
 jupyter>=1.0.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 
+# Pywin32 is used (at least?) by jupyter.
+# TODO: Workaround for issue #1946 is to pin pywin32 to version 225.
+pywin32>=222,<=225; sys_platform == 'win32'
+
 # The tornado package is used by ipykernel which is used by jupyter.
 # Tornado 5.0.0 and 5.0.1 rejects installation if the Python ssl module
 # does not have certain symbols required by Tornado. This issue exists for

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,9 @@ Released: not yet
 
 * Docs: Fixed errors in description of CIMInstance.update_existing().
 
+* Added dependency to pywin32 package for Windows, and pinned it to version 225
+  to work around an issue in its version 226. (See issue ##1946)
+
 **Enhancements:**
 
 * Removed the use of the 'pbr' package because it caused too many undesirable

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -109,6 +109,9 @@ twine==1.8.1
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter==1.0.0
 
+# Pywin32 is used (at least?) by jupyter.
+pywin32==222; sys_platform == 'win32'
+
 # Table output formatter used by the manual performance tests to display
 # timing results
 tabulate >= 0.8.3


### PR DESCRIPTION
Rolls back PR #1947 into 0.15.0