### PR TITLE
0.15: Fixes #1956: mof_compiler does not send CreateInstance, CreateClass to conn (#1957)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -69,6 +69,10 @@ Released: not yet
 * Circumvented removal of Python 2.7 in Appveyor's CygWin installation
   by manually installing the python2 CygWin package. (See issue #1949)
 
+* Fixed issue with MOFCompiler class where mof_compiler script was not writing
+  the new classes and instances to the remote repository defined with the -s
+  parameter. (see issue #1956 )
+
 **Enhancements:**
 
 * Removed the use of the 'pbr' package because it caused too many undesirable

--- a/mof_compiler
+++ b/mof_compiler
@@ -43,7 +43,7 @@ from pywbem._logging import LOG_DESTINATIONS, \
     LOG_DETAIL_LEVELS, LOGGER_SIMPLE_NAMES, DEFAULT_LOG_DETAIL_LEVEL, \
     DEFAULT_LOG_DESTINATION, configure_loggers_from_string
 
-MOFCOMP_LOG_FILENAME = 'mofcompServer.log'
+MOFCOMP_LOG_FILENAME = 'mofcompserver.log'
 
 
 def main():
@@ -252,6 +252,9 @@ Example:
     if args.user and not passwd:
         passwd = getpass('Enter password for %s: ' % args.user)
 
+    if args.dry_run and args.remove:
+        argparser.error('--dry-run not allowed with --remove.')
+
     # if client cert and key provided, create dictionary for
     # wbem connection
     x509_dict = None
@@ -272,10 +275,15 @@ Example:
     if args.log:
         configure_loggers_from_string(args.log, MOFCOMP_LOG_FILENAME, conn)
 
+    # Define the connection to be use as the compile handle
+    # If remove or dry_run set new objects are not written to the
+    # repository defined by conn. However, if conn is defined, CIM
+    # objects needed for the compile are retrieved from the implementation
+    # defined by conn
     if args.remove or args.dry_run:
-
+        # Write classes/instances to local repo but get them from
+        # conn if it is defined.
         conn_mof = MOFWBEMConnection(conn=conn)
-
         # Make it simple for this script to use these attributes:
         conn_mof.default_namespace = conn.default_namespace
         conn_mof.url = conn.url

--- a/tests/unittest/pywbem/test.mof
+++ b/tests/unittest/pywbem/test.mof
@@ -165,6 +165,3 @@ instance of PyWBEM_AllTypes {
    arrayString = {"This is a test string", "Second String"};
    arrayDateTime = {"19991224120000.000000+360", "19991224120000.000000+360"};
 };
-
-
-

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -109,8 +109,7 @@ class Test_MOFCompiler_init(unittest.TestCase):
 
         mofcomp = MOFCompiler(conn)
 
-        self.assertIsInstance(mofcomp.handle, MOFWBEMConnection)
-        self.assertIs(mofcomp.handle.conn, conn)
+        self.assertIsInstance(mofcomp.handle, FakedWBEMConnection)
 
     def test_handle_invalid(self):
         """Test init with a handle that is an invalid type"""


### PR DESCRIPTION
Rolls back PR #1957 into 0.15.0.