### PR TITLE
Fixes #2071: Pinned PyYAML to <5.3 on py34; simplified rtd-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,6 +47,7 @@ pytest-cov>=2.4.0
 tox>=2.0.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
+# Keep in sync with rtd-requirements.txt
 Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD
 Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
 # TODO: On Python 3.5 and higher, Sphinx currently fails, see issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,10 @@
 
 mock>=2.0.0
 ply>=3.10
-PyYAML>=5.1
+# PyYAML 5.3 has removed support for Python 3.4
+PyYAML>=5.1; python_version == '2.7'
+PyYAML>=5.1,<5.3; python_version == '3.4'
+PyYAML>=5.1; python_version > '3.4'
 six>=1.10.0
 requests>=2.20.0
 

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -3,10 +3,16 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance.
 
-six>=1.10.0
-ply>=3.10
-PyYAML>=3.13  # yaml package
-Sphinx>=1.7.6
+-r requirements.txt
+
+# Minimum set of packages for Sphinx processing
+# Keep in sync with dev-requirements.txt
+
+Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD
+Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
+# TODO: On Python 3.5 and higher, Sphinx currently fails, see issue
+#       https://github.com/sphinx-doc/sphinx/issues/6246. Therefore, Sphinx has
+#       been pinned to below 2.0.0 also for those Python versions.
 sphinx-git>=10.1.1
+GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0
-requests>=2.20.0


### PR DESCRIPTION
See commit message.
No review needed.