### PR TITLE
Fixes #805: Added support for garbage checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -215,6 +215,7 @@ script:
   # - if [[ -n $_MANUAL_CI_RUN ]]; then make pylint; fi
   - make pylint
   - make test
+  - make leaktest
 
 after_success:
 # Note: In case of error 422 (Couldn't find a repository matching this job),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,6 +15,7 @@
 pytest>=4.3.1,<5.0.0; python_version < '3.5'
 pytest>=4.3.1; python_version >= '3.5'
 testfixtures>=6.9.0
+yagot>=0.5.0
 requests-mock>=1.6.0
 # lxml 4.4.0 removed Python 3.4 support.
 # lxml 4.4.1 added Python 3.8 support. However, while providing binary wheel

--- a/makefile
+++ b/makefile
@@ -313,9 +313,10 @@ help:
 	@echo "  builddoc   - Build documentation in: $(doc_build_dir)"
 	@echo "  check      - Run Flake8 on sources"
 	@echo "  pylint     - Run PyLint on sources"
-	@echo "  test       - Run unit and function tests"
+	@echo "  test       - Run unit and function tests (in tests/unittest and tests/functiontest)"
+	@echo "  leaktest   - Run memory leak tests (in tests/leaktest)"
 	@echo "  all        - Do all of the above"
-	@echo "  end2end    - Run end2end tests"
+	@echo "  end2end    - Run end2end tests (in tests/end2endtest)"
 	@echo "  develop_os - Install OS-level development prereqs"
 	@echo "  upload     - build + upload the distribution archive files to PyPI"
 	@echo "  clean      - Remove any temporary files"
@@ -350,6 +351,12 @@ help:
 	@echo "      Optional, defaults to 'python'."
 	@echo "  PIP_CMD - Pip command to be used. Useful for Python 3 in some envs."
 	@echo "      Optional, defaults to 'pip'."
+	@echo "  YAGOT - Optional: When non-empty, 'test' target checks for garbage (=collected and "
+	@echo "      uncollectable) objects caused by the pytest test cases."
+	@echo "  YAGOT_LEAKS_ONLY - Optional: When non-empty, garbage checks are limited to "
+	@echo "      uncollectable (=leak) objects only."
+	@echo "  YAGOT_IGNORE_TYPES - Optional: Ignore the specified comma-separated list of types in"
+	@echo "      garbage checks."
 
 .PHONY: platform
 platform:
@@ -465,7 +472,7 @@ pylint: pylint_$(pymn).done
 	@echo "makefile: Target $@ done."
 
 .PHONY: all
-all: install develop build builddoc check pylint test
+all: install develop build builddoc check pylint test leaktest
 	@echo "makefile: Target $@ done."
 
 .PHONY: clobber
@@ -663,7 +670,13 @@ endif
 test: $(test_deps)
 	@echo "makefile: Running unit and function tests"
 	py.test --color=yes --cov $(package_name) --cov $(mock_package_name) $(coverage_report) --cov-config coveragerc $(pytest_warning_opts) $(pytest_opts) tests/unittest tests/functiontest -s
-	@echo "makefile: Done running tests"
+	@echo "makefile: Done running unit and function tests"
+
+.PHONY: leaktest
+leaktest: $(test_deps)
+	@echo "makefile: Running memory leak tests"
+	py.test --color=yes $(pytest_warning_opts) $(pytest_opts) tests/leaktest -s
+	@echo "makefile: Done running memory leak tests"
 
 .PHONY: end2end
 end2end: develop_$(pymn).done $(moftab_files)

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -73,6 +73,7 @@ requests==2.20.0
 # Unit test (imports into testcases):
 pytest==4.3.1
 testfixtures==6.9.0
+yagot==0.5.0
 requests-mock==1.6.0
 lxml==4.2.4; python_version <= '3.7'
 lxml==4.4.1; python_version >= '3.8'

