### PR TITLE
Part 2 of pywbem_mock refactor. This pr separates repository from _wbemconnection

### DIFF
--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -888,10 +888,16 @@ Mock inmemory CIM repository
 pywbem_mock provides a standard interface to a CIM repository that
 stores CIM classes, CIM instances, and CIM qualifier declarations.
 
-This repository implements an repository in memory that is created and
+This repository implements a repository in memory that is created and
 destroyed each time the FakedWBEMConnection class is constructed and
 destroyed.
 
+The following classes implement this repository.
+
+.. _`Inmemory CIM Repository class`:
+
+Inmemory CIM Repository class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pywbem_mock._inmemoryrepository
 
@@ -911,10 +917,10 @@ destroyed.
 
    .. rubric:: Details
 
-.. _`Mock inmemory object store`:
+.. _`Inmemory object store class`:
 
-Mock inmemory object store
---------------------------
+Inmemory object store class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pywbem_mock._inmemoryrepository
 

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -885,20 +885,6 @@ DMTF CIM schema download support
 Mock inmemory CIM repository
 ----------------------------
 
-pywbem_mock provides a standard interface to a CIM repository that
-stores CIM classes, CIM instances, and CIM qualifier declarations.
-
-This repository implements a repository in memory that is created and
-destroyed each time the FakedWBEMConnection class is constructed and
-destroyed.
-
-The following classes implement this repository.
-
-.. _`Inmemory CIM Repository class`:
-
-Inmemory CIM Repository class
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 .. automodule:: pywbem_mock._inmemoryrepository
 
 .. autoclass:: pywbem_mock.InMemoryRepository
@@ -917,12 +903,6 @@ Inmemory CIM Repository class
 
    .. rubric:: Details
 
-.. _`Inmemory object store class`:
-
-Inmemory object store class
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: pywbem_mock._inmemoryrepository
 
 .. autoclass:: pywbem_mock.InMemoryObjectStore
    :members:

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -878,3 +878,58 @@ DMTF CIM schema download support
       :attributes:
 
    .. rubric:: Details
+
+
+.. _`Mock InMemory CIM Repository`:
+
+Mock in-memory CIM repository
+-----------------------------
+
+pywbem_mock provides a standard interface to a CIM repository that
+stores CIM classes, CIM instances, and CIM qualifier declarations.
+
+This repository implements an repository in memmory that is created and
+destroyed each time the FakedWBEMConnection class is constructed and
+destroyed.
+
+
+.. automodule:: pywbem_mock._inmemoryrepository
+
+.. autoclass:: pywbem_mock.InMemoryRepository
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem_mock.InMemoryRepository
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem_mock.InMemoryRepository
+      :attributes:
+
+   .. rubric:: Details
+
+.. _`Mock InMemory Object store`:
+
+Mock InMemory object store
+--------------------------
+
+.. automodule:: pywbem_mock._inmemoryrepository
+
+.. autoclass:: pywbem_mock.InMemoryObjectStore
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem_mock.InMemoryObjectStore
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem_mock.InMemoryObjectStore
+      :attributes:
+
+   .. rubric:: Details

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -880,15 +880,15 @@ DMTF CIM schema download support
    .. rubric:: Details
 
 
-.. _`Mock InMemory CIM Repository`:
+.. _`Mock inmemory CIM repository`:
 
-Mock in-memory CIM repository
------------------------------
+Mock inmemory CIM repository
+----------------------------
 
 pywbem_mock provides a standard interface to a CIM repository that
 stores CIM classes, CIM instances, and CIM qualifier declarations.
 
-This repository implements an repository in memmory that is created and
+This repository implements an repository in memory that is created and
 destroyed each time the FakedWBEMConnection class is constructed and
 destroyed.
 
@@ -911,9 +911,9 @@ destroyed.
 
    .. rubric:: Details
 
-.. _`Mock InMemory Object store`:
+.. _`Mock inmemory object store`:
 
-Mock InMemory object store
+Mock inmemory object store
 --------------------------
 
 .. automodule:: pywbem_mock._inmemoryrepository

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -61,6 +61,7 @@ ply==3.10
 PyYAML==5.1
 six==1.10.0
 requests==2.20.0
+custom-inherit==2.2.2
 
 
 # Indirect dependencies for install (not in requirements.txt)

--- a/pywbem_mock/__init__.py
+++ b/pywbem_mock/__init__.py
@@ -27,3 +27,5 @@ from ._wbemconnection_mock import *        # noqa: F403,F401
 from ._dmtf_cim_schema import *            # noqa: F403,F401
 from ._resolvermixin import *              # noqa: F403,F401
 from ._mockmofwbemconnection import *  # noqa: F403,F401
+from ._baserepository import *       # noqa: F403,F401
+from ._inmemoryrepository import *       # noqa: F403,F401

--- a/pywbem_mock/__init__.py
+++ b/pywbem_mock/__init__.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 from ._wbemconnection_mock import *        # noqa: F403,F401
 from ._dmtf_cim_schema import *            # noqa: F403,F401
 from ._resolvermixin import *              # noqa: F403,F401
-from ._mockmofwbemconnection import *  # noqa: F403,F401
-from ._baserepository import *       # noqa: F403,F401
-from ._inmemoryrepository import *       # noqa: F403,F401
+from ._mockmofwbemconnection import *      # noqa: F403,F401
+from ._baserepository import *             # noqa: F403,F401
+from ._inmemoryrepository import *         # noqa: F403,F401
+from ._utils import *                      # noqa: F403,F401

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -29,6 +29,19 @@ types.
 The repository is organized by namespace such that a
 namespace must be created before it can be used to create CIM object collections
 and each namespace contains a collection of each of these CIM objects.
