### PR TITLE
Fixes #2054: Added missing children in docstring of IRETURNVALUE() in cim_xml.py

### DIFF
--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -1809,10 +1809,12 @@ class IRETURNVALUE(CIMElement):
 
         <!ELEMENT IRETURNVALUE (CLASSNAME* | INSTANCENAME* | VALUE* |
                                 VALUE.OBJECTWITHPATH* |
-                                VALUE.OBJECTWITHLOCALPATH* | VALUE.OBJECT* |
-                                OBJECTPATH* | QUALIFIER.DECLARATION* |
-                                VALUE.ARRAY? | VALUE.REFERENCE? | CLASS* |
-                                INSTANCE* | VALUE.NAMEDINSTANCE*)>
+                                VALUE.OBJECTWITHLOCALPATH* |
+                                VALUE.OBJECT* | OBJECTPATH* |
+                                QUALIFIER.DECLARATION* | VALUE.ARRAY? |
+                                VALUE.REFERENCE? | CLASS* | INSTANCE* |
+                                INSTANCEPATH* | VALUE.NAMEDINSTANCE* |
+                                VALUE.INSTANCEWITHPATH*)>
     """
 
     def __init__(self, data):


### PR DESCRIPTION
See commit message.
No rollback needed, as it only fixes the docstring.