--- a/tests/leaktest/test_leaks_cim_obj.py
+++ b/tests/leaktest/test_leaks_cim_obj.py
@@ -1,0 +1,211 @@
+"""
+Test memory leaks for cim_obj.py module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import sys
+import pytest
+import yagot
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ..utils import import_installed
+pywbem = import_installed('pywbem')  # noqa: E402
+from pywbem import CIMClassName, CIMInstanceName, CIMClass, CIMInstance, \
+    CIMProperty, CIMMethod, CIMParameter, CIMQualifier, CIMQualifierDeclaration
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+# NocaseDict uses collections.OrderedDict which fixed its reference cycles in
+# Python 3.2
+NOCASEDICT_LEAKFREE_VERSION = (3, 2)
+
+
+@yagot.garbage_checked()
+def test_leaks_CIMClassName_minimal():
+    """
+    Test function with a minimal CIMClassName object (i.e. no keybindings).
+    """
+    _ = CIMClassName(
+        'CIM_Foo',
+        namespace='root',
+        host='woot.com',
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMClass uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMClass_minimal():
+    """
+    Test function with a minimal CIMClass object (i.e. no members, no path).
+    """
+    _ = CIMClass(
+        'CIM_Foo',
+        superclass='CIM_Super',
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMClass uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMClass_property():
+    """
+    Test function with a CIMClass object that has one property.
+    """
+    _ = CIMClass(
+        'CIM_Foo',
+        properties=[
+            CIMProperty('P1', value=None, type='string'),
+        ]
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMClass uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMClass_method():
+    """
+    Test function with a CIMClass object that has one method.
+    """
+    _ = CIMClass(
+        'CIM_Foo',
+        methods=[
+            CIMMethod('M1', return_type='string'),
+        ]
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMClass uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMClass_qualifier():
+    """
+    Test function with a CIMClass object that has one qualifier.
+    """
+    _ = CIMClass(
+        'CIM_Foo',
+        qualifiers=[
+            CIMQualifier('Q1', value='q'),
+        ]
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMInstanceName uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMInstanceName_minimal():
+    """
+    Test function with a CIMInstanceName object that has keybindings with two
+    keys.
+    """
+    _ = CIMInstanceName(
+        'CIM_Foo',
+        namespace='root',
+        host='woot.com',
+        keybindings=dict(P1='a', P2=42),
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMInstance uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMInstance_minimal():
+    """
+    Test function with a minimal CIMInstance object (i.e. no properties, no
+    qualifiers).
+    """
+    _ = CIMInstance(
+        'CIM_Foo',
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMInstance uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMInstance_property():
+    """
+    Test function with a CIMInstance object that has one property.
+    """
+    _ = CIMInstance(
+        'CIM_Foo',
+        properties=[
+            CIMProperty('P1', value='p'),
+        ]
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMInstance uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMInstance_property():
+    """
+    Test function with a CIMInstance object that has one qualifier.
+    """
+    _ = CIMInstance(
+        'CIM_Foo',
+        qualifiers=[
+            CIMQualifier('Q1', value='q'),
+        ]
+    )
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMProperty uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMProperty_minimal():
+    """
+    Test function with a minimal CIMProperty object (i.e. no qualifiers).
+    """
+    _ = CIMProperty('P1', value='bla')
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMMethod uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMMethod_minimal():
+    """
+    Test function with a minimal CIMMethod object (i.e. no parameters, no
+    qualifiers).
+    """
+    _ = CIMMethod('M1', return_type='string')
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMParameter uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMParameter_minimal():
+    """
+    Test function with a minimal CIMParameter object (i.e. no qualifiers).
+    """
+    _ = CIMParameter('P1', type='string')
+
+
+@yagot.garbage_checked()
+def test_leaks_CIMQualifier_minimal():
+    """
+    Test function with a minimal CIMQualifier object.
+    """
+    _ = CIMQualifier('Q1', value='bla')
+
+
+@pytest.mark.xfail(
+    sys.version_info < NOCASEDICT_LEAKFREE_VERSION,
+    reason="CIMQualifierDeclaration uses NocaseDict")
+@yagot.garbage_checked()
+def test_leaks_CIMQualifierDeclaration_minimal():
+    """
+    Test function with a minimal CIMQualifierDeclaration object (i.e. no
+    scopes).
+    """
+    _ = CIMQualifierDeclaration('Q1', type='string')

--- a/tests/leaktest/test_leaks_cim_xml.py
+++ b/tests/leaktest/test_leaks_cim_xml.py
@@ -1,0 +1,39 @@
+"""
+Test memory leaks for cim_xml.py module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import yagot
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ..utils import import_installed
+pywbem = import_installed('pywbem')  # noqa: E402
+from pywbem._cim_xml import CIMElement, VALUE
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+
+@yagot.garbage_checked()
+def test_leaks_CIMElement_empty():
+    """
+    Test function with an empty CIMElement object.
+    """
+    _ = CIMElement('dummy')
+
+
+@yagot.garbage_checked()
+def test_leaks_VALUE_empty():
+    """
+    Test function with a VALUE object that is empty (ie. no text child).
+    """
+    _ = VALUE(pcdata=None)
+
+
+@pytest.mark.skip("Temporarily skipped")
+@yagot.garbage_checked()
+def test_leaks_VALUE_string():
+    """
+    Test function with a VALUE object of string.
+    """
+    _ = VALUE(pcdata='abc')

