### PR TITLE
0.17: Updated minimum package versions for py34/py38

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,11 @@
 
 # Direct dependencies:
 
+
 # Unit test (imports into testcases):
+packaging>=16.6,<17.0; python_version == '2.6'
+packaging>=16.6; python_version > '2.6'
+funcsigs>=1.0.2; python_version < '3.3'
 unittest2>=1.1.0; python_version == '2.6'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
@@ -37,8 +41,12 @@ lxml>=4.4.1; python_version >= '3.8'
 #       requests 2.20.0 has dropped support for Python 2.6.
 requests>=2.19.1; python_version == '2.6'
 requests>=2.20.1; python_version > '2.6'
-decorator>=4.0.11
 
+# Unit test (indirect dependencies):
+# Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
+pluggy>=0.5.0,<0.6.0; python_version == '2.6'
+pluggy>=0.13.0; python_version >= '2.7'
+decorator>=4.0.11
 # PyYAML is an indirect dependency used by yamlordereddictloader that is
 # needed due to version pinning. Keep in sync with requirements.txt.
 # PyYAML 5.3 has removed support for Python 3.4
@@ -46,36 +54,34 @@ PyYAML>=3.11,<3.12; python_version == '2.6'
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'
 PyYAML>=5.1; python_version > '3.4'
-
 yamlordereddictloader>=0.4.0; python_version == '2.6'
 yamlloader>=0.5.5; python_version > '2.6'
-funcsigs>=1.0.2
 
-# Coverage reporting (no imports, invoked via coveralls script).
-coverage>=4.5.3
+# Coverage reporting (no imports, invoked via coveralls script):
+# coverage 5.0 has removed support for py34
+coverage>=4.5,<5.0
+# python-coveralls 2.9.2 no longer has requirement coverage==4.0.3.
 python-coveralls>=2.9.2
+pytest-cov>=2.4.0,<2.6.0; python_version == '2.6'
+pytest-cov>=2.7.0; python_version >= '2.7'
 
 # Safety CI by pyup.io
-safety>=1.8.4
-
-# Unit test (no imports, invoked via py.test script):
-
-pytest-cov>=2.4.0,<2.6.0; python_version == '2.6'
-pytest-cov>=2.4.0; python_version >= '2.7'
+safety>=1.8.4; python_version >= '2.7'
+dparse>=0.4.1; python_version >= '2.7'
 
 # Tox
 tox>=2.0.0
 
 # Sphinx (no imports, invoked via sphinx-build script, issues on py26):
 # Keep in sync with rtd-requirements.txt
-Sphinx>=1.7.6,<2.0.0; python_version >= '2.7' and python_version < '3.5'  # BSD
-Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
-# TODO: On py3.5+, Sphinx currently fails, see issue
-#       https://github.com/sphinx-doc/sphinx/issues/6246. Therefore, Sphinx has
-#       been pinned to below 2.0.0 also for py3.5+.
+Sphinx>=1.7.6; python_version >= '2.7'
 sphinx-git>=10.1.1; python_version >= '2.7'
 GitPython>=2.1.1; python_version >= '2.7'
 sphinxcontrib-fulltoc>=1.2.0; python_version >= '2.7'
+# Pygments 2.4.0 has removed support for Python 3.4
+Pygments>=2.1.3; python_version == '2.7'
+Pygments>=2.1.3,<2.4.0; python_version == '3.4'
+Pygments>=2.1.3; python_version >= '3.5'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -87,11 +93,20 @@ astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0; python_version >= '3.4'
 
 # Flake8 (no imports, invoked via flake8 script):
-flake8>=2.6.2,<3.0.0; python_version == '2.6'
-flake8>=3.7.0; python_version > '2.6'
+flake8>=3.7.9; python_version >= '2.7'
+mccabe>=0.6.0; python_version >= '2.7'
+pycodestyle>=2.5.0; python_version >= '2.7'
+pyflakes>=2.1.0; python_version >= '2.7'
+entrypoints>=0.3.0; python_version >= '2.7'
+functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
 twine>=1.8.1; python_version >= '2.7'
+# readme-renderer 25.0 has removed support for Python 3.4
+# readme-renderer 23.0 has made cmarkgfm part of extras (it fails on Cygwin)
+readme-renderer>=23.0; python_version == '2.7'
+readme-renderer>=23.0,<25.0; python_version == '3.4'
+readme-renderer>=23.0; python_version >= '3.5'
 
 # Jupyter Notebook (no imports, invoked via jupyter script, some deps do not support py26):
 # The jupyter package is not installed on Python 3.4 on Windows, because its

--- a/makefile
+++ b/makefile
@@ -679,11 +679,15 @@ else
 endif
 
 safety_$(pymn).done: develop_$(pymn).done makefile minimum-constraints.txt
+ifeq ($(python_mn_version),2.6)
+	@echo "makefile: Warning: Skipping pyup.io safety check on Python $(python_version)" >&2
+else
 	@echo "makefile: Running pyup.io safety check"
 	-$(call RM_FUNC,$@)
 	-safety check -r minimum-constraints.txt --full-report
 	echo "done" >$@
 	@echo "makefile: Done running pyup.io safety check"
