### PR TITLE
0.16: Pinned PyYAML to <5.3 on py34; simplified rtd-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,13 +38,18 @@ lxml>=4.4.1; python_version >= '3.8'
 requests>=2.19.1; python_version == '2.6'
 requests>=2.20.1; python_version > '2.6'
 decorator>=4.0.11
+
+# PyYAML is an indirect dependency used by yamlordereddictloader that is
+# needed due to version pinning. Keep in sync with requirements.txt.
+# PyYAML 5.3 has removed support for Python 3.4
+PyYAML>=3.11,<3.12; python_version == '2.6'
+PyYAML>=5.1; python_version == '2.7'
+PyYAML>=5.1,<5.3; python_version == '3.4'
+PyYAML>=5.1; python_version > '3.4'
+
 yamlordereddictloader>=0.4.0; python_version == '2.6'
 yamlloader>=0.5.5; python_version > '2.6'
 funcsigs>=1.0.2
-
-# Indirect dependencies that are needed due to version pinning
-PyYAML==3.11; python_version == '2.6'  # yaml package, used by yamlordereddictloader
-PyYAML>=3.13; python_version >= '2.7'  # yaml package, used by yamlordereddictloader
 
 # Coverage reporting (no imports, invoked via coveralls script).
 coverage>=4.5.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -62,6 +62,7 @@ pytest-cov>=2.4.0; python_version >= '2.7'
 tox>=2.0.0
 
 # Sphinx (no imports, invoked via sphinx-build script, issues on py26):
+# Keep in sync with rtd-requirements.txt
 Sphinx>=1.7.6,<2.0.0; python_version >= '2.7' and python_version < '3.5'  # BSD
 Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
 # TODO: On py3.5+, Sphinx currently fails, see issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,11 @@ M2Crypto>=0.31.0; python_version < '3.0' and sys_platform != 'win32'
 mock>=2.0.0
 ordereddict>=1.1; python_version == '2.6'
 ply>=3.10
-PyYAML>=3.11,<3.12; python_version == '2.6'  # yaml package
-PyYAML>=5.1; python_version >= '2.7'  # yaml package
+# PyYAML 5.3 has removed support for Python 3.4
+PyYAML>=3.11,<3.12; python_version == '2.6'
+PyYAML>=5.1; python_version == '2.7'
+PyYAML>=5.1,<5.3; python_version == '3.4'
+PyYAML>=5.1; python_version > '3.4'
 six>=1.10.0
 backport_collections>=0.1; python_version == '2.6'
 

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -3,11 +3,16 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance.
 
-six>=1.10.0
-ply>=3.10
-PyYAML==3.11; python_version == '2.6'  # yaml package
-PyYAML>=3.13; python_version >= '2.7'  # yaml package
-# M2Crypto>=0.31.0  # we cannot install M2Crypto because RTD does not have Swig
-Sphinx>=1.7.6
+-r requirements.txt
+
+# Minimum set of packages for Sphinx processing
+# Keep in sync with dev-requirements.txt
+
+Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD
+Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
+# TODO: On Python 3.5 and higher, Sphinx currently fails, see issue
+#       https://github.com/sphinx-doc/sphinx/issues/6246. Therefore, Sphinx has
+#       been pinned to below 2.0.0 also for those Python versions.
 sphinx-git>=10.1.1
+GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
Rolls back PR #2072 to 0.16.0.