### PR TITLE
Fixes #1956: mof_compiler does not send CreateInstance, CreateClass to conn

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -234,6 +234,11 @@ Released: not yet
 * Circumvented removal of Python 2.7 in Appveyor's CygWin installation
   by manually installing the python2 CygWin package. (See issue #1949)
 
+* Fix issue with MOFCompiler class where mof_compilersscript was not writing
+  the new classes and instances to the remote repository defined with the -s
+  parameter. (see issue #1956 )
+
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -234,7 +234,7 @@ Released: not yet
 * Circumvented removal of Python 2.7 in Appveyor's CygWin installation
   by manually installing the python2 CygWin package. (See issue #1949)
 
-* Fix issue with MOFCompiler class where mof_compilersscript was not writing
+* Fixed issue with MOFCompiler class where mof_compiler script was not writing
   the new classes and instances to the remote repository defined with the -s
   parameter. (see issue #1956 )
 

--- a/mof_compiler
+++ b/mof_compiler
@@ -43,7 +43,7 @@ from pywbem._logging import LOG_DESTINATIONS, \
     LOG_DETAIL_LEVELS, LOGGER_SIMPLE_NAMES, DEFAULT_LOG_DETAIL_LEVEL, \
     DEFAULT_LOG_DESTINATION, configure_loggers_from_string
 
-MOFCOMP_LOG_FILENAME = 'mofcompServer.log'
+MOFCOMP_LOG_FILENAME = 'mofcompserver.log'
 
 
 def main():
@@ -252,6 +252,9 @@ Example:
     if args.user and not passwd:
         passwd = getpass('Enter password for %s: ' % args.user)
 
+    if args.dry_run and args.remove:
+        argparser.error('--dry-run not allowed with --remove.')
+
     # if client cert and key provided, create dictionary for
     # wbem connection
     x509_dict = None
@@ -272,10 +275,15 @@ Example:
     if args.log:
         configure_loggers_from_string(args.log, MOFCOMP_LOG_FILENAME, conn)
 
+    # Define the connection to be use as the compile handle
+    # If remove or dry_run set new objects are not written to the
+    # repository defined by conn. However, if conn is defined, CIM
+    # objects needed for the compile are retrieved from the implementation
+    # defined by conn
     if args.remove or args.dry_run:
-
+        # Write classes/instances to local repo but get them from
+        # conn if it is defined.
         conn_mof = MOFWBEMConnection(conn=conn)
-
         # Make it simple for this script to use these attributes:
         conn_mof.default_namespace = conn.default_namespace
         conn_mof.url = conn.url

--- a/tests/unittest/pywbem/test.mof
+++ b/tests/unittest/pywbem/test.mof
@@ -165,6 +165,3 @@ instance of PyWBEM_AllTypes {
    arrayString = {"This is a test string", "Second String"};
    arrayDateTime = {"19991224120000.000000+360", "19991224120000.000000+360"};
 };
-
-
-

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -109,8 +109,7 @@ class Test_MOFCompiler_init(unittest.TestCase):
 
         mofcomp = MOFCompiler(conn)
 
-        self.assertIsInstance(mofcomp.handle, MOFWBEMConnection)
-        self.assertIs(mofcomp.handle.conn, conn)
+        self.assertIsInstance(mofcomp.handle, FakedWBEMConnection)
 
     def test_handle_invalid(self):
         """Test init with a handle that is an invalid type"""


### PR DESCRIPTION
Fixed issue where mof_compiler does not write new instances to the implementation defined by the conn attribute.  It wasgetting from that repo but writing new class and instances to the cache defined by MOFWBEMConnection.

ANDY: This changes a basic perception of MOFCompiler class, the use of MOFWBEMConnection as the handle when the conn constructor parameter exists and is a WBEMConnection class or subclass.

This PR bypasses the the MOFWBEMConnection completely when conn is specified on MOF_Compiler by removing the line in MOFCompiler.__init__ that defines the handle as MOFWBEMConnection. Note that there is an alternative where we use this intermediate and then transfer all of the newly created instances to the conn repository if the compile is successful, i.e. make a single compile atomic. Note that even this creates questions, i.e. should it be part of the MOFCompiler or the mof_compile script if we were to make this atomic.  However, as it was implemented, it simply wrote all CreateClass, CreateInstance, and SetQualifier requests to the MOFWBEMConnection and then threw them away.

The adaption of MOFWBEMConnection to MyMOFWBEMConnection was dropped.

NOTE: mof_compiler script still uses the MOFWBEMConnection as the local interface when --dry-run or --remove options are defined.

**DISCUSSION** Should we implement this as atomic or leave with this change.

Example of use with this PR:

mof_compiler -s http://localhost tests/unittest/pywbem/test.mof  -v --log all=file -I tests/schema/mofFinal2.51.0/
MOF repository: Namespace root/cimv2 in WBEM server http://localhost
Compiling file './tests/unittest/pywbem/test.mof'
Creating class 'root/cimv2':'PyWBEM_Person'
Created class 'root/cimv2':'PyWBEM_Person'
Creating class 'root/cimv2':'PyWBEM_PersonCollection'
Created class 'root/cimv2':'PyWBEM_PersonCollection'
Creating class 'root/cimv2':'PyWBEM_MemberOfPersonCollection'
Created class 'root/cimv2':'PyWBEM_MemberOfPersonCollection'
Creating instance of 'PyWBEM_Person'.
Creating instance of 'PyWBEM_Person'.
Creating instance of 'PyWBEM_Person'.
Creating instance of 'PyWBEM_PersonCollection'.
Creating instance of 'PyWBEM_MemberOfPersonCollection'.
Creating instance of 'PyWBEM_MemberOfPersonCollection'.
Creating instance of 'PyWBEM_MemberOfPersonCollection'.
Creating class 'root/cimv2':'PyWBEM_AllTypes'
Created class 'root/cimv2':'PyWBEM_AllTypes'
Creating instance of 'PyWBEM_AllTypes'.
Creating instance of 'PyWBEM_AllTypes'.

pywbemcli confirms the new objects existL

pywbemcli> class find pywbem*
  root/cimv2:PyWBEM_AllTypes
  root/cimv2:PyWBEM_MemberOfPersonCollection
  root/cimv2:PyWBEM_Person
  root/cimv2:PyWBEM_PersonCollection