+endif
 
 ifdef TEST_INSTALLED
   test_deps =

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -73,6 +73,8 @@ typing==3.6.1  # from M2Crypto
 # Direct dependencies for develop (must be consistent with dev-requirements.txt)
 
 # Unit test (imports into testcases):
+packaging==16.6
+funcsigs==1.0.2; python_version < '3.3'
 unittest2==1.1.0; python_version == '2.6'
 pytest==3.1.0; python_version == '2.6'
 pytest==4.3.1; python_version > '2.6'
@@ -84,22 +86,25 @@ lxml==4.2.4; python_version <= '3.7'
 lxml==4.4.1; python_version >= '3.8'
 requests==2.19.1; python_version == '2.6'
 requests==2.20.1; python_version > '2.6'
+
+# Unit test (indirect dependencies):
+pluggy==0.5.0; python_version == '2.6'
+pluggy==0.13.0; python_version >= '2.7'
 decorator==4.0.11
 yamlordereddictloader==0.4.0; python_version == '2.6'
 yamlloader==0.5.5; python_version > '2.6'
-funcsigs==1.0.2
+# PyYAML is covered in direct deps for install
 FormEncode==1.3.1
 
 # Coverage reporting (no imports, invoked via coveralls script):
+coverage==4.5
 python-coveralls==2.9.2
-coverage==4.5.3
+pytest-cov==2.4.0; python_version == '2.6'
+pytest-cov==2.7.0; python_version >= '2.7'
 
 # Safety CI by pyup.io
-safety==1.8.4
-dparse==0.4.1
-
-# Unit test (no imports, invoked via py.test script):
-pytest-cov==2.4.0
+safety==1.8.4; python_version >= '2.7'
+dparse==0.4.1; python_version >= '2.7'
 
 # Tox
 tox==2.0.0
@@ -108,7 +113,8 @@ tox==2.0.0
 Sphinx==1.7.6
 sphinx-git==10.1.1
 GitPython==2.1.1
-sphinxcontrib-fulltoc>=1.2.0
+sphinxcontrib-fulltoc==1.2.0
+Pygments==2.1.3
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:
 pylint==1.6.4; python_version == '2.7'
@@ -117,19 +123,16 @@ astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version >= '3.4'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-#
-flake8==2.6.2; python_version == '2.6'
-mccabe==0.5.3; python_version == '2.6'
-pycodestyle==2.0.0; python_version == '2.6'
-pyflakes==1.2.3; python_version == '2.6'
-#
-flake8==3.7.0; python_version > '2.6'
-mccabe==0.6.1; python_version > '2.6'
-pycodestyle==2.5.0; python_version > '2.6'
-pyflakes==2.1.1; python_version > '2.6'
+flake8==3.7.0; python_version >= '2.7'
+mccabe==0.6.1; python_version >= '2.7'
+pycodestyle==2.5.0; python_version >= '2.7'
+pyflakes==2.1.1; python_version >= '2.7'
+entrypoints==0.3.0; python_version >= '2.7'
+functools32==3.2.3.post2; python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-twine==1.8.1
+twine==1.8.1; python_version >= '2.7'
+readme-renderer==23.0; python_version >= '2.7'
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter==1.0.0
@@ -148,10 +151,10 @@ pywin32==223; sys_platform == 'win32' and python_version == '3.7'
 
 # Table output formatter used by the manual performance tests to display
 # timing results
-tabulate >= 0.8.3
+tabulate==0.8.3
 
 # Performance profiling tools
-pyinstrument >=3.0.1
+pyinstrument==3.0.1
 pyinstrument-cext==0.2.0  # from pyinstrument
 
 typed-ast==1.3.0; python_version >= '3.4' and python_version < '3.8'
@@ -166,10 +169,7 @@ Babel==2.3.4
 bleach==2.1.4
 chardet==3.0.2
 clint==0.5.1
-coverage==4.0.3
-decorator==4.0.10
 docutils==0.13.1
-entrypoints==0.2.2
 filelock==3.0.0
 gitdb2==2.0.0
 html5lib==0.999999999
@@ -199,7 +199,6 @@ ptyprocess==0.5.1
 # py version is determined by pytest:
 py==1.4.32; python_version == '2.6'
 py==1.5.1; python_version > '2.6'
-Pygments==2.1.3
 pytz==2016.10
 pyzmq==16.0.4
 qtconsole==4.2.1

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -8,11 +8,7 @@
 # Minimum set of packages for Sphinx processing
 # Keep in sync with dev-requirements.txt
 
-Sphinx>=1.7.6,<2.0.0; python_version < '3.5'  # BSD
-Sphinx>=1.7.6,<2.0.0; python_version >= '3.5'  # BSD
-# TODO: On Python 3.5 and higher, Sphinx currently fails, see issue
-#       https://github.com/sphinx-doc/sphinx/issues/6246. Therefore, Sphinx has
-#       been pinned to below 2.0.0 also for those Python versions.
+Sphinx>=1.7.6
 sphinx-git>=10.1.1
 GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
Roll back of PR #2127 into 0.5.1, plus disabling flake8 on python 2.6