### PR TITLE
Release 0.16.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Pywbem - A WBEM client and related utilities, written in pure Python
 ====================================================================
 
 .. # begin of customization for the current version
-.. |pywbem-version| replace:: 0.15.0
+.. |pywbem-version| replace:: 0.16.0
 .. |pywbem-next-version| replace:: 1.0.0
 .. |pywbem-next-issue| replace:: 1413
 .. # end of customization for the current version

--- a/README_PYPI.rst
+++ b/README_PYPI.rst
@@ -4,10 +4,10 @@
 .. # we have to specify the package version directly in the links.
 
 .. # begin of customization for the current version
-.. |pywbem-version-mn| replace:: 0.15
-.. _Readme file on GitHub: https://github.com/pywbem/pywbem/blob/stable_0.15/README.rst
-.. _Documentation on RTD: https://pywbem.readthedocs.io/en/stable_0.15/
-.. _Change log on RTD: https://pywbem.readthedocs.io/en/stable_0.15/changes.html
+.. |pywbem-version-mn| replace:: 0.16
+.. _Readme file on GitHub: https://github.com/pywbem/pywbem/blob/stable_0.16/README.rst
+.. _Documentation on RTD: https://pywbem.readthedocs.io/en/stable_0.16/
+.. _Change log on RTD: https://pywbem.readthedocs.io/en/stable_0.16/changes.html
 .. # end of customization for the current version
 
 Pywbem is a WBEM client, written in pure Python. It supports Python 2 and

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,18 +13,12 @@ Change log
       :revisions: 1
 
 
-pywbem 0.16.0.dev1
-------------------
-
-This version is currently in development and is shown as |version|.
+pywbem 0.16.0
+-------------
 
 This version contains all fixes up to pywbem 0.15.0.
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2020-01-09
 
 **Bug fixes:**
 
@@ -64,12 +58,6 @@ Released: not yet
 * For Python 2.7 and higher, replaced the yamlordereddictloader package with
   yamlloader, as it was deprecated. For Python 2.6, still using
   yamlordereddictloader. (See issue #2008)
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/pywbem/pywbem/issues
 
 
 pywbem 0.15.0

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -29,4 +29,4 @@ Version of the pywbem package.
 #:
 #: * "M.N.P.devD": Development level D of a not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '0.16.0.dev1'
+__version__ = '0.16.0'


### PR DESCRIPTION
The fix for the removal of Python 3.4 support in PyYAML 5.3 should be released, otherwise pywbem users have a show stopper issue on Python 3.4.
This motivates the release of pywbem 0.16.0 which contains that fix.