### PR TITLE
0.16: Fixed that the MOFCompiler can be created with handle=None

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,10 @@ Released: not yet
   the LEX/YACC parser table files to be written to the pywbem installation
   when using TEST_INSTALLED. (Related to issue #2004)
 
+* Fixed that the MOFCompiler could be created with handle=None to work against
+  a local repository. It was documented that way, but failed with
+  AttributeError. (See issue #1998)
+
 **Enhancements:**
 
 * Test: Removed the dependency on unittest2 for Python 2.7 and higher.

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -2386,6 +2386,9 @@ class MOFCompiler(object):
         if isinstance(handle, WBEMConnection):
             conn = handle  # handle will be the WBEMConnection object
         elif handle is None:
+            # The compiler needs a place to store compiled elements, so it
+            # gets a local-only MOFWBEMConnection in this case.
+            handle = MOFWBEMConnection(conn=None)
             conn = None
         elif isinstance(handle, BaseRepositoryConnection):
             conn = getattr(handle, 'conn', None)


### PR DESCRIPTION
Rolls back PR #2009 into 0.16.0.