### PR TITLE
Fixes #1951: pywbem_mock display_repository cmt mark.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -224,6 +224,10 @@ Released: not yet
 * Added dependency to pywin32 package for Windows, and pinned it to version 225
   to work around an issue in its version 226. (See issue ##1946)
 
+* pywbem_mock display_repository() comment defintion that surrounds comments
+  in the output was defined as # but mof comments are // so changed. (see
+  issue #1951)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -945,8 +945,10 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
           output_format (:term:`string`):
             Output format, one of: 'mof', 'xml', or 'repr'.
         """
+
+        # The comments are line oriented.
         if output_format == 'mof':
-            cmt_begin = '# '
+            cmt_begin = '// '
             cmt_end = ''
         elif output_format == 'xml':
             cmt_begin = '<!-- '
@@ -994,7 +996,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                   cmt_begin, cmt_end, dest=dest,
                                   summary=summary, output_format=output_format)
 
-        _uprint(dest, u'============End Repository=================')
+        _uprint(dest,
+                _format(u'{0}============End Repository================={1}',
+                        cmt_begin, cmt_end))
 
     @staticmethod
     def _display_objects(obj_type, object_repo, namespace, cmt_begin, cmt_end,

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1289,16 +1289,16 @@ class TestRepoMethods(object):
 
         result = captured.out
         assert result.startswith(
-            "# ========Mock Repo Display fmt=mof namespaces=all")
+            "// ========Mock Repo Display fmt=mof namespaces=all")
         assert "class CIM_Foo_sub_sub : CIM_Foo_sub {" in result
         assert "instance of CIM_Foo {" in result
         for ns in namespaces:
-            assert _format("# Namespace {0!A}: contains 9 Qualifier "
+            assert _format("// Namespace {0!A}: contains 9 Qualifier "
                            "Declarations", ns) \
                 in result
-            assert _format("# Namespace {0!A}: contains 5 Classes", ns) \
+            assert _format("// Namespace {0!A}: contains 5 Classes", ns) \
                 in result
-            assert _format("# Namespace {0!A}: contains 8 Instances", ns) \
+            assert _format("// Namespace {0!A}: contains 8 Instances", ns) \
                 in result
         assert "Qualifier Abstract : boolean = false," in result
 
@@ -1344,7 +1344,7 @@ class TestRepoMethods(object):
         with open(tst_file, 'r') as f:
             data = f.read()
         assert data.startswith(
-            "# ========Mock Repo Display fmt=mof namespaces=all")
+            "// ========Mock Repo Display fmt=mof namespaces=all")
         assert 'class CIM_Foo_sub_sub : CIM_Foo_sub {' in data
         assert 'instance of CIM_Foo {' in data
         assert 'Qualifier Abstract : boolean = false,' in data


### PR DESCRIPTION
Comment mark for MOF was incorrect so the output could not be recompiled
without changes.  was #; changed to //