### PR TITLE
0.16: Silenced MOFCompiler for verbose=False; Fixed moftab version check

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,14 @@ Released: not yet
 
 **Bug fixes:**
 
+* Silenced the MOFCompiler class for verbose=False. So far, it still printed
+  messages for generating the YACC parser table, causing one test to fail,
+  and others to issue useless prints. (Issue #2004)
+
+* Test: Fixed an error in testing the PLY table version in testcases that caused
+  the LEX/YACC parser table files to be written to the pywbem installation
+  when using TEST_INSTALLED. (Related to issue #2004)
+
 **Enhancements:**
 
 **Known issues:**

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2639,9 +2639,10 @@ def _yacc(verbose=False, out_dir=None):
                      tabmodule=_tabmodule,
                      outputdir=out_dir,
                      write_tables=write_tables,
-                     debug=True,
+                     debug=verbose,
                      debuglog=yacc.NullLogger(),
-                     errorlog=yacc.PlyLogger(sys.stdout))
+                     errorlog=yacc.PlyLogger(sys.stdout) if verbose
+                     else yacc.NullLogger())
 
 
 def _lex(verbose=False, out_dir=None):
@@ -2675,4 +2676,5 @@ def _lex(verbose=False, out_dir=None):
                    outputdir=out_dir,
                    debug=False,
                    # debuglog = lex.PlyLogger(sys.stdout),
-                   errorlog=lex.PlyLogger(sys.stdout))
+                   errorlog=yacc.PlyLogger(sys.stdout) if verbose
+                   else yacc.NullLogger())

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -79,7 +79,7 @@ class MOFTest(unittest.TestCase):
         self.mofcomp = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
-            verbose=True,
+            verbose=False,
             log_func=moflog)
 
         self.partial_schema_file = None
@@ -623,7 +623,7 @@ class TestSchemaSearch(MOFTest):
         mofcomp = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=TEST_DMTF_CIMSCHEMA_MOF_DIR,
-            verbose=True,
+            verbose=False,
             log_func=moflog)
         mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                           'System',
@@ -648,7 +648,7 @@ class TestSchemaSearch(MOFTest):
         open(moflog_file, 'w')
         mofcomp = MOFCompiler(
             MOFWBEMConnection(),
-            verbose=True,
+            verbose=False,
             log_func=moflog)
         try:
             mofcomp.compile_file(os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
@@ -2594,7 +2594,7 @@ class Test_CreateInstanceWithDups(unittest.TestCase):
         self.mofcomp = MOFCompiler(
             MOFWBEMConnectionInstDups(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
-            verbose=True,
+            verbose=False,
             log_func=moflog)
 
         self.partial_schema_file = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import sys
 import os
 import pytest
-import ply
+from ply import yacc, lex
 from packaging.version import parse as parse_version
 
 
@@ -64,25 +64,24 @@ def skip_if_moftab_regenerated():
     mofparsetab_version = mofparsetab._tabversion
     moflextab_version = moflextab._tabversion
     # pylint: enable=protected-access
-    ply_version = ply.__version__
 
     mofparsetab_mismatch = parse_version(mofparsetab_version) != \
-        parse_version(ply_version)
+        parse_version(yacc.__tabversion__)
     moflextab_mismatch = parse_version(moflextab_version) != \
-        parse_version(ply_version)
+        parse_version(lex.__tabversion__)
 
     if test_installed and pywbem_not_tolerant and \
             (mofparsetab_mismatch or moflextab_mismatch):
         pytest.skip("Cannot run this MOF testcase against an installed "
                     "pywbem (version {0}, installed at {1}) because that "
-                    "pywbem version does not tolerate version mismatches "
-                    "between the current ply version and the ply version that "
-                    "was used to create the pywbem mof*tab files: "
-                    "current ply: {2}, ply in mofparsetab.py: {3}, "
-                    "ply in moflextab.py: {4}".
+                    "pywbem version does not tolerate table version mismatches "
+                    "between the current ply package and the generated pywbem "
+                    "mof*tab files: yacc table version: current ply: {2}, "
+                    "mofparsetab.py: {3}, lex table version: current ply: {4}, "
+                    "moflextab.py: {5}".
                     format(pywbem.__version__, pywbem.__file__,
-                           ply_version,
-                           mofparsetab_version, moflextab_version))
+                           yacc.__tabversion__, mofparsetab_version,
+                           lex.__tabversion__, moflextab_version))
 
 
 def import_installed(module_name):


### PR DESCRIPTION
Rolls back PR #2006 into 0.16.0.