### PR TITLE
0.16: Moved coveralls run back to Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,8 +243,6 @@ after_success:
 # Note: In case of error 422 (Couldn't find a repository matching this job),
 #       log on to https://coveralls.io to refresh the OAuth token, and
 #       make sure this project is enabled there.
-# Make sure the Python version matches the one specified for python-coveralls
-# in dev-requirements.txt.
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.8" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.4" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
       coveralls;
     fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,9 +47,8 @@ PyYAML==3.11; python_version == '2.6'  # yaml package, used by yamlordereddictlo
 PyYAML>=3.13; python_version >= '2.7'  # yaml package, used by yamlordereddictloader
 
 # Coverage reporting (no imports, invoked via coveralls script).
-# Make sure the Python version matches the one used in .travis.yml.
-coverage>=4.5.3; python_version == '3.8'
-python-coveralls>=2.9.2; python_version == '3.8'
+coverage>=4.5.3
+python-coveralls>=2.9.2
 
 # Safety CI by pyup.io
 safety>=1.8.4


### PR DESCRIPTION
Rolls back PR #2045 into 0.16.0