### PR TITLE
0.16: Replaced yamlordereddictloader package with yamlloader

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,7 +38,8 @@ lxml>=4.4.1; python_version >= '3.8'
 requests>=2.19.1; python_version == '2.6'
 requests>=2.20.1; python_version > '2.6'
 decorator>=4.0.11
-yamlordereddictloader>=0.4.0
+yamlordereddictloader>=0.4.0; python_version == '2.6'
+yamlloader>=0.5.5; python_version > '2.6'
 funcsigs>=1.0.2
 
 # Indirect dependencies that are needed due to version pinning

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,12 @@ Released: not yet
 * Test: Removed the dependency on unittest2 for Python 2.7 and higher.
   (See issue #2003)
 
+**Cleanup**:
+
+* For Python 2.7 and higher, replaced the yamlordereddictloader package with 
+  yamlloader, as it was deprecated. For Python 2.6, still using
+  yamlordereddictloader. (See issue #2008)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -85,7 +85,8 @@ lxml==4.4.1; python_version >= '3.8'
 requests==2.19.1; python_version == '2.6'
 requests==2.20.1; python_version > '2.6'
 decorator==4.0.11
-yamlordereddictloader==0.4.0
+yamlordereddictloader==0.4.0; python_version == '2.6'
+yamlloader==0.5.5; python_version > '2.6'
 funcsigs==1.0.2
 FormEncode==1.3.1
 


### PR DESCRIPTION
Rolls back PR #2021 into 0.16.0.