### PR TITLE
Fixes #1941: documentation full TOC

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,6 +47,7 @@ Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
 #       been pinned to below 2.0.0 also for those Python versions.
 sphinx-git>=10.1.1
 GitPython>=2.1.1
+sphinxcontrib-fulltoc>=1.2.0
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ extensions = [
     'sphinx.ext.viewcode',   # disabed, raises anexception
     'sphinx.ext.ifconfig',
     'sphinx_git',            # requires 'sphinx-git' Python package
+    'sphinxcontrib.fulltoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ The general pywbem web site is: https://pywbem.github.io/pywbem/index.html.
 .. toctree::
    :maxdepth: 2
    :numbered:
+   :name: mastertoc
 
    intro.rst
    concepts.rst

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -84,6 +84,18 @@ General options:
   -v, --verbose         Print more messages while processing
   -V, --version         Display pywbem version and exit.
   -h, --help            Show this help message and exit
+  --log log_spec[,logspec]
+                        Log_spec defines characteristics of the various named
+                        loggers. It is the form:
+                         COMP=[DEST[:DETAIL]] where:
+                           COMP:   Logger component name:[api|http|all].
+                                   (Default=all)
+                           DEST:   Destination for component:[file|stderr].
+                                   (Default=file)
+                           DETAIL: Detail Level to log: [all|paths|summary] or
+                                   an integer that defines the maximum length of
+                                   of each log record.
+                                   (Default=all)
 
 Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost -n root/cimv2
 -u sheldon -p p42

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -77,6 +77,7 @@ tox==2.0.0
 Sphinx==1.7.6
 sphinx-git==10.1.1
 GitPython==2.1.1
+sphinxcontrib-fulltoc>=1.2.0
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:
 pylint==1.6.4; python_version == '2.7'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -9,3 +9,4 @@ PyYAML>=3.13  # yaml package
 # M2Crypto>=0.31.0  # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.7.6
 sphinx-git>=10.1.1
+sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
This pr incorporates the sphinx fulltoc extension into the pywbem documentation so that the full  top level table of contents always shows on the sidebar menu

It should be noted that apparently this extension does not support the
toctree maxdepth directive however.  In otherwords you see the level 3 section entries in the sidebar menu.

Per the github page, the support for this extension appears to be
minimal (i.e. no new commits in a year or so despite both issues and
prs.) There is one outstanding pr that was a first cut at fixing the
maxdepth issue but no comments exist for this pr.

**DISCUSSION:**

1. Are we worried about the question of supporting the maxdepth of the shinx toctree?  If so we will have to do something like fork that repo and patch it.

See https://github.com/sphinx-contrib/fulltoc for more information and pr at https://github.com/sphinx-contrib/fulltoc/pull/18
