### PR TITLE
0.17: Pinned mock version to support setup.py install from source tar

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Pinned mock to <4.0.0 on Python <3.6 due to an install issue when installing
+  from the source tarball. (See issue #2150).
+
 **Cleanup:**
 
 **Known issues:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@
 
 # On Windows, M2Crypto must be installed via pywbem_os_setup.bat
 M2Crypto>=0.31.0; python_version < '3.0' and sys_platform != 'win32'
-mock>=2.0.0
+mock>=2.0.0,<4.0.0; python_version < '3.6'
+mock>=2.0.0; python_version >= '3.6'
 ordereddict>=1.1; python_version == '2.6'
 ply>=3.10
 # PyYAML 5.3 has removed support for Python 3.4


### PR DESCRIPTION
Rolls back PR #2151 into 0.17.1.