### PR TITLE
0.15: Fixes #1958: Mocker adds path to new instance on CreateInstance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -55,6 +55,17 @@ Released: not yet
 * Added dependency to pywin32 package for Windows, and pinned it to version 225
   to work around an issue in its version 226. (See issue ##1946)
 
+* Modified pywbem_mock to create the instance path of new instances
+  created by the compiler.  Previously, the mocker generated an exception
+  if the path for a compiler created new instance was not set by the
+  compiler using the instance alias. That requirement has been removed so
+  the mock repository will attempt to create the path (which is required
+  for the mock repository) from properties provided in the new instance.
+  If any key properties of the class are not in the instance it will generate
+  an exception.  This is backward compatible since the mocker will accept
+  paths created by the compiler.  The incompatibility is that the mocker
+  tests for the existance of all key properties. (see issue # 1958)
+
 **Enhancements:**
 
 * Removed the use of the 'pbr' package because it caused too many undesirable


### PR DESCRIPTION
This PR rolls back PR #1962 into 0.15.0.