### PR TITLE
0.15: Fixes #1158: mofcomp rollback of test.mof with mof_compiler fails

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -73,6 +73,12 @@ Released: not yet
   the new classes and instances to the remote repository defined with the -s
   parameter. (see issue #1956 )
 
+* Fixed issue with mof_compiler and mof rollback where instances were
+  not removed when rollback was executed.  This was caused by MOFWBEMConnection
+  code that did not put correct paths on the instances when they were
+  inserted into the local repository so the rollback delete of the instances
+  could not identify the instances. (see issue #1158)
+
 **Enhancements:**
 
 * Removed the use of the 'pbr' package because it caused too many undesirable

--- a/tests/manualtest/run_mof_compiler_script.sh
+++ b/tests/manualtest/run_mof_compiler_script.sh
@@ -1,0 +1,30 @@
+# Test mof_compiler creation and removal of a collection of MOF in
+# a single file
+# This is a very limited simplistic test.  It simply runs the script
+# mof_compiler twice, once to build the test mof into defined server and
+# a second time to remove it.  The only validation is that the scripts
+# run without error.
+# Further, it assumes that the WBEMServer is running, uses http, and is
+# at localhost.. It does this twice to confirm that everything was removed
+# on the first remove.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+echo DIR = $DIR
+PYWBEM_ROOT_DIR=$DIR/../../
+
+MOF_FILE=$PYWBEM_ROOT_DIR/tests/unittest/pywbem/test.mof
+SCHEMA=$PYWBEM_ROOT_DIR/tests/schema/mofFinal2.51.0/
+SERVER_URL=http://localhost
+# To get verbose output, set VERBOSE=-v
+VERBOSE=""
+NAMESPACE=root/SampleProvider
+
+mof_compiler -s $SERVER_URL $VERBOSE -I $SCHEMA $MOF_FILE
+mof_compiler -s $SERVER_URL $VERBOSE -r -I $SCHEMA $MOF_FILE
+mof_compiler -s $SERVER_URL $VERBOSE -I $SCHEMA $MOF_FILE
+mof_compiler -s $SERVER_URL $VERBOSE -r -I $SCHEMA $MOF_FILE
+
+mof_compiler -s $SERVER_URL $VERBOSE -I $SCHEMA $MOF_FILE -n $NAMESPACE
+mof_compiler -s $SERVER_URL $VERBOSE -r -I $SCHEMA $MOF_FILE -n $NAMESPACE
+mof_compiler -s $SERVER_URL $VERBOSE -I $SCHEMA $MOF_FILE -n $NAMESPACE
+mof_compiler -s $SERVER_URL $VERBOSE -r -I $SCHEMA $MOF_FILE -n $NAMESPACE


### PR DESCRIPTION
Rolls back PR #1944 into 0.15.0.