### PR TITLE
0.16: Fixes #2003: Removed usage of unittest2 except when on py26

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@
 # Direct dependencies:
 
 # Unit test (imports into testcases):
-unittest2>=1.1.0
+unittest2>=1.1.0; python_version == '2.6'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest>=3.0.7,<3.3.0; python_version == '2.6'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Test: Removed the dependency on unittest2 for Python 2.7 and higher.
+  (See issue #2003)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -73,7 +73,7 @@ typing==3.6.1  # from M2Crypto
 # Direct dependencies for develop (must be consistent with dev-requirements.txt)
 
 # Unit test (imports into testcases):
-unittest2==1.1.0
+unittest2==1.1.0; python_version == '2.6'
 pytest==3.0.7; python_version == '2.6'
 pytest==4.3.1; python_version > '2.6'
 testfixtures==4.3.3; python_version == '2.6'

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -7,8 +7,8 @@
 
 from __future__ import print_function, absolute_import
 
+import sys
 import os
-import unittest2 as unittest  # we use assertRaises(exc) introduced in py27
 import six
 from ply import lex
 try:
@@ -36,6 +36,11 @@ from pywbem._utils import _format
 from pywbem._nocasedict import NocaseDict
 pywbem_mock = import_installed('pywbem_mock')  # noqa: E402
 from pywbem_mock import FakedWBEMConnection
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest  # we use assertRaises(exc) introduced in py27
+else:
+    import unittest
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
 # Location of the schema for use by test_mof_compiler.

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -10,13 +10,12 @@ from __future__ import absolute_import, print_function
 # Allows use of lots of single character variable names.
 # pylint: disable=invalid-name,missing-docstring,too-many-statements
 # pylint: disable=too-many-lines,no-self-use
+import sys
 import os
 import os.path
 import logging
 import logging.handlers
 from io import open as _open
-
-import unittest2 as unittest  # we use @skip introduced in py27
 import six
 from testfixtures import LogCapture, log_capture
 # Enabled only to display a tree of loggers
@@ -43,6 +42,11 @@ from pywbem.cim_operations import pull_path_result_tuple, pull_inst_result_tuple
 from pywbem._utils import _format
 pywbem_mock = import_installed('pywbem_mock')  # noqa: E402
 from pywbem_mock import FakedWBEMConnection
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest  # we use @skip introduced in py27
+else:
+    import unittest
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
 


### PR DESCRIPTION
See commit message.

No need to roll this forward to master, because usage of unittest2 had alredy been removed earlier from master.