### PR TITLE
Fixes #2055: Removed children in docstring of EXPPARAMVALUE() in cim_xml.py

### DIFF
--- a/pywbem/cim_xml.py
+++ b/pywbem/cim_xml.py
@@ -1592,8 +1592,7 @@ class EXPPARAMVALUE(CIMElement):
 
       ::
 
-        <!ELEMENT EXPPARAMVALUE (INSTANCE? | VALUE? | METHODRESPONSE? |
-                                 IMETHODRESPONSE?)>
+        <!ELEMENT EXPPARAMVALUE (INSTANCE?)>
         <!ATTLIST EXPPARAMVALUE
             %CIMName;
             %ParamType;  #IMPLIED>


### PR DESCRIPTION
See commit message.
No rollback needed, as it only fixes the docstring.