### PR TITLE
Fixes #2126 Add option to disable pull operations to mocker

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -487,6 +487,10 @@ Released: not yet
   On Python versions before 2.7.9, pywbem will continue to use the deprecated
   `ssl.wrap_socket()` function. (See issue #2002)
 
+* Add property to pywbem_mock Fake_WBEMConnection to allow the user to modify
+  the mocker behavior to forbid the use of the pull operations.
+  (See issue #2126)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -2005,6 +2005,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         result_con = _format(
             "Connection:{0} FakedWBEMConnection("
             "response_delay=None, "
+            "disable_pull_operations=False "
             "super=WBEMConnection("
             "url='http://FakedUrl:5988', "
             "creds=None, "
@@ -2050,6 +2051,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         result_con = _format(
             "Connection:{0} FakedWBEMConnection("
             "response_delay=None, "
+            "disable_pull_operations=False "
             "super=WBEMConnection("
             "url='http://FakedUrl:5988', "
             "creds=None, "
@@ -2101,6 +2103,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         result_con = _format(
             "Connection:{0} FakedWBEMConnection("
             "response_delay=None, "
+            "disable_pull_operations=False "
             "super=WBEMConnection("
             "url='http://FakedUrl:5988', "
             "creds=None, "
@@ -2146,6 +2149,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         result_con = _format(
             "Connection:{0} FakedWBEMConnection("
             "response_delay=None, "
+            "disable_pull_operations=False "
             "super=WBEMConnection("
             "url='http://FakedUrl:5988', "
             "creds=None, "
@@ -2190,6 +2194,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         result_con = _format(
             "Connection:{0} FakedWBEMConnection("
             "response_delay=None, "
+            "disable_pull_operations=False "
             "super=WBEMConnection("
             "url='http://FakedUrl:5988', "
             "creds=None, "


### PR DESCRIPTION
Add a property to Fake_WBEMConnection to forbid_pull which when set to
False (either in the __init__ or a property setter) forces all call to
the Open... request operations to return CIM_ERR_NOT_SUPPORTED.

Adds a test to validate property is set correctly and the operations
react correctly.

I set rollback because I would like to make that test part of pywbemcli.

ANDY: Forget discussion of the forbid word.  Changed the __init__ option to disallow-pull-operations. In case the question comes up, I do not want to merge the use_pull and disable_pull_operations (one is the client, the other is the server) and I specifically want to have a client that uses pull with server mock that disallows it to test client ability to handle error response if server mock cannot handle pulls.