+
+Example :
+
+.. code-block:: python
+
+    # XXXRepository is a class derived from BaseRepository
+    repo = XXXRepository()                           # create the repo
+    repo.add_namespace("root/cimv2")                 # add a namespace
+    class_store = .repo.get_class_store("root/cimv2") # get class obj store
+    test_class = CIMClass('CIM_Blah', ...)           # create a class
+    class_store.add(test_class)                      # add to xxxrepo classes
+    if 'CIM_Blah' in class_store:                    # test if class exists
+        klass = class_store.get('CIM_Blah;)          # get the class
 """
 
 from abc import abstractmethod, abstractproperty
@@ -64,12 +77,15 @@ class BaseObjectStore(object):
     An object store stores only a single CIM object type.
     """
 
+    @abstractmethod
     def __init__(self, cim_object_type):
         """
+        Instantiate the self.cim_object_type variable.
+
         Parameters:
 
             cim_object_type(:term:`CIM object`):
-              The Pywbem cim object type as defined in cim_types.py for the
+              The Pywbem CIM object type as defined in cim_types.py for the
               objects in the data store. Used to verify values on create.
         """
         self._cim_object_type = cim_object_type
@@ -77,7 +93,7 @@ class BaseObjectStore(object):
     @abstractmethod
     def exists(self, name):
         """
-        Test if the CIM object defined by name exists in the object store.
+        Test if the CIM object identified by name exists in the object store.
 
         Parameters:
 
@@ -93,47 +109,49 @@ class BaseObjectStore(object):
     @abstractmethod
     def get(self, name, copy=True):
         """
-        Return the CIM object defined by name if it exists in the object store.
+        Return the CIM object identified by name if it exists in the object
+        store.
 
         Parameters:
 
           name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
             Name by which the object is identified in the object store
 
-          copy: If True, returns a copy of the object to insure that modifying
-          the returned object does not change the data store. The default
-          behavior is True .  If copy is False, the object in the object store
-          is returned but if it is modified by the user, the object in the
-          store may be modified also.
-
+          copy(:class:`py:bool`):
+            If True, returns a copy of the object to insure that modifying the
+            returned object does not change the data store. The default
+            behavior is True .  If copy is False, the object in the object
+            store is returned but if it is modified by the user, the object in
+            the store may be modified also.
         Returns:
 
-            Returns the cim_object identified by the name parameter
+            :term:`CIM object`: Returns the CIM object identified by the
+              name parameter.
 
         Raises:
 
-            KeyError: cim_object with name not in this object store
+            KeyError: CIM object identified with name not in the object store
         """
         pass
 
     @abstractmethod
     def create(self, name, cim_object):
         """
-        Adds the cim_object identified by name to the object store.
+        Add the cim_object to the object store.
 
         Parameters:
 
           name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
-            Name by which the object is identified in the object store .
+            Name by which the CIM object will be identified in the object store.
 
-          cim_object(:term:`CIM object` to be added to the object store):
-            The CIM object that will be inserted into the object store. The
+          cim_object(:term:`CIM object`):
+            The CIM object to be added to the object store. The
             object is copied into the object store so the user can safely
             modify the original object without affecting the store.
 
         Raises:
 
-            ValueError: If object already exists in the object store.
+            ValueError: If CIM object already exists in the object store.
         """
         pass
 
@@ -155,7 +173,7 @@ class BaseObjectStore(object):
 
         Raises:
 
-            KeyError: If no object with name exists in the object store.
+            KeyError: If no CIM object with name exists in the object store.
         """
         pass
 
@@ -180,25 +198,25 @@ class BaseObjectStore(object):
     def iter_names(self):
         """
         Return an iterator to the names of the CIM objects in the object store.
-        The order of returned names is undefined. Objects may be accessed using
-        iterator methods.
+        Objects may be accessed using iterator methods.
 
-        The order of returned object is undetermined.
+        The order of returned names is undetermined.
 
         Returns:
 
-            Python iterator for the names of CIM objects in the object store.
+            :term:`iterator`: An iterator for the names of CIM objects in the
+            object store.
         """
         pass
 
     @abstractmethod
     def iter_values(self, copy=True):
         """
-        Return an iterator to the cim objects in the object store. This allows
+        Return an iterator to the CIM objects in the object store. This allows
         iteration through all the objects in this object store using iterator
         methods.
 
-        The order of returned values is undetermined.
+        The order of returned CIM objects is undetermined.
 
         Parameters:
 
@@ -210,8 +228,9 @@ class BaseObjectStore(object):
 
         Returns:
 
-            Python iterator for the object values in the object store.
-            If copy == True, each object is copied before it is returned.
+            :term:`iterator`: An iterator for the objects in the object
+            store. If copy == True, each object is copied before it is
+            returned.
         """
         pass
 
@@ -222,7 +241,7 @@ class BaseObjectStore(object):
 
         Returns:
 
-            Integer that is count of objects in this object store.
+            int: Integer that is count of objects in this object store.
 
         """
         pass
@@ -238,20 +257,9 @@ class BaseRepository(object):
        and getting a list of the existing namespaces.
     2. Access the object store for each CIM object type in the repository for
        the objects of the following CIM types: (:class:`~pywbem.CIMClass`,
-       :class:`~pywbem.CIMInstance`, and :class:`~pywbem.QualifierDeclaration`
-       decelarations) so that methods of the BaseObjectStore are used to access
-       and manipulate CIM objects of a single CIM type by namespace in the
-       repository.
-
-    Example :
-      # XXXRepository is a class derived from BaseRepository
-      repo = XXXRepository()                           # create the repo
-      repo.add_namespace("root/cimv2")                 # add a namespace
-      class_store = .repo.get_class_store("root/cimv2") # get class obj store
-      test_class = CIMClass('CIM_Blah', ...)           # create a class
-      class_store.add(test_class)                      # add to xxxrepo classes
-      if 'CIM_Blah' in class_store:                    # test if class exists
-          klass = class_store.get('CIM_Blah;)          # get the class
+       :class:`~pywbem.CIMInstance`, and :class:`~pywbem.QualifierDeclaration`)
+       so that methods of the BaseObjectStore are used to access and manipulate
+       CIM objects of a single CIM type by namespace in the repository.
     """
 
     @compatibleabstractproperty

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -56,15 +56,10 @@ class BaseObjectStore(object):
     objectsthat constitute a WBEM server repository.  This
     class provides the abstract methods for creating, accessing, and deleting,
     CIM objects of a single CIM object type in the repository.
-
-    These APIs allows creating, updating, deleting, and retrieving these
-    objects.
     """
 
     def __init__(self, cim_object_type):
         """
-        Initialize the object store.
-
         Parameters:
 
             cim_object_type(:term:`string`):
@@ -79,7 +74,7 @@ class BaseObjectStore(object):
         Test if cim_object defined by name exists in the
         object store
 
-        Paramsters
+        Parameters
           name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
             Name by which the object is identified in the object store
 
@@ -231,7 +226,7 @@ class BaseRepository(object):
 
       xxxrepo = XXXRepository()                        # create the repo
       xxxrepo.add_namespace("root/cimv2")              # add a namespace
-      class_repo = xxx.repo.get_class_repo("root/cimv2") # get class obj store
+      class_repo = xxx.repo.get_class_store("root/cimv2") # get class obj store
       test_class = CIMClass(...)                       # create a class
       class_repo.add(test_class)                       # add to xxxrepo classes
     """
@@ -320,10 +315,9 @@ class BaseRepository(object):
         pass
 
     @abstractmethod
-    def get_class_repo(self, namespace):
+    def get_class_store(self, namespace):
         """
-        Get the handle for the data CIM class object store for the namespace
-        provided.
+        Return the CIM class object store for the namespace provided.
 
         Parameters:
           namespace (:term:`string`):
@@ -334,9 +328,8 @@ class BaseRepository(object):
 
         Returns:
 
-          Returns the instance of :class:`~pywbem_mock.InMemoryObjectStore` for
-          CIM classes which defines the methods exists(name), get(name)
-          create(), etc. for accessing the data in this store.
+          :class:`~pywbem_mock.InMemoryObjectStore` : CIM class object store for
+          the namespace provided.
 
         Raises:
 
@@ -347,9 +340,34 @@ class BaseRepository(object):
         pass
 
     @abstractmethod
-    def get_instance_repo(self, namespace):
+    def get_instance_store(self, namespace):
         """
-        Get the handle for the data CIM instance object store for the namespace
+        Return the CIM instance object store for the namespace provided.
+
+        Parameters:
+
+          namespace (:term:`string`):
+            The name of the CIM namespace in the CIM repository. The name is
+            treated case insensitively and it must not be `None`. Any leading
+            and trailing slash characters in the namespace string are ignored
+            when accessing the repository.
+
+        Returns:
+
+          :class:`~pywbem_mock.InMemoryObjectStore` : CIM instance object store
+          for the namespace provided.
+
+        Raises:
+
+          ValueError: Namespace argument is None.
+          KeyError: The namespace parameter does not define an existing
+            namespace
+        """
+
+    @abstractmethod
+    def get_qualifier_store(self, namespace):
+        """
+        Return the  CIM qualifier declaration object store for the namespace
         provided.
 
         Parameters:
@@ -362,36 +380,8 @@ class BaseRepository(object):
 
         Returns:
 
-          Returns the instance of :class:`~pywbem_mock.InMemoryObjectStore`
-          for CIM instances which defines the methods exists(), get() create(),
-          etc. for accessing the data in this store.
-
-        Raises:
-
-          ValueError: Namespace argument is None.
-          KeyError: The namespace parameter does not define an existing
-            namespace
-        """
-
-    @abstractmethod
-    def get_qualifier_repo(self, namespace):
-        """
-        Gets the handle for the data CIM qualifier declaration object store for
-        the namespace provided.
-
-        Parameters:
-
-          namespace (:term:`string`):
-            The name of the CIM namespace in the CIM repository. The name is
-            treated case insensitively and it must not be `None`. Any leading
-            and trailing slash characters in the namespace string are ignored
-            when accessing the repository.
-
-        Returns:
-
-          Returns the instance of :class:`~pywbem_mock.InMemoryObjectStore` for
-          CIM qualifier declarations which defines the methods exists(), get()
-          create(), etc. for accessing the data in this store.
+          :class:`~pywbem_mock.InMemoryObjectStore`: CIM qualifier declaration
+          object store for the namespace provided.
 
         Raises:
 

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -20,9 +20,15 @@
 
 
 """
-Base classes for an object store for CIM classes, CIM instances, and CIM
-qualifier declarations and the generic API for a CIM repository of these object
-types organized by repository.
+Base abscract classes for an object store for collections of
+:class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`, and
+:class:`~pywbem.CIMQualifierDeclaration`s and a generic API for a CIM
+repository to access and manage the collections of each of these CIM object
+types.
+
+The repository is organized by namespace such that a
+namespace must be created before it can be used to create CIM object collections
+and each namespace contains a collection of each of these CIM objects.
 """
 
 from abc import abstractmethod, abstractproperty
@@ -54,6 +60,8 @@ class BaseObjectStore(object):
     objectsthat constitute a WBEM server repository.  This
     class provides the abstract methods for creating, accessing, and deleting,
     CIM objects of a single CIM object type in the repository.
+
+    An object store stores only a single CIM object type.
     """
 
     def __init__(self, cim_object_type):
@@ -69,7 +77,7 @@ class BaseObjectStore(object):
     @abstractmethod
     def exists(self, name):
         """
-        Test if CIM object defined by name exists in the object store.
+        Test if the CIM object defined by name exists in the object store.
 
         Parameters:
 
@@ -132,8 +140,8 @@ class BaseObjectStore(object):
     @abstractmethod
     def update(self, name, cim_object):
         """
-        Replace the CIM object defined by name in the object store with
-        the object defined by cim_object.
+        Replace the CIM object in the object store defined by the name argument
+        with the CIM object defined by cim_object.
 
         Parameters:
 
@@ -171,9 +179,11 @@ class BaseObjectStore(object):
     @abstractmethod
     def iter_names(self):
         """
-        Return iterator to the names of the CIM objects in the object store.
+        Return an iterator to the names of the CIM objects in the object store.
         The order of returned names is undefined. Objects may be accessed using
-        iterator methods. The order of returned object is undetermined.
+        iterator methods.
+
+        The order of returned object is undetermined.
 
         Returns:
 
@@ -184,9 +194,9 @@ class BaseObjectStore(object):
     @abstractmethod
     def iter_values(self, copy=True):
         """
-        Return iterator to the cim objects in the object store. This allows
-        iteration through all the objects in this
-        object store. Objects may be accessed using iterator methods.
+        Return an iterator to the cim objects in the object store. This allows
+        iteration through all the objects in this object store using iterator
+        methods.
 
         The order of returned values is undetermined.
 
@@ -208,7 +218,7 @@ class BaseObjectStore(object):
     @abstractmethod
     def len(self):
         """
-        Get count of objects in this object store.
+        Return the count of objects in this object store.
 
         Returns:
 
@@ -226,18 +236,22 @@ class BaseRepository(object):
 
     1. Manage CIM namespaces in the data repository including creation, deletion
        and getting a list of the existing namespaces.
-    2. Access the object store within the repository for the objects of the
-       following CIM types: (CIM classes, CIM instances, and CIM qualifier
+    2. Access the object store for each CIM object type in the repository for
+       the objects of the following CIM types: (:class:`~pywbem.CIMClass`,
+       :class:`~pywbem.CIMInstance`, and :class:`~pywbem.QualifierDeclaration`
        decelarations) so that methods of the BaseObjectStore are used to access
-       and manipulate CIM objects by namespace in the repository.
+       and manipulate CIM objects of a single CIM type by namespace in the
+       repository.
 
     Example :
-
-      xxxrepo = XXXRepository()                        # create the repo
-      xxxrepo.add_namespace("root/cimv2")              # add a namespace
-      class_repo = xxx.repo.get_class_store("root/cimv2") # get class obj store
-      test_class = CIMClass(...)                       # create a class
-      class_repo.add(test_class)                       # add to xxxrepo classes
+      # XXXRepository is a class derived from BaseRepository
+      repo = XXXRepository()                           # create the repo
+      repo.add_namespace("root/cimv2")                 # add a namespace
+      class_store = .repo.get_class_store("root/cimv2") # get class obj store
+      test_class = CIMClass('CIM_Blah', ...)           # create a class
+      class_store.add(test_class)                      # add to xxxrepo classes
+      if 'CIM_Blah' in class_store:                    # test if class exists
+          klass = class_store.get('CIM_Blah;)          # get the class
     """
 
     @compatibleabstractproperty

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -1,0 +1,343 @@
+#
+# (C) Copyright 2020 InovaDevelopment.comn
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+
+"""
+Base classes for an object store for CIM classes, CIM instances, and CIM
+qualifier declarations and the generic API for a repository of these object
+types organized by repository.
+
+For documentation, see mocksupport.rst.
+"""
+from abc import ABCMeta, abstractmethod
+
+import six
+
+
+@six.add_metaclass(ABCMeta)
+class ObjectStoreAPI(object):
+    """
+    This abstract class defines the APIs for the methods of an object store
+    for the CIM objects that constitute a WBEM server repository.  This
+    class provides the abstract methods for creating, accessing, and deleting,
+    CIM objects of a single CIM object type in the repository.
+    """
+
+    def __init__(self, case_insensitive_names, cim_object_type):
+        """
+        Initialize the object store.
+
+        Parameters:
+
+            case_insensitive-names(:class:`py:bool`):
+              If True, the names uniquely identify objects in the object store
+              case insensitively. The names must be strings.
+              If False, names identify objects. The names may be strings
+              or other objects that can be used to uniquely identify
+              objects in the object store.
+
+            cim_object_type(:term:`string`):
+              The Pywbem cim object type as defined in cim_types.py for the
+              objects in the data store. Used to verify values on create.
+        """
+        self._case_insensitive_names = case_insensitive_names
+        self._cim_object_type = cim_object_type
+
+    @abstractmethod
+    def exists(self, name):
+        """
+        Test if cim_object defined by name and namespace exists in the
+        object store
+
+        Paramsters
+          name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
+            Name by which the object is identified in the object store
+
+        Returns:
+            True if the object exists; False if it does not exist
+        """
+        pass
+
+    @abstractmethod
+    def get(self, name, copy=True):
+        """
+        Return the cim_object defined by name and namespace if it exists.
+
+        Parameters:
+          name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
+            Name by which the object is identified in the object store
+
+          copy: If True, insures that modifying the returned object does not
+            change the data store
+
+        Returns: The cim_object identified by the name parameter
+
+        Raises:
+            KeyError: Object not in this object store
+        """
+        pass
+
+    @abstractmethod
+    def create(self, name, cim_object):
+        """
+        Insert the cim_object into the object store identified by name.
+
+        Parameters:
+
+          name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
+            Name by which the object is identified in the object store .
+
+          cim_object(cim_object to be added to the object store):
+
+        Raises:
+            ValueError: If object already in the object store
+        """
+        pass
+
+    @abstractmethod
+    def update(self, name, cim_object):
+        """
+        Replace the object defined by name in the object store with
+        the object defined by cim_object.
+
+        Parameters:
+
+          name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
+            Name by which the object is identified in the object store.
+
+          cim_object(cim_object to be added to the object store):
+
+        Raises:
+            KeyError: If no object with name exists in this object store
+
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, name):
+        """
+        Delete the object identified by name in the object store
+
+        Parameters:
+
+          name(:term:`string` or :class:`~pywbem.CIMInstanceName`):
+            Name by which the object is identified in the object store.
+
+        Raises:
+            KeyError: If there is no object with name in this object store
+
+        """
+        pass
+
+    @abstractmethod
+    def iter_names(self):
+        """
+        Return iterator to the names of the objects in the object store.
+
+        Returns:
+            List of the names of CIM objects in the object store
+        """
+        pass
+
+    @abstractmethod
+    def iter_values(self, copy=True):
+        """
+        Return iterator to the cim objects in the object store. This allows
+        iteration through all the objects in this
+        object store. Objects may be accessed using iterator methods.
+
+        Parameters:
+          copy (:class:`py:bool`):
+            Copy the objects before returning them.  This is the default
+            behavior and also the mode that should be used unless the
+            user is certain the object will NOT be modified after it is
+            returned.
+
+        Returns:
+            Python iterator for the object values in the object store.
+            If copy == True, each object is copied before it is returned.
+        """
+        pass
+
+    @abstractmethod
+    def len(self):
+        """
+        Get count of objects in this object store
+
+        Returns:
+            Integer that is count of objects in this objectstore
+
+        """
+        pass
+
+
+@six.add_metaclass(ABCMeta)
+class BaseRepositoryAPI(object):
+    """
+    An abstract base class for  the APIs to provide access to a data store for
+    a CIM repository.  The API provides functions to:
+
+    1. Manage CIM namespaces in the data repository including creation, deletion
+       and getting a list of the available namespaces.
+    2. Accessing the object store within the repository for the objects of the
+       following CIM types: (CIM classes, CIM instances, and CIM qualifier
+       decelarations) so that methods of the ObjStoreAPI can be used to access
+       objects by namespace so that CIM objects can be manupulated in the
+       repository by namespace.
+
+    """
+
+    # TODO I need to limit the obj store to defined types in API
+    # def __init__(self, repository, obj_store):
+    # """
+    # Construct the repository by defining the namespace with the supplied
+    # default_namespace and setting the objects for the classes, instances,
+    # and qualifiers
+    # """
+
+    # self.repository.classes = obj_store(True, CIMClass)
+    # self.repository.instances = obj_store(False, CIMInstance)
+    # self.repository.qualifiers = obj_store(True, CIMQualifierDeclaration)
+
+    @abstractmethod
+    def validate_namespace(self, namespace):
+        """
+        Validate if the namespace parameter exists in the repository. If the
+        namespace does not exist a KeyError is raised.
+
+        Raises:
+            KeyError: If the namespace is not defined in the repository
+        """
+        pass
+
+    @abstractmethod
+    def add_namespace(self, namespace):
+        """
+        Add a CIM namespace to the repository.
+
+        The namespace must not yet exist in the mock repository.
+
+        The default connection namespace is automatically added to
+        the mock repository upon creation of this connection.
+
+          Parameters:
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`. Leading and trailing slash characters are split off
+              from the provided string.
+
+          Raises:
+            ValueError: If the namespace argument is None or the
+             namespace already exists.
+        """
+        pass
+
+    @abstractmethod
+    def remove_namespace(self, namespace):
+        """
+        Remove a CIM namespace from the repository.
+
+        The namespace must exist in the repository and must be empty.
+
+        Parameters:
+
+          namespace (:term:`string`):
+            The name of the CIM namespace in the mock repository. Must not be
+            `None`. Any leading and trailing slash characters are split off
+            from the provided string.
+
+        Raises:
+
+          ValueError: Namespace argument is None or the repository namespace
+            is not empty
+          KeyError:  The namespace does not exist in the mock repository.
+        """
+        pass
+
+    @abstractmethod
+    def list_namespaces(self):
+        """
+        List the namespaces that exist in the repository
+
+        Returns:
+            list of :term:`string` items containing the namespace names
+        """
+        pass
+
+    @abstractmethod
+    def get_class_repo(self, namespace):
+        """
+        Get the handle for the data CIM class object store for the namespace
+        provided.
+
+          Parameters:
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+
+          Returns:
+            Returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+
+          Raises:
+            KeyError: If the namespace does not exist in the repository
+        """
+
+        pass
+
+    @abstractmethod
+    def get_instance_repo(self, namespace):
+        """
+        Get the handle for the data CIM instance object store for the namespace
+        provided.
+
+          Parameters:
+
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+          Returns:
+            returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+        """
+
+    @abstractmethod
+    def get_qualifier_repo(self, namespace):
+        """
+        Gets the handle for the data CIM qualifier declaration object store for
+        the namespace provided.
+
+          Parameters:
+
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+          Returns:
+            returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+
+          Raises:
+            ValueError if namespace parameter is None
+            KeyError if the namespace parameter does not define an existing
+              namespace
+        """

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -20,15 +20,16 @@
 
 
 """
-Base abscract classes for an object store for collections of
+Base abstract classes for an object store for collections of
 :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`, and
 :class:`~pywbem.CIMQualifierDeclaration` objects and a generic API for a CIM
 repository to access and manage the collections of each of these CIM object
 types.
 
-The repository is organized by namespace such that a
-namespace must be created before it can be used to create CIM object collections
-and each namespace contains a collection of each of these CIM objects.
+The repository is organized by namespace such that a namespace must be created
+before it can be used to contain CIM object collections and each namespace
+contains an object store for each CIM object type containing the CIM objects
+that have been added to the CIM repository.
 
 Example :
 

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -22,7 +22,7 @@
 """
 Base abscract classes for an object store for collections of
 :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`, and
-:class:`~pywbem.CIMQualifierDeclaration`s and a generic API for a CIM
+:class:`~pywbem.CIMQualifierDeclaration` objects and a generic API for a CIM
 repository to access and manage the collections of each of these CIM object
 types.
 
@@ -70,11 +70,15 @@ class BaseObjectStore(object):
     """
     An abstract class that defines the APIs for the methods of an object store
     for CIM objects including CIMClass, CIMInstance, and CIMQualifierDeclaration
-    objectsthat constitute a WBEM server repository.  This
+    objects that constitute a WBEM server repository.  This
     class provides the abstract methods for creating, accessing, and deleting,
     CIM objects of a single CIM object type in the repository.
 
-    An object store stores only a single CIM object type.
+    CIM objects in the object store are identified by a name which is part of
+    the methods that access the CIM objects and must be unique within a single
+    object store.
+
+    Each object store conatins only a single CIM object type.
     """
 
     @abstractmethod
@@ -126,7 +130,7 @@ class BaseObjectStore(object):
         Returns:
 
             :term:`CIM object`: Returns the CIM object identified by the
-              name parameter.
+            name parameter.
 
         Raises:
 
@@ -137,7 +141,7 @@ class BaseObjectStore(object):
     @abstractmethod
     def create(self, name, cim_object):
         """
-        Add the cim_object to the object store.
+        Add the CIM object to the object store.
 
         Parameters:
 
@@ -158,8 +162,8 @@ class BaseObjectStore(object):
     @abstractmethod
     def update(self, name, cim_object):
         """
-        Replace the CIM object in the object store defined by the name argument
-        with the CIM object defined by cim_object.
+        Replace the CIM object in the object store idenfified by the name
+        argument with the CIM object defined by the cim_object argument.
 
         Parameters:
 

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -19,16 +19,17 @@
 #
 
 """
-The pywbem_mock module provides a standard interface to a CIM repository that
-stores collections of :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`,
-and :class:`~pywbem.CIMQualifierDeclaration` as Python asbstract classes in the
-module :py:mod:`pywbem_mock/_baserepository.py`.
+This module provides an implementation of a CIM repository that stores
+collections of :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`, and
+:class:`~pywbem.CIMQualifierDeclaration` objects based on abstract classes that
+define the API for the repository.
 
-The pywbem_mock inmemory CIM repository implements a repository derived from
-:py:mod:`pywbem_mock/_baserepository.py` that stores the CIM objects only in
-memory. This CIM repository is created each time a
-:class:`~pywbem_mock.InMemoryRepository` is constructed and destroyed each
-time it is destroyed.
+The class :class:`~pywbem_mock.InMemoryRepository` implements a CIM repository
+that stores the CIM objects only in memory, partitioned by CIM namespaces, and
+containing an object store for each CIM object type using
+:class:`~pywbem_mock.InMemoryObjectStore` for each defined namespace. The CIM
+repository is created each time a :class:`~pywbem_mock.InMemoryRepository` is
+constructed and destroyed each time it is destroyed.
 
 Example:
 
@@ -70,8 +71,8 @@ class InMemoryObjectStore(BaseObjectStore):
     """
     # Documentation for the methods and properties inherited from
     # ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
-    # documentation. Therefore the methods in this class have no documentation
-    # string.
+    # documentation. Therefore the methods in this class that are derived
+    # from abstrace methods have no documentation string.
 
     # pylint: disable=line-too-long
     def __init__(self, cim_object_type):
@@ -91,7 +92,6 @@ class InMemoryObjectStore(BaseObjectStore):
         else:
             assert False, "InMemoryObjectStore: Invalid input parameter {}." \
                 .format(cim_object_type)
-    # pylint: enable=line-too-long
 
     def __repr__(self):
         return _format('InMemoryObjectStore(type={0},  dict={1}, size={2}',
@@ -173,13 +173,13 @@ class InMemoryRepository(BaseRepository):
             the CIM repository.
         """
 
-        # This variable defines the top level NocaseDict() which defines the
+        # Defines the top level NocaseDict() which defines the
         # namespaces in the repository. The keys of this dictionary
         # are namespace names and the values are dictionaries
         # defining the CIM classes, CIM instances, and CIM qualifier
         # declarations where the keys are "classes", "instance", and
         # "qualifiers" and the value for each is an instance of the
-        # class InMemoryObjectStore
+        # class InMemoryObjectStore that containe the CIM objects.
         self._repository = NocaseDict()
 
         # If an initial namespace is defined, add it to the repository

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -40,15 +40,14 @@ __all__ = ['InMemoryRepository', 'InMemoryObjectStore']
 
 class InMemoryObjectStore(BaseObjectStore):
     """
-    Derived from the :class:`BaseObjectStore`, this class implements a
-    dictionary based in-memory repository for CIM objects that manages
-    CIM classes, CIM instances, and CIM qualifier declarations.
-
-    Documentation for the methods and properties inherited from
-    ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
-    documentation. Therefore the methods in this class have no
-    documentation string.
+    A store for CIM objects of a single type (CIM classes, CIM instances,
+    or CIM qualifier declarations) that maintains its data in memory.
     """
+    # Documentation for the methods and properties inherited from
+    # ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
+    # documentation. Therefore the methods in this class have no documentation
+    # string.
+
     # pylint: disable=line-too-long
     def __init__(self, cim_object_type):
 
@@ -127,16 +126,14 @@ class InMemoryObjectStore(BaseObjectStore):
 class InMemoryRepository(BaseRepository):
     """
     A CIM repository that maintains its data in memory.
-
-    Documentation for the methods and properties inherited from
-    ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
-    documentation. Therefore the methods in this class have no
-    documentation string.
     """
+    # Documentation for the methods and properties inherited from
+    # ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
+    # documentation. Therefore the methods in this class have no documentation
+    # string.
+
     def __init__(self, initial_namespace=None):
         """
-        Initialize the InMemoryRepository.
-
         Parameters:
 
           initial_namespace:(:term:`string` or None):
@@ -159,7 +156,7 @@ class InMemoryRepository(BaseRepository):
 
     def print_repository(self, dest=None, ):
         """
-        Display the items in the repository. This displays information on
+        Print the CIM repository to a destination. This displays information on
         the items in the data base and is only a diagnostic tool.
 
         Parameters:
@@ -173,18 +170,17 @@ class InMemoryRepository(BaseRepository):
             """
             for ns in self._repository:
                 if objstore_name == 'class':
-                    repo = self.get_class_repo(ns)
+                    store = self.get_class_store(ns)
                 elif objstore_name == 'qualifier':
-                    repo = self.get_qualifier_repo(ns)
+                    store = self.get_qualifier_store(ns)
                 elif objstore_name == 'instance':
-                    repo = self.get_instance_repo(ns)
+                    store = self.get_instance_store(ns)
                 else:
-                    assert objstore_name == 'instance'
-                    repo = self.get_instance_repo(ns)
+                    assert 'Invalid data store name {}'.format(objstore_name)
 
                 rtn_str = u'Namespace: {} Repo: {} len:{}\n'.format(
-                    ns, objstore_name, repo.len())
-                for val in repo.iter_values():
+                    ns, objstore_name, store.len())
+                for val in store.iter_values():
                     rtn_str += (u'{}\n'.format(val))
                 return rtn_str
 
@@ -230,9 +226,9 @@ class InMemoryRepository(BaseRepository):
         self.validate_namespace(namespace)
         namespace = namespace.strip('/')
 
-        if self.get_class_repo(namespace).len() != 0 or \
-                self.get_qualifier_repo(namespace).len() != 0 or \
-                self.get_instance_repo(namespace).len() != 0:
+        if self.get_class_store(namespace).len() != 0 or \
+                self.get_qualifier_store(namespace).len() != 0 or \
+                self.get_instance_store(namespace).len() != 0:
             raise ValueError('Namespace {} removal invalid. Namespace not '
                              'empty'.format(namespace))
 
@@ -242,21 +238,21 @@ class InMemoryRepository(BaseRepository):
     def namespaces(self):
         return list(self._repository)
 
-    def get_class_repo(self, namespace):
+    def get_class_store(self, namespace):
         if namespace is None:
             raise ValueError("Namespace None not permitted.")
         namespace = namespace.strip('/')
         self.validate_namespace(namespace)
         return self._repository[namespace]['classes']
 
-    def get_instance_repo(self, namespace):
+    def get_instance_store(self, namespace):
         if namespace is None:
             raise ValueError("Namespace None not permitted.")
         namespace = namespace.strip('/')
         self.validate_namespace(namespace)
         return self._repository[namespace]['instances']
 
-    def get_qualifier_repo(self, namespace):
+    def get_qualifier_store(self, namespace):
         if namespace is None:
             raise ValueError("Namespace None not permitted.")
         namespace = namespace.strip('/')

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -19,8 +19,28 @@
 #
 
 """
-Implementation of the BaseRepository abstract classes that defines an in-memory
-repository based on dictionaries.
+The pywbem_mock module provides a standard interface to a CIM repository that
+stores collections of :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`,
+and :class:`~pywbem.CIMQualifierDeclaration` as Python asbstract classes in the
+module :py:mod:`pywbem_mock/_baserepository.py`.
+
+The pywbem_mock inmemory CIM repository implements a repository derived from
+:py:mod:`pywbem_mock/_baserepository.py` that stores the CIM objects only in
+memory. This CIMrepository is created each time a
+:class:`~pywbem_mock.FakedWBEMConnection` is constructed and destroyed each
+time it is destroyed.
+
+.. code-block:: python
+  Example:
+  repo = InMemoryRepository()                      # create the repo
+  repo.add_namespace("root/cimv2")                 # add a namespace
+  class_store = .repo.get_class_store("root/cimv2") # get class obj store
+  test_class = CIMClass('CIM_Blah', ...)           # create a class
+  class_store.add(test_class)                      # add to xxxrepo classes
+  if 'CIM_Blah' in class_store:                    # test if class exists
+      klass = class_store.get('CIM_Blah;)          # get the class
+
+The following classes implement this repository:
 """
 
 from __future__ import absolute_import, print_function

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -1,0 +1,408 @@
+#
+# (C) Copyright 2020 InovaDevelopment.comn
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+Implementation of the BaseRepository abstract classes that defines an in-memory
+repository based on dictionaries.
+"""
+
+import six
+
+from pywbem._nocasedict import NocaseDict
+
+from pywbem import CIMClass, CIMQualifierDeclaration, CIMInstance
+from pywbem._utils import _format
+from ._baserepository import ObjectStoreAPI, BaseRepositoryAPI
+
+
+class InMemoryObjStore(ObjectStoreAPI):
+    """
+    Derived from the :class:`ObjectStoreAPI`, this class implements a
+    dictionary based in-memory repository for CIM objects that manages
+    CIM classes, CIM instances, and CIM qualifier declarations.
+    """
+
+    def __init__(self, case_insensitive_names, cim_object_type):
+        """
+          Parameters:
+
+            case_insensitive_names(:class:`py:bool`):
+                Defines whether the data store for this type handles
+                case insesitive names or not
+
+            cim_object_type ():
+             CIMType of the object stored in this object store. Only CIMClass,
+             CIMInstance, and CIMQualifierDeclaration types are allowed.
+        """
+
+        self._case_insensitive_names = case_insensitive_names
+        self._cim_object_type = cim_object_type
+
+        self._data = NocaseDict() if case_insensitive_names else {}
+
+    def __repr__(self):
+        return _format('InMemoryObjStore(type={0},  dict={1}, size {2}',
+                       self._cim_object_type, type(self._data),
+                       len(self._data))
+
+    def exists(self, name):
+        """
+        Overrides the abstract method.
+
+        Returns boolean True if the object is in the dictionary. Otherwise
+        returns False
+        """
+        return True if name in self._data else False
+
+    def get(self, name, copy=True):
+        """
+        Overrides the abstract method.
+
+        Gets the object with name from the dictionary or returns an exception
+        if an object with name does note exist.
+
+        If copy is True, it generates creates a copy and returns the copy
+        """
+
+        if name in self._data:
+            if copy:
+                return self._data[name].copy()
+            return self._data[name]
+        else:
+            raise KeyError('{} not in {} object store'
+                           .format(name, self._cim_object_type))
+
+    def create(self, name, cim_object):
+        """
+        Overrides the abstract method.
+
+        Creates a new cim_object in the object store dictionary or fails
+        with an exception if the name already exists in the dictionary.
+        """
+
+        assert isinstance(cim_object, self._cim_object_type)
+
+        if name in self._data:
+            raise ValueError('{} already in {} object store'
+                             .format(name, self._cim_object_type))
+
+        self._data[name] = cim_object.copy()
+
+    def update(self, name, cim_object):
+        """
+        Overrides the abstract method.
+
+        This method updates the corresponding dictionary with the cim_object
+        if the object exists in the dictionary. Otherwise it returns
+        an exception.
+
+        """
+
+        assert isinstance(cim_object, self._cim_object_type)
+
+        if name not in self._data:
+            raise KeyError('{} not in {} object store'
+                           .format(name, self._cim_object_type))
+
+        # Replace the existing object with a copy of the input object
+        self._data[name] = cim_object.copy()
+
+    def delete(self, name):
+        """
+        Overrides the abstract method.
+
+        If the object exists in the object store dictionary, it is deleted.
+        If it does not exist an exception is returned.
+        """
+        if name in self._data:
+            del self._data[name]
+        else:
+            raise KeyError('{} not in {} object store'
+                           .format(name, self._cim_object_type))
+
+    def iter_names(self):
+        """
+        Overrides the abstract method.
+
+        Returns iterator for names of the objects in the object store
+
+        """
+        return six.iterkeys(self._data)
+
+    def iter_values(self, copy=True):
+        """
+        Overrides the abstract method.
+
+        Returns an iterator for the object values in the object store
+        """
+        if copy:
+            for value in six.itervalues(self._data):
+                yield(value.copy())
+        else:
+            return six.itervalues(self._data)
+
+    def len(self):
+        """
+        Overrides the abstract method
+        :class:`~pywbem_mock._baserepository.ObjectStoreAPI.len`
+
+        Returns count of number of objects in the object store dictionary.
+        """
+        return len(self._data)
+
+
+class InMemoryRepository(BaseRepositoryAPI):
+    """
+    Defines the data store and access methods for a simple CIMClass,
+    CIMInstance, and CIMQualifierDeclaration repository that maintains the date
+    in memory.
+
+    The API for this data store is defined in the BaseRepositoryAPI class and
+    the ObjectStoreAPI class.
+    """
+    def __init__(self, initial_namespace):
+        """
+        Initialize the InMemoryRepository by creatiing the initial
+        namespace definition and the data stores for CIM classes, CIM instances,
+        and CIM qualifier declarations.
+
+          Parameters:
+             Initial namespace defined for this repository
+        """
+
+        # Create the in memory repository.  This defines the top level
+        # NocaseDict which defines the namespaces.
+        self._repository = NocaseDict()
+
+        # Create the initial namespace
+        self.add_namespace(initial_namespace)
+        namespace = initial_namespace.strip('/')
+
+        # Create the object store for each the CIM types to be stored
+        self._repository[namespace]['classes'] = InMemoryObjStore(
+            True, CIMClass)
+        self._repository[namespace]['instances'] = InMemoryObjStore(
+            False, CIMInstance)
+        self._repository[namespace]['qualifiers'] = InMemoryObjStore(
+            True, CIMQualifierDeclaration)
+
+    def print(self):
+        """
+        Display the items in the repository. This displays information on
+        the items in the data base
+        """
+        def repo_info(repo_name):
+            for ns in self._repository.keys():
+                if repo_name == 'class':
+                    repo = self.get_class_repo(ns)
+                elif repo_name == 'qualifier':
+                    repo = self.get_qualifier_repo(ns)
+                elif repo_name == 'instance':
+                    repo = self.get_instance_repo(ns)
+                else:
+                    assert False
+                rtn_str = 'Namespace: {} Repo: {} len:{}\n'.format(ns,
+                                                                   repo_name,
+                                                                   repo.len())
+                for val in repo.iter_values():
+                    rtn_str += ('{}\n'.format(val))
+                return rtn_str
+
+        print('NAMESPACES: {}'.format(self._repository.keys()))
+
+        print('QUALIFIERS: {}'.format(repo_info('qualifier')))
+        print('CLASSES: {}'.format(repo_info('class')))
+        print('INSTANCES: {}'.format(repo_info('instance')))
+
+    def validate_namespace(self, namespace):
+        """
+        Validate if the namespace existsin the repository. If the namespace
+        does not exist a KeyError is raised.
+
+        Raises:
+            KeyError: If the namespace is not defined in the repository
+        """
+
+        namespace = namespace.strip('/')
+        try:
+            self._repository[namespace]
+        except KeyError:
+            raise
+
+    def add_namespace(self, namespace):
+        """
+        Add a CIM namespace to the repository.
+
+        The namespace must not yet exist in the mock repository.
+
+        The default connection namespace is automatically added to
+        the mock repository upon creation of this connection.
+
+          Parameters:
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`. Leading and trailing slash characters are split off
+              from the provided string.
+
+          Raises:
+            ValueError: If the namespace argument is None or the
+             namespace already exists.
+        """
+
+        if namespace is None:
+            raise ValueError("Namespace argument must not be None")
+
+        namespace = namespace.strip('/')
+
+        if namespace in self._repository:
+            raise ValueError('Namespace {} already nn repository'.
+                             format(namespace))
+
+        self._repository[namespace] = {}
+
+        # Create the data store for each of the object types.
+        self._repository[namespace]['classes'] = InMemoryObjStore(
+            True, CIMClass)
+
+        self._repository[namespace]['instances'] = InMemoryObjStore(
+            False, CIMInstance)
+
+        self._repository[namespace]['qualifiers'] = InMemoryObjStore(
+            True, CIMQualifierDeclaration)
+
+    def remove_namespace(self, namespace):
+        """
+        Remove a CIM namespace from the repository.
+
+        The namespace must exist in the repository and must be empty.
+
+        Parameters:
+
+          namespace (:term:`string`):
+            The name of the CIM namespace in the mock repository. Must not be
+            `None`. Any leading and trailing slash characters are split off
+            from the provided string.
+
+        Raises:
+
+          ValueError: Namespace argument is None or the repository namespace
+            is not empty
+          KeyError:  The namespace does not exist in the mock repository.
+        """
+
+        if namespace is None:
+            raise ValueError("Namespace argument must not be None")
+
+        namespace = namespace.strip('/')
+
+        if namespace not in self._repository:
+            raise KeyError("Invalid namespace name {}".format(namespace))
+
+        if self.get_class_repo(namespace).len() != 0 or \
+                self.get_qualifier_repo(namespace).len() != 0 or \
+                self.get_instance_repo(namespace).len() != 0:
+            raise ValueError('Namespace {} removal invalid. Namespace not '
+                             'empty'.format(namespace))
+
+        del self._repository[namespace]
+
+    # TODO: Why not make this a property
+    def list_namespaces(self):
+        """
+        List the namespaces that exist in the repository
+
+        Returns:
+            list of :term:`string` items containing the namespace names
+        """
+        return self._repository.keys()
+
+    def get_class_repo(self, namespace):
+        """
+        Get the handle for the data CIM class data store for the namespace
+        provided.
+
+          Parameters:
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+
+          Returns:
+            Returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+
+          Raises:
+            KeyError: If the namespace does not exist in the repository
+        """
+
+        if namespace is None:
+            raise ValueError("Namespace None not permitted.")
+        namespace = namespace.strip('/')
+        self.validate_namespace(namespace)
+        return self._repository[namespace]['classes']
+
+    def get_instance_repo(self, namespace):
+        """
+        Get the handle for the data CIM instance data store for the namespace
+        provided.
+
+          Parameters:
+
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+          Returns:
+            returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+        """
+
+        if namespace is None:
+            raise ValueError("Namespace None not permitted.")
+        namespace = namespace.strip('/')
+        self.validate_namespace(namespace)
+        return self._repository[namespace]['instances']
+
+    def get_qualifier_repo(self, namespace):
+        """
+        Gets the handle for the data CIM qualifier declaration data store for
+        the namespace provided.
+
+          Parameters:
+
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`
+          Returns:
+            returns an instance of InMemoryObjStore which defines the
+            methods exists(), get() create(), etc. for accessing the
+            data in this store.
+
+          Raises:
+            ValueError if namespace parameter is None
+            KeyError if the namespace parameter does not define an existing
+              namespace
+        """
+
+        if namespace is None:
+            raise ValueError("Namespace None not permitted.")
+        namespace = namespace.strip('/')
+        self.validate_namespace(namespace)
+        return self._repository[namespace]['qualifiers']

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -25,11 +25,14 @@ collections of :class:`~pywbem.CIMClass`, :class:`~pywbem.CIMInstance`, and
 define the API for the repository.
 
 The class :class:`~pywbem_mock.InMemoryRepository` implements a CIM repository
-that stores the CIM objects only in memory, partitioned by CIM namespaces, and
-containing an object store for each CIM object type using
-:class:`~pywbem_mock.InMemoryObjectStore` for each defined namespace. The CIM
-repository is created each time a :class:`~pywbem_mock.InMemoryRepository` is
-constructed and destroyed each time it is destroyed.
+that stores the CIM objects only in memory partitioned by CIM namespaces, and
+containing an object store (:class:`~pywbem_mock.InMemoryObjectStore`) for each
+CIM object type in each defined namespace. Each object store contains the CIM
+objects of the defined CIM type that have been added to the repository.
+
+The CIM repository is created each time a
+:class:`~pywbem_mock.InMemoryRepository` is constructed and destroyed each time
+it is destroyed.
 
 Example:
 

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -141,9 +141,9 @@ class InMemoryRepository(BaseRepository):
             the CIM repository.
         """
 
-        # Create the in memory repository.  This defines the top level
-        # NocaseDict which defines the namespaces. The keys of this
-        # dictionary are namespace names and the values are the dictionaries
+        # This variable defines the top level NocaseDict() which defines the
+        # namespaces in the repository. The keys of this dictionary
+        # are namespace names and the values are dictionaries
         # defining the CIM classes, CIM instances, and CIM qualifier
         # declarations where the keys are "classes", "instance", and
         # "qualifiers" and the value for each is an instance of the
@@ -173,10 +173,9 @@ class InMemoryRepository(BaseRepository):
                     store = self.get_class_store(ns)
                 elif objstore_name == 'qualifier':
                     store = self.get_qualifier_store(ns)
-                elif objstore_name == 'instance':
-                    store = self.get_instance_store(ns)
                 else:
-                    assert 'Invalid data store name {}'.format(objstore_name)
+                    assert objstore_name == 'instance'
+                    store = self.get_instance_store(ns)
 
                 rtn_str = u'Namespace: {} Repo: {} len:{}\n'.format(
                     ns, objstore_name, store.len())

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -23,64 +23,60 @@ Implementation of the BaseRepository abstract classes that defines an in-memory
 repository based on dictionaries.
 """
 
+from __future__ import absolute_import, print_function
+
 import six
 
-from pywbem._nocasedict import NocaseDict
-
 from pywbem import CIMClass, CIMQualifierDeclaration, CIMInstance
+
+from pywbem._nocasedict import NocaseDict
 from pywbem._utils import _format
-from ._baserepository import ObjectStoreAPI, BaseRepositoryAPI
+
+from ._baserepository import BaseObjectStore, BaseRepository
+from ._utils import _uprint
+
+__all__ = ['InMemoryRepository']
 
 
-class InMemoryObjStore(ObjectStoreAPI):
+class InMemoryObjStore(BaseObjectStore):
     """
-    Derived from the :class:`ObjectStoreAPI`, this class implements a
+    Derived from the :class:`BaseObjectStore`, this class implements a
     dictionary based in-memory repository for CIM objects that manages
     CIM classes, CIM instances, and CIM qualifier declarations.
     """
-
+    # pylint: disable=line-too-long
     def __init__(self, case_insensitive_names, cim_object_type):
         """
-          Parameters:
-
-            case_insensitive_names(:class:`py:bool`):
-                Defines whether the data store for this type handles
-                case insesitive names or not
-
-            cim_object_type ():
-             CIMType of the object stored in this object store. Only CIMClass,
-             CIMInstance, and CIMQualifierDeclaration types are allowed.
+        See :meth:`~pywbem_mock.BaseObjectStore.__init__`
         """
 
-        self._case_insensitive_names = case_insensitive_names
-        self._cim_object_type = cim_object_type
+        super(InMemoryObjStore, self).__init__(case_insensitive_names,
+                                               cim_object_type)
 
+        # Define the dictionary that implements the object store.
+        # The keys in this dictionary are the names of the objects and
+        # the values the corresponding CIM objects.
         self._data = NocaseDict() if case_insensitive_names else {}
 
+    # pylint: enable=line-too-long
+
     def __repr__(self):
-        return _format('InMemoryObjStore(type={0},  dict={1}, size {2}',
+        return _format('InMemoryObjStore(type={0},  dict={1}, size={2}',
                        self._cim_object_type, type(self._data),
                        len(self._data))
 
     def exists(self, name):
         """
-        Overrides the abstract method.
-
-        Returns boolean True if the object is in the dictionary. Otherwise
-        returns False
+        See :meth:`~pywbem_mock.BaseObjectStore.exists`
         """
-        return True if name in self._data else False
+        return name in self._data
 
     def get(self, name, copy=True):
         """
-        Overrides the abstract method.
-
-        Gets the object with name from the dictionary or returns an exception
-        if an object with name does note exist.
-
-        If copy is True, it generates creates a copy and returns the copy
+        See :meth:`~pywbem_mock.BaseObjectStore.get`
         """
 
+        # pylint: disable=no-else-return
         if name in self._data:
             if copy:
                 return self._data[name].copy()
@@ -91,10 +87,7 @@ class InMemoryObjStore(ObjectStoreAPI):
 
     def create(self, name, cim_object):
         """
-        Overrides the abstract method.
-
-        Creates a new cim_object in the object store dictionary or fails
-        with an exception if the name already exists in the dictionary.
+        See :meth:`~pywbem_mock.BaseObjectStore.create`
         """
 
         assert isinstance(cim_object, self._cim_object_type)
@@ -107,12 +100,7 @@ class InMemoryObjStore(ObjectStoreAPI):
 
     def update(self, name, cim_object):
         """
-        Overrides the abstract method.
-
-        This method updates the corresponding dictionary with the cim_object
-        if the object exists in the dictionary. Otherwise it returns
-        an exception.
-
+        See :meth:`~pywbem_mock.BaseObjectStore.update`
         """
 
         assert isinstance(cim_object, self._cim_object_type)
@@ -126,10 +114,7 @@ class InMemoryObjStore(ObjectStoreAPI):
 
     def delete(self, name):
         """
-        Overrides the abstract method.
-
-        If the object exists in the object store dictionary, it is deleted.
-        If it does not exist an exception is returned.
+        See :meth:`~pywbem_mock.BaseObjectStore.delete`
         """
         if name in self._data:
             del self._data[name]
@@ -139,131 +124,113 @@ class InMemoryObjStore(ObjectStoreAPI):
 
     def iter_names(self):
         """
-        Overrides the abstract method.
-
-        Returns iterator for names of the objects in the object store
-
+        See :meth:`~pywbem_mock.BaseObjectStore.iter_names`
         """
         return six.iterkeys(self._data)
 
     def iter_values(self, copy=True):
         """
-        Overrides the abstract method.
+        See :meth:`~pywbem_mock.BaseObjectStore.iter_values`
 
-        Returns an iterator for the object values in the object store
         """
-        if copy:
-            for value in six.itervalues(self._data):
+        for value in six.itervalues(self._data):
+            if copy:
                 yield(value.copy())
-        else:
-            return six.itervalues(self._data)
+            else:
+                yield(value)
 
     def len(self):
         """
-        Overrides the abstract method
-        :class:`~pywbem_mock._baserepository.ObjectStoreAPI.len`
-
-        Returns count of number of objects in the object store dictionary.
+        See :meth:`~pywbem_mock.BaseObjectStore.len`
         """
         return len(self._data)
 
 
-class InMemoryRepository(BaseRepositoryAPI):
+class InMemoryRepository(BaseRepository):
     """
-    Defines the data store and access methods for a simple CIMClass,
-    CIMInstance, and CIMQualifierDeclaration repository that maintains the date
-    in memory.
+    A CIM repository that keeps its data in memory..
 
-    The API for this data store is defined in the BaseRepositoryAPI class and
-    the ObjectStoreAPI class.
+    The API for this data store is defined in
+    :class:`~pywbem_mock.BaseObjectStore and :class:.
     """
-    def __init__(self, initial_namespace):
+    def __init__(self, initial_namespace=None):
         """
-        Initialize the InMemoryRepository by creatiing the initial
-        namespace definition and the data stores for CIM classes, CIM instances,
-        and CIM qualifier declarations.
+        Initialize the InMemoryRepository.
 
-          Parameters:
-             Initial namespace defined for this repository
+        Parameters:
+
+          initial_namespace:(:term:`string` or None):
+            Optional initial namespace that will be added to
+            the CIM repository.
         """
 
         # Create the in memory repository.  This defines the top level
-        # NocaseDict which defines the namespaces.
+        # NocaseDict which defines the namespaces. The keys of this
+        # dictionary are namespace names and the values are the dictionaries
+        # defining the CIM classes, CIM instances, and CIM qualifier
+        # declarations where the keys are "classes", "instance", and
+        # "qualifiers" and the value for each is an instance of the
+        # class InMemoryObjStore
         self._repository = NocaseDict()
 
-        # Create the initial namespace
-        self.add_namespace(initial_namespace)
-        namespace = initial_namespace.strip('/')
+        # If an initial namespace is defined, add it to the repository
+        if initial_namespace:
+            self.add_namespace(initial_namespace)
 
-        # Create the object store for each the CIM types to be stored
-        self._repository[namespace]['classes'] = InMemoryObjStore(
-            True, CIMClass)
-        self._repository[namespace]['instances'] = InMemoryObjStore(
-            False, CIMInstance)
-        self._repository[namespace]['qualifiers'] = InMemoryObjStore(
-            True, CIMQualifierDeclaration)
-
-    def print(self):
+    def print_repository(self, dest=None, ):
         """
         Display the items in the repository. This displays information on
-        the items in the data base
+        the items in the data base and is only a diagnostic tool.
+
+        Parameters:
+          dest (:term:`string`):
+            File-like object(ex. file_path, or other data stream definition )
+            for the output. If `None`, the output is written to stdout.
         """
-        def repo_info(repo_name):
-            for ns in self._repository.keys():
-                if repo_name == 'class':
+        def objstore_info(objstore_name):
+            """
+            Display the date for the object
+            """
+            for ns in self._repository:
+                if objstore_name == 'class':
                     repo = self.get_class_repo(ns)
-                elif repo_name == 'qualifier':
+                elif objstore_name == 'qualifier':
                     repo = self.get_qualifier_repo(ns)
-                elif repo_name == 'instance':
+                elif objstore_name == 'instance':
                     repo = self.get_instance_repo(ns)
                 else:
-                    assert False
-                rtn_str = 'Namespace: {} Repo: {} len:{}\n'.format(ns,
-                                                                   repo_name,
-                                                                   repo.len())
+                    assert objstore_name == 'instance'
+                    repo = self.get_instance_repo(ns)
+
+                rtn_str = u'Namespace: {} Repo: {} len:{}\n'.format(
+                    ns, objstore_name, repo.len())
                 for val in repo.iter_values():
-                    rtn_str += ('{}\n'.format(val))
+                    rtn_str += (u'{}\n'.format(val))
                 return rtn_str
 
-        print('NAMESPACES: {}'.format(self._repository.keys()))
-
-        print('QUALIFIERS: {}'.format(repo_info('qualifier')))
-        print('CLASSES: {}'.format(repo_info('class')))
-        print('INSTANCES: {}'.format(repo_info('instance')))
+        namespaces = ",".join(self._repository.keys())
+        _uprint(dest, _format(u'NAMESPACES: {0}', namespaces))
+        _uprint(dest, _format(u'QUALIFIERS: {0}', objstore_info('qualifier')))
+        _uprint(dest, _format(u'CLASSES: {0}', objstore_info('class')))
+        _uprint(dest, _format(u'INSTANCES: {0}', objstore_info('instance')))
 
     def validate_namespace(self, namespace):
         """
-        Validate if the namespace existsin the repository. If the namespace
-        does not exist a KeyError is raised.
-
-        Raises:
-            KeyError: If the namespace is not defined in the repository
+        See :meth:`~pywbem_mock.BaseRepository.validate_namespace`
         """
+        if namespace is None:
+            raise ValueError("Namespace argument must not be None")
 
         namespace = namespace.strip('/')
         try:
             self._repository[namespace]
         except KeyError:
-            raise
+            raise KeyError('Namespace {} does not exist in repository'.
+                           format(namespace))
 
     def add_namespace(self, namespace):
         """
-        Add a CIM namespace to the repository.
-
-        The namespace must not yet exist in the mock repository.
-
-        The default connection namespace is automatically added to
-        the mock repository upon creation of this connection.
-
-          Parameters:
-            namespace (:term:`string`):
-              The name of the CIM namespace in the mock repository. Must not be
-              `None`. Leading and trailing slash characters are split off
-              from the provided string.
-
-          Raises:
-            ValueError: If the namespace argument is None or the
-             namespace already exists.
+        See :meth:`~pywbem_mock.BaseRepository.add_namespace`
         """
 
         if namespace is None:
@@ -272,7 +239,7 @@ class InMemoryRepository(BaseRepositoryAPI):
         namespace = namespace.strip('/')
 
         if namespace in self._repository:
-            raise ValueError('Namespace {} already nn repository'.
+            raise ValueError('Namespace {} already in repository'.
                              format(namespace))
 
         self._repository[namespace] = {}
@@ -289,31 +256,11 @@ class InMemoryRepository(BaseRepositoryAPI):
 
     def remove_namespace(self, namespace):
         """
-        Remove a CIM namespace from the repository.
-
-        The namespace must exist in the repository and must be empty.
-
-        Parameters:
-
-          namespace (:term:`string`):
-            The name of the CIM namespace in the mock repository. Must not be
-            `None`. Any leading and trailing slash characters are split off
-            from the provided string.
-
-        Raises:
-
-          ValueError: Namespace argument is None or the repository namespace
-            is not empty
-          KeyError:  The namespace does not exist in the mock repository.
+        See :meth:`~pywbem_mock.BaseRepository.remove_namespace`
         """
 
-        if namespace is None:
-            raise ValueError("Namespace argument must not be None")
-
+        self.validate_namespace(namespace)
         namespace = namespace.strip('/')
-
-        if namespace not in self._repository:
-            raise KeyError("Invalid namespace name {}".format(namespace))
 
         if self.get_class_repo(namespace).len() != 0 or \
                 self.get_qualifier_repo(namespace).len() != 0 or \
@@ -323,33 +270,17 @@ class InMemoryRepository(BaseRepositoryAPI):
 
         del self._repository[namespace]
 
-    # TODO: Why not make this a property
-    def list_namespaces(self):
+    @property
+    def namespaces(self):
         """
-        List the namespaces that exist in the repository
+        See :meth:`~pywbem_mock.BaseRepository.namespaces`
 
-        Returns:
-            list of :term:`string` items containing the namespace names
         """
-        return self._repository.keys()
+        return [ns for ns in self._repository]
 
     def get_class_repo(self, namespace):
         """
-        Get the handle for the data CIM class data store for the namespace
-        provided.
-
-          Parameters:
-            namespace (:term:`string`):
-              The name of the CIM namespace in the mock repository. Must not be
-              `None`
-
-          Returns:
-            Returns an instance of InMemoryObjStore which defines the
-            methods exists(), get() create(), etc. for accessing the
-            data in this store.
-
-          Raises:
-            KeyError: If the namespace does not exist in the repository
+        See :meth:`~pywbem_mock.BaseRepository.get_class_repo`
         """
 
         if namespace is None:
@@ -360,18 +291,8 @@ class InMemoryRepository(BaseRepositoryAPI):
 
     def get_instance_repo(self, namespace):
         """
-        Get the handle for the data CIM instance data store for the namespace
-        provided.
+        See :meth:`~pywbem_mock.BaseRepository.get_instance_repo`
 
-          Parameters:
-
-            namespace (:term:`string`):
-              The name of the CIM namespace in the mock repository. Must not be
-              `None`
-          Returns:
-            returns an instance of InMemoryObjStore which defines the
-            methods exists(), get() create(), etc. for accessing the
-            data in this store.
         """
 
         if namespace is None:
@@ -382,23 +303,8 @@ class InMemoryRepository(BaseRepositoryAPI):
 
     def get_qualifier_repo(self, namespace):
         """
-        Gets the handle for the data CIM qualifier declaration data store for
-        the namespace provided.
+        See :meth:`~pywbem_mock.BaseRepository.get_qualifier_repo`
 
-          Parameters:
-
-            namespace (:term:`string`):
-              The name of the CIM namespace in the mock repository. Must not be
-              `None`
-          Returns:
-            returns an instance of InMemoryObjStore which defines the
-            methods exists(), get() create(), etc. for accessing the
-            data in this store.
-
-          Raises:
-            ValueError if namespace parameter is None
-            KeyError if the namespace parameter does not define an existing
-              namespace
         """
 
         if namespace is None:

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -28,16 +28,17 @@ For documentation, see mocksupport.rst.
 from __future__ import absolute_import, print_function
 
 from pywbem import CIMError, CIM_ERR_INVALID_PARAMETER, \
-    CIM_ERR_NOT_FOUND, CIM_ERR_ALREADY_EXISTS, \
-    CIM_ERR_INVALID_NAMESPACE, CIMInstanceName
+    CIM_ERR_NOT_FOUND, CIM_ERR_ALREADY_EXISTS, CIM_ERR_FAILED, \
+    CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_NAMESPACE, CIMInstanceName
 from pywbem._nocasedict import NocaseDict
 from pywbem._mof_compiler import MOFWBEMConnection
 
 from pywbem._utils import _format
 from ._resolvermixin import ResolverMixin
+from pywbem._nocasedict import NocaseDict
 
-# Issue # 2062 Refactor this into a class that represents the repository
-# data store.
+# Issue #2062 TODO/ks Remove this code and use the methods in _WBEMConnection
+# in their place
 
 
 class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
@@ -50,7 +51,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
     that allows resolving the created class before it is inserted into the
     repository.
 
-    This class is private to pywbem_mock
+    This class adaption is private to pywbem_mock
     """
     def __init__(self, faked_conn_object):
         """
@@ -65,89 +66,64 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         """
         super(_MockMOFWBEMConnection, self).__init__(conn=faked_conn_object)
 
-        # Reassign the variables that represent the repository to the
-        # faked_conn_object so that we have a common repository
-        self.qualifiers = faked_conn_object.qualifiers
-        self.instances = faked_conn_object.instances
-        self.classes = faked_conn_object.classes
+        self.classes = NocaseDict()
 
-    def CreateClass(self, *args, **kwargs):
+        self.repo = faked_conn_object.repo
+
+    def _getns(self):
         """
-        Override the CreateClass method in MOFWBEMConnection. NOTE: This is
-        currently only used by the compiler.  The methods of Fake_WBEMConnectin
-        go directly to the repository, not through this method.
-        This modifies the overridden method to add validation.
+        :term:`string`: Return the default repository namespace to be used.
 
-        For a description of the parameters, see
-        :meth:`pywbem.WBEMConnection.CreateClass`.
+        This method exists for compatibility. Use the :attr:`default_namespace`
+        property instead.
         """
-        cc = args[0] if args else kwargs['NewClass']
-        namespace = self.getns()
+        if self.conn is not None:
+            return self.conn.default_namespace
+        return self.__default_namespace
 
-        try:
-            self.compile_ordered_classnames.append(cc.classname)
+    def _setns(self, value):
+        """
+        Set the default repository namespace to be used.
 
-            # The following generates an exception for each new ns
-            self.classes[self.default_namespace][cc.classname] = cc
-        except KeyError:
-            self.classes[namespace] = \
-                NocaseDict({cc.classname: cc})
+        This method exists for compatibility. Use the :attr:`default_namespace`
+        property instead.
+        """
+        if self.conn is not None:
+            self.conn.default_namespace = value
+        else:
+            self.__default_namespace = value
 
-        # Validate that references and embedded instance properties, methods,
-        # etc. have classes that exist in repo. This  also institates the
-        # mechanism that gets insures that prerequisite classes are inserted
-        # into the repo.
-        objects = list(cc.properties.values())
-        for meth in cc.methods.values():
-            objects += list(meth.parameters.values())
+    getns = _getns  # for compatibility
+    setns = _setns  # for compatibility
 
-        for obj in objects:
-            # Validate that reference_class exists in repo
-            if obj.type == 'reference':
-                try:
-                    self.GetClass(obj.reference_class, LocalOnly=True,
-                                  IncludeQualifiers=True)
-                except CIMError as ce:
-                    if ce.status_code == CIM_ERR_NOT_FOUND:
-                        raise CIMError(
-                            CIM_ERR_INVALID_PARAMETER,
-                            _format("Class {0!A} referenced by element {1!A} "
-                                    "of class {2!A} in namespace {3!A} does "
-                                    "not exist",
-                                    obj.reference_class, obj.name,
-                                    cc.classname, self.getns()),
-                            conn_id=self.conn_id)
-                    raise
+    default_namespace = property(
+        _getns, _setns, None,
+        """
+        :term:`string`: The default repository namespace to be used.
 
-            elif obj.type == 'string':
-                if 'EmbeddedInstance' in obj.qualifiers:
-                    eiqualifier = obj.qualifiers['EmbeddedInstance']
-                    try:
-                        self.GetClass(eiqualifier.value, LocalOnly=True,
-                                      IncludeQualifiers=False)
-                    except CIMError as ce:
-                        if ce.status_code == CIM_ERR_NOT_FOUND:
-                            raise CIMError(
-                                CIM_ERR_INVALID_PARAMETER,
-                                _format("Class {0!A} specified by "
-                                        "EmbeddInstance qualifier on element "
-                                        "{1!A} of class {2!A} in namespace "
-                                        "{3!A} does not exist",
-                                        eiqualifier.value, obj.name,
-                                        cc.classname, self.getns()),
-                                conn_id=self.conn_id)
-                        raise
+        The default repository namespace is the default namespace of the
+        underlying repository connection if there is such an underlying
+        connection, or the default namespace of this object.
 
-        ccr = self.conn._resolve_class(  # pylint: disable=protected-access
-            cc, namespace, self.qualifiers[namespace])
-        if namespace not in self.classes:
-            self.classes[namespace] = NocaseDict()
-        self.classes[namespace][ccr.classname] = ccr
+        Initially, the default namespace of this object is 'root/cimv2'.
 
-        try:
-            self.class_names[namespace].append(ccr.classname)
-        except KeyError:
-            self.class_names[namespace] = [ccr.classname]
+        This property is settable. Setting it will cause the default namespace
+        of the underlying repository connection to be updated if there is such
+        an underlying connection, or the default namespace of this object.
+        """
+    )
+
+    def EnumerateInstanceNames(self, *args, **kwargs):
+        """This method is used by the MOF compiler only when it creates a
+        namespace in the course of handling CIM_ERR_NAMESPACE_NOT_FOUND.
+        Because the operations of this class silently create every namespace
+        that is needed and never return that error, this method is never
+        called, and is therefore not implemented.
+        """
+
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def CreateInstance(self, *args, **kwargs):
         """
@@ -166,7 +142,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         For a description of the parameters, see
         :meth:`pywbem.WBEMConnection.CreateInstance`.
         """
-
+        namespace = self.default_namespace
         inst = args[0] if args else kwargs['NewInstance']
 
         # Get list of properties in class defined for this instance
@@ -190,21 +166,19 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
             inst.path = CIMInstanceName.from_instance(
                 cls, inst, namespace=self.default_namespace)
 
-        if self.default_namespace not in self.instances:
-            self.instances[self.default_namespace] = {}
-
-        # exception if duplicate. NOTE: compiler overrides this with
+        # Exception if duplicate. NOTE: compiler overrides this with
         # modify instance.
-        if inst.path in self.instances[self.default_namespace]:
+        instance_repo = self.repo.get_instance_repo(namespace)
+        if instance_repo.exists(inst.path):
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format('CreateInstance failed. Instance with path {0!A} '
                         'already exists in mock repository', inst.path))
         try:
-            self.instances[self.default_namespace][inst.path] = inst
+            # TODO: This should go through self.conn.CreateInstance
+            instance_repo.create(inst.path, inst)
         except KeyError:
-            self.instances[self.default_namespace] = {}
-            self.instances[self.default_namespace][inst.path] = inst
+            raise
 
         return inst.path
 
@@ -217,24 +191,243 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         each created instance include the instance path which means that
         the MOF must include the instance alias on each created instance.
         """
+        namespace = self.default_namespace
         mod_inst = args[0] if args else kwargs['ModifiedInstance']
-        if self.default_namespace not in self.instances:
+        instance_repo = self.conn._get_instance_repo(namespace)
+
+        if self.default_namespace not in self.repo.list_namespaces():
             raise CIMError(
                 CIM_ERR_INVALID_NAMESPACE,
                 _format('ModifyInstance failed. No instance repo exists. '
                         'Use compiler instance alias to set path on '
                         'instance declaration. inst: {0!A}', mod_inst))
 
-        if mod_inst.path not in self.instances[self.default_namespace]:
+        if not instance_repo.exists(mod_inst.path):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format('ModifyInstance failed. No instance exists. '
                         'Use compiler instance alias to set path on '
                         'instance declaration. inst: {0!A}', mod_inst))
 
-        orig_instance = self.instances[self.default_namespace][mod_inst.path]
-        orig_instance.update(mod_inst.properties)
-        self.instances[self.default_namespace][mod_inst.path] = orig_instance
+        # Update the instance in the repository from the modified inst
+        orig_inst = instance_repo.get(mod_inst.path)
+        orig_inst.update(mod_inst.properties)
+        instance_repo.update(mod_inst.path, orig_inst)
+
+    def DeleteInstance(self, *args, **kwargs):
+        """This method is only invoked by :meth:`rollback` (on the underlying
+        repository), and never by the MOF compiler, and is therefore not
+        implemented."""
+
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
+
+    def GetClass(self, *args, **kwargs):
+        """Retrieve a CIM class from the local repository of this class.
+
+        For a description of the parameters, see
+        :meth:`pywbem.WBEMConnection.GetClass`.
+        """
+        cname = args[0] if args else kwargs['ClassName']
+
+        try:
+            cc = self.classes[self.default_namespace][cname]
+        except KeyError:
+            if self.conn is None:
+                ce = CIMError(CIM_ERR_NOT_FOUND, cname)
+                raise ce
+            cc = self.conn.GetClass(*args, **kwargs)
+            try:
+                self.classes[self.default_namespace][cc.classname] = cc
+            except KeyError:
+                self.classes[self.default_namespace] = \
+                    NocaseDict({cc.classname: cc})
+
+        if 'LocalOnly' in kwargs and not kwargs['LocalOnly']:
+            if cc.superclass:
+                try:
+                    del kwargs['ClassName']
+                except KeyError:
+                    pass
+                if args:
+                    args = args[1:]
+                super_ = self.GetClass(cc.superclass, *args, **kwargs)
+                for prop in super_.properties.values():
+                    if prop.name not in cc.properties:
+                        cc.properties[prop.name] = prop
+                for meth in super_.methods.values():
+                    if meth.name not in cc.methods:
+                        cc.methods[meth.name] = meth
+        return cc
+
+    def CreateClass(self, *args, **kwargs):
+        """
+        Override the CreateClass method in MOFWBEMConnection. NOTE: This is
+        currently only used by the compiler.  The methods of Fake_WBEMConnectin
+        go directly to the repository, not through this method.
+        This modifies the overridden method to add validation.
+
+        For a description of the parameters, see
+        :meth:`pywbem.WBEMConnection.CreateClass`.
+        """
+        cc = args[0] if args else kwargs['NewClass']
+        namespace = self.default_namespace
+        class_repo = self.repo.get_class_repo(namespace)
+
+        if cc.superclass:
+            # Since this may cause additional GetClass calls
+            # IncludeQualifiers = True insures reference properties on
+            # instances with aliases get built correctly.
+            try:
+                self.GetClass(cc.superclass, LocalOnly=True,
+                              IncludeQualifiers=True)
+            except CIMError as ce:
+                if ce.status_code == CIM_ERR_NOT_FOUND:
+                    raise CIMError(
+                        CIM_ERR_INVALID_SUPERCLASS,
+                        _format("Cannot create class {0!A} in namespace "
+                                "{1!A} because its superclass {2!A} does "
+                                "not exist",
+                                cc.classname, self.getns(), cc.superclass),
+                        conn_id=self.conn_id)
+                raise
+
+        # Class created in local repo before tests because that allows
+        # tests that may actually include this class to succeed in
+        # the test code below.
+        try:
+            # The following generates an exception for each new ns
+            self.classes[self.default_namespace][cc.classname] = cc
+        except KeyError:
+            self.classes[namespace] = NocaseDict({cc.classname: cc})
+
+        # Validate that references and embedded instance properties, methods,
+        # etc. have classes that exist in repo. This  also institates the
+        # mechanism that gets insures that prerequisite classes are inserted
+        # into the repo.
+        objects = list(cc.properties.values())
+        for meth in cc.methods.values():
+            objects += list(meth.parameters.values())
+
+        for obj in objects:
+            # Validate that reference_class exists in repo
+            if obj.type == 'reference':
+                try:
+                    self.GetClass(obj.reference_class, LocalOnly=True,
+                                  IncludeQualifiers=True)
+                except KeyError:
+                    raise CIMError(CIM_ERR_INVALID_PARAMETER,
+                                   obj.reference_class)
+                # TODO: When we hook to server this returns to CIMError
+                except CIMError as ce:
+                    if ce.status_code == CIM_ERR_NOT_FOUND:
+                        raise CIMError(
+                            CIM_ERR_INVALID_PARAMETER,
+                            _format("Class {0!A} referenced by element {1!A} "
+                                    "of class {2!A} in namespace {3!A} does "
+                                    "not exist",
+                                    obj.reference_class, obj.name,
+                                    cc.classname, self.getns()),
+                            conn_id=self.conn_id)
+                    raise
+
+            elif obj.type == 'string':
+                if 'EmbeddedInstance' in obj.qualifiers:
+                    eiqualifier = obj.qualifiers['EmbeddedInstance']
+                    try:
+                        self.GetClass(eiqualifier.value, LocalOnly=True,
+                                      IncludeQualifiers=False)
+                    except KeyError:
+                        raise CIMError(CIM_ERR_INVALID_PARAMETER,
+                                       eiqualifier.value)
+                    except CIMError as ce:
+                        if ce.status_code == CIM_ERR_NOT_FOUND:
+                            raise CIMError(
+                                CIM_ERR_INVALID_PARAMETER,
+                                _format("Class {0!A} specified by "
+                                        "EmbeddInstance qualifier on element "
+                                        "{1!A} of class {2!A} in namespace "
+                                        "{3!A} does not exist",
+                                        eiqualifier.value, obj.name,
+                                        cc.classname, self.getns()),
+                                conn_id=self.conn_id)
+                        raise
+
+        ccr = self.conn._resolve_class(  # pylint: disable=protected-access
+            cc, namespace, self.repo.get_qualifier_repo(namespace))
+
+        # If the class exists, update it. Otherwise create it
+        # TODO: Validate that this is correct behavior. That is what the
+        # original MOFWBEMConnection does.
+        if class_repo.exists(ccr.classname):
+            class_repo.update(ccr.classname, ccr)
+        else:
+            class_repo.create(ccr.classname, ccr)
+        self.classes[namespace][ccr.classname] = ccr
+
+    def EnumerateQualifiers(self, *args, **kwargs):
+        """Enumerate the qualifier types in the local repository of this class.
+
+        For a description of the parameters, see
+        :meth:`pywbem.WBEMConnection.EnumerateQualifiers`.
+        """
+
+        if self.conn is not None:
+            rv = self.conn.EnumerateQualifiers(*args, **kwargs)
+        else:
+            rv = []
+        try:
+            rv += list(self.qualifiers[self.default_namespace].values())
+        except KeyError:
+            pass
+        return rv
+
+    def GetQualifier(self, *args, **kwargs):
+        """Retrieve a qualifier type from the local repository of this class.
+
+        For a description of the parameters, see
+        :meth:`pywbem.WBEMConnection.GetQualifier`.
+        """
+
+        qualname = args[0] if args else kwargs['QualifierName']
+        namespace = self.default_namespace
+        try:
+            # TODO: This should get from real repo I think
+            qualifier_repo = self.repo.get_qualifier_repo(namespace)
+            qual = qualifier_repo.get(qualname)
+        except KeyError:
+            raise
+        return qual
+
+    def SetQualifier(self, *args, **kwargs):
+        """Create or modify a qualifier type in the local repository of this
+        class.
+
+        For a description of the parameters, see
+        :meth:`pywbem.WBEMConnection.SetQualifier`.
+        """
+        namespace = self.default_namespace
+        qual = args[0] if args else kwargs['QualifierDeclaration']
+        qualifier_repo = self.repo.get_qualifier_repo(namespace)
+        try:
+            qualifier_repo.create(qual.name, qual)
+        except KeyError:
+            # If qualifier already in repo, update it. This is defined
+            # specification behavior
+            qualifier_repo.update(qual.name, qual)
+            # raise
+            # self.qualifiers[self.default_namespace] = \
+            #    # NocaseDict({qual.name: qual})
+
+    def DeleteQualifier(self, *args, **kwargs):
+        """This method is only invoked by :meth:`rollback` (on the underlying
+        repository), and never by the MOF compiler, and is therefore not
+        implemented."""
+
+        raise CIMError(
+            CIM_ERR_FAILED, 'This should not happen!',
+            conn_id=self.conn_id)
 
     def _get_class(self, superclass, namespace=None,
                    local_only=False, include_qualifiers=True,

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -195,7 +195,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         mod_inst = args[0] if args else kwargs['ModifiedInstance']
         instance_repo = self.conn._get_instance_repo(namespace)
 
-        if self.default_namespace not in self.repo.list_namespaces():
+        if self.default_namespace not in self.repo.namespaces:
             raise CIMError(
                 CIM_ERR_INVALID_NAMESPACE,
                 _format('ModifyInstance failed. No instance repo exists. '

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -475,7 +475,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                                  qualifier_repo,
                                  propagate=False)
 
-        classrepo = self._get_class_repo(namespace)
+        classrepo = self._get_class_store(namespace)
         # resolve properties in new class
         self._resolve_objects(new_class.properties,
                               superclass.properties if superclass else None,

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -81,7 +81,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
         """
         if qualifier_repo is None:
             return
-        if qualifier.name not in qualifier_repo:
+        if not qualifier_repo.exists(qualifier.name):
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
                 _format("Qualifier declaration {0!A} required by CreateClass "
@@ -89,7 +89,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                         qualifier.name, namespace))
 
     @staticmethod
-    def _validate_qualifiers(qualifier_list, qual_repo, new_class, scope):
+    def _validate_qualifiers(qualifier_list, qualifier_repo, new_class, scope):
         """
         Validate a list of qualifiers against the Qualifier decl in the
         repository.
@@ -101,13 +101,13 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
         5. Whether the qualifier should be propagated to the subclass.
         """
         for qname, qvalue in qualifier_list.items():
-            if qname not in qual_repo:
+            if not qualifier_repo.exists(qname):
                 raise CIMError(
                     CIM_ERR_INVALID_PARAMETER,
                     _format("Qualifier {0!A} used in new class {1!A} "
                             "has no qualifier declaration in repository.",
                             qname, new_class.classname))
-            q_decl = qual_repo[qname]
+            q_decl = qualifier_repo.get(qname)
             if qvalue.type != q_decl.type:
                 raise CIMError(
                     CIM_ERR_INVALID_PARAMETER,
@@ -125,12 +125,12 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                             qname, new_class.classname, scope, q_decl.scopes))
 
     @staticmethod
-    def _init_qualifier(qualifier, qual_repo):
+    def _init_qualifier(qualifier, qualifier_repo):
         """
         Initialize the flavors of a qualifier from the qualifier repo and
         initialize propagated.
         """
-        qual_dict_entry = qual_repo[qualifier.name]
+        qual_dict_entry = qualifier_repo.get(qualifier.name)
         qualifier.propagated = False
         if qualifier.tosubclass is None:
             if qual_dict_entry.tosubclass is None:
@@ -146,12 +146,12 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
             qualifier.translatable = qual_dict_entry.translatable
 
     @staticmethod
-    def _init_qualifier_decl(qualifier_decl, qual_repo):
+    def _init_qualifier_decl(qualifier_decl, qualifier_repo):
         """
         Initialize the flavors of a qualifier declaration if they are not
         already set.
         """
-        assert qualifier_decl.name not in qual_repo
+        assert qualifier_repo.exists(qualifier_decl.name)
         if qualifier_decl.tosubclass is None:
             qualifier_decl.tosubclass = True
         if qualifier_decl.overridable is None:

--- a/pywbem_mock/_utils.py
+++ b/pywbem_mock/_utils.py
@@ -1,0 +1,87 @@
+#
+# (C) Copyright 2018 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+Utility functionsto support pywbem_mock.
+"""
+
+from __future__ import absolute_import, print_function
+
+import locale
+import sys
+import six
+
+if six.PY2:
+    import codecs  # pylint: disable=wrong-import-order
+
+STDOUT_ENCODING = getattr(sys.stdout, 'encoding', None)
+if not STDOUT_ENCODING:
+    STDOUT_ENCODING = locale.getpreferredencoding()
+if not STDOUT_ENCODING:
+    STDOUT_ENCODING = 'utf-8'
+
+
+def _uprint(dest, text):
+    """
+    Write text to dest, adding a newline character.
+
+    Text may be a unicode string, or a byte string in UTF-8 encoding.
+    It must not be None.
+
+    If dest is None, the text is encoded to a codepage suitable for the current
+    stdout and is written to stdout.
+
+    Otherwise, dest must be a file path, and the text is encoded to a UTF-8
+    Byte sequence and is appended to the file (opening and closing the file).
+    """
+    if isinstance(text, six.text_type):
+        text = text + u'\n'
+    elif isinstance(text, six.binary_type):
+        text = text + b'\n'
+    else:
+        raise TypeError(
+            "text must be a unicode or byte string, but is {0}".
+            format(type(text)))
+    if dest is None:
+        if six.PY2:
+            # On py2, stdout.write() requires byte strings
+            if isinstance(text, six.text_type):
+                text = text.encode(STDOUT_ENCODING, 'replace')
+        else:
+            # On py3, stdout.write() requires unicode strings
+            if isinstance(text, six.binary_type):
+                text = text.decode('utf-8')
+        sys.stdout.write(text)
+    elif isinstance(dest, (six.text_type, six.binary_type)):
+        if isinstance(text, six.text_type):
+            open_kwargs = dict(mode='a', encoding='utf-8')
+        else:
+            open_kwargs = dict(mode='ab')
+        if six.PY2:
+            # Open with codecs to be able to set text mode
+            with codecs.open(dest, **open_kwargs) as f:
+                f.write(text)
+        else:
+            with open(dest, **open_kwargs) as f:
+                f.write(text)
+    else:
+        raise TypeError(
+            "dest must be None or a string, but is {0}".
+            format(type(text)))

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -52,18 +52,21 @@ from pywbem import WBEMConnection, CIMClass, CIMClassName, \
     CIMInstance, CIMInstanceName, CIMQualifierDeclaration, \
     CIMParameter, cimtype, CIMError, \
     CIM_ERR_NOT_FOUND, CIM_ERR_METHOD_NOT_FOUND, CIM_ERR_FAILED, \
-    CIM_ERR_INVALID_PARAMETER, \
+    CIM_ERR_INVALID_PARAMETER, CIM_ERR_NAMESPACE_NOT_EMPTY, \
     CIM_ERR_INVALID_CLASS, CIM_ERR_ALREADY_EXISTS, \
     CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED, \
-    CIM_ERR_NAMESPACE_NOT_EMPTY, \
     DEFAULT_NAMESPACE, MOFCompiler
 from pywbem._nocasedict import NocaseDict
 from pywbem._utils import _format
 
+
+from ._inmemoryrepository import InMemoryRepository
+
+from ._mockmofwbemconnection import _MockMOFWBEMConnection
+
 from ._dmtf_cim_schema import DMTFCIMSchema
 from ._resolvermixin import ResolverMixin
-from ._mockmofwbemconnection import _MockMOFWBEMConnection
 
 if six.PY2:
     import codecs  # pylint: disable=wrong-import-order
@@ -315,44 +318,16 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             use_pull_operations=use_pull_operations,
             stats_enabled=stats_enabled, timeout=timeout)
 
-        # The namespaces that may exist in the mock repository. This is a
-        # dictionary where the key is the namespace name, and the value does
-        # not matter (this approach is used to ensure namespace names are
-        # treated case insensitively). This set of namespaces is used to
-        # control into which namespaces of the mock repository classes,
-        # qualifier types and instances may be added.
-        self.namespaces = NocaseDict({default_namespace: True})
+        # Implementation of the CIM object repository that is the data store
+        # for CIM classes, CIM instances, CIM qualifier declarations and
+        # CIM methods for the mocker.  All access to the mocker CIM data must
+        # pass through this variable to the datastore.
+        self.repo = InMemoryRepository(self.default_namespace)
 
-        # The CIM classes in the mock repository.
-        # This is a dictionary of dictionaries where the top level key is the
-        # CIM namespace name and the keys for each sub-dictionary in a
-        # namespace are class names, and the values in each sub-dictionary are
-        # the CIM classes in that namespace, represented as CIMClass objects.
-        # The dictionaries are NocaseDict since namespaces should be case
-        # insensitive.
-        # The namespaces are added to the outer dictionary as needed (if
-        # permitted as per self.namesaces).
-        self.classes = NocaseDict()
-
-        # The CIM qualifier types in the mock repository.
-        # Same format as for classes above, except that the values in each
-        # sub-dictionary are CIMQualifierDeclaration objects.
-        # The namespaces are added to the outer dictionary as needed (if
-        # permitted as per self.namesaces).
-        self.qualifiers = NocaseDict()
-
-        # The CIM instances in the mock repository.
-        # This is a dictionary of dictionaries where the top level key is the
-        # CIM namespace name, the keys for each dictionary in a
-        # namespace are CIM instance names, and the values in each dictionary
-        # are the CIM instances in that namespace, represented as CIMInstance
-        # should be objects. The namespace dictionaris is NocaseDict since
-        # namespaces case insensitive but the instance dictionaries are not
-        # NocaseDict since they use CIMInstanceName as the key.
-        # The namespaces are added to the outer dictionary as needed (if
-        # permitted as per self.namesaces).
-
-        self.instances = NocaseDict()
+        # Defines the connection for the compiler.  The compiler uses
+        # its local repo for work but sends new objects back to the
+        # methods in this class
+        self._mofwbemconnection = _MockMOFWBEMConnection(self)
 
         # The CIM methods with callback in the mock repository.
         # This is a dictionary of dictionaries of dictionaries, where the top
@@ -361,6 +336,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # The values at the last level are (TBD: method callbacks?).
         # The namespaces are added to the outer dictionary as needed (if
         # permitted as per self.namesaces).
+        # TODO: This must move to provider when provider is defined
         self.methods = NocaseDict()
 
         # Open Pull Contexts. The key for each context is an enumeration
@@ -371,6 +347,12 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         self._imethodcall = Mock(side_effect=self._mock_imethodcall)
         self._methodcall = Mock(side_effect=self._mock_methodcall)
+
+        # Current namespace.  Set by the mock calls it is used by the
+        # request methods to determine the current namespace.  This is used
+        # because namespace is NOT part of the WBEMConnection calls.
+        #
+        self.namespace = None
 
     @property
     def response_delay(self):
@@ -415,25 +397,27 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
     #
     ################################################################
 
-    def _validate_namespace(self, namespace):
+    def validate_namespace(self, namespace):
         """
-        Validate whether a namespace exists in the mock repository.
+        Validates that a namespace is defined in the repository.
 
-        Parameters:
+          Parameters:
 
-          namespace (:term:`string`):
-            The name of the CIM namespace in the mock repository. Must not be
-            `None`.
+            namespace (:term:`string`):
+              The name of the CIM namespace in the mock repository. Must not be
+              `None`.
 
-        Raises:
+          Returns:
+             True if the namespace is defined
+
+          Raises:
 
           :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
             not exist.
         """
-        # Normalize the namespace name
-        namespace = namespace.strip('/')
-
-        if namespace not in self.namespaces:
+        try:
+            self.repo.validate_namespace(namespace)
+        except KeyError:
             raise CIMError(
                 CIM_ERR_INVALID_NAMESPACE,
                 _format("Namespace does not exist in mock repository: {0!A}",
@@ -465,16 +449,13 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         if namespace is None:
             raise ValueError("Namespace argument must not be None")
 
-        # Normalize the namespace name
-        namespace = namespace.strip('/')
-
-        if namespace in self.namespaces:
+        try:
+            self.repo.add_namespace(namespace)
+        except ValueError:
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format("Namespace {0!A} already exists in the mock "
                         "repository", namespace))
-
-        self.namespaces[namespace] = True
 
     def _remove_namespace(self, namespace):
         """
@@ -494,39 +475,39 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Raises:
 
           ValueError: Namespace argument must not be None
-          CIMError: CIM_ERR_NOT_FOUND if the namespace does not exist in
-            the mock repository.
-          CIMError: CIM_ERR_NAMESPACE_NOT_EMPTY if the namespace is not empty.
-          CIMError: CIM_ERR_NAMESPACE_NOT_EMPTY if the default connection
-            namespace was attempted to be deleted.
+          :exc:`~pywbem.CIMError`:  CIM_ERR_NOT_FOUND if the namespace does
+            not exist in the mock repository.
+          :exc:`~pywbem.CIMError`:  CIM_ERR_NAMESPACE_NOT_EMPTY if the
+            namespace is not empty.
+          :exc:`~pywbem.CIMError`:  CIM_ERR_NAMESPACE_NOT_EMPTY if attempting
+            to delete the default connection namespace.  This namespace cannot
+            be deleted from the mock repository
         """
-
         if namespace is None:
             raise ValueError("Namespace argument must not be None")
-
-        # Normalize the namespace name
-        namespace = namespace.strip('/')
-
-        if namespace not in self.namespaces:
-            raise CIMError(
-                CIM_ERR_NOT_FOUND,
-                _format("Namespace {0!A} does not exist in the mock "
-                        "repository", namespace))
-
-        if not self._class_repo_empty(namespace) or \
-                not self._instance_repo_empty(namespace) or \
-                not self._qualifier_repo_empty(namespace):
-            raise CIMError(
-                CIM_ERR_NAMESPACE_NOT_EMPTY,
-                _format("Namespace {0!A} is not empty", namespace))
 
         if namespace == self.default_namespace:
             raise CIMError(
                 CIM_ERR_NAMESPACE_NOT_EMPTY,
                 _format("Connection default namespace {0!A} cannot be "
                         "deleted from mock repository", namespace))
+        try:
+            self.repo.remove_namespace(namespace)
+        except KeyError:
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                _format("Namespace {0!A} does not exist in the mock "
+                        "repository", namespace))
+        except ValueError:
+            raise CIMError(
+                CIM_ERR_NAMESPACE_NOT_EMPTY,
+                _format("Namespace {0!A} contains objects.", namespace))
 
-        del self.namespaces[namespace]
+    ###########################################################################
+    #
+    #  Methods to compile mof files into repository
+    #
+    ###########################################################################
 
     def compile_mof_file(self, mof_file, namespace=None, search_paths=None,
                          verbose=None):
@@ -580,11 +561,11 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         """
 
         namespace = namespace or self.default_namespace
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
         # issue #2063 refactor this so there is cleaner interface to
         # WBEMConnection
-        mofcomp = MOFCompiler(_MockMOFWBEMConnection(self),
+        mofcomp = MOFCompiler(self._mofwbemconnection,
                               search_paths=search_paths,
                               verbose=verbose, log_func=None)
 
@@ -640,11 +621,12 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
           IOError: MOF file not found.
           :exc:`~pywbem.MOFCompileError`: Compile error in the MOF.
         """
+
         namespace = namespace or self.default_namespace
 
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
-        mofcomp = MOFCompiler(_MockMOFWBEMConnection(self),
+        mofcomp = MOFCompiler(self._mofwbemconnection,
                               search_paths=search_paths,
                               verbose=verbose, log_func=None)
 
@@ -744,6 +726,12 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                 search_paths=[search_paths],
                                 verbose=verbose)
 
+    ######################################################################
+    #
+    #       Add Pywbem CIM objects directly to the data store
+    #
+    ######################################################################
+
     def add_cimobjects(self, objects, namespace=None):
         # pylint: disable=line-too-long
         """
@@ -793,7 +781,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         """  # noqa: E501
         # pylint: enable=line-too-long
         namespace = namespace or self.default_namespace
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
         if isinstance(objects, list):
             for obj in objects:
@@ -802,7 +790,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         else:
             obj = objects
             if isinstance(obj, CIMClass):
-                cc = deepcopy(obj)
+                cc = obj.copy()
                 if cc.superclass:
                     if not self._class_exists(cc.superclass, namespace):
                         raise ValueError(
@@ -817,10 +805,12 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 cc1 = self._resolve_class(cc, namespace, qualifier_repo,
                                           verbose=False)
 
-                class_repo[cc.classname] = cc1.copy()
+                # TODO: ks. Originally this impled set whether exists or not
+                # using create changes semantic to only add
+                class_repo.create(cc.classname, cc1.copy())
 
             elif isinstance(obj, CIMInstance):
-                inst = deepcopy(obj)
+                inst = obj.copy()
                 if inst.path is None:
                     raise ValueError(
                         _format("Instances added must include a path. "
@@ -841,15 +831,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         CIM_ERR_FAILED,
                         _format("Internal failure of add_cimobject operation. "
                                 "Rcvd CIMError {0}", ce))
-                self._add_instance(inst, instance_repo)
+                instance_repo.create(inst.path, inst)
 
             elif isinstance(obj, CIMQualifierDeclaration):
-                qual = deepcopy(obj)
+                qual = obj.copy()
                 qualifier_repo = self._get_qualifier_repo(namespace)
-                self._init_qualifier_decl(qual, qualifier_repo)
-                qualifier_repo[qual.name] = qual
+                qualifier_repo.create(qual.name, qual)
 
             else:
+                # Internal mocker error
                 assert False, \
                     _format("Object to add_cimobjects. {0} invalid type",
                             type(obj))
@@ -908,8 +898,11 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # Validate namespace
         method_repo = self._get_method_repo(namespace)
 
+        # TODO: Future, when we add provider, this should move to provider
+        # support
         if classname not in method_repo:
             method_repo[classname] = NocaseDict()
+
         if methodname in method_repo[classname]:
             raise ValueError("Duplicate method specification")
 
@@ -965,29 +958,23 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         cmt_end))
 
         # get all namespaces
-        repo_ns_set = set(self.namespaces.keys())
+        repo_ns = sorted(self.repo.list_namespaces())
 
-        if namespaces:
-            if isinstance(namespaces, six.string_types):
-                namespaces = [namespaces]
-
-            repo_ns_set = repo_ns_set.intersection(set(namespaces))
-        repo_ns_list = sorted(list(repo_ns_set))
-
-        for ns in repo_ns_list:
+        for ns in repo_ns:
             _uprint(dest,
                     _format(u"\n{0}NAMESPACE {1!A}{2}\n",
                             cmt_begin, ns, cmt_end))
-            self._display_objects('Qualifier Declarations', self.qualifiers,
+            self._display_objects('Qualifier Declarations',
+                                  self._get_qualifier_repo(ns),
                                   ns, cmt_begin, cmt_end, dest=dest,
                                   summary=summary, output_format=output_format)
-            self._display_objects('Classes', self.classes, ns, cmt_begin,
-                                  cmt_end, dest=dest,
-                                  summary=summary, output_format=output_format)
-            self._display_objects('Instances', self.instances, ns,
+            self._display_objects('Classes', self._get_class_repo(ns), ns,
                                   cmt_begin, cmt_end, dest=dest,
                                   summary=summary, output_format=output_format)
-            self._display_objects('Methods', self.methods, ns,
+            self._display_objects('Instances', self._get_instance_repo(ns), ns,
+                                  cmt_begin, cmt_end, dest=dest,
+                                  summary=summary, output_format=output_format)
+            self._display_objects('Methods', self._get_method_repo(ns), ns,
                                   cmt_begin, cmt_end, dest=dest,
                                   summary=summary, output_format=output_format)
 
@@ -1008,70 +995,63 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # Issue #2062: TODO/ks FUTURE Consider sorting to preserve order of
         # compile/add. Make this part of refactor to separate repository and
         # datastore because it may be data store dependent
-        if namespace in object_repo:
-            if obj_type == 'Methods':
-                _uprint(dest,
-                        _format(u"{0}Namespace {1!A}: contains {2} {3}:{4}\n",
-                                cmt_begin, namespace,
-                                len(object_repo[namespace]),
-                                obj_type, cmt_end))
-            else:
-                _uprint(dest,
-                        _format(u"{0}Namespace {1!A}: contains {2} {3} {4}\n",
-                                cmt_begin, namespace,
-                                len(object_repo[namespace]),
-                                obj_type, cmt_end))
-            if summary:
+        if obj_type == 'Methods':
+            _uprint(dest,
+                    _format(u"{0}Namespace {1!A}: contains {2} {3}:{4}\n",
+                            cmt_begin, namespace,
+                            len(object_repo),
+                            obj_type, cmt_end))
+        else:
+            _uprint(dest,
+                    _format(u"{0}Namespace {1!A}: contains {2} {3} {4}\n",
+                            cmt_begin, namespace,
+                            object_repo.len(),
+                            obj_type, cmt_end))
+        if summary:
+            return
+
+        # instances are special because the inner struct is a list
+        if obj_type == 'Instances':
+            # Issue # 2062 - Consider sorting here in the future
+            for inst in object_repo.iter_values():
+                if output_format == 'xml':
+                    _uprint(dest,
+                            _format(u"{0} Path={1} {2}\n{3}",
+                                    cmt_begin, inst.path.to_wbem_uri(),
+                                    cmt_end,
+                                    _pretty_xml(inst.tocimxmlstr())))
+                elif output_format == 'repr':
+                    _uprint(dest,
+                            _format(u"Path:\n{0!A}\nInst:\n{1!A}\n",
+                                    inst.path, inst))
+                else:
+                    _uprint(dest,
+                            _format(u"{0} Path={1} {2}\n{3}",
+                                    cmt_begin, inst.path.to_wbem_uri(),
+                                    cmt_end, inst.tomof()))
+
+        elif obj_type == 'Methods':
+            try:
+                methods = object_repo
+            except KeyError:
                 return
 
-            # instances are special because the inner struct is a list
-            if obj_type == 'Instances':
-                try:
-                    insts = object_repo[namespace]
-                except KeyError:
-                    return
+            for cln in methods:
+                for method in methods[cln]:
+                    _uprint(dest,
+                            _format(u"{0}Class: {1}, method: {2}, "
+                                    u"callback: {3} {4}",
+                                    cmt_begin, cln, method,
+                                    methods[cln][method].__name__,
+                                    cmt_end))
 
-                # Issue # 2062 - Consider sorting here in the future
-                for inst in six.itervalues(insts):
-                    if output_format == 'xml':
-                        _uprint(dest,
-                                _format(u"{0} Path={1} {2}\n{3}",
-                                        cmt_begin, inst.path.to_wbem_uri(),
-                                        cmt_end,
-                                        _pretty_xml(inst.tocimxmlstr())))
-                    elif output_format == 'repr':
-                        _uprint(dest,
-                                _format(u"Path:\n{0!A}\nInst:\n{1!A}\n",
-                                        inst.path, inst))
-                    else:
-                        _uprint(dest,
-                                _format(u"{0} Path={1} {2}\n{3}",
-                                        cmt_begin, inst.path.to_wbem_uri(),
-                                        cmt_end, inst.tomof()))
-
-            elif obj_type == 'Methods':
-                try:
-                    methods = object_repo[namespace]
-                except KeyError:
-                    return
-
-                for cln in methods:
-                    for method in methods[cln]:
-                        _uprint(dest,
-                                _format(u"{0}Class: {1}, method: {2}, "
-                                        u"callback: {3} {4}",
-                                        cmt_begin, cln, method,
-                                        methods[cln][method].__name__,
-                                        cmt_end))
-
-            else:
-                assert obj_type in ['Classes', 'Qualifier Declarations']
-                try:
-                    objs = object_repo[namespace]
-                except KeyError:
-                    return
-                for key in sorted(objs):
-                    obj = objs[key]
+        else:
+            # Display classes and qualifier declarations sorted
+            assert obj_type in ['Classes', 'Qualifier Declarations']
+            names = [n for n in object_repo.iter_names()]
+            if names:
+                for name in sorted(names):
+                    obj = object_repo.get(name)
                     if output_format == 'xml':
                         _uprint(dest, _pretty_xml(obj.tocimxmlstr()))
                     elif output_format == 'repr':
@@ -1079,23 +1059,13 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                     else:
                         _uprint(dest, obj.tomof())
 
-    def _get_inst_repo(self, namespace=None):
-        """
-        Test support method that returns instances from the repository with
-        no processing.  It uses the default namespace if input parameter
-        for namespace is None
-        """
-        if namespace is None:
-            namespace = self.default_namespace
-        return self.instances[namespace]
-
-    ##########################################################
+    ########################################################################
     #
-    #   Functions Mocked. WBEMConnection only mocks the WBEMConnection
+    #   Pywbem functions mocked. WBEMConnection only mocks the WBEMConnection
     #   _imethodcall and _methodcall methods.  This captures all calls
     #   to the wbem server.
     #
-    ##########################################################
+    ########################################################################
 
     def _mock_imethodcall(self, methodname, namespace, response_params_rqd=None,
                           **params):  # pylint: disable=unused-argument
@@ -1109,11 +1079,12 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Each function is named with the method name prepended with
         '_fake_'.
         """
+        self.namespace = namespace
         method_name = '_fake_' + methodname
 
         method_name = getattr(self, method_name)
 
-        result = method_name(namespace, **params)
+        result = method_name(**params)
 
         # sleep for defined number of seconds
         if self._response_delay:
@@ -1154,12 +1125,13 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Exception if the namespace does not exist
         """
         class_repo = self._get_class_repo(namespace)
-        return classname in class_repo
+        return class_repo.exists(classname)
 
     @staticmethod
     def _make_tuple(rtn_value):
         """
-        Make the return value into a tuple in accord with _imethodcall
+        Change the return value from the value consistent with the definition
+        in cim_operations.py into a tuple in accord with _imethodcall
         """
         return [("IRETURNVALUE", {}, rtn_value)]
 
@@ -1199,203 +1171,29 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             for method in obj.methods:
                 obj.methods[method].class_origin = None
 
-    def _get_class_repo(self, namespace):
-        """
-        Returns the class repository for the specified CIM namespace
-        within the mock repository. This is the original instance variable,
-        so any modifications will change the mock repository.
-
-        Validates that the namespace exists in the mock repository.
-
-        If the class repository does not contain the namespace yet, it is
-        added.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          No case dictionary where each entry is:
-            <classname> :CIMClass
-
-        Raises:
-
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-        """
-        self._validate_namespace(namespace)
-        if namespace not in self.classes:
-            self.classes[namespace] = NocaseDict()
-        return self.classes[namespace]
-
-    def _get_instance_repo(self, namespace):
-        """
-        Returns the instance repository for the specified CIM namespace
-        within the mock repository.
-
-        Validates that the namespace exists in the mock repository.
-
-        If the instance repository does not contain the namespace yet, it is
-        added.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          Dictionary of instances where each dictionary entry is:
-              <CIMInstanceName> : CIMInstance
-
-        Raises:
-
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-        """
-        self._validate_namespace(namespace)
-        if namespace not in self.instances:
-            self.instances[namespace] = {}
-        return self.instances[namespace]
-
-    def _get_qualifier_repo(self, namespace):
-        """
-        Returns the qualifier repository for the specified CIM namespace
-        within the mock repository. This is the original instance variable,
-        so any modifications will change the mock repository.
-
-        Validates that the namespace exists in the mock repository.
-
-        If the qualifier repository does not contain the namespace yet, it is
-        added.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          No case dictionary of <qualifier_name>: CIMQualifierDeclaration
-          entries.
-
-
-        Raises:
-
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-        """
-        self._validate_namespace(namespace)
-        if namespace not in self.qualifiers:
-            self.qualifiers[namespace] = NocaseDict()
-        return self.qualifiers[namespace]
-
-    def _get_method_repo(self, namespace=None):
-        """
-        Returns the method repository for the specified CIM namespace
-        within the mock repository. This is the original instance variable,
-        so any modifications will change the mock repository.
-
-        Validates that the namespace exists in the mock repository.
-
-        If the method repository does not contain the namespace yet, it is
-        added.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          No case dictionary where each entry is
-            <method name>: <Callable method>
-
-        Raises:
-
-          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
-            not exist.
-        """
-        self._validate_namespace(namespace)
-        if namespace not in self.methods:
-            self.methods[namespace] = NocaseDict()
-        return self.methods[namespace]
-
-    def _class_repo_empty(self, namespace):
-        """
-        Returns a bool indicating whether the class repository for the
-        specified CIM namespace within the mock repository is empty.
-
-        The class repository is considered empty if it does not exist for
-        the namespace, or if it exists and is empty.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          bool: Class repository is empty (or does not exist for the namespace)
-        """
-        return namespace not in self.classes or not self.classes[namespace]
-
-    def _instance_repo_empty(self, namespace):
-        """
-        Returns a bool indicating whether the instance repository for the
-        specified CIM namespace within the mock repository is empty.
-
-        The instance repository is considered empty if it does not exist for
-        the namespace, or if it exists and is empty.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          bool: Instance repository is empty (or does not exist for the
-            namespace)
-        """
-        return namespace not in self.instances or not self.instances[namespace]
-
-    def _qualifier_repo_empty(self, namespace):
-        """
-        Returns a bool indicating whether the qualifier repository for the
-        specified CIM namespace within the mock repository is empty.
-
-        The qualifier repository is considered empty if it does not exist for
-        the namespace, or if it exists and is empty.
-
-        Parameters:
-
-          namespace(:term:`string`): Namespace name. Must not be `None`.
-
-        Returns:
-
-          bool: Qualifier repository is empty (or does not exist for the
-            namespace)
-        """
-        return namespace not in self.qualifiers or \
-            not self.qualifiers[namespace]
-
-    def _get_superclassnames(self, cn, namespace):
+    def _get_superclass_names(self, cln, class_repo):
         """
         Get list of superclasses names from the class repository for the
-        defined classname in the namespace.
+        defined classname (cln) in the namespace.
 
-        Returns in order of descending class hiearchy.
+        Returns:
+         List of classnames in order of descending class hierarchy or an
+         empty list if cln is None
         """
-        class_repo = self._get_class_repo(namespace)
+
         superclass_names = []
-        if cn is not None:
-            cnwork = cn
-            while cnwork:
-                cnsuper = class_repo[cnwork].superclass
-                if cnsuper:
-                    superclass_names.append(cnsuper)
-                cnwork = cnsuper
+        if cln is not None:
+            cln_work = cln
+            while cln_work:
+                # Accesses class in repository. Note, no copy made
+                cln_superclass = class_repo.get(cln_work).superclass
+                if cln_superclass:
+                    superclass_names.append(cln_superclass)
+                cln_work = cln_superclass
             superclass_names.reverse()
         return superclass_names
 
-    def _get_subclass_names(self, classname, namespace, deep_inheritance):
+    def _get_subclass_names(self, classname, class_repo, deep_inheritance):
         """
             Get class names that are subclasses of the
             classname input parameter from the repository.
@@ -1412,33 +1210,29 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             list of strings with the names of all subclasses of `classname`.
 
         """
+
         assert classname is None or isinstance(classname, (six.string_types,
                                                            CIMClassName))
 
         if isinstance(classname, CIMClassName):
             classname = classname.classname
 
-        # retrieve first level of subclasses for which classname is superclass
-        try:
-            classes = self.classes[namespace]
-        except KeyError:
-            classes = NocaseDict()
         if classname is None:
             rtn_classnames = [
-                cl.classname for cl in six.itervalues(classes)
-                if cl.superclass is None]
+                c.classname for c in class_repo.iter_values()
+                if c.superclass is None]
         else:
             rtn_classnames = [
-                cl.classname for cl in six.itervalues(classes)
-                if cl.superclass and cl.superclass.lower() == classname.lower()]
+                c.classname for c in class_repo.iter_values()
+                if c.superclass and c.superclass.lower() == classname.lower()]
 
-        # recurse for next level of class hiearchy
+        # Recurse for next level of class hiearchy
         if deep_inheritance:
             subclass_names = []
             if rtn_classnames:
-                for cn in rtn_classnames:
+                for cln in rtn_classnames:
                     subclass_names.extend(
-                        self._get_subclass_names(cn, namespace,
+                        self._get_subclass_names(cln, class_repo,
                                                  deep_inheritance))
             rtn_classnames.extend(subclass_names)
         return rtn_classnames
@@ -1461,7 +1255,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         """
         class_repo = self._get_class_repo(namespace)
-        return classname in class_repo
+        return class_repo.exists(classname)
 
     def _get_class(self, classname, namespace, local_only=None,
                    include_qualifiers=None, include_classorigin=None,
@@ -1511,15 +1305,18 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         class_repo = self._get_class_repo(namespace)
 
-        # try to get the target class and create a copy for response
+        # Try to get the target class and create a copy for response
         try:
-            c = class_repo[classname]
+            cls = class_repo.get(classname)
         except KeyError:
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format("Class {0!A} not found in namespace {1!A}.",
                         classname, namespace))
-        cc = deepcopy(c)
+
+        # TODO/ks: changing this to cls.copy() causes failures with
+        # class qualifiers not created.
+        cc = deepcopy(cls)
 
         if local_only:
             for prop, pvalue in cc.properties.items():
@@ -1551,67 +1348,10 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         """
 
         class_repo = self._get_class_repo(namespace)
-        for cl in six.itervalues(class_repo):
+        for cl in class_repo.iter_values():
             if 'Association' in cl.qualifiers:
                 yield cl
         return
-
-    #
-    #   The following static methods provide access to an instance repo for
-    #   a single namespace. They should be the basis for access to the
-    #   instance repo until we convert to using a class that cleanly provides
-    #   access to the repo.
-    #
-    @staticmethod
-    def _iter_instance_repo(instance_repo):
-        """
-        Return an iterator for the defined instance repository (instance_repo)
-        """
-        assert isinstance(instance_repo, dict)
-        return six.itervalues(instance_repo)
-
-    @staticmethod
-    def _add_instance(new_instance, instance_repo):
-        """
-        Add a completely verified instance (new_instance) to the instance
-        repository defined by instance_repo.
-        This is a completely internal method and does no validation
-        """
-        assert isinstance(instance_repo, dict)
-        assert isinstance(new_instance, CIMInstance)
-        assert isinstance(new_instance.path, CIMInstanceName)
-        instance_repo[new_instance.path] = new_instance
-
-    @staticmethod
-    def _modify_instance(modified_instance, instance_repo):
-        """
-        Modify a single instance (modified_instance) in the instance_repo
-        defined by instance_repo.
-        This method does not validate before changing values.
-        """
-        assert isinstance(instance_repo, dict)
-        assert isinstance(modified_instance, CIMInstance)
-        assert isinstance(modified_instance.path, CIMInstanceName)
-        try:
-            inst = instance_repo[modified_instance.path]
-        except KeyError:
-            print("Instance %s not in repo" % modified_instance.path)
-            for iname in instance_repo:
-                print('NAME %s' % iname)
-            raise
-        # Modify the value of properties in the repo with those from
-        # modified instance
-        inst.update(modified_instance.properties)
-        instance_repo[modified_instance.path] = inst
-
-    @staticmethod
-    def _delete_instance(inst_name, instance_repo):
-        """
-        Delete an instance with name iname from the instance repo instance_repo
-        """
-        assert isinstance(instance_repo, dict)
-        assert isinstance(inst_name, CIMInstanceName)
-        del instance_repo[inst_name]
 
     @staticmethod
     def _find_instance(iname, instance_repo, copy_inst=None):
@@ -1636,33 +1376,60 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
           CIMError: Failed if repo invalid.
         """
-        assert isinstance(instance_repo, dict)
-        if iname in instance_repo:
+
+        if instance_repo.exists(iname):
             if copy_inst:
-                return deepcopy(instance_repo[iname])
-            return instance_repo[iname]
+                return instance_repo.get(iname).copy()
+            return instance_repo.get(iname)
 
         return None
 
-    def _get_instance(self, iname, namespace, property_list, local_only,
-                      include_class_origin, include_qualifiers):
+    def _get_instance(self, iname, namespace, instance_repo, property_list,
+                      local_only, include_class_origin, include_qualifiers):
         """
         Local method implements getinstance. This is generally used by
         other instance methods that need to get an instance from the
         repository.
 
         It attempts to get the instance, copies it, and filters it
-        for input parameters like localonly, includequalifiers, and
-        propertylist.
+        for input parameters of local_only, include_qualifiers,
+        include_class_origin, and propertylist.
+
+        Parameters:
+
+            iname (:class:`~pywbem.CIMInstanceName`)
+                The instance name of the instance to be retrieved.
+
+            namespace (:term:`string`)
+                Namespace containing the instance. This is used only for
+                explanatory data in exceptions
+
+            instance_repo:
+                Validated instance repository for the current namespace
+
+            property_list: (:term:`string` or :term:`py:iterable` of :term:`string`)  # noqa: E501
+
+            local_only:(:class:`pybool`)
+                If True only properties with classorigin same as classname
+                are returned.
+            include_class_origin:(:class:`pybool`)
+                If True, class_origin included in returned object.
+
+            include_qualifiers:(:class:`pybool`)
+                If True, any qualifiers in the stored instance the instance and
+                properties are returned
+                NOTE: This is deprecated so generally has no effect.
 
         Returns:
 
           CIMInstance copy from the repository with property_list filtered,
           and qualifers removed if include_qualifiers=False and
           class origin removed if include_class_origin False
-        """
 
-        instance_repo = self._get_instance_repo(namespace)
+        Raises:
+            CIMError: (CIM_ERR_NOT_FOUND) if the or its class instance do not
+            exist in the repository
+        """
 
         rtn_inst = self._find_instance(iname, instance_repo, copy_inst=True)
 
@@ -1709,23 +1476,28 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             self._remove_classorigin(rtn_inst)
         return rtn_inst
 
-    def _get_subclass_list_for_enums(self, classname, namespace):
-        """ Get class list (i.e names of subclasses for classname for the
-            enumerateinstance methods.
-
-            Returns NocaseDict where only the keys are important, This allows
-            case insensitive matches of the names with Python "for cln in clns".
+    def _get_subclass_list_for_enums(self, classname, namespace, class_repo):
         """
-        if not self._class_exists(classname, namespace):
+        Get class list (i.e names of subclasses for classname for the
+        enumerateinstance methods in a case-insenstive dictionary. The input
+        classname is included in this dictionary.
+
+        Returns:
+           NocaseDict where only the keys are important, This allows case
+           insensitive matches of the names with Python "for cln in clns".
+
+        Raises:
+
+            CIMError: (CIM_ERR_INVALID_CLASS) if classname not in repository
+        """
+
+        if not class_repo.exists(classname):
             raise CIMError(
                 CIM_ERR_INVALID_CLASS,
                 _format("Class {0!A} not found in namespace {1!A}.",
                         classname, namespace))
 
-        if not self.classes:
-            return NocaseDict()
-
-        clnslist = self._get_subclass_names(classname, namespace, True)
+        clnslist = self._get_subclass_names(classname, class_repo, True)
         clnsdict = NocaseDict()
         for cln in clnslist:
             clnsdict[cln] = cln
@@ -1737,7 +1509,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
     def _filter_properties(obj, property_list):
         """
         Remove properties from an instance or class that aren't in the
-        plist parameter
+        property_list parameter
 
         obj(:class:`~pywbem.CIMClass` or :class:`~pywbem.CIMInstance):
             The class or instance from which properties are to be filtered
