### PR TITLE
Fixes #2033: 0.16: Fixed handling of Unicode string in ca_certs parm of WBEMConnection on py2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -51,6 +51,9 @@ Released: not yet
 * Test: Fixed an error in test_format_random() for the backslash character.
   (See issue #2027)
 
+* Fixed handling of Unicode string in ca_certs parm of WBEMConnection on py2
+  (See issue #2033)
+
 **Enhancements:**
 
 * Test: Removed the dependency on unittest2 for Python 2.7 and higher.

--- a/pywbem/cim_http.py
+++ b/pywbem/cim_http.py
@@ -565,10 +565,13 @@ def wbem_request(url, data, creds, cimxml_headers=None, debug=False, x509=None,
                     ctx.set_verify(
                         SSL.verify_peer | SSL.verify_fail_if_no_peer_cert,
                         depth=9, callback=verify_callback)
+                    # M2Crypto requires binary strings as path names and
+                    # otherwise raises TypeError.
+                    ca_certs = _ensure_bytes(self.ca_certs)
                     if os.path.isdir(self.ca_certs):
-                        ctx.load_verify_locations(capath=self.ca_certs)
+                        ctx.load_verify_locations(capath=ca_certs)
                     else:
-                        ctx.load_verify_locations(cafile=self.ca_certs)
+                        ctx.load_verify_locations(cafile=ca_certs)
                 try:
                     self.sock = SSL.Connection(ctx, self.sock)
 

--- a/pywbem/cim_operations.py
+++ b/pywbem/cim_operations.py
@@ -554,13 +554,15 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
             The parameter value must be one of:
 
-            * a path to a file containing one or more CA certificates in
-              PEM format. See the description of `CAfile` in the OpenSSL
-              `SSL_CTX_load_verify_locations`_ function for details.
+            * :term:`string`: A path to a file containing one or more CA
+              certificates in PEM format. See the description of `CAfile` in
+              the OpenSSL `SSL_CTX_load_verify_locations`_ function for
+              details.
 
-            * a path to a directory with files each of which contains one CA
-              certificate in PEM format. See the description of `CApath` in the
-              OpenSSL `SSL_CTX_load_verify_locations`_ function for details.
+            * :term:`string`: A path to a directory with files each of which
+              contains one CA certificate in PEM format. See the description
+              of `CApath` in the OpenSSL `SSL_CTX_load_verify_locations`_
+              function for details.
 
             If `None`, the directory path of the first existing directory from
             the list in :data:`~pywbem.cim_http.DEFAULT_CA_CERT_PATHS` will be


### PR DESCRIPTION
See commit message.

Note that this PR does not need to be rolled forward into master. However, the clarification about the type of string that can be used for the `ca_certs` parameter of `WBEMConnection` has been applied to PR #2023.