### PR TITLE
Fixes #1959: Remove conn_lite mode from mocker

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -120,6 +120,10 @@ Released: not yet
 * Made the MOFWBEMConnection class internal and undocumented. It has an
   inconsistent semantics and should not be used by users. (See issue #2001).
 
+* Completely removed the pywbem_mock initialization attribute conn_lite and
+  its implementation and tests.  This turned out too simplistic for mock testing
+  and of no real value while adding complexity.  (See issue #1959)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -428,6 +432,8 @@ Released: not yet
 
 * Replaced the yamlordereddictloader package with yamlloader, as it was
   deprecated. (See issue #2008)
+
+* Removed pywbem_mock conn_lite mode. (See issue # 1959)
 
 **Known issues:**
 

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -80,7 +80,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
     def _test_qualifier_decl(qualifier, qualifier_repo, namespace):
         """
         Test that qualifier is in repo and valid.
-        For for conn_lite, ignore this test
         """
         if qualifier_repo is None:
             return


### PR DESCRIPTION
Completely removes the mode of operation called conn_lite,
the constructor attribute, tests that require conn_lite
and documentation from the code and documentation.

No other functional changes.