@@ -1754,18 +1526,158 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 if pname.lower() not in property_list:
                     del obj.properties[pname]
 
+    ###############################################################
+    #
+    #   Access  to instance data repository
+    #
+    #   The following methods provide access to the instance repo for
+    #   a single namespace. They should be the basis for access to the
+    #   instance repo until we convert to using a class that cleanly provides
+    #   access to the repo.
+    #
+    ##################################################################
+
+    def _get_class_repo(self, namespace):
+        """
+        Returns the class repository for the specified CIM namespace
+        within the mock repository. This is the original instance variable,
+        so any modifications will change the mock repository.
+
+        Validates that the namespace exists in the mock repository.
+
+        If the class repository does not contain the namespace yet, it is
+        added.
+
+        Parameters:
+
+          namespace(:term:`string`): Namespace name. Must not be `None`.
+
+        Returns:
+
+          Case independent dictionary where each entry is:
+            <classname> :CIMClass
+
+        Raises:
+
+          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
+            not exist.
+        """
+        self.validate_namespace(namespace)
+        return self.repo.get_class_repo(namespace)
+
+    def _get_instance_repo(self, namespace):
+        """
+        Returns the instance repository for the specified CIM namespace
+        within the mock repository.
+
+        Validates that the namespace exists in the mock repository.
+
+        If the instance repository does not contain the namespace yet, it is
+        added.
+
+        Parameters:
+
+          namespace(:term:`string`): Namespace name. Must not be `None`.
+
+        Returns:
+
+          Dictionary of instances where each dictionary entry is:
+              <CIMInstanceName> : CIMInstance
+
+        Raises:
+
+          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
+            not exist.
+        """
+
+        self.validate_namespace(namespace)
+        return self.repo.get_instance_repo(namespace)
+
+    def _get_qualifier_repo(self, namespace):
+        """
+        Returns the qualifier repository for the specified CIM namespace
+        within the mock repository. This is the original instance variable,
+        so any modifications will change the mock repository.
+
+        Validates that the namespace exists in the mock repository.
+
+        If the qualifier repository does not contain the namespace yet, it is
+        added.
+
+        Parameters:
+
+          namespace(:term:`string`): Namespace name. Must not be `None`.
+
+        Returns:
+
+          No case dictionary of <qualifier_name>: CIMQualifierDeclaration
+          entries.
+
+
+        Raises:
+
+          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
+            not exist.
+        """
+
+        self.validate_namespace(namespace)
+        return self.repo.get_qualifier_repo(namespace)
+
+    def _get_method_repo(self, namespace=None):
+        """
+        Returns the method repository for the specified CIM namespace
+        within the mock repository. This is the original instance variable,
+        so any modifications will change the mock repository.
+
+        Validates that the namespace exists in the mock repository.
+
+        If the method repository does not contain the namespace yet, it is
+        added.
+
+        Parameters:
+
+          namespace(:term:`string`): Namespace name. Must not be `None`.
+
+        Returns:
+
+          No case dictionary where each entry is
+            <method name>: <Callable method>
+
+        Raises:
+
+          :exc:`~pywbem.CIMError`: CIM_ERR_INVALID_NAMESPACE: Namespace does
+            not exist.
+        """
+        self.validate_namespace(namespace)
+        if namespace not in self.methods:
+            self.methods[namespace] = NocaseDict()
+        return self.methods[namespace]
+
     #####################################################################
     #
