### PR TITLE
Fixes #2041: Improved performance of and cleaned up equality test for CIM objects

### DIFF
--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -97,6 +97,52 @@ def _to_bytes(obj):
     return obj.encode("utf-8")
 
 
+def _eq_name(name1, name2):
+    """
+    Test two CIM names for equality.
+
+    The comparison is performed case-insensitively.
+
+    One or both of the names may be `None`; Two names that are `None` are
+    considered equal.
+    """
+    if name1 is None:
+        return name2 is None
+    else:
+        if name2 is None:
+            return False
+        else:
+            return name1.lower() == name2.lower()
+
+
+def _eq_item(item1, item2):
+    """
+    Test two items (CIM values, CIM objects) for equality.
+
+    One or both of the items may be `None`; Two items that are `None` are
+    considered equal.
+    """
+    if item1 is None:
+        return item2 is None
+    else:
+        if item2 is None:
+            return False
+        else:
+            return item1 == item2
+
+
+def _eq_dict(dict1, dict2):
+    """
+    Test two dictionary objects for equality.
+
+    The dictionaries must not be `None`; This is ensured by the respective
+    setter functions for the attributes of the CIM objects that use ths function
+    for equality test.
+    """
+    assert dict1 is not None and dict2 is not None
+    return dict1 == dict2
+
+
 def _hash_name(name):
     """
     Hash a CIM name, case-insensitively.

--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -88,7 +88,7 @@ def _to_unicode(obj):
     return obj.decode("utf-8")
 
 
-def _to__bytes(obj):
+def _to_bytes(obj):
     """
     Convert the input binary string to a :term:`byte string`.
     The input object must be a unicode string.

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -145,6 +145,12 @@ DATETIME1_DT = datetime(year=2014, month=9, day=24, hour=19, minute=30,
 DATETIME1_OBJ = CIMDateTime(DATETIME1_DT)
 DATETIME1_STR = '20140924193040.654321+120'
 
+DATETIME2_DT = datetime(year=2020, month=1, day=28, hour=14, minute=46,
+                        second=40, microsecond=654321,
+                        tzinfo=MinutesFromUTC(120))
+DATETIME2_OBJ = CIMDateTime(DATETIME2_DT)
+DATETIME2_STR = '20200128144640.654321+120'
+
 TIMEDELTA1_TD = timedelta(183, (13 * 60 + 25) * 60 + 42, 234567)
 TIMEDELTA1_OBJ = CIMDateTime(TIMEDELTA1_TD)
 TIMEDELTA1_STR = '00000183132542.234567:000'
@@ -1890,6 +1896,42 @@ TESTCASES_CIMINSTANCENAME_HASH_EQ = [
     ),
 
     # Keybindings tests
+    (
+        "Matching keybindings, both None",
+        dict(
+            obj1=CIMInstanceName('CIM_Foo', keybindings=None),
+            obj2=CIMInstanceName('CIM_Foo', keybindings=None),
+            exp_equal=True,
+        ),
+        None, None, True
+    ),
+    (
+        "Matching keybindings, one None, one empty dict",
+        dict(
+            obj1=CIMInstanceName('CIM_Foo', keybindings=None),
+            obj2=CIMInstanceName('CIM_Foo', keybindings={}),
+            exp_equal=True,
+        ),
+        None, None, True
+    ),
+    (
+        "Non-matching keybindings, first one None and second one not None",
+        dict(
+            obj1=CIMInstanceName('CIM_Foo', keybindings=None),
+            obj2=CIMInstanceName('CIM_Foo', keybindings={'Cheepy': 'Birds'}),
+            exp_equal=False,
+        ),
+        None, None, True
+    ),
+    (
+        "Non-matching keybindings, first one not None and second one None",
+        dict(
+            obj1=CIMInstanceName('CIM_Foo', keybindings={'Cheepy': 'Birds'}),
+            obj2=CIMInstanceName('CIM_Foo', keybindings=None),
+            exp_equal=False,
+        ),
+        None, None, True
+    ),
     (
         "Matching keybindings, key names with same lexical case",
         dict(
@@ -7972,7 +8014,7 @@ TESTCASES_CIMINSTANCE_EQ = [
         TypeError, None, True
     ),
     (
-        "Invalid type of second object: CIMInstance",
+        "Invalid type of second object: CIMInstanceName",
         dict(
             obj1=CIMInstance('CIM_Foo'),
             obj2=CIMInstanceName('CIM_Foo'),
@@ -8011,7 +8053,7 @@ def test_CIMInstance_hash(testcase, obj1, obj2, exp_equal):
 
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
-    TESTCASES_CIMINSTANCE_HASH_EQ)
+    TESTCASES_CIMINSTANCE_HASH_EQ + TESTCASES_CIMINSTANCE_EQ)
 @simplified_test_function
 def test_CIMInstance_eq(testcase, obj1, obj2, exp_equal):
     """
@@ -14499,6 +14541,42 @@ TESTCASES_CIMPROPERTY_HASH_EQ = [
         dict(
             obj1=CIMProperty('Prop1', value='abc', type='string'),
             obj2=CIMProperty('Prop1', value=Uint32(42), type='string'),
+            exp_equal=False,
+        ),
+        None, None, True
+    ),
+    (
+        "Value, datetime with unequal datetime",
+        dict(
+            obj1=CIMProperty('Prop1', value=DATETIME1_OBJ, type='datetime'),
+            obj2=CIMProperty('Prop1', value=DATETIME2_OBJ, type='datetime'),
+            exp_equal=False,
+        ),
+        None, None, True
+    ),
+    (
+        "Value, datetime with equal datetime",
+        dict(
+            obj1=CIMProperty('Prop1', value=DATETIME1_OBJ, type='datetime'),
+            obj2=CIMProperty('Prop1', value=DATETIME1_OBJ, type='datetime'),
+            exp_equal=True,
+        ),
+        None, None, True
+    ),
+    (
+        "Value, datetime with uint8",
+        dict(
+            obj1=CIMProperty('Prop1', value=DATETIME1_OBJ, type='datetime'),
+            obj2=CIMProperty('Prop1', value=42, type='uint8'),
+            exp_equal=False,
+        ),
+        None, None, True
+    ),
+    (
+        "Value, uint8 with datetime",
+        dict(
+            obj1=CIMProperty('Prop1', value=42, type='uint8'),
+            obj2=CIMProperty('Prop1', value=DATETIME1_OBJ, type='datetime'),
             exp_equal=False,
         ),
         None, None, True
@@ -24118,7 +24196,7 @@ def test_CIMClassName_hash(testcase, obj1, obj2, exp_equal):
 
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
-    TESTCASES_CIMCLASSNAME_HASH_EQ)
+    TESTCASES_CIMCLASSNAME_HASH_EQ + TESTCASES_CIMCLASSNAME_EQ)
 @simplified_test_function
 def test_CIMClassName_eq(testcase, obj1, obj2, exp_equal):
     """
@@ -33866,7 +33944,7 @@ def test_CIMParameter_hash(testcase, obj1, obj2, exp_equal):
 
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
-    TESTCASES_CIMPARAMETER_HASH_EQ)
+    TESTCASES_CIMPARAMETER_HASH_EQ + TESTCASES_CIMPARAMETER_EQ)
 @simplified_test_function
 def test_CIMParameter_eq(testcase, obj1, obj2, exp_equal):
     """

--- a/tests/unittest/pywbem/test_perf_equality.py
+++ b/tests/unittest/pywbem/test_perf_equality.py
@@ -138,7 +138,8 @@ def timeit(measure_func, precision):
     measure_func()
     t2_s = process_time()
     t_s = t2_s - t1_s
-    rep = max(int(res_s / t_s) / precision, min_rep) if t_s != 0 else min_rep
+    rep = max(int(float(res_s) / t_s / precision), min_rep) \
+        if t_s != 0 else min_rep
 
     # Perform the measurement a number of times and store the results
     results = []


### PR DESCRIPTION
This is the second stage of addressing issue #2041, in which the actual performance improvement gets implemented.

Original equality performance:
* CIMInstanceName with two keybindings, last one different: 14.077 us (stddev 5.2% in 100 runs with 14 outliers)
* CIMClass with 10 properties, last one different: 197.023 us (stddev 3.0% in 100 runs with 11 outliers)

Improved equality performance:
* CIMInstanceName with two keybindings, last one different: 12.952 us (stddev 4.6% in 100 runs with 11 outliers)
* CIMClass with 10 properties, last one different: 173.040 us (stddev 3.5% in 100 runs with 7 outliers)

As a result, this change is not a significant performance improvement, but it did clean up the code and eliminated the old comparator-based logic.

**Update** related to Karl's suggestion in a review comment to merge 4 lines of conditional into an expression:

This makes the improvement slightly better. Note that there are still variations in the measured result:

With the original code (4 lines of conditional):
* CIMInstanceName with two keybindings, last one different: 13.448 us (std.dev. 4.3% in 100 runs with 12 outliers)
* CIMClass with 10 properties, last one different: 176.183 us (std.dev. 2.8% in 100 runs with 14 outliers)

Latest code in this PR (4 lines condensed into one expression):
* CIMInstanceName with two keybindings, last one different: 13.703 us (std.dev. 6.1% in 100 runs with 12 outliers)
* CIMClass with 10 properties, last one different: 182.927 us (std.dev. 3.2% in 100 runs with 17 outliers)