--- a/tests/leaktest/test_leaks_dict.py
+++ b/tests/leaktest/test_leaks_dict.py
@@ -1,0 +1,76 @@
+"""
+Test memory leaks for dictionary classes used by pywbem.
+"""
+
+from __future__ import absolute_import, print_function
+
+import sys
+from collections import OrderedDict
+try:
+    from django.utils.datastructures import SortedDict as Django_SortedDict
+except ImportError:
+    Django_SortedDict = None
+import pytest
+import yagot
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ..utils import import_installed
+pywbem = import_installed('pywbem')  # noqa: E402
+from pywbem._cim_obj import NocaseDict
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+
+# collections.OrderedDict has fixed its ref.cycles starting with Python 3.2
+ORDEREDDICT_LEAKFREE_VERSION = (3, 2)
+
+
+@pytest.mark.xfail(
+    sys.version_info < ORDEREDDICT_LEAKFREE_VERSION,
+    reason="OrderedDict has reference cycles on py<3.2")
+@yagot.garbage_checked()
+def test_leaks_OrderedDict_empty():
+    """
+    Test function with empty OrderedDict object.
+
+    Note: collections.OrderedDict has memory leaks on Python 2.7; see
+    https://bugs.python.org/issue9825. That issue was fixed in Python 3.2, but
+    the change in Python 2.7 apparently was not sufficient to remove the leak.
+    """
+    _ = OrderedDict()
+
+
+@pytest.mark.skipif(
+    Django_SortedDict is None,
+    reason="django with SortedDict is not installed")
+@yagot.garbage_checked()
+def test_leaks_Django_SortedDict_empty():
+    """
+    Test function with empty django SortedDict object.
+
+    Note: Django's SortedDict has been removed from the django package as of
+    version 1.9. This test requires django<1.9 to be installed and is skipped
+    otherwise.
+    """
+    _ = Django_SortedDict()
+
+
+@pytest.mark.xfail(
+    sys.version_info < ORDEREDDICT_LEAKFREE_VERSION,
+    reason="NocaseDict uses OrderedDict")
+@yagot.garbage_checked()
+def test_leaks_NocaseDict_empty():
+    """
+    Test function with empty NocaseDict object.
+    """
+    _ = NocaseDict()
+
+
+@pytest.mark.xfail(
+    sys.version_info < ORDEREDDICT_LEAKFREE_VERSION,
+    reason="NocaseDict uses OrderedDict")
+@yagot.garbage_checked()
+def test_leaks_NocaseDict_one():
+    """
+    Test function with NocaseDict object containing one string item.
+    """
+    _ = NocaseDict(a='b')

--- a/tests/leaktest/test_leaks_elementtree.py
+++ b/tests/leaktest/test_leaks_elementtree.py
@@ -1,0 +1,47 @@
+"""
+Test memory leaks for xml.etree.ElementTree classes.
+"""
+
+from __future__ import absolute_import, print_function
+
+import xml.etree.ElementTree as ET
+import yagot
+
+
+@yagot.garbage_checked()
+def test_leaks_ET_Element_empty():
+    """
+    Test function with an empty Element object (i.e. no attributes,
+    no child elements, no content).
+    """
+    _ = ET.Element('FOO')
+
+
+@yagot.garbage_checked()
+def test_leaks_ET_Element_one_attribute():
+    """
+    Test function with an Element object that has one attribute set.
+    """
+    elem = ET.Element('FOO')
+    elem.attrib["BAR"] = 'bla'
+
+
+@yagot.garbage_checked()
+def test_leaks_ET_Element_one_child():
+    """
+    Test function with an Element object that has one child element.
+    """
+    elem = ET.Element('FOO')
+    _ = ET.SubElement(elem, 'GOO')
+
+
+@yagot.garbage_checked()
+def test_leaks_ET_Element_one_child_text_attr():
+    """
+    Test function with an Element object that has one child element with
+    text content and one attribute.
+    """
+    elem = ET.Element('FOO')
+    subelem = ET.SubElement(elem, 'GOO')
+    subelem.attrib["BAT"] = 'bla'
+    subelem.text = 'some text'

