### PR TITLE
0.15: Fixes #1951: pywbem_mock display_repository cmt mark.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -237,6 +237,10 @@ Released: 2019-07-20
   pull operations are used, and the documentation has been updated accordingly.
   (See issue #1780)
 
+* pywbem_mock display_repository() comment defintion that surrounds comments
+  in the output was defined as # but mof comments are // so changed. (see
+  issue #1951)
+
 **Enhancements:**
 
 * Docs: Clarified how the pywbem_os_setup.sh/bat scripts can be downloaded

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -945,8 +945,10 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
           output_format (:term:`string`):
             Output format, one of: 'mof', 'xml', or 'repr'.
         """
+
+        # The comments are line oriented.
         if output_format == 'mof':
-            cmt_begin = '# '
+            cmt_begin = '// '
             cmt_end = ''
         elif output_format == 'xml':
             cmt_begin = '<!-- '
@@ -994,7 +996,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                   cmt_begin, cmt_end, dest=dest,
                                   summary=summary, output_format=output_format)
 
-        _uprint(dest, u'============End Repository=================')
+        _uprint(dest,
+                _format(u'{0}============End Repository================={1}',
+                        cmt_begin, cmt_end))
 
     @staticmethod
     def _display_objects(obj_type, object_repo, namespace, cmt_begin, cmt_end,

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1293,16 +1293,16 @@ class TestRepoMethods(object):
         if sys.version_info[0:2] != (2, 6):
             result = captured.out
             assert result.startswith(
-                "# ========Mock Repo Display fmt=mof namespaces=all")
+                "// ========Mock Repo Display fmt=mof namespaces=all")
             assert "class CIM_Foo_sub_sub : CIM_Foo_sub {" in result
             assert "instance of CIM_Foo {" in result
             for ns in namespaces:
-                assert _format("# Namespace {0!A}: contains 9 Qualifier "
+                assert _format("// Namespace {0!A}: contains 9 Qualifier "
                                "Declarations", ns) \
                     in result
-                assert _format("# Namespace {0!A}: contains 5 Classes", ns) \
+                assert _format("// Namespace {0!A}: contains 5 Classes", ns) \
                     in result
-                assert _format("# Namespace {0!A}: contains 8 Instances", ns) \
+                assert _format("// Namespace {0!A}: contains 8 Instances", ns) \
                     in result
             assert "Qualifier Abstract : boolean = false," in result
 
@@ -1353,7 +1353,7 @@ class TestRepoMethods(object):
         with open(tst_file, 'r') as f:
             data = f.read()
         assert data.startswith(
-            "# ========Mock Repo Display fmt=mof namespaces=all")
+            "// ========Mock Repo Display fmt=mof namespaces=all")
         assert 'class CIM_Foo_sub_sub : CIM_Foo_sub {' in data
         assert 'instance of CIM_Foo {' in data
         assert 'Qualifier Abstract : boolean = false,' in data


### PR DESCRIPTION
Rolls back PR #1952 into 0.15.0.