### PR TITLE
Finally Fixes #2094: Removed mitigation for installing make using choco

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -141,8 +141,7 @@ install:
   - choco --version
 
   # Install GNU make
-  # TODO: Remove interims solution for installing make by removing the version again.
-  - if "%UNIX_PATH%"=="none" tools\retry choco install -y make --version 4.3
+  - if "%UNIX_PATH%"=="none" tools\retry choco install -y make
   - if "%UNIX_PATH%"=="none" where make
   - if "%UNIX_PATH%"=="none" make --version
 


### PR DESCRIPTION
This PR removes the mitigation for installing the make package using chocolatey on Appveyor back to what it was before (i.e. using the default version of make).