--- a/tests/leaktest/test_leaks_minidom.py
+++ b/tests/leaktest/test_leaks_minidom.py
@@ -1,0 +1,78 @@
+"""
+Test memory leaks for xml.dom.minidom classes used by pywbem.
+
+Notes on "standalone" vs "anchored" Element objects in Python minidom:
+- The definition of "standalone" Element objects is that they are
+  instantiated from their implementation class directly, without using
+  factory methods such as Document.createElement(). Using standalone Element
+  objects is discouraged in the Python minidom docs. In fact, on Python 3,
+  the use of setAttribute() on a standalone Element object fails with
+  AttributeError "ownerDocument".
+- The definition of "anchored" Element objects is that they are part of a
+  Document object, and have been created by factory methods such as
+  Document.createElement().
+- Using anchored Element objects is the recommended approach as per the
+  Python minidom docs, but pywbem currently uses standalone Element objects
+  in its cim_xml.py module.
+"""
+
+from __future__ import absolute_import, print_function
+
+from xml.dom.minidom import Document, Element
+import pytest
+import yagot
+
+
+@yagot.garbage_checked()
+def test_leaks_standalone_Element_empty():
+    """
+    Test function with an empty standalone Element object (i.e. no attributes,
+    no child elements, no content).
+    """
+    _ = Element('FOO')
+
+
+@pytest.mark.xfail(
+    reason="On Py2, Element.setAttribute() creates reference cycles;"
+           "On Py3, Element.setAttribute() raises AttributeError")
+@yagot.garbage_checked()
+def test_leaks_standalone_Element_one_attribute():
+    """
+    Test function with a standalone Element object that has one attribute set.
+    """
+    elem = Element('FOO')
+    elem.setAttribute('BAR', 'bla')
+
+
+@yagot.garbage_checked()
+def test_leaks_Document_empty():
+    """
+    Test function with empty Document object.
+    """
+    _ = Document()
+
+
+@pytest.mark.xfail(
+    reason="Element in a Document creates reference cycles")
+@yagot.garbage_checked()
+def test_leaks_Element_empty():
+    """
+    Test function with an empty anchored Element object (i.e. no attributes,
+    no child elements, no content).
+    """
+    doc = Document()
+    elem = doc.createElement('FOO')
+    doc.appendChild(elem)
+
+
+@pytest.mark.xfail(
+    reason="Element.setAttribute() creates reference cycles")
+@yagot.garbage_checked()
+def test_leaks_Element_one_attribute():
+    """
+    Test function with an anchored Element object that has one attribute set.
+    """
+    doc = Document()
+    elem = doc.createElement('FOO')
+    elem.setAttribute('BAR', 'bla')
+    doc.appendChild(elem)

--- a/tests/leaktest/test_leaks_statistics.py
+++ b/tests/leaktest/test_leaks_statistics.py
@@ -1,0 +1,24 @@
+"""
+Test memory leaks for _statistics.py module.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+import yagot
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ..utils import import_installed
+pywbem = import_installed('pywbem')  # noqa: E402
+from pywbem import Statistics
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+
+@pytest.mark.xfail(
+    reason="Statistics and OperationStatistic have reference cycle")
+@yagot.garbage_checked()
+def test_leaks_Statistics_minimal():
+    """
+    Test function with a minimal Statistics object.
+    """
+    _ = Statistics()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@
 Utility functions for pywbem testing
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import sys
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ commands =
     make develop
     make check
     make test
+    make leaktest
 
 [testenv:py27]
 platform = linux2|darwin


### PR DESCRIPTION
See commit messages for details.

Invoke `make help` to understand how to run the memory leak tests, and look at the description of the new `leaktest` target and of the new `YAGOT*` env vars.

A complete `YAGOT=1 make test` runs for about 4h on my Mac, where without leak checking it takes about 4min. This seems to be caused by the many runs of the Python garbage collector that happen. Note that the `make leaktest` which runs just the specific leak tests is very fast.

Some tests that fail due to leaks have been excluded as XFAIL, and they can be run with: `TESTOPTS='--runxfail' make leaktest`.

**Discussion points (1): DONE**
* The implemented approach can be enabled for the pytest testcases, but the problem are the garbage objects pytest leaves in several situations (e.g. skipped testcase, failed testcase, use of pytest.raises()). -> Put on back burner for now
* Are independent memory leak testcases needed? -> Yes - DONE, with `make leaktest`.
* Should it be useable outside of the pytest context, e.g. in the manual test scripts? -> No
* Should a user of the pywbem library be able to enable it for their use of pywbem? -> No

**Discussion points (2): DONE**
* Find a non-leaking alternative to `collections.OrderedDict` we can use for `NocaseDict` on Python 2.7 (See https://stackoverflow.com/q/60134482/1424462). Starting with Python 3.2, `collections.OrderedDict` has been fixed to be leak-free. Note that the standard `dict` does not have leaks but is order-preserving only starting with CPython 3.6 and on other Python implementations starting with 3.7.
  -> DONE: decided to document this for python 2.7 and to run the leak tests only on python 3.
* Find a non-leaking alternative to `xml.dom.minidom` for use in cim_xml.py. It creates reference cycles even for simple usages. `xml.etree.ElementTree` did not have leaks at least in the few testcases I have added. If we stay with minidom: Change cim_xml.py and its users to no longer create standalone minidom objects but have them anchored under a Document object. 
See https://bugs.python.org/issue15290, https://bugs.python.org/issue4851. I was able to reproduce this issue: AttributeError "ownerDocument" when using minidom `Element.setAttribute()` on Python 3.7. Can be seen when running `test_leaks_standalone_Element_one_attribute()` with `--runxfail` on Python 3.7.
  -> DONE: decided to migrate from minidom to ElementTree, in a separate PR. Created issue #2121 to capture that.