### PR TITLE
Fixes #1235,#1997: Redesigned error handling in MOF compiler

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -89,6 +89,34 @@ Released: not yet
   in their code. Such users need to adjust the type of exception that is
   handled, accordingly. (See issue #1429)
 
+* Changed the logging behavior of the MOF compilation methods
+  `FakedWBEMConnection.compile_mof_string()`, `compile_mof_file()` and
+  `compile_dmtf_schema()` to do no logging at all. In support of that, `None`
+  is now a permitted value for the `log_func` init argument of `MOFCompiler`.
+
+  This change will cause any MOF compile errors to no longer be printed to
+  stdout by default. If you are using these MOF compilation methods and
+  want to continue having the MOF compile errors printed to stdout, you
+  need to print the exception in your code. See also the next item for which
+  exception class to catch. (See issue #1997)
+
+* Changed the exception behavior of the MOF compilation methods of the
+  `MOFCompiler` and `FakedWBEMConnection` classes to no longer raise
+  `CIMError`, but to raise the following exceptions which are all derived
+  from a new base class `MOFCompileError`:
+
+  - `MOFParseError` MOF parsing errors. This class already existed and was
+    already used for this purpose.
+  - `MOFDependencyError`: New class for MOF dependency errors (e.g. superclass
+    not found).
+  - `MOFRepositoryError`: New class for errors returned from target CIM
+    repository. The `CIMError` exception raised by the CIM repository is
+    attached to that exception in its attribute `cim_error`.
+
+  If you are using these MOF compilation methods, please change your catching
+  of exceptions to catch the new base class `MOFCompileError`.
+  (See issue #1235)
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -69,9 +69,24 @@ Repository connections
 Exceptions
 ----------
 
-The MOF compiler API may raise the exceptions that can be raised by the
-:ref:`WBEM client library API`, and in addition the
-:exc:`~pywbem.MOFParseError` exception.
+The MOF compiler API raises exceptions that are derived from the common base
+class :exc:`~pywbem.MOFCompileError`.
+
+.. autoclass:: pywbem.MOFCompileError
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.MOFCompileError
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.MOFCompileError
+      :attributes:
+
+   .. rubric:: Details
 
 .. autoclass:: pywbem.MOFParseError
    :members:
@@ -85,6 +100,38 @@ The MOF compiler API may raise the exceptions that can be raised by the
    .. rubric:: Attributes
 
    .. autoautosummary:: pywbem.MOFParseError
+      :attributes:
+
+   .. rubric:: Details
+
+.. autoclass:: pywbem.MOFDependencyError
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.MOFDependencyError
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.MOFDependencyError
+      :attributes:
+
+   .. rubric:: Details
+
+.. autoclass:: pywbem.MOFRepositoryError
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.MOFRepositoryError
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.MOFRepositoryError
       :attributes:
 
    .. rubric:: Details

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -569,11 +569,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Raises:
 
           IOError: MOF file not found.
-          :exc:`~pywbem.MOFParseError`: Compile error in the MOF.
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-          :exc:`~pywbem.CIMError`: Failure related to the CIM objects in the
-            mock repository.
+          :exc:`~pywbem.MOFCompileError`: Compile error in the MOF.
         """
 
         namespace = namespace or self.default_namespace
@@ -582,7 +578,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # TODO fix this also so there is cleaner interface to WBEMConnection
         mofcomp = MOFCompiler(_MockMOFWBEMConnection(self),
                               search_paths=search_paths,
-                              verbose=verbose)
+                              verbose=verbose, log_func=None)
 
         mofcomp.compile_file(mof_file, namespace)
 
@@ -634,12 +630,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Raises:
 
           IOError: MOF file not found.
-          :exc:`~pywbem.MOFParseError`: Compile error in the MOF.
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-          :exc:`~pywbem.CIMError`: CIM_ERR_ALREADY_EXISTS Entity already exists.
-          :exc:`~pywbem.CIMError`: Failure related to the CIM objects in the
-            mock repository.
+          :exc:`~pywbem.MOFCompileError`: Compile error in the MOF.
         """
         namespace = namespace or self.default_namespace
 
@@ -649,7 +640,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         mofcomp = MOFCompiler(_MockMOFWBEMConnection(self),
                               search_paths=search_paths,
-                              verbose=verbose)
+                              verbose=verbose, log_func=None)
 
         mofcomp.compile_string(mof_str, namespace)
 
@@ -735,11 +726,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             be found in the defined DMTF CIM schema.
           TypeError: The 'schema_version' is not a valid tuple with 3
             integer components
-          :exc:`~pywbem.MOFParseError`: Compile error in the MOF.
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-          :exc:`~pywbem.CIMError`: Failure related to the CIM objects in the
-            mock repository.
+          :exc:`~pywbem.MOFCompileError`: Compile error in the MOF.
         """
 
         schema = DMTFCIMSchema(schema_version, schema_root_dir,


### PR DESCRIPTION
See commit message.

When reviewing, have a closer look at:
* Exception class structure (MOFCompileError and its derived classes)
* Disabling of error logging in compile methods of FakedWBEMConnection (see also issue #1997).

No rollback into 0.16 planned.