### PR TITLE
Made all pywbem sub-namespaces private, except config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ cprofilerstats*.profile
 /build/
 /build_doc/
 mofparsetab.py
+_mofparsetab.py
 moflextab.py
+_moflextab.py
 tests/runtests.log
 /tests/testtmp/
 /tests/schema/mof*/

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,16 @@ Released: not yet
   On Python versions before 2.7.9, pywbem will continue to use the deprecated
   `ssl.wrap_socket()` function. (See issue #2002)
 
+**Cleanup:**
+
+* Renamed all sub-modules within the pywbem namespace so they are now private
+  (i.e. with a leading underscore). This has been done for consistency with
+  the upcoming 1.0.0 version of pywbem, for eaier rollback of changes from
+  that version. For compatibility to users of pywbem who use these sub-modules
+  directly, despite the recommendation to import only the symbols from the
+  pywbem namespace, these sub-modules are still available under their previous
+  names.  (See issue #1925)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/makefile
+++ b/makefile
@@ -173,11 +173,11 @@ package_py_files := \
     $(wildcard $(package_name)/*/*.py) \
 
 # Lex/Yacc table files, generated from and by mof_compiler.py
-moftab_files := $(package_name)/mofparsetab.py $(package_name)/moflextab.py
+moftab_files := $(package_name)/_mofparsetab.py $(package_name)/_moflextab.py
 
 # Dependents for Lex/Yacc table files
 moftab_dependent_files := \
-    $(package_name)/mof_compiler.py \
+    $(package_name)/_mof_compiler.py \
 
 # Directory for generated API documentation
 doc_build_dir := build_doc
@@ -214,14 +214,14 @@ doc_dependent_files := \
     $(package_name)/_valuemapping.py \
     $(package_name)/_version.py \
     $(package_name)/_nocasedict.py \
-    $(package_name)/cim_constants.py \
-    $(package_name)/cim_http.py \
-    $(package_name)/cim_obj.py \
-    $(package_name)/cim_operations.py \
-    $(package_name)/cim_types.py \
+    $(package_name)/_cim_constants.py \
+    $(package_name)/_cim_http.py \
+    $(package_name)/_cim_obj.py \
+    $(package_name)/_cim_operations.py \
+    $(package_name)/_cim_types.py \
+    $(package_name)/_exceptions.py \
+    $(package_name)/_mof_compiler.py \
     $(package_name)/config.py \
-    $(package_name)/exceptions.py \
-    $(package_name)/mof_compiler.py \
     $(mock_package_name)/__init__.py \
     $(mock_package_name)/_wbemconnection_mock.py\
     $(mock_package_name)/_dmtf_cim_schema.py\
@@ -517,6 +517,7 @@ clean:
 	-$(call RM_R_FUNC,.*~)
 	-$(call RMDIR_R_FUNC,__pycache__)
 	-$(call RM_FUNC,MANIFEST parser.out .coverage $(package_name)/parser.out)
+	-$(call RM_FUNC,$(package_name)/mofparsetab.py* $(package_name)/moflextab.py*)
 	-$(call RMDIR_FUNC,build .cache $(package_name).egg-info .eggs)
 	@echo "makefile: Done removing temporary build products"
 	@echo "makefile: Target $@ done."
@@ -638,8 +639,8 @@ $(bdist_file) $(sdist_file): _check_version setup.py MANIFEST.in $(dist_dependen
 # purpose of this rule is to build the mof*tab files in ./pywbem.
 $(moftab_files): install_$(pymn).done $(moftab_dependent_files) build_moftab.py
 	@echo "makefile: Creating the LEX/YACC table modules"
-	-$(call RM_FUNC,$(package_name)/mofparsetab.py* $(package_name)/moflextab.py*)
-	$(PYTHON_CMD) -c "from pywbem import mof_compiler; mof_compiler._build(verbose=True)"
+	-$(call RM_FUNC,$(package_name)/_mofparsetab.py* $(package_name)/_moflextab.py*)
+	$(PYTHON_CMD) -c "from pywbem import _mof_compiler; _mof_compiler._build(verbose=True)"
 	@echo "makefile: Done creating the LEX/YACC table modules: $(moftab_files)"
 
 # TODO: Once pylint has no more errors, remove the dash "-"
@@ -711,7 +712,7 @@ else
 endif
 	@echo "makefile: Done creating wbemcli script help message file: $@"
 
-$(doc_conf_dir)/mof_compiler.help.txt: mof_compiler $(package_name)/mof_compiler.py
+$(doc_conf_dir)/mof_compiler.help.txt: mof_compiler $(package_name)/_mof_compiler.py
 	@echo "makefile: Creating mof_compiler script help message file"
 ifeq ($(PLATFORM),Windows_native)
 	mof_compiler.bat --help >$@

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -41,15 +41,15 @@ import logging
 from . import config  # noqa: F401
 
 from ._utils import *  # noqa: F403,F401
-from .cim_types import *  # noqa: F403,F401
-from .cim_constants import *  # noqa: F403,F401
-from .cim_operations import *  # noqa: F403,F401
+from ._cim_types import *  # noqa: F403,F401
+from ._cim_constants import *  # noqa: F403,F401
+from ._cim_operations import *  # noqa: F403,F401
 from ._nocasedict import *  # noqa: F403,F401
-from .cim_obj import *  # noqa: F403,F401
-from .tupleparse import *  # noqa: F403,F401
-from .cim_http import *  # noqa: F403,F401
-from .exceptions import *  # noqa: F403,F401
-from .mof_compiler import *  # noqa: F403,F401
+from ._cim_obj import *  # noqa: F403,F401
+from ._tupleparse import *  # noqa: F403,F401
+from ._cim_http import *  # noqa: F403,F401
+from ._exceptions import *  # noqa: F403,F401
+from ._mof_compiler import *  # noqa: F403,F401
 from ._valuemapping import *  # noqa: F403,F401
 from ._server import *  # noqa: F403,F401
 from ._subscription_manager import *  # noqa: F403,F401
@@ -60,6 +60,28 @@ from ._logging import *  # noqa: F403,F401
 from ._warnings import *  # noqa: F403,F401 pylint: disable=redefined-builtin
 
 from ._version import __version__  # noqa: F401
+
+# Establish compatibility with old module names:
+from . import _cim_types as cim_types  # noqa: F401
+from . import _cim_constants as cim_constants  # noqa: F401
+from . import _cim_operations as cim_operations  # noqa: F401
+from . import _cim_obj as cim_obj  # noqa: F401
+from . import _tupleparse as tupleparse  # noqa: F401
+from . import _cim_http as cim_http  # noqa: F401
+from . import _exceptions as exceptions  # noqa: F401
+from . import _mof_compiler as mof_compiler  # noqa: F401
+from . import _cim_xml as cim_xml  # noqa: F401
+from . import _tupletree as tupletree  # noqa: F401
+sys.modules['pywbem.cim_types'] = cim_types
+sys.modules['pywbem.cim_constants'] = cim_constants
+sys.modules['pywbem.cim_operations'] = cim_operations
+sys.modules['pywbem.cim_obj'] = cim_obj
+sys.modules['pywbem.tupleparse'] = tupleparse
+sys.modules['pywbem.cim_http'] = cim_http
+sys.modules['pywbem.exceptions'] = exceptions
+sys.modules['pywbem.mof_compiler'] = mof_compiler
+sys.modules['pywbem.cim_xml'] = cim_xml
+sys.modules['pywbem.tupletree'] = tupletree
 
 _python_m = sys.version_info[0]  # pylint: disable=invalid-name
 _python_n = sys.version_info[1]  # pylint: disable=invalid-name

--- a/pywbem/_cim_constants.py
+++ b/pywbem/_cim_constants.py
@@ -23,13 +23,13 @@ This section defines constants for two areas:
 
 * CIM status codes (the ``CIM_ERR_*`` symbols). They are for example stored in
   :exc:`~pywbem.CIMError` exceptions.
-* Default CIM namespace :data:`~pywbem.cim_constants.DEFAULT_NAMESPACE`. It is
+* Default CIM namespace :data:`~pywbem._cim_constants.DEFAULT_NAMESPACE`. It is
   used as a default namespace for a connection (see
   :class:`~pywbem.WBEMConnection`) when no namespace is provided for an
   operation.
 
 Note: For tooling reasons, the constants are shown in the namespace
-``pywbem.cim_constants``. However, they are also available in the ``pywbem``
+``pywbem._cim_constants``. However, they are also available in the ``pywbem``
 namespace and should be used from there.
 """
 

--- a/pywbem/_cim_http.py
+++ b/pywbem/_cim_http.py
@@ -50,8 +50,8 @@ import six
 from six.moves import http_client as httplib
 from six.moves import urllib
 
-from .cim_obj import CIMClassName, CIMInstanceName
-from .exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
+from ._cim_obj import CIMClassName, CIMInstanceName
+from ._exceptions import ConnectionError, AuthError, TimeoutError, HTTPError
 from ._warnings import ToleratedServerIssueWarning
 from ._utils import _ensure_unicode, _ensure_bytes, _format
 

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -254,10 +254,10 @@ except ImportError:  # py2
     from __builtin__ import type as builtin_type
 import six
 
-from . import cim_xml
+from . import _cim_xml
 from .config import DEBUG_WARNING_ORIGIN, SEND_VALUE_NULL
 from . import config
-from .cim_types import _CIMComparisonMixin, type_from_name, cimtype, \
+from ._cim_types import _CIMComparisonMixin, type_from_name, cimtype, \
     atomic_to_cim_xml, CIMType, CIMDateTime, Uint8, Sint8, Uint16, Sint16, \
     Uint32, Sint32, Uint64, Sint64, Real32, Real64, number_types, CIMInt, \
     CIMFloat, _Longint
@@ -1651,8 +1651,8 @@ class CIMInstanceName(_CIMComparisonMixin):
             # References can only by instance names.
 
             if isinstance(value, CIMInstanceName):
-                kbs.append(cim_xml.KEYBINDING(
-                    key, cim_xml.VALUE_REFERENCE(value.tocimxml())))
+                kbs.append(_cim_xml.KEYBINDING(
+                    key, _cim_xml.VALUE_REFERENCE(value.tocimxml())))
                 continue
 
             if isinstance(value, six.text_type):
@@ -1679,23 +1679,23 @@ class CIMInstanceName(_CIMComparisonMixin):
                     _format("Keybinding {0!A} has invalid type: {1}",
                             key, builtin_type(value)))
 
-            kbs.append(cim_xml.KEYBINDING(
-                key, cim_xml.KEYVALUE(value, type_)))
+            kbs.append(_cim_xml.KEYBINDING(
+                key, _cim_xml.KEYVALUE(value, type_)))
 
-        instancename_xml = cim_xml.INSTANCENAME(self.classname, kbs)
+        instancename_xml = _cim_xml.INSTANCENAME(self.classname, kbs)
 
         if self.namespace is None or ignore_namespace:
             return instancename_xml
 
-        localnsp_xml = cim_xml.LOCALNAMESPACEPATH(
-            [cim_xml.NAMESPACE(ns)
+        localnsp_xml = _cim_xml.LOCALNAMESPACEPATH(
+            [_cim_xml.NAMESPACE(ns)
              for ns in self.namespace.split('/')])
 
         if self.host is None or ignore_host:
-            return cim_xml.LOCALINSTANCEPATH(localnsp_xml, instancename_xml)
+            return _cim_xml.LOCALINSTANCEPATH(localnsp_xml, instancename_xml)
 
-        return cim_xml.INSTANCEPATH(
-            cim_xml.NAMESPACEPATH(cim_xml.HOST(self.host), localnsp_xml),
+        return _cim_xml.INSTANCEPATH(
+            _cim_xml.NAMESPACEPATH(_cim_xml.HOST(self.host), localnsp_xml),
             instancename_xml)
 
     def tocimxmlstr(self, indent=None, ignore_host=False,
@@ -2966,7 +2966,7 @@ class CIMInstance(_CIMComparisonMixin):
                     _format("Property {0!A} has invalid type: {1} (must be "
                             "CIMProperty)", key, builtin_type(value)))
 
-        instance_xml = cim_xml.INSTANCE(
+        instance_xml = _cim_xml.INSTANCE(
             self.classname,
             properties=[p.tocimxml() for p in self.properties.values()],
             qualifiers=[q.tocimxml() for q in self.qualifiers.values()])
@@ -2975,16 +2975,16 @@ class CIMInstance(_CIMComparisonMixin):
             return instance_xml
 
         if self.path.namespace is None:
-            return cim_xml.VALUE_NAMEDINSTANCE(
+            return _cim_xml.VALUE_NAMEDINSTANCE(
                 self.path.tocimxml(),
                 instance_xml)
 
         if self.path.host is None:
-            return cim_xml.VALUE_OBJECTWITHLOCALPATH(
+            return _cim_xml.VALUE_OBJECTWITHLOCALPATH(
                 self.path.tocimxml(),
                 instance_xml)
 
-        return cim_xml.VALUE_INSTANCEWITHPATH(
+        return _cim_xml.VALUE_INSTANCEWITHPATH(
             self.path.tocimxml(),
             instance_xml)
 
@@ -3496,20 +3496,20 @@ class CIMClassName(_CIMComparisonMixin):
           of :term:`Element`.
         """
 
-        classname_xml = cim_xml.CLASSNAME(self.classname)
+        classname_xml = _cim_xml.CLASSNAME(self.classname)
 
         if self.namespace is None or ignore_namespace:
             return classname_xml
 
-        localnsp_xml = cim_xml.LOCALNAMESPACEPATH(
-            [cim_xml.NAMESPACE(ns)
+        localnsp_xml = _cim_xml.LOCALNAMESPACEPATH(
+            [_cim_xml.NAMESPACE(ns)
              for ns in self.namespace.split('/')])
 
         if self.host is None or ignore_host:
-            return cim_xml.LOCALCLASSPATH(localnsp_xml, classname_xml)
+            return _cim_xml.LOCALCLASSPATH(localnsp_xml, classname_xml)
 
-        return cim_xml.CLASSPATH(
-            cim_xml.NAMESPACEPATH(cim_xml.HOST(self.host), localnsp_xml),
+        return _cim_xml.CLASSPATH(
+            _cim_xml.NAMESPACEPATH(_cim_xml.HOST(self.host), localnsp_xml),
             classname_xml)
 
     def tocimxmlstr(self, indent=None, ignore_host=False,
@@ -4237,7 +4237,7 @@ class CIMClass(_CIMComparisonMixin):
           The CIM-XML representation, as an object of an appropriate subclass
           of :term:`Element`.
         """
-        return cim_xml.CLASS(
+        return _cim_xml.CLASS(
             self.classname,
             properties=[p.tocimxml() for p in self.properties.values()],
             methods=[m.tocimxml() for m in self.methods.values()],
@@ -4948,17 +4948,17 @@ class CIMProperty(_CIMComparisonMixin):
                 for v in self.value:
                     if v is None:
                         if SEND_VALUE_NULL:
-                            array_xml.append(cim_xml.VALUE_NULL())
+                            array_xml.append(_cim_xml.VALUE_NULL())
                         else:
-                            array_xml.append(cim_xml.VALUE(None))
+                            array_xml.append(_cim_xml.VALUE(None))
                     elif self.embedded_object is not None:
                         assert isinstance(v, (CIMInstance, CIMClass))
-                        array_xml.append(cim_xml.VALUE(v.tocimxml().toxml()))
+                        array_xml.append(_cim_xml.VALUE(v.tocimxml().toxml()))
                     else:
-                        array_xml.append(cim_xml.VALUE(atomic_to_cim_xml(v)))
-                value_xml = cim_xml.VALUE_ARRAY(array_xml)
+                        array_xml.append(_cim_xml.VALUE(atomic_to_cim_xml(v)))
+                value_xml = _cim_xml.VALUE_ARRAY(array_xml)
 
-            return cim_xml.PROPERTY_ARRAY(
+            return _cim_xml.PROPERTY_ARRAY(
                 self.name,
                 self.type,
                 value_xml,
@@ -4973,9 +4973,9 @@ class CIMProperty(_CIMComparisonMixin):
             if self.value is None:
                 value_xml = None
             else:
-                value_xml = cim_xml.VALUE_REFERENCE(self.value.tocimxml())
+                value_xml = _cim_xml.VALUE_REFERENCE(self.value.tocimxml())
 
-            return cim_xml.PROPERTY_REFERENCE(
+            return _cim_xml.PROPERTY_REFERENCE(
                 self.name,
                 value_xml,
                 reference_class=self.reference_class,
@@ -4990,11 +4990,11 @@ class CIMProperty(_CIMComparisonMixin):
             else:
                 if self.embedded_object is not None:
                     assert isinstance(self.value, (CIMInstance, CIMClass))
-                    value_xml = cim_xml.VALUE(self.value.tocimxml().toxml())
+                    value_xml = _cim_xml.VALUE(self.value.tocimxml().toxml())
                 else:
-                    value_xml = cim_xml.VALUE(atomic_to_cim_xml(self.value))
+                    value_xml = _cim_xml.VALUE(atomic_to_cim_xml(self.value))
 
-            return cim_xml.PROPERTY(
+            return _cim_xml.PROPERTY(
                 self.name,
                 self.type,
                 value_xml,
@@ -5644,7 +5644,7 @@ class CIMMethod(_CIMComparisonMixin):
           The CIM-XML representation, as an object of an appropriate subclass
           of :term:`Element`.
         """
-        return cim_xml.METHOD(
+        return _cim_xml.METHOD(
             self.name,
             parameters=[p.tocimxml() for p in self.parameters.values()],
             return_type=self.return_type,
@@ -6268,13 +6268,13 @@ class CIMParameter(_CIMComparisonMixin):
                     for v in self.value:
                         if v is None:
                             if SEND_VALUE_NULL:
-                                array_xml.append(cim_xml.VALUE_NULL())
+                                array_xml.append(_cim_xml.VALUE_NULL())
                             else:
-                                array_xml.append(cim_xml.VALUE(None))
+                                array_xml.append(_cim_xml.VALUE(None))
                         else:
                             array_xml.append(
-                                cim_xml.VALUE_REFERENCE(v.tocimxml()))
-                    value_xml = cim_xml.VALUE_REFARRAY(array_xml)
+                                _cim_xml.VALUE_REFERENCE(v.tocimxml()))
+                    value_xml = _cim_xml.VALUE_REFARRAY(array_xml)
 
                 else:  # array non-reference
 
@@ -6282,27 +6282,27 @@ class CIMParameter(_CIMComparisonMixin):
                     for v in self.value:
                         if v is None:
                             if SEND_VALUE_NULL:
-                                array_xml.append(cim_xml.VALUE_NULL())
+                                array_xml.append(_cim_xml.VALUE_NULL())
                             else:
-                                array_xml.append(cim_xml.VALUE(None))
+                                array_xml.append(_cim_xml.VALUE(None))
                         elif self.embedded_object is not None:
                             array_xml.append(
-                                cim_xml.VALUE(v.tocimxml().toxml()))
+                                _cim_xml.VALUE(v.tocimxml().toxml()))
                         else:
                             array_xml.append(
-                                cim_xml.VALUE(atomic_to_cim_xml(v)))
-                    value_xml = cim_xml.VALUE_ARRAY(array_xml)
+                                _cim_xml.VALUE(atomic_to_cim_xml(v)))
+                    value_xml = _cim_xml.VALUE_ARRAY(array_xml)
 
             else:  # scalar
 
                 if self.type == 'reference':
-                    value_xml = cim_xml.VALUE_REFERENCE(self.value.tocimxml())
+                    value_xml = _cim_xml.VALUE_REFERENCE(self.value.tocimxml())
                 elif self.embedded_object is not None:
-                    value_xml = cim_xml.VALUE(self.value.tocimxml().toxml())
+                    value_xml = _cim_xml.VALUE(self.value.tocimxml().toxml())
                 else:
-                    value_xml = cim_xml.VALUE(atomic_to_cim_xml(self.value))
+                    value_xml = _cim_xml.VALUE(atomic_to_cim_xml(self.value))
 
-            return cim_xml.PARAMVALUE(
+            return _cim_xml.PARAMVALUE(
                 self.name,
                 value_xml,
                 paramtype=self.type,
@@ -6320,14 +6320,14 @@ class CIMParameter(_CIMComparisonMixin):
                     array_size = str(self.array_size)
 
                 if self.type == 'reference':
-                    return cim_xml.PARAMETER_REFARRAY(
+                    return _cim_xml.PARAMETER_REFARRAY(
                         self.name,
                         self.reference_class,
                         array_size,
                         qualifiers=qualifiers)
 
                 # For non-reference array types:
-                return cim_xml.PARAMETER_ARRAY(
+                return _cim_xml.PARAMETER_ARRAY(
                     self.name,
                     self.type,
                     array_size,
@@ -6336,13 +6336,13 @@ class CIMParameter(_CIMComparisonMixin):
             else:  # scalar
 
                 if self.type == 'reference':
-                    return cim_xml.PARAMETER_REFERENCE(
+                    return _cim_xml.PARAMETER_REFERENCE(
                         self.name,
                         self.reference_class,
                         qualifiers=qualifiers)
 
                 # For non-reference types:
-                return cim_xml.PARAMETER(
+                return _cim_xml.PARAMETER(
                     self.name,
                     self.type,
                     qualifiers=qualifiers)
@@ -6922,24 +6922,25 @@ class CIMQualifier(_CIMComparisonMixin):
             for v in self.value:
                 if v is None:
                     if SEND_VALUE_NULL:
-                        array_xml.append(cim_xml.VALUE_NULL())
+                        array_xml.append(_cim_xml.VALUE_NULL())
                     else:
-                        array_xml.append(cim_xml.VALUE(None))
+                        array_xml.append(_cim_xml.VALUE(None))
                 else:
-                    array_xml.append(cim_xml.VALUE(atomic_to_cim_xml(v)))
-            value_xml = cim_xml.VALUE_ARRAY(array_xml)
+                    array_xml.append(_cim_xml.VALUE(atomic_to_cim_xml(v)))
+            value_xml = _cim_xml.VALUE_ARRAY(array_xml)
 
         else:
-            value_xml = cim_xml.VALUE(atomic_to_cim_xml(self.value))
+            value_xml = _cim_xml.VALUE(atomic_to_cim_xml(self.value))
 
-        return cim_xml.QUALIFIER(self.name,
-                                 self.type,
-                                 value_xml,
-                                 propagated=self.propagated,
-                                 overridable=self.overridable,
-                                 tosubclass=self.tosubclass,
-                                 toinstance=self.toinstance,
-                                 translatable=self.translatable)
+        return _cim_xml.QUALIFIER(
+            self.name,
+            self.type,
+            value_xml,
+            propagated=self.propagated,
+            overridable=self.overridable,
+            tosubclass=self.tosubclass,
+            toinstance=self.toinstance,
+            translatable=self.translatable)
 
     def tocimxmlstr(self, indent=None):
         """
@@ -7600,26 +7601,27 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
             for v in self.value:
                 if v is None:
                     if SEND_VALUE_NULL:
-                        array_xml.append(cim_xml.VALUE_NULL())
+                        array_xml.append(_cim_xml.VALUE_NULL())
                     else:
-                        array_xml.append(cim_xml.VALUE(None))
+                        array_xml.append(_cim_xml.VALUE(None))
                 else:
-                    array_xml.append(cim_xml.VALUE(atomic_to_cim_xml(v)))
-            value_xml = cim_xml.VALUE_ARRAY(array_xml)
+                    array_xml.append(_cim_xml.VALUE(atomic_to_cim_xml(v)))
+            value_xml = _cim_xml.VALUE_ARRAY(array_xml)
 
         else:
-            value_xml = cim_xml.VALUE(atomic_to_cim_xml(self.value))
+            value_xml = _cim_xml.VALUE(atomic_to_cim_xml(self.value))
 
-        return cim_xml.QUALIFIER_DECLARATION(self.name,
-                                             self.type,
-                                             value_xml,
-                                             is_array=self.is_array,
-                                             array_size=self.array_size,
-                                             qualifier_scopes=self.scopes,
-                                             overridable=self.overridable,
-                                             tosubclass=self.tosubclass,
-                                             toinstance=self.toinstance,
-                                             translatable=self.translatable)
+        return _cim_xml.QUALIFIER_DECLARATION(
+            self.name,
+            self.type,
+            value_xml,
+            is_array=self.is_array,
+            array_size=self.array_size,
+            qualifier_scopes=self.scopes,
+            overridable=self.overridable,
+            tosubclass=self.tosubclass,
+            toinstance=self.toinstance,
+            translatable=self.translatable)
 
     def tocimxmlstr(self, indent=None):
         """
@@ -7764,12 +7766,12 @@ def tocimxml(value):
         for v in value:
             if v is None:
                 if SEND_VALUE_NULL:
-                    array_xml.append(cim_xml.VALUE_NULL())
+                    array_xml.append(_cim_xml.VALUE_NULL())
                 else:
-                    array_xml.append(cim_xml.VALUE(None))
+                    array_xml.append(_cim_xml.VALUE(None))
             else:
-                array_xml.append(cim_xml.VALUE(atomic_to_cim_xml(v)))
-        value_xml = cim_xml.VALUE_ARRAY(array_xml)
+                array_xml.append(_cim_xml.VALUE(atomic_to_cim_xml(v)))
+        value_xml = _cim_xml.VALUE_ARRAY(array_xml)
         return value_xml
 
     if hasattr(value, 'tocimxml'):
@@ -7780,7 +7782,7 @@ def tocimxml(value):
                       "deprecated.",
                       DeprecationWarning, stacklevel=2)
 
-    return cim_xml.VALUE(atomic_to_cim_xml(value))
+    return _cim_xml.VALUE(atomic_to_cim_xml(value))
 
 
 def tocimxmlstr(value, indent=None):

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -142,18 +142,18 @@ import logging
 
 import six
 
-from . import cim_xml
+from . import _cim_xml
 from .config import DEFAULT_ITER_MAXOBJECTCOUNT, AUTO_GENERATE_SFCB_UEP_HEADER
-from .cim_constants import DEFAULT_NAMESPACE, CIM_ERR_NOT_SUPPORTED
-from .cim_types import CIMType, CIMDateTime, atomic_to_cim_xml
+from ._cim_constants import DEFAULT_NAMESPACE, CIM_ERR_NOT_SUPPORTED
+from ._cim_types import CIMType, CIMDateTime, atomic_to_cim_xml
 from ._nocasedict import NocaseDict
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
+from ._cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMParameter, CIMQualifierDeclaration, tocimxml, cimvalue
-from .cim_http import get_cimobject_header, wbem_request
-from .tupleparse import TupleParser
-from .tupletree import xml_to_tupletree_sax
-from .cim_http import parse_url
-from .exceptions import CIMXMLParseError, XMLParseError, CIMError
+from ._cim_http import get_cimobject_header, wbem_request
+from ._tupleparse import TupleParser
+from ._tupletree import xml_to_tupletree_sax
+from ._cim_http import parse_url
+from ._exceptions import CIMXMLParseError, XMLParseError, CIMError
 from ._statistics import Statistics
 from ._recorder import LogOperationRecorder
 from ._logging import DEFAULT_LOG_DETAIL_LEVEL, LOG_DESTINATIONS, \
@@ -566,7 +566,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
               function for details.
 
             If `None`, the directory path of the first existing directory from
-            the list in :data:`~pywbem.cim_http.DEFAULT_CA_CERT_PATHS` will be
+            the list in :data:`~pywbem._cim_http.DEFAULT_CA_CERT_PATHS` will be
             used as a default.
 
             .. _`SSL_CTX_load_verify_locations`: https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_load_verify_locations.html
@@ -1720,18 +1720,18 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         # Create parameter list
 
-        plist = [cim_xml.IPARAMVALUE(x[0], tocimxml(x[1]))
+        plist = [_cim_xml.IPARAMVALUE(x[0], tocimxml(x[1]))
                  for x in params.items() if x[1] is not None]
 
         # Build XML request
 
-        req_xml = cim_xml.CIM(
-            cim_xml.MESSAGE(
-                cim_xml.SIMPLEREQ(
-                    cim_xml.IMETHODCALL(
+        req_xml = _cim_xml.CIM(
+            _cim_xml.MESSAGE(
+                _cim_xml.SIMPLEREQ(
+                    _cim_xml.IMETHODCALL(
                         methodname,
-                        cim_xml.LOCALNAMESPACEPATH(
-                            [cim_xml.NAMESPACE(ns)
+                        _cim_xml.LOCALNAMESPACEPATH(
+                            [_cim_xml.NAMESPACE(ns)
                              for ns in namespace.split('/')]),
                         plist)),
                 '1001', '1.0'),
@@ -1985,24 +1985,24 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
         def paramvalue(obj):
             """
-            Return a cim_xml node to be used as the value for a parameter.
+            Return a _cim_xml node to be used as the value for a parameter.
             """
             if isinstance(obj, (datetime, timedelta)):
                 obj = CIMDateTime(obj)
             if isinstance(obj, (CIMType, bool, six.string_types)):
                 # This includes CIMDateTime (subclass of CIMType)
-                return cim_xml.VALUE(atomic_to_cim_xml(obj))
+                return _cim_xml.VALUE(atomic_to_cim_xml(obj))
             if isinstance(obj, (CIMClassName, CIMInstanceName)):
-                return cim_xml.VALUE_REFERENCE(obj.tocimxml())
+                return _cim_xml.VALUE_REFERENCE(obj.tocimxml())
             if isinstance(obj, CIMInstance):
-                return cim_xml.VALUE(obj.tocimxml(ignore_path=True).toxml())
+                return _cim_xml.VALUE(obj.tocimxml(ignore_path=True).toxml())
             if isinstance(obj, CIMClass):
                 # CIMClass.tocimxml() always ignores path
-                return cim_xml.VALUE(obj.tocimxml().toxml())
+                return _cim_xml.VALUE(obj.tocimxml().toxml())
             if isinstance(obj, list):
                 if obj and isinstance(obj[0], (CIMClassName, CIMInstanceName)):
-                    return cim_xml.VALUE_REFARRAY([paramvalue(x) for x in obj])
-                return cim_xml.VALUE_ARRAY([paramvalue(x) for x in obj])
+                    return _cim_xml.VALUE_REFARRAY([paramvalue(x) for x in obj])
+                return _cim_xml.VALUE_ARRAY([paramvalue(x) for x in obj])
             # The type has been checked in infer_type(), so we can assert
             assert obj is None
 
@@ -2033,15 +2033,15 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             ptuple = (n, v, infer_type(v, n), infer_embedded_object(v))
             ptuples.append(ptuple)
 
-        plist = [cim_xml.PARAMVALUE(n, paramvalue(v), t, embedded_object=eo)
+        plist = [_cim_xml.PARAMVALUE(n, paramvalue(v), t, embedded_object=eo)
                  for n, v, t, eo in ptuples]
 
         # Build XML request
 
-        req_xml = cim_xml.CIM(
-            cim_xml.MESSAGE(
-                cim_xml.SIMPLEREQ(
-                    cim_xml.METHODCALL(
+        req_xml = _cim_xml.CIM(
+            _cim_xml.MESSAGE(
+                _cim_xml.SIMPLEREQ(
+                    _cim_xml.METHODCALL(
                         methodname,
                         localobject.tocimxml(),
                         plist)),

--- a/pywbem/_cim_types.py
+++ b/pywbem/_cim_types.py
@@ -1062,7 +1062,7 @@ def cimtype(obj):
         instancename_type = CIMInstanceName
     except NameError:
         # Defer import due to circular import dependencies:
-        from pywbem.cim_obj import CIMInstanceName as instancename_type
+        from pywbem._cim_obj import CIMInstanceName as instancename_type
     if isinstance(obj, instancename_type):
         return 'reference'
 
@@ -1070,7 +1070,7 @@ def cimtype(obj):
         instance_type = CIMInstance
     except NameError:
         # Defer import due to circular import dependencies:
-        from pywbem.cim_obj import CIMInstance as instance_type
+        from pywbem._cim_obj import CIMInstance as instance_type
     if isinstance(obj, instance_type):  # embedded instance
         return 'string'
 
@@ -1078,7 +1078,7 @@ def cimtype(obj):
         class_type = CIMClass
     except NameError:
         # Defer import due to circular import dependencies:
-        from pywbem.cim_obj import CIMClass as class_type
+        from pywbem._cim_obj import CIMClass as class_type
     if isinstance(obj, class_type):  # embedded class
         return 'string'
 
@@ -1150,7 +1150,7 @@ def type_from_name(type_name):
     """
     if type_name == 'reference':
         # Defer import due to circular import dependencies:
-        from .cim_obj import CIMInstanceName
+        from ._cim_obj import CIMInstanceName
         return CIMInstanceName
     try:
         type_obj = _TYPE_FROM_NAME[type_name]

--- a/pywbem/_cim_xml.py
+++ b/pywbem/_cim_xml.py
@@ -33,7 +33,7 @@ DTD:
   https://www.dmtf.org/standards/wbem/CIM_DTD_V22.dtd
 
 There should be one class for each element described in the DTD.  Their
-init methods take builtin Python types, or other cim_xml classes where
+init methods take builtin Python types, or other _cim_xml classes where
 child elements are required.
 
 Every class is a subclass of the Element class and so shares the same
@@ -105,7 +105,7 @@ def _pcdata_nodes(pcdata):
     For example, if the pcdata string is ``a&amp;b``, the XML-escaped string
     will be ``a&amp;amp;b``.
 
-    If the ``cim_xml._CDATA_ESCAPING`` switch is set to True, CDATA-based
+    If the ``_cim_xml._CDATA_ESCAPING`` switch is set to True, CDATA-based
     escaping is used instead. CDATA-based escaping will cause a CDATA section
     to be used for the entire string, or consecutive CDATA sequences (see
     discussion of nesting, below). The returned node list contains only CDATA

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -19,7 +19,7 @@ The following exceptions are pywbem specific exceptions that can be raised at
 the WBEM client library API.
 """
 
-from .cim_constants import _statuscode2name, _statuscode2string
+from ._cim_constants import _statuscode2name, _statuscode2string
 
 # This module is meant to be safe for 'import *'.
 

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -137,14 +137,14 @@ from six.moves import BaseHTTPServer
 from six.moves import socketserver
 from six.moves import http_client
 
-from . import cim_xml
+from . import _cim_xml
 from ._version import __version__
-from .cim_obj import CIMInstance
-from .cim_constants import CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_PARAMETER, \
+from ._cim_obj import CIMInstance
+from ._cim_constants import CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_PARAMETER, \
     _statuscode2name
-from .tupleparse import TupleParser
-from .tupletree import xml_to_tupletree_sax
-from .exceptions import CIMXMLParseError, XMLParseError, VersionError
+from ._tupleparse import TupleParser
+from ._tupletree import xml_to_tupletree_sax
+from ._exceptions import CIMXMLParseError, XMLParseError, VersionError
 from ._utils import _format
 
 # CIM-XML protocol related versions implemented by the WBEM listener.
@@ -430,12 +430,12 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """Send a CIM-XML response message back to the WBEM server that
         indicates error."""
 
-        resp_xml = cim_xml.CIM(
-            cim_xml.MESSAGE(
-                cim_xml.SIMPLEEXPRSP(
-                    cim_xml.EXPMETHODRESPONSE(
+        resp_xml = _cim_xml.CIM(
+            _cim_xml.MESSAGE(
+                _cim_xml.SIMPLEEXPRSP(
+                    _cim_xml.EXPMETHODRESPONSE(
                         methodname,
-                        cim_xml.ERROR(
+                        _cim_xml.ERROR(
                             str(status_code),
                             status_desc,
                             error_insts),
@@ -466,10 +466,10 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """Send a CIM-XML response message back to the WBEM server that
         indicates success."""
 
-        resp_xml = cim_xml.CIM(
-            cim_xml.MESSAGE(
-                cim_xml.SIMPLEEXPRSP(
-                    cim_xml.EXPMETHODRESPONSE(
+        resp_xml = _cim_xml.CIM(
+            _cim_xml.MESSAGE(
+                _cim_xml.SIMPLEEXPRSP(
+                    _cim_xml.EXPMETHODRESPONSE(
                         methodname),
                     ),  # noqa: E123
                 msgid, IMPLEMENTED_PROTOCOL_VERSION),

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -91,16 +91,16 @@ import six
 from ply import yacc, lex
 
 from ._nocasedict import NocaseDict
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMProperty, \
+from ._cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMProperty, \
     CIMMethod, CIMParameter, CIMQualifier, CIMQualifierDeclaration, \
     cimvalue
-from .cim_operations import WBEMConnection
+from ._cim_operations import WBEMConnection
 from ._server import WBEMServer
-from .cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
+from ._cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_NAMESPACE, \
     CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_INVALID_CLASS, _statuscode2string
-from .exceptions import Error, CIMError
+from ._exceptions import Error, CIMError
 from ._utils import _format
 
 __all__ = ['MOFParseError', 'MOFWBEMConnection', 'MOFCompiler',
@@ -113,8 +113,8 @@ __all__ = ['MOFParseError', 'MOFWBEMConnection', 'MOFCompiler',
 # pylint: disable=invalid-name
 
 _optimize = 1
-_tabmodule = 'mofparsetab'
-_lextab = 'moflextab'
+_tabmodule = '_mofparsetab'
+_lextab = '_moflextab'
 
 # Directory for _tabmodule and _lextab
 _tabdir = os.path.dirname(os.path.abspath(__file__))
@@ -2628,7 +2628,7 @@ def _yacc(verbose=False, out_dir=None):
       verbose (bool): Print messages while creating the parser object.
 
       out_dir (string): Path name of the directory in which the YACC table
-        module source file (mofparsetab.py) for the MOF compiler will be
+        module source file (_mofparsetab.py) for the MOF compiler will be
         generated. If None, that file will not be generated.
 
     Returns:
@@ -2665,7 +2665,7 @@ def _lex(verbose=False, out_dir=None):
       verbose (bool): Print messages while creating the parser object.
 
       out_dir (string): Path name of the directory in which the LEX table
-        module source file (moflextab.py) for the MOF compiler will be
+        module source file (_moflextab.py) for the MOF compiler will be
         generated. If None, that file will not be generated.
 
     Returns:

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -35,11 +35,11 @@ import yaml
 from yaml.representer import RepresenterError
 
 from ._nocasedict import NocaseDict
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
+from ._cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
     CIMQualifierDeclaration
-from .cim_types import CIMInt, CIMFloat, CIMDateTime
-from .exceptions import CIMError
+from ._cim_types import CIMInt, CIMFloat, CIMDateTime
+from ._exceptions import CIMError
 from ._logging import LOGGER_API_CALLS_NAME, LOGGER_HTTP_NAME
 from ._utils import _ensure_unicode, _format
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -97,15 +97,15 @@ Example output:
 import re
 import warnings
 
-from .cim_constants import CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_CLASS, \
+from ._cim_constants import CIM_ERR_INVALID_NAMESPACE, CIM_ERR_INVALID_CLASS, \
     CIM_ERR_METHOD_NOT_FOUND, CIM_ERR_METHOD_NOT_AVAILABLE, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_NAMESPACE_NOT_EMPTY
-from .exceptions import CIMError, CIMXMLParseError, XMLParseError, ModelError
+from ._exceptions import CIMError, CIMXMLParseError, XMLParseError, ModelError
 from ._warnings import ToleratedServerIssueWarning
 from ._nocasedict import NocaseDict
-from .cim_obj import CIMInstanceName, CIMInstance
-from .cim_operations import WBEMConnection
+from ._cim_obj import CIMInstanceName, CIMInstance
+from ._cim_operations import WBEMConnection
 from ._valuemapping import ValueMapping
 from ._utils import _ensure_unicode, _format
 

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -146,10 +146,10 @@ import uuid
 import six
 
 from ._server import WBEMServer
-from .cim_obj import CIMInstance, CIMInstanceName
-from .cim_http import parse_url
-from .cim_constants import CIM_ERR_FAILED
-from .exceptions import CIMError
+from ._cim_obj import CIMInstance, CIMInstanceName
+from ._cim_http import parse_url
+from ._cim_constants import CIM_ERR_FAILED
+from ._exceptions import CIMError
 from ._utils import _format
 
 # CIM model classnames for subscription components

--- a/pywbem/_tupleparse.py
+++ b/pywbem/_tupleparse.py
@@ -41,8 +41,7 @@ representation of CIM in XML by having the following properties:
 # Implementation:
 #
 # This works by a recursive descent down the CIM XML tupletree.  As we walk
-# down, we produce cim_obj and cim_type objects representing the CIM message
-# in digested form.
+# down, we produce CIM objects representing the CIM message in digested form.
 #
 # For each XML node type FOO there is one function parse_foo, which
 # returns the digested form by examining a tuple tree rooted at FOO.
@@ -84,12 +83,12 @@ import six
 
 from ._utils import _stacklevel_above_module, _format
 from ._nocasedict import NocaseDict
-from .cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
+from ._cim_obj import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
     CIMQualifierDeclaration
-from .cim_types import CIMDateTime, type_from_name
-from .tupletree import xml_to_tupletree_sax
-from .exceptions import CIMXMLParseError
+from ._cim_types import CIMDateTime, type_from_name
+from ._tupletree import xml_to_tupletree_sax
+from ._exceptions import CIMXMLParseError
 from ._warnings import ToleratedServerIssueWarning
 
 

--- a/pywbem/_tupletree.py
+++ b/pywbem/_tupletree.py
@@ -20,7 +20,7 @@
 #
 
 """
-tupletree - Convert XML DOM objects to and from tuple trees.
+_tupletree - Convert XML DOM objects to and from tuple trees.
 
 DOM is the standard in-memory representation of XML documents, but it
 is very cumbersome for some types of processing where XML encodes
@@ -60,7 +60,7 @@ import re
 import sys
 import six
 
-from .exceptions import XMLParseError
+from ._exceptions import XMLParseError
 from ._utils import _format, _ensure_bytes
 
 __all__ = []

--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -131,7 +131,7 @@ def _hash_dict(dict_):
 def _stacklevel_above_module(mod_name):
     """
     Return the stack level (with 1 = caller of this function) of the first
-    caller that is not defined in the specified module (e.g. "pywbem.cim_obj").
+    caller that is not defined in the specified module (e.g. "pywbem._cim_obj").
 
     The returned stack level can be used directly by the caller of this
     function as an argument for the stacklevel parameter of warnings.warn().

--- a/pywbem/_valuemapping.py
+++ b/pywbem/_valuemapping.py
@@ -31,8 +31,8 @@ except ImportError:
     from ordereddict import OrderedDict
 import six
 
-from .cim_types import CIMInt, type_from_name
-from .cim_obj import CIMProperty, CIMMethod, CIMParameter
+from ._cim_types import CIMInt, type_from_name
+from ._cim_obj import CIMProperty, CIMMethod, CIMParameter
 from ._utils import _format, _integerValue_to_int
 
 __all__ = ['ValueMapping']

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -20,7 +20,7 @@ the WBEM client library.
 """
 
 import six
-from .exceptions import Error
+from ._exceptions import Error
 
 # This module is meant to be safe for 'import *'.
 


### PR DESCRIPTION
For details, see commit message.

Note this rollback of PR #2105 adds compatibility to the old sub-namespaces and therefore does not change any usages of the pywbem sub-modules e.g. in tests or in the docs.