### PR TITLE
0.16: Enabled all Python 2.6 flavors on Travis for stable releases; fixed pkg versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ sudo: required
 # to install Python.
 matrix:
   include:
-#    - os: linux
-#      language: python
-#      python: "2.6"
-#      dist: trusty
-#      env:
-#        - PACKAGE_LEVEL=minimum
+    - os: linux
+      language: python
+      python: "2.6"
+      dist: trusty
+      env:
+        - PACKAGE_LEVEL=minimum
     - os: linux
       language: python
       python: "2.6"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,7 @@
 unittest2>=1.1.0; python_version == '2.6'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=3.0.7,<3.3.0; python_version == '2.6'
+pytest>=3.1.0,<3.3.0; python_version == '2.6'
 pytest>=4.3.1,<5.0.0; python_version > '2.6' and python_version < '3.5'
 pytest>=4.3.1; python_version >= '3.5'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -74,7 +74,7 @@ typing==3.6.1  # from M2Crypto
 
 # Unit test (imports into testcases):
 unittest2==1.1.0; python_version == '2.6'
-pytest==3.0.7; python_version == '2.6'
+pytest==3.1.0; python_version == '2.6'
 pytest==4.3.1; python_version > '2.6'
 testfixtures==4.3.3; python_version == '2.6'
 testfixtures==6.9.0; python_version > '2.6'


### PR DESCRIPTION
See commit message.
No review needed.