-    #        Faked WBEMConnection operation methods.
-    #        All the methods are named _fake_<methodname> and
-    #        are responders that emulate the server response.
+    #   Faked WBEMConnection operation methods.
+    #   All the methods are named _fake_<methodname> and
+    #   are responders that emulate the server response.
     #
-    #        This is all the WBEMConnection methods that communicate with
-    #        a WBEMServer.
+    #   This is all the WBEMConnection methods that communicate with
+    #   a WBEMServer.
+    #
+    #   The API for these calls differes from the methods in _WBEMConnection
+    #   in that every call API includes the namespace as a positional
+    #   in all of the calls including those where _WBEMConnection does not
+    #   include the naespace. This is logical in that the server
+    #   does not have the concept of a default whereas the client does.
+    #
+    #   The pattern we try to use in the processing is to use the
+    #   namespace only to validate namespace, and get the corresponding
+    #   repository for the CIM type and namespace from the data store
+    #   and use that in further processing. The only other use of namespace
+    #   should be in possibly preparing data for sending to the data
+    #   store and generating excption messages.
     #
     ######################################################################
 
-    def _fake_EnumerateClasses(self, namespace, **params):
+    def _fake_EnumerateClasses(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.EnumerateClasses`.
@@ -1786,25 +1698,23 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_CLASS: class defined by the classname
             parameter does not exist.
         """
-
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        # Validate namespace and get class_repo for this namespace
+        class_repo = self._get_class_repo(namespace)
 
         classname = params.get('ClassName', None)
         if classname:
             assert(isinstance(classname, CIMClassName))
-            if not self._class_exists(classname.classname, namespace):
+            if not class_repo.exists(classname.classname):
                 raise CIMError(
                     CIM_ERR_INVALID_CLASS,
                     _format("The class {0!A} defined by 'ClassName' parameter "
                             "does not exist in namespace {1!A}",
                             classname, namespace))
 
-        clns = self._get_subclass_names(classname, namespace,
+        clns = self._get_subclass_names(classname, class_repo,
                                         params['DeepInheritance'])
 
-        # Note: _get_class will return NOT_FOUND if the class not in the
-        # repo but it was just found by _get_subclass_names so that would
-        # probably be some form of repo corruption.
         classes = [
             self._get_class(cn, namespace,
                             local_only=params['LocalOnly'],
@@ -1814,7 +1724,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._make_tuple(classes)
 
-    def _fake_EnumerateClassNames(self, namespace, **params):
+    def _fake_EnumerateClassNames(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.EnumerateClassNames`.
@@ -1832,20 +1742,22 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_CLASS: class defined by the classname
             parameter does not exist
         """
+        namespace = self.namespace
 
-        self._validate_namespace(namespace)
+        # Validate namespace and get class_repo for this namespace
+        class_repo = self._get_class_repo(namespace)
 
         classname = params.get('ClassName', None)
         if classname:
             assert(isinstance(classname, CIMClassName))
-            if not self._class_exists(classname.classname, namespace):
+            if not class_repo.exists(classname.classname):
                 raise CIMError(
                     CIM_ERR_INVALID_CLASS,
                     _format("The class {0!A} defined by 'ClassName' parameter "
                             "does not exist in namespace {1!A}",
                             classname, namespace))
 
-        clns = self._get_subclass_names(classname, namespace,
+        clns = self._get_subclass_names(classname, class_repo,
                                         params['DeepInheritance'])
         rtn_clns = [
             CIMClassName(cn, namespace=namespace, host=self.host)
@@ -1853,7 +1765,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._make_tuple(rtn_clns)
 
-    def _fake_GetClass(self, namespace, **params):
+    def _fake_GetClass(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.GetClass
@@ -1863,8 +1775,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         For a description of the parameters, see
         :meth:`pywbem.WBEMConnection.GetClass`.
         """
+        namespace = self.namespace
 
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
         cname = params['ClassName'].classname
 
@@ -1875,7 +1788,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._make_tuple([cc])
 
-    def _fake_CreateClass(self, namespace, **params):
+    def _fake_CreateClass(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.CreateClass`
@@ -1900,6 +1813,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
             CIMError: CIM_ERR_ALREADY_EXISTS if class already exists
         """
+        namespace = self.namespace
         # Validate parameters
         new_class = params['NewClass']
         if not isinstance(new_class, CIMClass):
@@ -1908,24 +1822,24 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 _format("NewClass not valid CIMClass. Rcvd type={0}",
                         type(new_class)))
 
-        # Validate namespace and get the class datastoe for this namespace
+        # Validate namespace and get the class datastore for this namespace
         class_repo = self._get_class_repo(namespace)
 
-        qualifier_repo = self._get_qualifier_repo(namespace)
-
-        if new_class.classname in class_repo:
+        if class_repo.exists(new_class.classname):
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format("Class {0!A} already exists in namespace {1!A}.",
                         new_class.classname, namespace))
 
-        new_class = deepcopy(new_class)
+        new_class = new_class.copy()
 
+        qualifier_repo = self._get_qualifier_repo(namespace)
         self._resolve_class(new_class, namespace, qualifier_repo, verbose=False)
 
-        class_repo[new_class.classname] = new_class
+        # add mew class to repository
+        class_repo.create(new_class.classname, new_class)
 
-    def _fake_ModifyClass(self, namespace, **params):
+    def _fake_ModifyClass(self, **params):
         # pylint: disable=unused-argument
         """
         Currently not implemented
@@ -1942,14 +1856,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
             CIMError: CIM_ERR_NOT_SUPPORTED
         """
+        namespace = self.namespace
 
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
         raise CIMError(
             CIM_ERR_NOT_SUPPORTED,
             "Currently ModifyClass not supported in Fake_WBEMConnection")
 
-    def _fake_DeleteClass(self, namespace, **params):
+    def _fake_DeleteClass(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.DeleteClass`
@@ -1968,30 +1883,36 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 repository
         """
 
+        namespace = self.namespace
+
         # Validate namespace and get the class datastore for this namespace
         class_repo = self._get_class_repo(namespace)
+        instance_repo = self._get_instance_repo(namespace)
 
         cname = params['ClassName'].classname
 
-        try:
-            class_repo[cname]
-        except KeyError:
+        if not class_repo.exists(cname):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format("Class {0!A} in namespace {1!A} not in repository. "
                         "Nothing deleted.", cname, namespace))
 
-        classnames = self._get_subclass_names(cname, namespace, True)
+        classnames = self._get_subclass_names(cname, class_repo, True)
         classnames.append(cname)
 
-        # delete all instances in this class and subclasses and delete
+        # Delete all instances in this class and subclasses and delete
         # this class and subclasses
         for clname in classnames:
-            if self.instances:
-                inst_names = self.EnumerateInstanceNames(clname, namespace)
-                for iname in inst_names:
-                    self.DeleteInstance(iname)
-            del class_repo[clname]
+            clns = self._get_subclass_list_for_enums(cname, namespace,
+                                                     class_repo)
+
+            inst_paths = [inst.path for inst in instance_repo.iter_values()
+                          if inst.path.classname in clns]
+
+            for iname in inst_paths:
+                self.DeleteInstance(iname)
+
+            class_repo.delete(clname)
 
     ##########################################################
     #
@@ -1999,7 +1920,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
     #
     ###########################################################
 
-    def _fake_EnumerateQualifiers(self, namespace, **params):
+    def _fake_EnumerateQualifiers(self, **params):
         # pylint: disable=unused-argument
         """
         Imlements a mock server responder for
@@ -2009,14 +1930,16 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         namespace.
         """
 
+        namespace = self.namespace
         # Validate namespace and get qualifier_repo for this namespace
         qualifier_repo = self._get_qualifier_repo(namespace)
 
-        qualifiers = list(qualifier_repo.values())
+        # pylint: disable=unnecessary-comprehension
+        qualifiers = [q for q in qualifier_repo.iter_values()]
 
         return self._make_tuple(qualifiers)
 
-    def _fake_GetQualifier(self, namespace, **params):
+    def _fake_GetQualifier(self, **params):
         """
         Implements a server responder for
         :meth:`pywbem.WBEMConnection.GetQualifier`.
@@ -2035,13 +1958,14 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_NOT_FOUND
         """
 
+        namespace = self.namespace
         # Validate namespace and get qualifier_repo for this namespace
         qualifier_repo = self._get_qualifier_repo(namespace)
 
         qname = params['QualifierName']
 
         try:
-            qualifier = qualifier_repo[qname]
+            qualifier = qualifier_repo.get(qname)
         except KeyError:
             ce = CIMError(
                 CIM_ERR_NOT_FOUND,
@@ -2051,7 +1975,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._make_tuple([qualifier])
 
-    def _fake_SetQualifier(self, namespace, **params):
+    def _fake_SetQualifier(self, **params):
         """
         Implements a server responder for
         :meth:`pywbem.WBEMConnection.SetQualifier`.
@@ -2066,6 +1990,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_ALREADY_EXISTS
         """
 
+        namespace = self.namespace
         # Issue #2062 ks Refactor to separate data store from repository method
 
         # Validate namespace and get the qualifier data store for this namespace
@@ -2079,17 +2004,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         "valid CIMQualifierDeclaration. Rcvd type={0}",
                         type(qual_decl)))
 
-        if qual_decl.name in qualifier_repo:
+        try:
+            qualifier_repo.create(qual_decl.name, qual_decl)
+        except ValueError:
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format("Qualifier declaration {0!A} already exists in "
                         "namespace {1!A}.", qual_decl.name, namespace))
 
-        self._init_qualifier_decl(qual_decl, qualifier_repo)
-
-        qualifier_repo[qual_decl.name] = qual_decl
-
-    def _fake_DeleteQualifier(self, namespace, **params):
+    def _fake_DeleteQualifier(self, **params):
         """
         Implements a server responder for
         :meth:`~pywbem.WBEMConnection.DeleteQualifier`
@@ -2102,13 +2025,14 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_NAMESPACE, CIM_ERR_NOT_FOUND
         """
 
+        namespace = self.namespace
         # Validate namespace and get the qualifier data store for this namespace
         qualifier_repo = self._get_qualifier_repo(namespace)
 
         qname = params['QualifierName']
 
-        if qname in qualifier_repo:
-            del qualifier_repo[qname]
+        if qualifier_repo.exists(qname):
+            qualifier_repo.delete(qname)
         else:
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
@@ -2121,7 +2045,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
     #
     #####################################################################
 
-    def _fake_CreateInstance(self, namespace, **params):
+    def _fake_CreateInstance(self, **params):
         """
         Implements a server responder for
         :meth:`~pywbem.WBEMConnection.CreateInstance`
@@ -2139,6 +2063,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_CLASS
         """
 
+        namespace = self.namespace
         # Validate parameters
         new_instance = params['NewInstance']
         if not isinstance(new_instance, CIMInstance):
@@ -2188,9 +2113,10 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                             new_instance.classname))
 
             # Normalize the namespace name
+            # TODO: We should not have to normalize here, that is lower level
             new_namespace = new_namespace.strip('/')
 
-            # Write it back to the instance in casde it was changed
+            # Write it back to the instance in case it was changed
             new_instance['Name'] = new_namespace
 
             # These values must match those in
@@ -2202,8 +2128,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             new_instance['SystemName'] = 'Mock_Test_WBEMServerTest'
             new_instance['SystemCreationClassName'] = 'CIM_ComputerSystem'
 
-        # Test all key properties in instance. This is our repository limit
-        # since the repository cannot add values for key properties. We do
+        # Test all key properties in instance. Mocker repository
+        # cannot add values for key properties and does
         # not allow creating key properties from class defaults.
         key_props = [p.name for p in six.itervalues(target_class.properties)
                      if 'key' in p.qualifiers]
@@ -2254,7 +2180,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             namespace=namespace)
 
         # Check for duplicate instances
-        if new_instance.path in instance_repo:
+        if instance_repo.exists(new_instance.path):
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format("NewInstance {0!A} already exists in namespace "
@@ -2265,12 +2191,13 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             self.add_namespace(new_namespace)
 
         # Store the new instance in the mock repository
-        self._add_instance(new_instance, instance_repo)
+        instance_repo.create(new_instance.path, new_instance)
 
         # Create instance returns model path, path relative to namespace
+        # TODO: Change to use copy
         return self._make_tuple([deepcopy(new_instance.path)])
 
-    def _fake_ModifyInstance(self, namespace, **params):
+    def _fake_ModifyInstance(self, **params):
         """
         Implements a server responder for
         :meth:`~pywbem.WBEMConnection.CreateInstance`
@@ -2282,17 +2209,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_CLASS
         """
 
+        namespace = self.namespace
         # Validate namespace and get instance data store
         instance_repo = self._get_instance_repo(namespace)
 
         modified_instance = deepcopy(params['ModifiedInstance'])
         property_list = params['PropertyList']
 
-        # Return if empty property list
+        # Return if empty property list, nothing would be changed
         if property_list is not None and not property_list:
-            return
-
-        if modified_instance is not None and not modified_instance:
             return
 
         if not isinstance(modified_instance, CIMInstance):
@@ -2327,7 +2252,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                             modified_instance.classname, namespace))
             raise
 
-        # Get original instance in repo.  Does not copy the orig instance.
+        # Get original instance in repo.
         if modified_instance.path.namespace is None:
             modified_instance.path.namespace = namespace
 
@@ -2419,11 +2344,14 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             if iprop.name != cprop.name:
                 modified_instance.properties[iprop.name].name = cprop.name
 
-        # Modify the instance in the instance repository
-        self._modify_instance(modified_instance, instance_repo)
+        # Modify the value of properties in the repo with those from
+        # modified instance inserted into the original instance
+        orig_instance.update(modified_instance.properties)
+        instance_repo.update(modified_instance.path, orig_instance)
+
         return
 
-    def _fake_GetInstance(self, namespace, **params):
+    def _fake_GetInstance(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.GetInstance`.
@@ -2440,11 +2368,13 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
               CIM_ERR_NOT_FOUND
         """
 
+        namespace = self.namespace
         iname = params['InstanceName']
         if iname.namespace is None:
             iname.namespace = namespace
+        assert iname.namespace == namespace
 
-        self._validate_namespace(namespace)
+        instance_repo = self._get_instance_repo(namespace)
 
         if not self._class_exists(iname.classname, namespace):
             raise CIMError(
@@ -2452,7 +2382,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 _format("Class {0!A} for GetInstance of instance {1!A} "
                         "does not exist.", iname.classname, iname))
 
-        inst = self._get_instance(iname, namespace,
+        inst = self._get_instance(iname, namespace, instance_repo,
                                   params['PropertyList'],
                                   params['LocalOnly'],
                                   params['IncludeClassOrigin'],
@@ -2460,7 +2390,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._make_tuple([inst])
 
-    def _fake_DeleteInstance(self, namespace, **params):
+    def _fake_DeleteInstance(self, **params):
         """
         Implements a mock server responder for
         :meth:`~pywbem.WBEMConnection.DeleteInstance`.
@@ -2478,7 +2408,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         commection cannot be deleted.
         """
 
+        namespace = self.namespace
         iname = params['InstanceName']
+        # assumes namespace input parameter is authoritive namespace name
         iname.namespace = namespace
 
         # Validate namespace and get instance datastore
@@ -2491,7 +2423,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         "Cannot delete instance {2!A}",
                         iname.classname, namespace, iname))
 
-        if iname not in instance_repo:
+        if not instance_repo.exists(iname):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format("Instance {0!A} not found in repository namespace "
@@ -2515,9 +2447,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             self._remove_namespace(namespace)
 
         # Delete the instance from the repository
-        self._delete_instance(iname, instance_repo)
+        instance_repo.delete(iname)
 
-    def _fake_EnumerateInstances(self, namespace, **params):
+    def _fake_EnumerateInstances(self, **params):
         """
         Implements a server responder for
         :meth:`~pywbem.WBEMConnection.EnumerateInstances`.
@@ -2531,8 +2463,11 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_NAMESPACE
         """
 
+        namespace = self.namespace
         # Validate namespace
         instance_repo = self._get_instance_repo(namespace)
+
+        class_repo = self._get_class_repo(namespace)
 
         cname = params['ClassName']
         assert isinstance(cname, CIMClassName)
@@ -2568,17 +2503,18 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                 pl_lower = [pc.lower() for pc in pl]
                 pl = [pc for pc in class_pl if pc.lower() in pl_lower]
 
-        clns_dict = self._get_subclass_list_for_enums(cname, namespace)
+        clns_dict = self._get_subclass_list_for_enums(cname, namespace,
+                                                      class_repo)
 
-        insts = [self._get_instance(inst.path, namespace, pl,
+        insts = [self._get_instance(inst.path, namespace, instance_repo, pl,
                                     None,  # LocalOnly never gets passed
                                     ico, iq)
-                 for inst in self._iter_instance_repo(instance_repo)
+                 for inst in instance_repo.iter_values()
                  if inst.path.classname in clns_dict]
 
         return self._make_tuple(insts)
 
-    def _fake_EnumerateInstanceNames(self, namespace, **params):
+    def _fake_EnumerateInstanceNames(self, **params):
         """
         Implements a server responder for
         :meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`
@@ -2586,24 +2522,26 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         Get instance names for instances that match the path define
         by `ClassName` and returns a list of the names.
         """
+
+        namespace = self.namespace
         cname = params['ClassName']
         assert isinstance(cname, CIMClassName)
         cname = cname.classname
 
         # Validate namespace and get instance datastore for this namespace
         instance_repo = self._get_instance_repo(namespace)
+        class_repo = self._get_class_repo(namespace)
 
-        clns = self._get_subclass_list_for_enums(cname, namespace)
+        clns = self._get_subclass_list_for_enums(cname, namespace, class_repo)
 
-        inst_paths = \
-            [inst.path for inst in self._iter_instance_repo(instance_repo)
-             if inst.path.classname in clns]
+        inst_paths = [inst.path for inst in instance_repo.iter_values()
+                      if inst.path.classname in clns]
 
-        rtn_paths = [deepcopy(path) for path in inst_paths]
+        rtn_paths = [path.copy() for path in inst_paths]
 
         return self._make_tuple(rtn_paths)
 
-    def _fake_ExecQuery(self, namespace, **params):
+    def _fake_ExecQuery(self, **params):
         # pylint: disable=unused-argument
         """
         Implements a mock WBEM server responder for
@@ -2613,7 +2551,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         the querylanguage and query defined
         """
 
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        self.validate_namespace(namespace)
 
         raise CIMError(
             CIM_ERR_NOT_SUPPORTED,
@@ -2680,16 +2619,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                              property_list=pl)))
         return self._return_assoc_tuple(rtn_tups)
 
-    def _subclasses_lc(self, classname, namespace):
+    def _subclasses_lc(self, classname, class_repo):
         """
         Return a list of this class and it subclasses in lower case.
         Exception of class is not in repository.
         """
-
         if not classname:
             return []
         clns = [classname]
-        clns.extend(self._get_subclass_names(classname, namespace, True))
+        clns.extend(self._get_subclass_names(classname, class_repo, True))
         return [cln.lower() for cln in clns]
 
     @staticmethod
@@ -2738,7 +2676,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             return False
         return True
 
-    def _get_reference_classnames(self, classname, namespace,
+    def _get_reference_classnames(self, classname, namespace, class_repo,
                                   result_class, role):
         """
         Get list of classnames that are references for which this classname
@@ -2751,6 +2689,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             list of classnames that satisfy the criteria.
         """
 
+        class_repo = self._get_class_repo(namespace)
         self._validate_class_exists(classname, namespace, "TargetClass")
 
         if result_class:
@@ -2758,11 +2697,11 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                         "ResultClass")
 
         # get list of subclasses in lower case.
-        result_classes = self._subclasses_lc(result_class, namespace)
+        result_classes = self._subclasses_lc(result_class, class_repo)
 
         # Get the set of superclasses for the target classname and set
         # lower case
-        target_classlist = self._get_superclassnames(classname, namespace)
+        target_classlist = self._get_superclass_names(classname, class_repo)
         target_classlist.append(classname)
         target_classlist = [cn.lower() for cn in target_classlist]
 
@@ -2783,7 +2722,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return list(rtn_classnames_set)
 
-    def _get_reference_instnames(self, instname, namespace, result_class, role):
+    def _get_reference_instnames(self, instname, namespace, class_repo,
+                                 result_class, role):
         """
         Get the reference instances from the repository for the target
         instname and filtered by the result_class and role parameters.
@@ -2794,7 +2734,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         instance_repo = self._get_instance_repo(namespace)
 
-        if not self._exists_class(instname.classname, namespace):
+        if not class_repo.exists(instname.classname):
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
                 _format("Class {0!A} not found in namespace {1!A}.",
@@ -2804,7 +2744,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         if result_class:
             self._validate_class_exists(result_class, namespace,
                                         "ResultClass")
-        resultclasses = self._subclasses_lc(result_class, namespace)
+        resultclasses = self._subclasses_lc(result_class, class_repo)
 
         instname.namespace = namespace
         role = role.lower() if role else None
@@ -2815,7 +2755,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # instance_repo to search all instances
 
         rtn_instpaths = set()
-        for inst in six.itervalues(instance_repo):
+        for inst in instance_repo.iter_values():
             for prop in six.itervalues(inst.properties):
                 if prop.type == 'reference':
                     # Does this prop instance name match target inst name
@@ -2843,6 +2783,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             list of classnames that satisfy the criteria.
         """
 
+        # Validate namespace and get class_repo for this namespace
         class_repo = self._get_class_repo(namespace)
         if assoc_class:
             self._validate_class_exists(assoc_class, namespace, "AssocClass")
@@ -2851,8 +2792,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             self._validate_class_exists(result_class, namespace, "ResultClass")
 
         # Get list of subclasses for result and assoc classes (lower case)
-        result_classes = self._subclasses_lc(result_class, namespace)
-        assoc_classes = self._subclasses_lc(assoc_class, namespace)
+        result_classes = self._subclasses_lc(result_class, class_repo)
+        assoc_classes = self._subclasses_lc(assoc_class, class_repo)
 
         rtn_classnames_set = set()
 
@@ -2860,11 +2801,11 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         result_role = result_role.lower() if result_role else result_role
 
         ref_clns = self._get_reference_classnames(classname, namespace,
-                                                  assoc_class, role)
+                                                  class_repo, assoc_class, role)
 
         # Find reference properties that have multiple use of
         # same reference_class
-        klasses = [class_repo[cln] for cln in ref_clns]
+        klasses = [class_repo.get(cln) for cln in ref_clns]
         for cl in klasses:
             # Count reference property usage.
             pd = Counter([p.reference_class for p in
@@ -2883,8 +2824,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         if prop.reference_class == classname and \
                                 prop.reference_class in single_use:
                             continue
-                        else:
-                            rtn_classnames_set.add(prop.reference_class)
+
+                        rtn_classnames_set.add(prop.reference_class)
 
         return list(rtn_classnames_set)
 
@@ -2899,6 +2840,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         """
 
         instance_repo = self._get_instance_repo(namespace)
+        class_repo = self._get_class_repo(namespace)
 
         if assoc_class:
             self._validate_class_exists(assoc_class, namespace, "AssocClass")
@@ -2906,14 +2848,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         if result_class:
             self._validate_class_exists(result_class, namespace, "ResultClass")
 
-        result_classes = self._subclasses_lc(result_class, namespace)
-        assoc_classes = self._subclasses_lc(assoc_class, namespace)
+        result_classes = self._subclasses_lc(result_class, class_repo)
+        assoc_classes = self._subclasses_lc(assoc_class, class_repo)
 
         inst_name.namespace = namespace
         role = role.lower() if role else role
         result_role = result_role.lower() if result_role else result_role
 
         ref_paths = self._get_reference_instnames(inst_name, namespace,
+                                                  class_repo,
                                                   assoc_class, role)
 
         # Get associated instance names
@@ -2937,13 +2880,16 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                         rtn_instpaths.add(prop.value)
         return rtn_instpaths
 
-    def _fake_ReferenceNames(self, namespace, **params):
+    def _fake_ReferenceNames(self, **params):
         """
         Implements a mock WBEM server responder for
         :meth:`~pywbem.WBEMConnection.ReferenceNames`
         """
 
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        self.validate_namespace(namespace)
+        class_repo = self._get_class_repo(namespace)
+
         assert params['ResultClass'] is None or \
             isinstance(params['ResultClass'], CIMClassName)
 
@@ -2956,6 +2902,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         if isinstance(obj_name, CIMClassName):
             ref_classnames = self._get_reference_classnames(classname,
                                                             namespace,
+                                                            class_repo,
                                                             rc, role)
 
             ref_result = [CIMClassName(classname=cn, host=self.host,
@@ -2966,8 +2913,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         assert isinstance(obj_name, CIMInstanceName)
         ref_paths = self._get_reference_instnames(obj_name, namespace,
+                                                  class_repo,
                                                   rc, role)
-        rtn_names = [deepcopy(r) for r in ref_paths]
+        rtn_names = [r.copy() for r in ref_paths]
 
         for iname in rtn_names:
             if iname.host is None:
@@ -2975,13 +2923,16 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._return_assoc_tuple(rtn_names)
 
-    def _fake_References(self, namespace, **params):
+    def _fake_References(self, **params):
         """
         Implements a mock WBEM server responder for
         :meth:`~pywbem.WBEMConnection.References`
         """
 
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        # validate namespace and get class_repository for this namespace
+        class_repo = self._get_class_repo(namespace)
+
         rc = None if params['ResultClass'] is None else \
             params['ResultClass'].classname
         role = params['Role']
@@ -2993,19 +2944,21 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         if isinstance(obj_name, CIMClassName):
             rtn_classnames = self._get_reference_classnames(
-                classname, namespace, rc, role)
+                classname, namespace, class_repo, rc, role)
             # returns list of tuples of (CIMClassname, CIMClass)
             return self._return_assoc_class_tuples(rtn_classnames, namespace,
                                                    iq, ico, pl)
 
+        # This is an  instance reference
+        instance_repo = self._get_instance_repo(namespace)
         assert isinstance(obj_name, CIMInstanceName)
-        ref_paths = self._get_reference_instnames(obj_name, namespace, rc,
+        ref_paths = self._get_reference_instnames(obj_name, namespace,
+                                                  class_repo, rc,
                                                   role)
-        rtn_insts = []
-        for path in ref_paths:
-            rtn_insts.append(self._get_instance(
-                path, namespace, None,
-                pl, ico, iq))
+
+        rtn_insts = [self._get_instance(p, namespace, instance_repo, None,
+                                        pl, ico, iq)
+                     for p in ref_paths]
 
         for inst in rtn_insts:
             if inst.path.host is None:
@@ -3013,13 +2966,15 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._return_assoc_tuple(rtn_insts)
 
-    def _fake_AssociatorNames(self, namespace, **params):
+    def _fake_AssociatorNames(self, **params):
         # pylint: disable=invalid-name
         """
         Implements a mock WBEM server responder for
         :meth:`~pywbem.WBEMConnection.AssociatorNames`
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
 
         rc = None if params['ResultClass'] is None else \
             params['ResultClass'].classname
@@ -3047,7 +3002,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                                                        namespace,
                                                        ac, rc,
                                                        result_role, role)
-        results = [deepcopy(p) for p in rtn_paths]
+        results = [p.copy() for p in rtn_paths]
 
         for iname in results:
             if iname.host is None:
@@ -3055,13 +3010,14 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
 
         return self._return_assoc_tuple(results)
 
-    def _fake_Associators(self, namespace, **params):
+    def _fake_Associators(self, **params):
         """
         Implements a mock WBEM server responder for
             :meth:`~pywbem.WBEMConnection.Associators`
         """
 
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        self.validate_namespace(namespace)
 
         rc = None if params['ResultClass'] is None else \
             params['ResultClass'].classname
@@ -3084,6 +3040,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             return self._return_assoc_class_tuples(rtn_classnames, namespace,
                                                    iq, ico, pl)
 
+        # Processing for instancename
+        instance_repo = self._get_instance_repo(namespace)
         assert isinstance(obj_name, CIMInstanceName)
         assoc_names = self._get_associated_instancenames(obj_name,
                                                          namespace,
@@ -3092,7 +3050,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         results = []
         for obj_name in assoc_names:
             results.append(self._get_instance(
-                obj_name, namespace, None,
+                obj_name, namespace, instance_repo, None,
                 pl, ico, iq))
 
         return self._return_assoc_tuple(results)
@@ -3177,7 +3135,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             CIMError: CIM_ERR_INVALID_ENUMERATION_CONTEXT
         """
 
-        self._validate_namespace(namespace)
+        self.validate_namespace(namespace)
 
         context_id = params['EnumerationContext']
 
@@ -3239,154 +3197,172 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
                     _format("OperationTimeout {0!A }must be positive integer "
                             "less than {1!A}", ot, OPEN_MAX_TIMEOUT))
 
-    def _fake_OpenEnumerateInstancePaths(self, namespace, **params):
+    def _fake_OpenEnumerateInstancePaths(self, **params):
         # pylint: disable=invalid-name
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenEnumerationInstancePaths`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
 
-        result_t = self._fake_EnumerateInstanceNames(namespace, **params)
+        result_t = self._fake_EnumerateInstanceNames(**params)
 
         return self._open_response(result_t[0][2], namespace,
                                    'PullInstancePaths', **params)
 
-    def _fake_OpenEnumerateInstances(self, namespace, **params):
+    def _fake_OpenEnumerateInstances(self, **params):
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenEnumerationInstances`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
 
-        result_t = self._fake_enumerateinstances(namespace, **params)
+        result_t = self._fake_EnumerateInstances(**params)
 
         return self._open_response(result_t[0][2], namespace,
                                    'PullInstancesWithPath', **params)
 
-    def _fake_OpenReferenceInstancePaths(self, namespace, **params):
+    def _fake_OpenReferenceInstancePaths(self, **params):
         # pylint: disable=invalid-name
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenReferenceInstancePaths`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
         params['ObjectName'] = params['InstanceName']
         del params['InstanceName']
 
-        result = self._fake_ReferenceNames(namespace, **params)
+        result = self._fake_ReferenceNames(**params)
 
         objects = [] if result is None else [x[2] for x in result[0][2]]
 
         return self._open_response(objects, namespace,
                                    'PullInstancePaths', **params)
 
-    def _fake_OpenReferenceInstances(self, namespace, **params):
+    def _fake_OpenReferenceInstances(self, **params):
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenReferenceInstances`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
         params['ObjectName'] = params['InstanceName']
         del params['InstanceName']
 
-        result = self._fake_References(namespace, **params)
+        result = self._fake_References(**params)
 
         objects = [] if result is None else [x[2] for x in result[0][2]]
 
         return self._open_response(objects, namespace,
                                    'PullInstancesWithPath', **params)
 
-    def _fake_OpenAssociatorInstancePaths(self, namespace, **params):
+    def _fake_OpenAssociatorInstancePaths(self, **params):
         # pylint: disable=invalid-name
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenAssociatorInstancePaths`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
         params['ObjectName'] = params['InstanceName']
         del params['InstanceName']
 
-        result = self._fake_AssociatorNames(namespace, **params)
+        result = self._fake_AssociatorNames(**params)
 
         objects = [] if result is None else [x[2] for x in result[0][2]]
 
         return self._open_response(objects, namespace,
                                    'PullInstancePaths', **params)
 
-    def _fake_OpenAssociatorInstances(self, namespace, **params):
+    def _fake_OpenAssociatorInstances(self, **params):
         """
         Implements WBEM server responder for
         WBEMConnection.OpenAssociatorInstances
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
         params['ObjectName'] = params['InstanceName']
         del params['InstanceName']
 
-        result = self._fake_Associators(namespace, **params)
+        result = self._fake_Associators(**params)
 
         objects = [] if result is None else [x[2] for x in result[0][2]]
 
         return self._open_response(objects, namespace,
                                    'PullInstancesWithPath', **params)
 
-    def _fake_OpenQueryInstances(self, namespace, **params):
+    def _fake_OpenQueryInstances(self, **params):
         # pylint: disable=invalid-name
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenQueryInstances`
         with data from the instance repository.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
         self._validate_open_params(**params)
 
         # pylint: disable=assignment-from-no-return
         # Issue #2064 TODO/ks implement execquery
-        result = self._fake_execquery(namespace, **params)
+        result = self._fake_ExecQuery(**params)
 
         objects = [] if result is None else [x[2] for x in result[0][2]]
 
         return self._open_response(objects, namespace,
                                    'PullInstancesWithPath', **params)
 
-    def _fake_PullInstancesWithPath(self, namespace, **params):
+    def _fake_PullInstancesWithPath(self, **params):
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenPullInstancesWithPath`
         with data from the instance repository.
         """
+
+        namespace = self.namespace
         return self._pull_response(namespace, 'PullInstancesWithPath',
                                    **params)
 
-    def _fake_PullInstancePaths(self, namespace, **params):
+    def _fake_PullInstancePaths(self, **params):
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenPullInstancePaths`
         with data from the instance repository.
         """
+
+        namespace = self.namespace
         return self._pull_response(namespace, 'PullInstancePaths', **params)
 
-    def _fake_PullInstances(self, namespace, **params):
+    def _fake_PullInstances(self, **params):
         """
         Implements WBEM server responder for
         :meth:`~pywbem.WBEMConnection.OpenPullInstances`
         with data from the instance repository.
         """
+
+        namespace = self.namespace
         return self._pull_response(namespace, 'PullInstances', **params)
 
-    def _fake_CloseEnumeration(self, namespace, **params):
+    def _fake_CloseEnumeration(self, **params):
         """
             Implements WBEM server responder for
             :meth:`~pywbem.WBEMConnection.CloseEnumeration`
@@ -3395,7 +3371,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             If the EnumerationContext is valid it removes it from the
             context repository. Otherwise it returns an exception.
         """
-        self._validate_namespace(namespace)
+
+        namespace = self.namespace
+        self.validate_namespace(namespace)
 
         context_id = params['EnumerationContext']
 
@@ -3439,7 +3417,7 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         WBEMConnection.InvokeMethod (ReturnValue, OutputParameters).
         """
         if isinstance(objectname, (CIMInstanceName, CIMClassName)):
-            localobject = deepcopy(objectname)
+            localobject = objectname.copy()
             if localobject.namespace is None:
                 localobject.namespace = self.default_namespace
                 localobject.host = None

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -262,7 +262,9 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
         # Implementation of the CIM object repository that is the data store
         # for CIM classes, CIM instances, CIM qualifier declarations and
         # CIM methods for the mocker.  All access to the mocker CIM data must
-        # pass through this variable to the datastore.
+        # pass through this variable to the CIM repository.
+        # See :py:module:`pywbem_mock/inmemoryrepository` for a description of
+        # the repository interface.
         self.repo = InMemoryRepository(self.default_namespace)
 
         # Defines the connection for the compiler.  The compiler uses

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -864,8 +864,8 @@ class FakedWBEMConnection(WBEMConnection, ResolverMixin):
             If `None`, all namespaces of the mock repository are displayed.
 
           dest (:term:`string`):
-            File-like object(ex. file_path, or other data stream definition )
-            for the output. If `None`, the output is written to stdout.
+            File path of an output file. If `None`, the output is written to
+            stdout.
 
           summary (:class:`py:bool`):
             Flag for summary mode. If `True`, only a summary count of CIM

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ PyYAML>=5.1,<5.3; python_version == '3.4'
 PyYAML>=5.1; python_version > '3.4'
 six>=1.10.0
 requests>=2.20.0
+# Pinned because this is the current version and the developer
+# is planing to remove python 2.7 support in next version.
+custom-inherit==2.2.2
 
 
 # Indirect dependencies are no longer specified here, but for testing with a

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -325,13 +325,10 @@ class TestRemove(MOFTest):
 
         skip_if_moftab_regenerated()
 
-        # compile the mof. The DMTF schema mof is installed by the setup
+        # Compile the mof. The DMTF schema mof is installed by the setup
 
         ns = 'root/test'
-
         conn = FakedWBEMConnection(default_namespace=ns)
-
-        # compile the file against the mocker
         moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
         self.logfile = open(moflog_file, 'w')
 
@@ -367,7 +364,7 @@ class TestRemove(MOFTest):
             verbose=False,
             log_func=moflog)
 
-        # recompile for to MOFWBEMConnection for remove
+        # recompile to MOFWBEMConnection for remove
         conn_mof_mofcomp.compile_file(
             os.path.join(TEST_DIR, 'test.mof'), ns)
 

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -81,7 +81,7 @@ class TestServerClass(BaseMethodsForTests):
         server = mock_wbemserver.wbem_server
 
         # Build instances for get_central instance
-        # Using central methodology, i.e. ElementConformsToProfile
+        # using central methodology, i.e. ElementConformsToProfile
 
         # Test basic brand, version, namespace methods
         assert server.namespace_classname == 'CIM_Namespace'

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -1,0 +1,423 @@
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+Test of pywbem_mock package.  This tests the implementation of pywbem_mock
+using a set of local mock qualifiers, classes, and instances.
+
+"""
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from pywbem import CIMClass, CIMInstance, CIMInstanceName, CIMProperty, \
+    CIMQualifierDeclaration, CIMQualifier
+
+from pywbem._nocasedict import NocaseDict
+
+from pywbem_mock._inmemoryrepository import InMemoryObjStore, InMemoryRepository
+
+from ..utils.pytest_extensions import simplified_test_function
+
+########################################################################
+#
+#      Test InMemoryObjStore
+#
+#########################################################################
+
+TESTCASES_OBJSTORE = [
+
+    # Testcases for OBJSTORE tests
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * init_args: list of
+    #   * cls_kwargs: single class def or list of class def
+    #   * inst_kwargs: Single inst def or list of class def
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    (
+        "Test with an class",
+        dict(
+            init_args=[True, CIMClass],
+            cls_kwargs=dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty(
+                        'P1', None, type='string',
+                        qualifiers=[
+                            CIMQualifier('Key', value=True)
+                        ]
+                    ),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            inst_kwargs=None,
+            qual_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "Test with an instance",
+        dict(
+            init_args=[False, CIMInstance],
+            cls_kwargs=dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty(
+                        'P1', None, type='string',
+                        qualifiers=[
+                            CIMQualifier('Key', value=True)
+                        ]
+                    ),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            inst_kwargs=dict(
+                classname='CIM_Foo',
+                properties=[
+                    CIMProperty('P1', value='Ham'),
+                    CIMProperty('P2', value='Cheese'),
+                ]
+            ),
+            qual_kwargs=None,
+
+        ),
+        None, None, True
+    ),
+    (
+        "Test with an qualifier declaration",
+        dict(
+            init_args=[False, CIMQualifierDeclaration],
+            cls_kwargs=None,
+            inst_kwargs=None,
+            qual_kwargs=dict(
+                name='Abstract',
+                type='string',
+                value='blah'),
+        ),
+        None, None, True
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_OBJSTORE)
+@simplified_test_function
+def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
+    """
+    Simple test inserts one inst of defined type and tests retrievail
+    methods.
+    """
+    namespace = "root/cimv2"
+
+    # setup the ObjStore
+    xxx_repo = InMemoryObjStore(*init_args)
+    if cls_kwargs:
+        cls = CIMClass(**cls_kwargs)
+    if inst_kwargs:
+        inst = CIMInstance(**inst_kwargs)
+        inst.path = CIMInstanceName.from_instance(
+            cls, inst, namespace=namespace, host='me', strict=True)
+    if qual_kwargs:
+        qual = CIMQualifierDeclaration(**qual_kwargs)
+
+    # is this instance or class test
+    if inst_kwargs:
+        name = inst.path
+        obj = inst
+    elif qual_kwargs:
+        name = qual.name
+        obj = qual
+    else:
+        name = cls.classname
+        obj = cls
+
+    # The code to be tested. The test include adding and testing the
+    # various inspection methods for correct returns
+
+    # Create the object in the object store
+    xxx_repo.create(name, obj)
+
+    # confirm that exists works
+    assert xxx_repo.exists(name)
+
+    # Test len()
+    assert xxx_repo.len() == 1
+
+    # Test get the object and test for same object
+    rtn_obj = xxx_repo.get(name)
+    assert rtn_obj == obj
+
+    names = [n for n in xxx_repo.iter_names()]
+    assert len(names) == 1
+    assert names[0] == name
+
+    objs = [x for x in xxx_repo.iter_values()]
+    assert len(objs) == 1
+    assert objs[0] == obj
+
+    # Test update
+
+    # Test update; should work
+    obj2 = obj.copy()
+    xxx_repo.update(name, obj2)
+    assert xxx_repo.get(name) == obj2
+
+    # Test valid delete of object
+    xxx_repo.delete(name)
+    assert not xxx_repo.exists(name)
+    assert xxx_repo.len() == 0
+
+    # Test errors
+
+    # Test update with unknown object; should fail
+    try:
+        xxx_repo.update(name, obj)
+    except KeyError:
+        pass
+
+    # Test delete nonexistent entity; should fail
+    try:
+        xxx_repo.delete(name)
+        assert False
+    except KeyError:
+        pass
+
+    # Test get non existent entity; should fail
+    try:
+        xxx_repo.get(name)
+        assert False
+    except KeyError:
+        pass
+
+    # Test exists; entity should not exist
+    assert not xxx_repo.exists(name)
+
+    # Test create with existing object
+    xxx_repo.create(name, obj)
+
+    # Test duplicate create; should fail
+    try:
+        xxx_repo.create(name, obj)
+        assert False
+    except ValueError:
+        pass
+
+#############################################################
+#
+# Test InmemoryRepository
+#
+#############################################################
+
+
+@pytest.mark.parametrize(
+    "default_ns, additional_ns, test_ns, exp_ns, exp_exc",
+    [
+        ('root/def', [], 'root/blah', 'root/blah', None),
+        ('root/def', [], '//root/blah//', 'root/blah', None),
+        ('root/def', ['root/foo'], 'root/blah', 'root/blah', None),
+        ('root/def', ['root/blah'], 'root/blah', None,
+         ValueError()),
+        ('root/def', [], None, 'root/def', ValueError()),
+        ('root/def', [], None, None, ValueError()),
+    ]
+)
+def test_add_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
+    # pylint: disable=no-self-use
+    """
+    Test add_namespace()
+    """
+    # setup the inmemory repository
+    repo = InMemoryRepository(default_ns)
+    for ns in additional_ns:
+        repo.add_namespace(ns)
+    if not exp_exc:
+        # The code to be tested
+        repo.add_namespace(test_ns)
+        assert exp_ns in repo.list_namespaces()
+    else:
+        with pytest.raises(exp_exc.__class__) as exec_info:
+
+            # The code to be tested
+            repo.add_namespace(test_ns)
+
+            print(exec_info)
+
+
+@pytest.mark.parametrize(
+    "default_ns, additional_ns, test_ns, exp_ns, exp_exc",
+    [
+        ('root/def', ['root/blah'], 'root/blah', 'root/blah', None),
+        ('root/def', ['root/blah'], '//root/blah//', 'root/blah', None),
+        ('root/def', ['root/blah', 'root/foo'], 'root/blah', 'root/blah',
+         None),
+        ('root/def', [], 'root/blah', None, KeyError()),
+        ('root/def', [], None, None, ValueError()),
+    ]
+)
+def test_remove_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
+    # pylint: disable=no-self-use
+    """
+    Test _remove_namespace()
+    """
+    repo = InMemoryRepository(default_ns)
+    for ns in additional_ns:
+        repo.add_namespace(ns)
+    if not exp_exc:
+
+        # The code to be tested
+        repo.remove_namespace(test_ns)
+
+        assert exp_ns not in repo.list_namespaces()
+    else:
+        with pytest.raises(exp_exc.__class__) as exec_info:
+
+            # The code to be tested
+            repo.remove_namespace(test_ns)
+            print(exec_info)
+
+
+@pytest.mark.parametrize(
+    # Testcases for Inmemory repository object management tests
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * init_args - list of Classes, instances, etc. to populate repo
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+    "desc, args, condition",
+    [
+        (
+            "Test basic setup of repository and execution of object mgt ",
+            dict(
+                init_args="root/blah",
+                init_objs=[
+                    CIMClass('Foo', properties=[
+                        CIMProperty('P1', None, type='string',
+                                    qualifiers=[CIMQualifier('Key', value=True)]
+                                    )]),
+                    CIMClass('Bar', properties=[
+                        CIMProperty('P2', None, type='string',
+                                    qualifiers=[CIMQualifier('Key', value=True)]
+                                    )]),
+                    CIMInstance('Foo',
+                                path=CIMInstanceName(
+                                    'Foo',
+                                    keybindings=NocaseDict(P1="P1"))),
+                    CIMInstance('Bar',
+                                path=CIMInstanceName(
+                                    'Bar',
+                                    keybindings=NocaseDict(P2="P2"))),
+                    CIMQualifierDeclaration('Qual1', type='string'),
+                    CIMQualifierDeclaration('Qual2', type='string'), ]
+            ),
+            True,
+        ),
+    ],
+)
+def test_repository_valid_methods(desc, args, condition):
+    """
+    This is a test of the various methods of the repository that return
+    valid responses for all of the types
+    """
+    if not condition:
+        pytest.skip("Condition for test case not met")
+
+    init_args = args['init_args']
+    init_objs = args['init_objs']
+
+    namespace = init_args
+
+    # setup the inmemory repository
+    repo = InMemoryRepository(namespace)
+    class_repo = repo.get_class_repo(namespace)
+    inst_repo = repo.get_instance_repo(namespace)
+    qual_repo = repo.get_qualifier_repo(namespace)
+
+    # Counter of number of objects by type created.
+    inst_count = 0
+    class_count = 0
+    qual_count = 0
+
+    # holding dict for items created in repository by repository name
+    input_items = {'classes': {}, 'instances': {}, 'qualifiers': {}}
+
+    # Relate repository names to corresponsing get_xxx_repo function
+    repos = {'classes': class_repo, 'instances': inst_repo,
+             'qualifiers': qual_repo}
+
+    # Insert the items in init_objs into the repository
+    for item in init_objs:
+        if isinstance(item, CIMClass):
+            class_repo.create(item.classname, item)
+            class_count += 1
+            input_items['classes'][item.classname] = item
+        elif isinstance(item, CIMInstance):
+            inst_repo.create(item.path, item)
+            inst_count += 1
+            input_items['instances'][item.path] = item
+        elif isinstance(item, CIMQualifierDeclaration):
+            qual_repo.create(item.name, item)
+            qual_count += 1
+            input_items['qualifiers'][item.name] = item
+        else:
+            assert False
+
+    #
+    #   Execute repository object access methods and verifyresults
+    #
+
+    # Test counts of objects in the repository
+    assert class_count == len(input_items['classes'])
+    assert inst_count == len(input_items['instances'])
+    assert qual_count == len(input_items['qualifiers'])
+
+    assert class_repo.len() == class_count
+    assert inst_repo.len() == inst_count
+    assert qual_repo.len() == qual_count
+
+    # Test exists(), get(), iter_names, iter_values, and delete with with
+    # valid names
+
+    print(repo.print())
+
+    for type_dict, obj_dict in input_items.items():
+        xxx_repo = repos[type_dict]
+        for name, obj in obj_dict.items():
+            assert xxx_repo.exists(name), '{} exists() fail {}'.format(desc,
+                                                                       name)
+
+            rtnd_obj = xxx_repo.get(name)
+            assert rtnd_obj == input_items[type_dict][name]
+
+        # Test iter_names and iter_values
+        names = list(xxx_repo.iter_names())
+        assert set(names) == set(input_items[type_dict].keys())
+
+        objs = list(xxx_repo.iter_values())
+        assert set(objs) == set(input_items[type_dict].values())
+
+        for name, obj in obj_dict.items():
+            xxx_repo.delete(name)
+
+    for type_dict, obj_dict in input_items.items():
+        xxx_repo = repos[type_dict]
+        assert xxx_repo.len() == 0
+
+# TODO: Tests missing: 1) object exception returns, use of copy parameter
+#                      2. Namespace name None on add an delete.
+#                      3. __repr__

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -25,7 +25,8 @@ from pywbem import CIMClass, CIMInstance, CIMInstanceName, CIMProperty, \
 
 from pywbem._nocasedict import NocaseDict
 
-from pywbem_mock._inmemoryrepository import InMemoryObjStore, InMemoryRepository
+from pywbem_mock import InMemoryRepository
+from pywbem_mock._inmemoryrepository import InMemoryObjStore
 
 from ..utils.pytest_extensions import simplified_test_function
 
@@ -231,8 +232,8 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
         ('root/def', [], 'root/blah', 'root/blah', None),
         ('root/def', [], '//root/blah//', 'root/blah', None),
         ('root/def', ['root/foo'], 'root/blah', 'root/blah', None),
-        ('root/def', ['root/blah'], 'root/blah', None,
-         ValueError()),
+        ('root/def', ['root/blah'], 'root/blah', None, ValueError()),
+        (None, ['root/foo'], 'root/blah', 'root/blah', None),
         ('root/def', [], None, 'root/def', ValueError()),
         ('root/def', [], None, None, ValueError()),
     ]
@@ -240,7 +241,7 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
 def test_add_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
     # pylint: disable=no-self-use
     """
-    Test add_namespace()
+    Test add_namespace() and the namespaces property
     """
     # setup the inmemory repository
     repo = InMemoryRepository(default_ns)
@@ -249,13 +250,18 @@ def test_add_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
     if not exp_exc:
         # The code to be tested
         repo.add_namespace(test_ns)
-        assert exp_ns in repo.list_namespaces()
+        assert isinstance(repo.namespaces, list)
+        assert exp_ns in repo.namespaces
+        for ns in additional_ns:
+            assert ns in repo.namespaces
+        if default_ns:
+            assert default_ns in repo.namespaces
+
     else:
         with pytest.raises(exp_exc.__class__) as exec_info:
 
             # The code to be tested
             repo.add_namespace(test_ns)
-
             print(exec_info)
 
 
@@ -283,7 +289,7 @@ def test_remove_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
         # The code to be tested
         repo.remove_namespace(test_ns)
 
-        assert exp_ns not in repo.list_namespaces()
+        assert exp_ns not in repo.namespaces
     else:
         with pytest.raises(exp_exc.__class__) as exec_info:
 
@@ -292,12 +298,29 @@ def test_remove_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
             print(exec_info)
 
 
+TEST_OBJECTS = [
+    CIMClass('Foo', properties=[
+        CIMProperty('P1', None, type='string',
+                    qualifiers=[CIMQualifier('Key', value=True)])]),
+    CIMClass('Bar', properties=[
+        CIMProperty('P2', None, type='string',
+                    qualifiers=[CIMQualifier('Key', value=True)])]),
+    CIMInstance('Foo', path=CIMInstanceName('Foo',
+                                            keybindings=NocaseDict(P1="P1"))),
+    CIMInstance('Bar', path=CIMInstanceName('Bar',
+                                            keybindings=NocaseDict(P2="P2"))),
+    CIMQualifierDeclaration('Qual1', type='string'),
+    CIMQualifierDeclaration('Qual2', type='string'), ]
+
+
 @pytest.mark.parametrize(
     # Testcases for Inmemory repository object management tests
 
     # Each list item is a testcase tuple with these items:
     # * desc: Short testcase description.
     # * init_args - list of Classes, instances, etc. to populate repo
+    # * init_objs - list of CIM objects that will be used to initialize the
+    #   repository when it is created.
     # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
     "desc, args, condition",
     [
@@ -305,34 +328,19 @@ def test_remove_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
             "Test basic setup of repository and execution of object mgt ",
             dict(
                 init_args="root/blah",
-                init_objs=[
-                    CIMClass('Foo', properties=[
-                        CIMProperty('P1', None, type='string',
-                                    qualifiers=[CIMQualifier('Key', value=True)]
-                                    )]),
-                    CIMClass('Bar', properties=[
-                        CIMProperty('P2', None, type='string',
-                                    qualifiers=[CIMQualifier('Key', value=True)]
-                                    )]),
-                    CIMInstance('Foo',
-                                path=CIMInstanceName(
-                                    'Foo',
-                                    keybindings=NocaseDict(P1="P1"))),
-                    CIMInstance('Bar',
-                                path=CIMInstanceName(
-                                    'Bar',
-                                    keybindings=NocaseDict(P2="P2"))),
-                    CIMQualifierDeclaration('Qual1', type='string'),
-                    CIMQualifierDeclaration('Qual2', type='string'), ]
+                init_objs=TEST_OBJECTS
             ),
             True,
         ),
     ],
 )
-def test_repository_valid_methods(desc, args, condition):
+def test_repository_valid_methods(desc, args, condition, capsys):
     """
     This is a test of the various methods of the repository that return
-    valid responses for all of the types
+    valid responses for all of the types. This test create, update,
+    get, delete and inter* methods of the object store as accessed through
+    the InMemoryRepository for good responses. It does not test exception
+    responses.
     """
     if not condition:
         pytest.skip("Condition for test case not met")
@@ -342,35 +350,40 @@ def test_repository_valid_methods(desc, args, condition):
 
     namespace = init_args
 
-    # setup the inmemory repository
-    repo = InMemoryRepository(namespace)
+    # setup the inmemory repository and the methods that provide access to
+    # the repository for each object type
+    repo = InMemoryRepository(initial_namespace=namespace)
+
     class_repo = repo.get_class_repo(namespace)
     inst_repo = repo.get_instance_repo(namespace)
     qual_repo = repo.get_qualifier_repo(namespace)
 
+    # Holding dict for items created in repository by repository name
+    input_items = {'classes': {}, 'instances': {}, 'qualifiers': {}}
+
+    # Relate repository names to corresponsing get_xxx_repo function
+    repos = {'classes': repo.get_class_repo(namespace),
+             'instances': repo.get_instance_repo(namespace),
+             'qualifiers': repo.get_qualifier_repo(namespace)}
+
+    # Insert the items in init_objs into the repository
     # Counter of number of objects by type created.
     inst_count = 0
     class_count = 0
     qual_count = 0
-
-    # holding dict for items created in repository by repository name
-    input_items = {'classes': {}, 'instances': {}, 'qualifiers': {}}
-
-    # Relate repository names to corresponsing get_xxx_repo function
-    repos = {'classes': class_repo, 'instances': inst_repo,
-             'qualifiers': qual_repo}
-
-    # Insert the items in init_objs into the repository
     for item in init_objs:
         if isinstance(item, CIMClass):
+            class_repo = repos['classes']
             class_repo.create(item.classname, item)
             class_count += 1
             input_items['classes'][item.classname] = item
         elif isinstance(item, CIMInstance):
+            inst_repo = repos['instances']
             inst_repo.create(item.path, item)
             inst_count += 1
             input_items['instances'][item.path] = item
         elif isinstance(item, CIMQualifierDeclaration):
+            qual_repo = repos['qualifiers']
             qual_repo.create(item.name, item)
             qual_count += 1
             input_items['qualifiers'][item.name] = item
@@ -390,11 +403,19 @@ def test_repository_valid_methods(desc, args, condition):
     assert inst_repo.len() == inst_count
     assert qual_repo.len() == qual_count
 
+    # verify the print_repository returns correct data
+    print(repo.print_repository())
+    captured = capsys.readouterr()
+
+    result = captured.out
+    assert "QUALIFIERS: Namespace: root/blah Repo: qualifier len:2" in result
+    assert "CLASSES: Namespace: root/blah Repo: class len:2" in result
+    assert "INSTANCES: Namespace: root/blah Repo: instance len:2" in result
+
     # Test exists(), get(), iter_names, iter_values, and delete with with
     # valid names
 
-    print(repo.print())
-
+    # Verify the correct response for each objstore
     for type_dict, obj_dict in input_items.items():
         xxx_repo = repos[type_dict]
         for name, obj in obj_dict.items():
@@ -403,6 +424,16 @@ def test_repository_valid_methods(desc, args, condition):
 
             rtnd_obj = xxx_repo.get(name)
             assert rtnd_obj == input_items[type_dict][name]
+
+            # update each object with the same object as originally installed.
+            xxx_repo.update(name, obj)
+
+        # test obj store repr
+        print(repr(xxx_repo))
+        captured = capsys.readouterr()
+        result = captured.out
+        assert "InMemoryObjStore(" in result
+        assert "size=2" in result
 
         # Test iter_names and iter_values
         names = list(xxx_repo.iter_names())
@@ -418,6 +449,114 @@ def test_repository_valid_methods(desc, args, condition):
         xxx_repo = repos[type_dict]
         assert xxx_repo.len() == 0
 
-# TODO: Tests missing: 1) object exception returns, use of copy parameter
+
+@pytest.mark.parametrize(
+    # Testcases for Inmemory repository object management tests
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * init_args - list of Classes, instances, etc. to populate repo
+    # * init_objs - list of CIM objects that will be used to initialize the
+    #   repository when it is created.
+    # * err_names - Object names that should return exception for
+    #   get and delete based on init_objs. These are objects not in the
+    #   repository so they can not be retrievied, deleted, or updated
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+    "desc, args, condition",
+    [
+        (
+            "Test basic setup of repository and execution of object mgt ",
+            dict(
+                init_args="root/blah",
+                init_objs=TEST_OBJECTS,
+                err_names={'classes': 'CIM_NotExist',
+                           'instances': CIMInstanceName(
+                               'NotExist', keybindings=NocaseDict(P1="P1")),
+                           'qualifiers': 'NotExist'},
+                valid_names={'classes': 'Foo',
+                             'instances': CIMInstanceName(
+                                 'Foo', keybindings=NocaseDict(P1="P1")),
+                             'qualifiers': 'Qual1'},
+                valid_objs={'classes': 'Foo',
+                            'instances': CIMInstanceName(
+                                'Foo', keybindings=NocaseDict(P1="P1")),
+                            'qualifiers': 'Qual1'},
+            ),
+            True,
+        ),
+    ],
+)
+def test_repository_method_errs(desc, args, condition, capsys):
+    """
+    This is a test of the various methods of the repository that return
+    valid responses for all of the types. This test create, update,
+    get, delete and inter* methods of the object store as accessed through
+    the InMemoryRepository for good responses. It does not test exception
+    responses.
+    """
+    if not condition:
+        pytest.skip("Condition for test case not met")
+
+    init_args = args['init_args']
+    init_objs = args['init_objs']
+    err_names = args['err_names']
+    valid_names = args['valid_names']
+
+    namespace = init_args
+
+    # setup the inmemory repository and the methods that provide access to
+    # the repository for each object type
+    repo = InMemoryRepository(namespace)
+
+    # Relate repository names to corresponsing get_xxx_repo function
+    repos = {'classes': repo.get_class_repo(namespace),
+             'instances': repo.get_instance_repo(namespace),
+             'qualifiers': repo.get_qualifier_repo(namespace)}
+
+    for item in init_objs:
+        if isinstance(item, CIMClass):
+            class_repo = repos['classes']
+            class_repo.create(item.classname, item)
+        elif isinstance(item, CIMInstance):
+            inst_repo = repos['instances']
+            inst_repo.create(item.path, item)
+        elif isinstance(item, CIMQualifierDeclaration):
+            qual_repo = repos['qualifiers']
+            qual_repo.create(item.name, item)
+        else:
+            assert False
+
+    for repo_name, xxx_repo in repos.items():
+        err_name = err_names[repo_name]
+        valid_name = valid_names[repo_name]
+        try:
+            xxx_repo.get(err_name)
+            assert False, "get should return exception"
+        except KeyError:
+            pass
+
+        try:
+            xxx_repo.delete(err_name)
+            assert False, "delete Exception failed {} {}"
+        except KeyError:
+            pass
+
+        # Try to get object from repo and create it.
+        try:
+            obj = xxx_repo.get(valid_name)
+            obj = xxx_repo.create(valid_name, obj)
+        except ValueError:
+            pass
+
+        # Try to get object from repo and update it with err_name.
+        # NOTE: this works because repo does not validate names against
+        # objects on create or update.
+        try:
+            obj = xxx_repo.get(valid_name)
+            obj = xxx_repo.update(err_name, obj)
+        except KeyError:
+            pass
+
+
+# TODO: Tests missing: 1) use of copy parameter
 #                      2. Namespace name None on add an delete.
-#                      3. __repr__

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -26,13 +26,13 @@ from pywbem import CIMClass, CIMInstance, CIMInstanceName, CIMProperty, \
 from pywbem._nocasedict import NocaseDict
 
 from pywbem_mock import InMemoryRepository
-from pywbem_mock._inmemoryrepository import InMemoryObjStore
+from pywbem_mock._inmemoryrepository import InMemoryObjectStore
 
 from ..utils.pytest_extensions import simplified_test_function
 
 ########################################################################
 #
-#      Test InMemoryObjStore
+#      Test InMemoryObjectStore
 #
 #########################################################################
 
@@ -53,7 +53,7 @@ TESTCASES_OBJSTORE = [
     (
         "Test with an class",
         dict(
-            init_args=[True, CIMClass],
+            init_args=[CIMClass],
             cls_kwargs=dict(
                 classname='CIM_Foo',
                 properties=[
@@ -74,7 +74,7 @@ TESTCASES_OBJSTORE = [
     (
         "Test with an instance",
         dict(
-            init_args=[False, CIMInstance],
+            init_args=[CIMInstance],
             cls_kwargs=dict(
                 classname='CIM_Foo',
                 properties=[
@@ -102,7 +102,7 @@ TESTCASES_OBJSTORE = [
     (
         "Test with an qualifier declaration",
         dict(
-            init_args=[False, CIMQualifierDeclaration],
+            init_args=[CIMQualifierDeclaration],
             cls_kwargs=None,
             inst_kwargs=None,
             qual_kwargs=dict(
@@ -126,8 +126,9 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
     """
     namespace = "root/cimv2"
 
-    # setup the ObjStore
-    xxx_repo = InMemoryObjStore(*init_args)
+    # Setup the ObjectStore
+    xxx_repo = InMemoryObjectStore(*init_args)
+
     if cls_kwargs:
         cls = CIMClass(**cls_kwargs)
     if inst_kwargs:
@@ -432,7 +433,7 @@ def test_repository_valid_methods(desc, args, condition, capsys):
         print(repr(xxx_repo))
         captured = capsys.readouterr()
         result = captured.out
-        assert "InMemoryObjStore(" in result
+        assert "InMemoryObjectStore(" in result
         assert "size=2" in result
 
         # Test iter_names and iter_values
@@ -531,13 +532,13 @@ def test_repository_method_errs(desc, args, condition, capsys):
         valid_name = valid_names[repo_name]
         try:
             xxx_repo.get(err_name)
-            assert False, "get should return exception"
+            assert False, "Get should return exception"
         except KeyError:
             pass
 
         try:
             xxx_repo.delete(err_name)
-            assert False, "delete Exception failed {} {}"
+            assert False, "Delete Exception failed {} {}"
         except KeyError:
             pass
 

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -355,17 +355,17 @@ def test_repository_valid_methods(desc, args, condition, capsys):
     # the repository for each object type
     repo = InMemoryRepository(initial_namespace=namespace)
 
-    class_repo = repo.get_class_repo(namespace)
-    inst_repo = repo.get_instance_repo(namespace)
-    qual_repo = repo.get_qualifier_repo(namespace)
+    class_store = repo.get_class_store(namespace)
+    inst_repo = repo.get_instance_store(namespace)
+    qual_repo = repo.get_qualifier_store(namespace)
 
     # Holding dict for items created in repository by repository name
     input_items = {'classes': {}, 'instances': {}, 'qualifiers': {}}
 
     # Relate repository names to corresponsing get_xxx_repo function
-    repos = {'classes': repo.get_class_repo(namespace),
-             'instances': repo.get_instance_repo(namespace),
-             'qualifiers': repo.get_qualifier_repo(namespace)}
+    repos = {'classes': repo.get_class_store(namespace),
+             'instances': repo.get_instance_store(namespace),
+             'qualifiers': repo.get_qualifier_store(namespace)}
 
     # Insert the items in init_objs into the repository
     # Counter of number of objects by type created.
@@ -374,8 +374,8 @@ def test_repository_valid_methods(desc, args, condition, capsys):
     qual_count = 0
     for item in init_objs:
         if isinstance(item, CIMClass):
-            class_repo = repos['classes']
-            class_repo.create(item.classname, item)
+            class_store = repos['classes']
+            class_store.create(item.classname, item)
             class_count += 1
             input_items['classes'][item.classname] = item
         elif isinstance(item, CIMInstance):
@@ -400,7 +400,7 @@ def test_repository_valid_methods(desc, args, condition, capsys):
     assert inst_count == len(input_items['instances'])
     assert qual_count == len(input_items['qualifiers'])
 
-    assert class_repo.len() == class_count
+    assert class_store.len() == class_count
     assert inst_repo.len() == inst_count
     assert qual_repo.len() == qual_count
 
@@ -510,14 +510,14 @@ def test_repository_method_errs(desc, args, condition, capsys):
     repo = InMemoryRepository(namespace)
 
     # Relate repository names to corresponsing get_xxx_repo function
-    repos = {'classes': repo.get_class_repo(namespace),
-             'instances': repo.get_instance_repo(namespace),
-             'qualifiers': repo.get_qualifier_repo(namespace)}
+    repos = {'classes': repo.get_class_store(namespace),
+             'instances': repo.get_instance_store(namespace),
+             'qualifiers': repo.get_qualifier_store(namespace)}
 
     for item in init_objs:
         if isinstance(item, CIMClass):
-            class_repo = repos['classes']
-            class_repo.create(item.classname, item)
+            class_store = repos['classes']
+            class_store.create(item.classname, item)
         elif isinstance(item, CIMInstance):
             inst_repo = repos['instances']
             inst_repo.create(item.path, item)

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1408,7 +1408,7 @@ class TestRepoMethods(object):
             # The code to be tested
             conn.add_namespace(test_ns)
 
-            assert exp_ns in conn.repo.list_namespaces()
+            assert exp_ns in conn.repo.namespaces
         else:
             with pytest.raises(exp_exc.__class__) as exec_info:
 
@@ -1436,6 +1436,7 @@ class TestRepoMethods(object):
         """
         Test _remove_namespace()
         """
+
         conn = FakedWBEMConnection(default_namespace=default_ns)
         for ns in additional_ns:
             conn.repo.add_namespace(ns)
@@ -1445,7 +1446,7 @@ class TestRepoMethods(object):
             # pylint: disable=protected-access
             conn._remove_namespace(test_ns)
 
-            assert exp_ns not in conn.repo.list_namespaces()
+            assert exp_ns not in conn.repo.namespaces
         else:
             with pytest.raises(exp_exc.__class__) as exec_info:
 
@@ -3594,7 +3595,7 @@ class TestInstanceOperations(object):
 
             act_ns = new_path.keybindings['Name']
             assert act_ns == exp_ns
-            assert act_ns in conn.repo.list_namespaces()
+            assert act_ns in conn.repo.namespaces
         else:
             with pytest.raises(exp_exc.__class__) as exec_info:
 
@@ -3979,7 +3980,7 @@ class TestInstanceOperations(object):
             conn.DeleteInstance(new_path)
 
         for ns in additional_objs:
-            if ns not in conn.repo.list_namespaces():
+            if ns not in conn.repo.namespaces:
                 conn.add_namespace(ns)
             conn.add_cimobjects(additional_objs[ns], namespace=ns)
 
@@ -3989,7 +3990,7 @@ class TestInstanceOperations(object):
             conn.DeleteInstance(new_path)
 
             act_ns = new_path.keybindings['Name']
-            assert act_ns not in conn.repo.list_namespaces()
+            assert act_ns not in conn.repo.namespaces
         else:
             with pytest.raises(exp_exc.__class__) as exec_info:
 

--- a/tests/unittest/utils/wbemserver_mock.py
+++ b/tests/unittest/utils/wbemserver_mock.py
@@ -321,8 +321,10 @@ class WbemServerMock(object):
 
         rtn_rpinsts = conn.EnumerateInstances("CIM_RegisteredProfile",
                                               namespace=self.interop_ns)
-        assert rtn_rpinsts, \
-            "Expected 1 or more RegisteredProfile instances, got none"
+
+        assert len(rtn_rpinsts) == len(profiles), \
+            "Expected registered profiles: %r, got %s" % (len(profiles),
+                                                          len(rtn_rpinsts))
 
     def build_elementconformstoprofile_inst(self, conn, profile_path,
                                             element_path):


### PR DESCRIPTION
See commit message for details:

1. Defines the abstract RepositoryInterface class as discussed in the presentation (by renaming and changing the current BaseRepositoryConnectionclass)
    
2. implements the in memory repository based on that RepositoryInterface class.

All communication with the repository is now through the InMemoryRepository interface.

NOTE: This PR, Part 2, leaves the code that was originally in MOFWBEMConnection temporarily in place except that it communicates with the inmemoryrepository.  I am in the process of moving the mof_compiler  interface to the repository code (similar to MOFWBEMconnection.py) but derived from the mof_compiler.BaseRepositoryConnection rather than MOFWBEMConnection.

It is 3 separate commits with the second two representing Andy's comments (Fixing the comments and using custome-inherit to avoid duping the doc-strings from base to inherited classes.