### PR TITLE
0.16: Fixed that MOF compiler did raise error when ModifyClass failed

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,11 @@ Released: not yet
   a local repository. It was documented that way, but failed with
   AttributeError. (See issue #1998)
 
+* Fixed the error that the MOF compilation of a class could fail but the
+  error was not surfaced. This only happened when the MOF compiler was invoked
+  against a WBEM server, when the class already existed, and when the
+  ModifyClass operation that was attempted in this case, failed.
+
 **Enhancements:**
 
 * Test: Removed the dependency on unittest2 for Python 2.7 and higher.

--- a/pywbem/mof_compiler.py
+++ b/pywbem/mof_compiler.py
@@ -613,6 +613,8 @@ def p_mp_createClass(p):
             p.parser.log(
                 _format("Error modifying class {0!A}: {1}, {2}",
                         cc.classname, ce.status_code, ce.status_description))
+            ce.file_line = (p.parser.file, p.lexer.lineno)
+            raise
 
 
 def p_mp_createInstance(p):


### PR DESCRIPTION
Rolls back PR #2011 into 0.16.0.