### PR TITLE
Fixes #1945: Fixed python2.7 command not found in CygWin in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -130,6 +130,16 @@ install:
   - if "%UNIX_PATH%"=="none" where make
   - if "%UNIX_PATH%"=="none" make --version
 
+  # Install Python 2.7 on CygWin
+  # TODO: Verify whether python2 has again been installed by default
+  - if not "%UNIX_PATH%"=="none" ( bash --noprofile --norc -c "which %PYTHON_CMD%; echo which %PYTHON_CMD% returns rc=\$?" )
+  - 'if "%UNIX_PATH%"=="C:\cygwin\bin" ( C:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -P python2 )'
+  - 'if "%UNIX_PATH%"=="C:\cygwin64\bin" ( C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -P python2 )'
+
+  # Verify that Python command is available, and fail if not
+  - if "%UNIX_PATH%"=="none" ( where %PYTHON_CMD% )
+  - if not "%UNIX_PATH%"=="none" ( bash --noprofile --norc -c "which %PYTHON_CMD%" )
+
   # Install Pip, where needed
   - if "%UNIX_PATH%"=="C:\cygwin\bin" ( bash --noprofile --norc -c "set -e; %PYTHON_CMD% -m ensurepip; %PYTHON_CMD% -m pip install --upgrade pip setuptools wheel" )
   - if "%UNIX_PATH%"=="C:\cygwin64\bin" ( bash --noprofile --norc -c "set -e; %PYTHON_CMD% -m ensurepip; %PYTHON_CMD% -m pip install --upgrade pip setuptools wheel" )

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -231,6 +231,9 @@ Released: not yet
 * Fixed that local tests (i.e. TEST_INSTALLED=False) skipped MOF tests if
   the mofparsetab or moflextab files did not exist. (See issue #1933)
 
+* Circumvented removal of Python 2.7 in Appveyor's CygWin installation
+  by manually installing the python2 CygWin package. (See issue #1949)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()


### PR DESCRIPTION
See commit message.

Note that while this PR contains the fix, it does not test it on CygWin with Python 2.7, because that environment is not tested normally. It is tested though in the manual-ci-run branch. That branch has been rebased on this PR to pick up the fix. See there for test results.