### PR TITLE
0.17: Pinned dparse to <0.5.0 on Python 2.7 due to an issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -67,7 +67,10 @@ pytest-cov>=2.7.0; python_version >= '2.7'
 
 # Safety CI by pyup.io
 safety>=1.8.4; python_version >= '2.7'
-dparse>=0.4.1; python_version >= '2.7'
+# dparse 0.5.0 has an infinite recursion issue on Python 2.7,
+#   see https://github.com/pyupio/dparse/issues/46
+dparse>=0.4.1,<0.5.0; python_version == '2.7'
+dparse>=0.4.1; python_version >= '3.4'
 
 # Tox
 tox>=2.0.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,8 @@ Released: not yet
   the appropriate minimum versions of the ipython package, per Python version.
   (See issue #2135)
 
+* Pinned dparse to <0.5.0 on Python 2.7 due to an issue. (See issue #2139)
+
 **Enhancements:**
 
 * Changed the HTTPS support of `pywbem.WBEMListener` from using the deprecated


### PR DESCRIPTION
Rolls back PR #2141 into 0.17.