### PR TITLE
Fixes #2139: Pinned dparse to <0.5.0 on Python 2.7 due to an issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,7 +49,10 @@ pytest-cov>=2.7.0
 
 # Safety CI by pyup.io
 safety>=1.8.4
-dparse>=0.4.1
+# dparse 0.5.0 has an infinite recursion issue on Python 2.7,
+#   see https://github.com/pyupio/dparse/issues/46
+dparse>=0.4.1,<0.5.0; python_version == '2.7'
+dparse>=0.4.1; python_version >= '3.4'
 
 # Tox
 tox>=2.0.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -380,6 +380,8 @@ Released: not yet
   the appropriate minimum versions of the ipython package, per Python version.
   (See issue #2135)
 
+* Pinned dparse to <0.5.0 on Python 2.7 due to an issue. (See issue #2139)
+
 **Enhancements:**
 
 * Changed GetCentralInstances methodology in WBEMServer.get_central_instances()


### PR DESCRIPTION
See commit message.