### PR TITLE
Partly fixes #1413: Fixed some more Pylint issues

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -66,7 +66,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=I0011,
+disable=I0011, bad-option-value,
         too-many-locals, too-many-branches, too-many-statements,
         too-many-lines, too-many-public-methods,
         too-many-nested-blocks, too-many-return-statements, too-many-arguments,

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -68,7 +68,7 @@ _python_n = sys.version_info[1]  # pylint: disable=invalid-name
 # Keep these Python versions in sync with setup.py
 if _python_m == 2 and _python_n < 7:
     raise RuntimeError('On Python 2, pywbem requires Python 2.7 or higher')
-elif _python_m == 3 and _python_n < 4:
+if _python_m == 3 and _python_n < 4:
     raise RuntimeError('On Python 3, pywbem requires Python 3.4 or higher')
 
 # On Python 2, add a NullHandler to suppress the warning "No handlers could be

--- a/pywbem/_cim_http.py
+++ b/pywbem/_cim_http.py
@@ -46,7 +46,7 @@ from ._cim_obj import CIMClassName, CIMInstanceName
 from ._cim_constants import DEFAULT_URL_SCHEME, DEFAULT_URL_PORT_HTTP, \
     DEFAULT_URL_PORT_HTTPS
 from ._exceptions import ConnectionError, AuthError, TimeoutError, HTTPError, \
-    HeaderParseError
+    HeaderParseError  # pylint: disable=redefined-builtin
 from ._utils import _ensure_unicode, _ensure_bytes, _format
 
 __all__ = []

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -305,7 +305,7 @@ _KB_VAL = r'(?:{0}|{1}|{2})'.format(
 # To get all repetitions, capture a repeated group instead of repeating a
 # capturing group: https://www.regular-expressions.info/captureall.html
 WBEM_URI_KEYBINDINGS_REGEXP = re.compile(
-    r'^(\w+={0})((?:,\w+={1})*)$'.format(_KB_VAL, _KB_VAL),
+    r'^(\w+={0})((?:,\w+={0})*)$'.format(_KB_VAL),
     flags=(re.UNICODE | re.IGNORECASE))
 
 WBEM_URI_KB_FINDALL_REGEXP = re.compile(
@@ -751,25 +751,28 @@ def _scalar_value_tomof(
                     "type {1} for conversion to a MOF string",
                     type, builtin_type(value)))
 
-    elif type == 'char16':
+    if type == 'char16':
         return mofstr(value, indent, maxline, line_pos, end_space, avoid_splits,
                       quote_char=u"'")
-    elif type == 'boolean':
+
+    if type == 'boolean':
         val = u'true' if value else u'false'
         return mofval(val, indent, maxline, line_pos, end_space)
-    elif type == 'datetime':
+
+    if type == 'datetime':
         val = six.text_type(value)
         return mofstr(val, indent, maxline, line_pos, end_space, avoid_splits)
-    elif type == 'reference':
+
+    if type == 'reference':
         val = value.to_wbem_uri()
         return mofstr(val, indent, maxline, line_pos, end_space, avoid_splits)
-    else:
-        assert isinstance(value, (CIMFloat, CIMInt)), \
-            _format("Scalar value of CIM type {0} has invalid Python type {1} "
-                    "for conversion to a MOF string",
-                    type, builtin_type(value))
-        val = six.text_type(value)
-        return mofval(val, indent, maxline, line_pos, end_space)
+
+    assert isinstance(value, (CIMFloat, CIMInt)), \
+        _format("Scalar value of CIM type {0} has invalid Python type {1} "
+                "for conversion to a MOF string",
+                type, builtin_type(value))
+    val = six.text_type(value)
+    return mofval(val, indent, maxline, line_pos, end_space)
 
 
 def _value_tomof(

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -2376,7 +2376,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 if isinstance(p[2], six.string_types):
                     p2 = p[2].lower()
                     if p2 in ['true', 'false']:  # noqa: E125
-                        end_of_sequence = True if p2 == 'true' else False
+                        end_of_sequence = (p2 == 'true')
                         end_of_sequence_found = True
                     else:
                         raise CIMXMLParseError(

--- a/pywbem/_cim_types.py
+++ b/pywbem/_cim_types.py
@@ -1049,6 +1049,7 @@ def cimtype(obj):
         instancename_type = CIMInstanceName
     except NameError:
         # Defer import due to circular import dependencies:
+        # pylint: disable=import-outside-toplevel
         from pywbem._cim_obj import CIMInstanceName as instancename_type
     if isinstance(obj, instancename_type):
         return 'reference'
@@ -1057,6 +1058,7 @@ def cimtype(obj):
         instance_type = CIMInstance
     except NameError:
         # Defer import due to circular import dependencies:
+        # pylint: disable=import-outside-toplevel
         from pywbem._cim_obj import CIMInstance as instance_type
     if isinstance(obj, instance_type):  # embedded instance
         return 'string'
@@ -1065,6 +1067,7 @@ def cimtype(obj):
         class_type = CIMClass
     except NameError:
         # Defer import due to circular import dependencies:
+        # pylint: disable=import-outside-toplevel
         from pywbem._cim_obj import CIMClass as class_type
     if isinstance(obj, class_type):  # embedded class
         return 'string'
@@ -1137,6 +1140,7 @@ def type_from_name(type_name):
     """
     if type_name == 'reference':
         # Defer import due to circular import dependencies:
+        # pylint: disable=import-outside-toplevel
         from ._cim_obj import CIMInstanceName
         return CIMInstanceName
     try:

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -296,7 +296,9 @@ class HTTPError(_RequestExceptionMixin, _ResponseExceptionMixin, Error):
 
         See :term:`RFC2616` for a list of HTTP status codes and reason phrases.
         """
-        return self.args[0]
+        # Note: The reporting of unsubscriptable-object seems to be a false
+        # positive in Pylint, see https://github.com/PyCQA/pylint/issues/1498
+        return self.args[0]  # pylint: disable=unsubscriptable-object
 
     @property
     def reason(self):
@@ -307,7 +309,7 @@ class HTTPError(_RequestExceptionMixin, _ResponseExceptionMixin, Error):
 
         See :term:`RFC2616` for a list of HTTP status codes and reason phrases.
         """
-        return self.args[1]
+        return self.args[1]  # pylint: disable=unsubscriptable-object
 
     @property
     def cimerror(self):
@@ -319,7 +321,7 @@ class HTTPError(_RequestExceptionMixin, _ResponseExceptionMixin, Error):
 
         See :term:`DSP0200` for a list of values.
         """
-        return self.args[2]
+        return self.args[2]  # pylint: disable=unsubscriptable-object
 
     @property
     def cimdetails(self):
@@ -332,7 +334,7 @@ class HTTPError(_RequestExceptionMixin, _ResponseExceptionMixin, Error):
         * Key: header field name (e.g. `PGErrorDetail`).
         * Value: header field value.
         """
-        return self.args[3]
+        return self.args[3]  # pylint: disable=unsubscriptable-object
 
     def __str__(self):
         ret_str = "{0} ({1})".format(self.status, self.reason)
@@ -567,7 +569,7 @@ class CIMError(_RequestExceptionMixin, Error):
 
         See :ref:`CIM status codes` for constants defining the numeric CIM
         status code values."""
-        return self.args[0]
+        return self.args[0]  # pylint: disable=unsubscriptable-object
 
     @property
     def status_code_name(self):
@@ -596,7 +598,8 @@ class CIMError(_RequestExceptionMixin, Error):
         the CIM status code is returned. If the CIM status code is invalid,
         the string "Invalid status code <status_code>" is returned.
         """
-        return self.args[1] or _statuscode2string(self.status_code)
+        desc = self.args[1]  # pylint: disable=unsubscriptable-object
+        return desc or _statuscode2string(self.status_code)
 
     @property
     def instances(self):
@@ -609,7 +612,7 @@ class CIMError(_RequestExceptionMixin, Error):
 
         `None` if there are no such instances.
         """
-        return self.args[2]
+        return self.args[2]  # pylint: disable=unsubscriptable-object
 
     def __str__(self):
         inst_str = " ({0} instances)".format(len(self.instances)) \

--- a/pywbem/_logging.py
+++ b/pywbem/_logging.py
@@ -369,6 +369,7 @@ def configure_logger(simple_name, log_dest=None,
 
     global _CONN  # pylint: disable=global-statement
     if _CONN is None:
+        # pylint: disable=import-outside-toplevel
         from . import WBEMConnection
         _CONN = WBEMConnection
 

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -305,8 +305,8 @@ def t_stringValue(t):  # pylint: disable=missing-docstring
     return t
 
 
-identifier_re = r'([a-zA-Z_]|({0}))([0-9a-zA-Z_]|({1}))*'.format(
-    utf8Char, utf8Char)
+identifier_re = r'([a-zA-Z_]|({0}))([0-9a-zA-Z_]|({0}))*'.format(
+    utf8Char)
 
 
 @lex.TOKEN(identifier_re)

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -956,32 +956,32 @@ class TestClientRecorder(BaseOperationRecorder):
             # converted to a dictionary first.
             ret_dict = obj._asdict()
             return self.toyaml(ret_dict)
-        elif isinstance(obj, (list, tuple)):
+        if isinstance(obj, (list, tuple)):
             # Note that namedtuple objects are handeled above.
             ret = []
             for item in obj:
                 ret.append(self.toyaml(item))
             return ret
-        elif isinstance(obj, (dict, NocaseDict)):
+        if isinstance(obj, (dict, NocaseDict)):
             ret_dict = OrderedDict()
             for key in obj.keys():  # get keys in original case
                 ret_dict[key] = self.toyaml(obj[key])
             return ret_dict
-        elif obj is None:
+        if obj is None:
             return obj
-        elif isinstance(obj, six.binary_type):
+        if isinstance(obj, six.binary_type):
             return obj.decode("utf-8")
-        elif isinstance(obj, six.text_type):
+        if isinstance(obj, six.text_type):
             return obj
-        elif isinstance(obj, bool):
+        if isinstance(obj, bool):
             # The check for bool must be before any integer checks, because
             # bool is a subclass of int in Python.
             return obj
-        elif isinstance(obj, CIMInt):
+        if isinstance(obj, CIMInt):
             # CIMInt is _Longint and therefore may exceed the value range of
             # int in Python 2. Therefore, we convert it to _Longint.
             return _Longint(obj)
-        elif isinstance(obj, six.integer_types):
+        if isinstance(obj, six.integer_types):
             # This case must be after CIMInt, because CIMInt is _Longint and
             # would match a long value in Python 2.
             # We don't convert six.integer_types to _Longint, because the value
@@ -990,15 +990,15 @@ class TestClientRecorder(BaseOperationRecorder):
             # and long do not inherit from each other, so it is likely best if
             # we just don't convert.
             return obj
-        elif isinstance(obj, CIMFloat):
+        if isinstance(obj, CIMFloat):
             return float(obj)
-        elif isinstance(obj, CIMDateTime):
+        if isinstance(obj, CIMDateTime):
             return str(obj)
-        elif isinstance(obj, datetime):
+        if isinstance(obj, datetime):
             return CIMDateTime(obj)
-        elif isinstance(obj, timedelta):
+        if isinstance(obj, timedelta):
             return CIMDateTime(obj)
-        elif isinstance(obj, CIMInstance):
+        if isinstance(obj, CIMInstance):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMInstance'
             ret_dict['classname'] = self.toyaml(obj.classname)
@@ -1006,7 +1006,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['qualifiers'] = self.toyaml(obj.qualifiers)
             ret_dict['path'] = self.toyaml(obj.path)
             return ret_dict
-        elif isinstance(obj, CIMInstanceName):
+        if isinstance(obj, CIMInstanceName):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMInstanceName'
             ret_dict['classname'] = self.toyaml(obj.classname)
@@ -1014,7 +1014,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['host'] = self.toyaml(obj.host)
             ret_dict['keybindings'] = self.toyaml(obj.keybindings)
             return ret_dict
-        elif isinstance(obj, CIMClass):
+        if isinstance(obj, CIMClass):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMClass'
             ret_dict['classname'] = self.toyaml(obj.classname)
@@ -1024,14 +1024,14 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['qualifiers'] = self.toyaml(obj.qualifiers)
             ret_dict['path'] = self.toyaml(obj.path)
             return ret_dict
-        elif isinstance(obj, CIMClassName):
+        if isinstance(obj, CIMClassName):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMClassName'
             ret_dict['classname'] = self.toyaml(obj.classname)
             ret_dict['host'] = self.toyaml(obj.host)
             ret_dict['namespace'] = self.toyaml(obj.namespace)
             return ret_dict
-        elif isinstance(obj, CIMProperty):
+        if isinstance(obj, CIMProperty):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMProperty'
             ret_dict['name'] = self.toyaml(obj.name)
@@ -1045,7 +1045,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['propagated'] = self.toyaml(obj.propagated)
             ret_dict['qualifiers'] = self.toyaml(obj.qualifiers)
             return ret_dict
-        elif isinstance(obj, CIMMethod):
+        if isinstance(obj, CIMMethod):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMMethod'
             ret_dict['name'] = self.toyaml(obj.name)
@@ -1055,7 +1055,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['parameters'] = self.toyaml(obj.parameters)
             ret_dict['qualifiers'] = self.toyaml(obj.qualifiers)
             return ret_dict
-        elif isinstance(obj, CIMParameter):
+        if isinstance(obj, CIMParameter):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMParameter'
             ret_dict['name'] = self.toyaml(obj.name)
@@ -1066,7 +1066,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['array_size'] = self.toyaml(obj.array_size)
             ret_dict['qualifiers'] = self.toyaml(obj.qualifiers)
             return ret_dict
-        elif isinstance(obj, CIMQualifier):
+        if isinstance(obj, CIMQualifier):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMQualifier'
             ret_dict['name'] = self.toyaml(obj.name)
@@ -1078,7 +1078,7 @@ class TestClientRecorder(BaseOperationRecorder):
             ret_dict['overridable'] = self.toyaml(obj.overridable)
             ret_dict['translatable'] = self.toyaml(obj.translatable)
             return ret_dict
-        elif isinstance(obj, CIMQualifierDeclaration):
+        if isinstance(obj, CIMQualifierDeclaration):
             ret_dict = OrderedDict()
             ret_dict['pywbem_object'] = 'CIMQualifierDeclaration'
             ret_dict['name'] = self.toyaml(obj.name)

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -1065,14 +1065,13 @@ class WBEMServer(object):
                 if exc.status_code == CIM_ERR_INVALID_NAMESPACE:
                     # Current namespace does not exist.
                     continue
-                elif exc.status_code in (CIM_ERR_INVALID_CLASS,
-                                         CIM_ERR_NOT_FOUND):
+                if exc.status_code in (CIM_ERR_INVALID_CLASS,
+                                       CIM_ERR_NOT_FOUND):
                     # Class is not implemented, but current namespace exists.
                     interop_ns = ns
                     break
-                else:
-                    # Some other error happened.
-                    raise
+                # Some other error happened.
+                raise
             else:
                 # Namespace class is implemented in the current namespace.
                 # Use the returned namespace name, if possible.
@@ -1163,9 +1162,8 @@ class WBEMServer(object):
                                        CIM_ERR_NOT_FOUND):
                     # Class is not implemented, try next one.
                     continue
-                else:
-                    # Some other error.
-                    raise
+                # Some other error.
+                raise
             else:
                 # Found a namespace class that is implemented.
                 ns_classname = classname

--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -108,7 +108,7 @@ def _eq_name(name1, name2):
     """
     if name1 is None:
         return name2 is None
-    elif name2 is None:
+    if name2 is None:
         return False
     return name1.lower() == name2.lower()
 
@@ -122,7 +122,7 @@ def _eq_item(item1, item2):
     """
     if item1 is None:
         return item2 is None
-    elif item2 is None:
+    if item2 is None:
         return False
     return item1 == item2
 

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -191,6 +191,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         """
         namespace = self.default_namespace
         mod_inst = args[0] if args else kwargs['ModifiedInstance']
+        # pylint: disable=protected-access
         instance_store = self.conn._get_instance_store(namespace)
 
         if self.default_namespace not in self.repo.namespaces:

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -368,8 +368,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                                         "in class {3!A}. Not overridable ",
                                         obj_type, obj_name, inh_qname,
                                         new_class.classname))
-                        else:
-                            new_quals[inh_qname].propagated = True
+                        new_quals[inh_qname].propagated = True
 
                     else:  # not in new class, add it
                         new_quals[inh_qname] = inherited_quals[inh_qname].copy()

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -379,16 +379,20 @@ class FakedWBEMConnection(WBEMConnection):
             s=self, super=super(FakedWBEMConnection, self).__repr__())
 
     def _get_qualifier_store(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         return self.cimrepository.get_qualifier_store(namespace)
 
     def _get_class_store(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         return self.cimrepository.get_class_store(namespace)
 
     def _get_instance_store(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         return self.cimrepository.get_instance_store(namespace)
 
     # TODO: This changes when we add provider concept.
     def _get_method_repo(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         self.cimrepository.validate_namespace(namespace)
         if namespace not in self.methods:
             self.methods[namespace] = NocaseDict()
@@ -399,9 +403,11 @@ class FakedWBEMConnection(WBEMConnection):
     # this class. they are considered part of the external API.
 
     def add_namespace(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         self.cimrepository.add_namespace(namespace)
 
     def remove_namespace(self, namespace):
+        # pylint: disable=missing-function-docstring,missing-docstring
         self.cimrepository.remove_namespace(namespace)
 
     ###########################################################################
@@ -693,6 +699,7 @@ class FakedWBEMConnection(WBEMConnection):
             if isinstance(obj, CIMClass):
                 cc = obj.copy()
                 if cc.superclass:
+                    # pylint: disable=protected-access
                     if not self.cimrepository._class_exists(cc.superclass,
                                                             namespace):
                         raise ValueError(
@@ -704,6 +711,7 @@ class FakedWBEMConnection(WBEMConnection):
 
                 qualifier_store = self._get_qualifier_store(namespace)
 
+                # pylint: disable=protected-access
                 cc1 = self.cimrepository._resolve_class(cc, namespace,
                                                         qualifier_store,
                                                         verbose=False)
@@ -725,6 +733,7 @@ class FakedWBEMConnection(WBEMConnection):
                     inst.path.host = None
                 instance_store = self._get_instance_store(namespace)
                 try:
+                    # pylint: disable=protected-access
                     if self.cimrepository._find_instance(inst.path,
                                                          instance_store):
                         raise ValueError(
@@ -952,7 +961,7 @@ class FakedWBEMConnection(WBEMConnection):
         else:
             # Display classes and qualifier declarations sorted
             assert obj_type in ['Classes', 'Qualifier Declarations']
-            names = [n for n in object_repo.iter_names()]
+            names = list(object_repo.iter_names())
             if names:
                 for name in sorted(names):
                     obj = object_repo.get(name)
@@ -1067,6 +1076,7 @@ class FakedWBEMConnection(WBEMConnection):
         # This raises CIM_ERR_NOT_FOUND or CIM_ERR_INVALID_NAMESPACE
         # Uses local_only = False to get characteristics from super classes
         # and include_class_origin to get origin of method in hiearchy
+        # pylint: disable=protected-access
         cc = self.cimrepository._get_class(localobject.classname, namespace,
                                            local_only=False,
                                            include_qualifiers=True,
@@ -1085,6 +1095,7 @@ class FakedWBEMConnection(WBEMConnection):
             # Issue #2062: add method to repo that allows privileged users
             # direct access so we don't have to go through _get_class and can
             # test classes directly in repo
+            # pylint: disable=protected-access
             tcc = self.cimrepository._get_class(target_cln, namespace,
                                                 local_only=False,
                                                 include_qualifiers=True,

--- a/tests/end2endtest/utils/server_definition_file.py
+++ b/tests/end2endtest/utils/server_definition_file.py
@@ -59,8 +59,7 @@ class ServerDefinitionFile(object):
                     "The WBEM server definition file {0!r} was not found; "
                     "copy it from {1!r}".
                     format(self._filepath, EXAMPLE_SERVER_FILE))
-            else:
-                raise
+            raise
         else:
             if data is None:
                 raise ServerDefinitionFileError(
@@ -167,11 +166,11 @@ class ServerDefinitionFile(object):
                         sd_list.append(sd)
                         sd_nick_list.append(sd.nickname)
             return sd_list
-        else:
-            raise ValueError(
-                "Server group or server with nickname {0!r} not found in WBEM "
-                "server definition file {1!r}".
-                format(nickname, self._filepath))
+
+        raise ValueError(
+            "Server group or server with nickname {0!r} not found in WBEM "
+            "server definition file {1!r}".
+            format(nickname, self._filepath))
 
     def list_all_servers(self):
         """

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -209,8 +209,7 @@ def instance_of(conn, obj_list, classname):
                     "namespace {3!r}".
                     format(conn.server_definition.nickname, conn.url,
                            classname, namespace))
-            else:
-                conn.raise_as_assertion_error(exc, 'EnumerateInstanceNames')
+            conn.raise_as_assertion_error(exc, 'EnumerateInstanceNames')
         except Error as exc:
             conn.raise_as_assertion_error(exc, 'EnumerateInstanceNames')
         ENUM_INST_CACHE.add_list(conn.url, enum_paths_id, enum_paths)

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -129,6 +129,7 @@ Syntax elements:
 
 from __future__ import absolute_import, print_function
 
+import sys
 import doctest
 import socket
 import re
@@ -168,7 +169,6 @@ class ExcThread(threading.Thread):
         try:
             threading.Thread.run(self)
         except Exception:  # pylint: disable=broad-except
-            import sys
             self.exc = sys.exc_info()
 
     def join(self, timeout=None):
@@ -285,7 +285,7 @@ class YamlItem(pytest.Item):
         runtestcase(self.testcase)
 
     @staticmethod
-    def repr_failure(excinfo):
+    def repr_failure(excinfo, style=None):
         """
         Called by py.test when the runtest() method raised an exception, to
         provide details about the failure.
@@ -293,7 +293,7 @@ class YamlItem(pytest.Item):
         exc = excinfo.value
         if isinstance(exc, ClientTestFailure):  # pylint: disable=no-else-return
             return "Failure running test case: %s" % exc
-        elif isinstance(exc, ClientTestError):
+        if isinstance(exc, ClientTestError):
             return "Error in definition of test case: %s" % exc
         return "Error: %s" % exc
 
@@ -922,7 +922,7 @@ def runtestcase(testcase):
                                  "operation %s, but no exception was "
                                  "actually raised." %
                                  (tc_name, exp_exception, op_name))
-        elif raised_exception.__class__.__name__ != exp_exception:
+        if raised_exception.__class__.__name__ != exp_exception:
             raise AssertionError("Testcase %s: A %s exception was "
                                  "expected to be raised by PyWBEM "
                                  "operation %s, but a different "

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -404,10 +404,10 @@ class ClientTest(unittest.TestCase):
         """
         if ignore_host:
             if path1.host is not None:
-                path1 = path1
+                path1 = path1.copy()
                 path1.host = None
             if path2.host is not None:
-                path2 = path2
+                path2 = path2.copy()
                 path2.host = None
 
         return path1 == path2
@@ -483,10 +483,10 @@ class ClientTest(unittest.TestCase):
                         self.assertTrue(isinstance(inst2, CIMInstance))
                         if ignore_host:
                             if inst1.path.host is not None:
-                                inst1 = inst1
+                                inst1 = inst1.copy()
                                 inst1.path.host = None
                             if inst2.path.host is not None:
-                                inst2 = inst2
+                                inst2 = inst2.copy()
                                 inst2.path.host = None
                         # detailed test of instance components if not equal
                         if inst1 != inst2:
@@ -553,7 +553,7 @@ class ClientTest(unittest.TestCase):
                           (path1, paths2))
             else:
                 for path2 in paths2:
-                    if self.pathsEqual(path2, path1, ignore_host=ignore_host):
+                    if self.pathsEqual(path1, path2, ignore_host=ignore_host):
                         return
                 self.fail('assertPathsEqual fail')
 
@@ -4602,7 +4602,7 @@ class IterEnumerateInstances(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_instances = [inst for inst in generator]
+        iter_instances = list(generator)
 
         if expected_response_count is not None:
             self.assertEqual(len(iter_instances), expected_response_count)
@@ -4924,7 +4924,7 @@ class IterEnumerateInstancePaths(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_paths = [path for path in generator]
+        iter_paths = list(generator)
 
         # execute open/pull operation sequence
         result = self.cimcall(self.conn.OpenEnumerateInstancePaths, ClassName,
@@ -5088,7 +5088,7 @@ class IterReferenceInstances(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_instances = [instance for instance in generator]
+        iter_instances = list(generator)
 
         # execute pull operation
         result = self.cimcall(self.conn.OpenReferenceInstances,
@@ -5263,7 +5263,7 @@ class IterReferenceInstancePaths(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_paths = [path for path in generator]
+        iter_paths = list(generator)
 
         # execute open/pull operation sequence
         result = self.cimcall(self.conn.OpenReferenceInstancePaths,
@@ -5429,7 +5429,7 @@ class IterAssociatorInstances(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_instances = [instance for instance in generator]
+        iter_instances = list(generator)
 
         # execute pull operation
         result = self.cimcall(self.conn.OpenAssociatorInstances,
@@ -5614,7 +5614,7 @@ class IterAssociatorInstancePaths(PegasusServerTestBase):
                                  ContinueOnError=ContinueOnError,
                                  MaxObjectCount=MaxObjectCount)
         self.assertTrue(isinstance(generator, types.GeneratorType))
-        iter_paths = [path for path in generator]
+        iter_paths = list(generator)
 
         # execute pull operation
         result = self.cimcall(self.conn.OpenAssociatorInstancePaths,

--- a/tests/manualtest/run_operationtimeouts.py
+++ b/tests/manualtest/run_operationtimeouts.py
@@ -201,7 +201,7 @@ class ServerTimeoutTest(ClientTest):
                 execution_time,
                 err_flag))
 
-        return (True if request_result == 1 else False)
+        return (request_result == 1)
 
     def test_all(self):
         """ Tests all of the variations in a loop."""
@@ -302,7 +302,8 @@ def parse_args(argv_):
         if argv[1][0] != '-':
             # Stop at first non-option
             break
-        elif argv[1] == '-t':
+
+        if argv[1] == '-t':
             args_['maxtimeout'] = int(argv[2])
             del argv[1:3]
         elif argv[1] == '-d':

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -18315,6 +18315,9 @@ TESTCASES_CIMPROPERTY_TOMOF = [
         ),
         None, None, True
     ),
+
+    # pylint: disable=line-too-long
+
     (
         "instance string property, with multi-line scalar value",
         dict(
@@ -18327,7 +18330,6 @@ TESTCASES_CIMPROPERTY_TOMOF = [
                 is_instance=True,
                 indent=12,
             ),
-            # pylint: disable=line-too-long
             exp_mof=u"""\
             P1 =
                "abc def abc def abc def abc def abc def abc def abc def abc "
@@ -18339,6 +18341,11 @@ TESTCASES_CIMPROPERTY_TOMOF = [
         ),
         None, None, True
     ),
+
+    # pylint: enable=line-too-long
+
+    # pylint: disable=line-too-long
+
     (
         "instance string array property, with multi-line short items",
         dict(
@@ -18351,7 +18358,6 @@ TESTCASES_CIMPROPERTY_TOMOF = [
                 is_instance=True,
                 indent=12,
             ),
-            # pylint: disable=line-too-long
             exp_mof=u"""\
             P1 = { "abcdef00", "abcdef01", "abcdef02", "abcdef03", "abcdef04",
                "abcdef05", "abcdef06", "abcdef07", "abcdef08", "abcdef09" };\n""" \
@@ -18371,6 +18377,9 @@ TESTCASES_CIMPROPERTY_TOMOF = [
         ),
         None, None, True
     ),
+
+    # pylint: enable=line-too-long
+
     (
         "instance uint32 property",
         dict(
@@ -23274,6 +23283,9 @@ TESTCASES_CIMQUALIFIER_TOMOF = [
         ),
         None, None, True
     ),
+
+    # pylint: disable=line-too-long
+
     (
         "string array type with multi line value with short items",
         dict(
@@ -23285,7 +23297,6 @@ TESTCASES_CIMQUALIFIER_TOMOF = [
             kwargs=dict(
                 indent=12,
             ),
-            # pylint: disable=line-too-long
             exp_mof=u"""Q1 { "abcdef00", "abcdef01", "abcdef02", "abcdef03", "abcdef04", "abcdef05",
             "abcdef06", "abcdef07", "abcdef08", "abcdef09" }""" \
             if CHECK_0_12_0 else \
@@ -23294,6 +23305,9 @@ TESTCASES_CIMQUALIFIER_TOMOF = [
         ),
         None, None, True
     ),
+
+    # pylint: enable=line-too-long
+
     (
         "string array type with with long items",
         dict(
@@ -27703,7 +27717,6 @@ class C1 : C2 {
                 ],
             ),
             kwargs=dict(),
-            # pylint: disable=line-too-long
             exp_mof=u"""\
 class C1 {
 

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -109,7 +109,7 @@ def send_indication(url, headers, payload, verbose):
                                                          response.headers,
                                                          response.text))
 
-    return True if(response.status_code == 200) else False
+    return (response.status_code == 200)
 
 
 def _process_indication(indication, host):

--- a/tests/unittest/pywbem/test_itermethods.py
+++ b/tests/unittest/pywbem/test_itermethods.py
@@ -123,30 +123,31 @@ class TestIterEnumerateInstances(object):
         conn.OpenEnumerateInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations == use_pull_param)
+        assert conn._use_enum_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterEnumerateInstances('CIM_Foo',
-                                              namespace=ns,
-                                              LocalOnly=lo,
-                                              DeepInheritance=di,
-                                              IncludeQualifiers=iq,
-                                              IncludeClassOrigin=ico,
-                                              PropertyList=pl)]
+        result = list(conn.IterEnumerateInstances(
+            'CIM_Foo',
+            namespace=ns,
+            LocalOnly=lo,
+            DeepInheritance=di,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl))
 
-        conn.EnumerateInstances.assert_called_with('CIM_Foo',
-                                                   namespace=ns,
-                                                   LocalOnly=lo,
-                                                   DeepInheritance=di,
-                                                   IncludeQualifiers=iq,
-                                                   IncludeClassOrigin=ico,
-                                                   PropertyList=pl)
+        conn.EnumerateInstances.assert_called_with(
+            'CIM_Foo',
+            namespace=ns,
+            LocalOnly=lo,
+            DeepInheritance=di,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl)
 
-        assert(conn._use_enum_inst_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_enum_inst_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -162,20 +163,19 @@ class TestIterEnumerateInstances(object):
         conn.OpenEnumerateInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations is True)
+        assert conn._use_enum_inst_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-argument
-            _ = [i for i in conn.IterEnumerateInstances('CIM_Foo')]  # noqa=F841
+            _ = list(conn.IterEnumerateInstances('CIM_Foo'))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_enum_inst_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -217,23 +217,24 @@ class TestIterEnumerateInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations == use_pull_param)
+        assert conn._use_enum_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterEnumerateInstances('CIM_Foo',
-                                              namespace=ns,
-                                              LocalOnly=lo,
-                                              DeepInheritance=di,
-                                              IncludeQualifiers=iq,
-                                              IncludeClassOrigin=ico,
-                                              PropertyList=pl,
-                                              FilterQueryLanguage=fl,
-                                              FilterQuery=fq,
-                                              OperationTimeout=ot,
-                                              ContinueOnError=coe,
-                                              MaxObjectCount=moc)]
+        result = list(conn.IterEnumerateInstances(
+            'CIM_Foo',
+            namespace=ns,
+            LocalOnly=lo,
+            DeepInheritance=di,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl,
+            FilterQueryLanguage=fl,
+            FilterQuery=fq,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc))
+
         conn.OpenEnumerateInstances.assert_called_with(
             'CIM_Foo',
             namespace=ns,
@@ -247,9 +248,9 @@ class TestIterEnumerateInstances(object):
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_enum_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -272,15 +273,15 @@ class TestIterEnumerateInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_inst_pull_operations == use_pull_param)
+        assert conn._use_enum_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterEnumerateInstances('CIM_Foo')]
+        result = list(conn.IterEnumerateInstances('CIM_Foo'))
 
-        assert(conn._use_enum_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_enum_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -296,10 +297,9 @@ class TestIterEnumerateInstances(object):
         conn.OpenEnumerateInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterEnumerateInstances('CIM_Foo',
-                                                  MaxObjectCount=max_cnt)]
+            _ = list(conn.IterEnumerateInstances(
+                'CIM_Foo',
+                MaxObjectCount=max_cnt))
 
 
 ########################################################################
@@ -328,21 +328,22 @@ class TestIterEnumerateInstancePaths(object):
         conn.OpenEnumerateInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations == use_pull_param)
+        assert conn._use_enum_path_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterEnumerateInstancePaths(
+        result = list(conn.IterEnumerateInstancePaths(
             'CIM_Foo',
-            namespace=ns)]
+            namespace=ns))
 
-        conn.EnumerateInstanceNames.assert_called_with('CIM_Foo',
-                                                       namespace=ns)
+        conn.EnumerateInstanceNames.assert_called_with(
+            'CIM_Foo',
+            namespace=ns)
 
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_enum_path_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -356,20 +357,19 @@ class TestIterEnumerateInstancePaths(object):
         conn.OpenEnumerateInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations is True)
+        assert conn._use_enum_path_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=expression-not-assigned
-            [i for i in conn.IterEnumerateInstancePaths('CIM_Foo')]  # noqa=F841
+            _ = list(conn.IterEnumerateInstancePaths('CIM_Foo'))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_enum_path_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -404,18 +404,18 @@ class TestIterEnumerateInstancePaths(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations == use_pull_param)
+        assert conn._use_enum_path_pull_operations == use_pull_param
 
-        result = [p for p in conn.IterEnumerateInstancePaths(
+        result = list(conn.IterEnumerateInstancePaths(
             'CIM_Foo',
             namespace=ns,
             FilterQueryLanguage=fl,
             FilterQuery=fq,
             OperationTimeout=ot,
             ContinueOnError=coe,
-            MaxObjectCount=moc)]
+            MaxObjectCount=moc))
 
         conn.OpenEnumerateInstancePaths.assert_called_with(
             'CIM_Foo',
@@ -427,9 +427,9 @@ class TestIterEnumerateInstancePaths(object):
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_enum_path_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -452,17 +452,17 @@ class TestIterEnumerateInstancePaths(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations == use_pull_param)
+        assert conn._use_enum_path_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterEnumerateInstancePaths('CIM_Foo')]
+        result = list(conn.IterEnumerateInstancePaths('CIM_Foo'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_enum_path_pull_operations is True)
+        assert conn._use_enum_path_pull_operations is True
 
-        assert(result == tst_paths)
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -477,11 +477,11 @@ class TestIterEnumerateInstancePaths(object):
         conn.EnumerateInstanceNames = Mock(return_value=tst_paths)
         conn.OpenEnumeratePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
+
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterEnumerateInstancePaths('CIM_Foo',
-                                                      MaxObjectCount=max_cnt)]
+            _ = list(conn.IterEnumerateInstancePaths(
+                'CIM_Foo',
+                MaxObjectCount=max_cnt))
 
 
 ########################################################################
@@ -545,28 +545,29 @@ class TestIterReferenceInstances(object):
         conn.OpenReferenceInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations == use_pull_param)
+        assert conn._use_ref_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterReferenceInstances(self.target_path(ns),
-                                              ResultClass=rc,
-                                              Role=ro,
-                                              IncludeQualifiers=iq,
-                                              IncludeClassOrigin=ico,
-                                              PropertyList=pl)]
+        result = list(conn.IterReferenceInstances(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl))
 
-        conn.References.assert_called_with(self.target_path(ns),
-                                           ResultClass=rc,
-                                           Role=ro,
-                                           IncludeQualifiers=iq,
-                                           IncludeClassOrigin=ico,
-                                           PropertyList=pl)
+        conn.References.assert_called_with(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl)
 
-        assert(conn._use_ref_inst_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_ref_inst_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -582,21 +583,20 @@ class TestIterReferenceInstances(object):
         conn.OpenReferenceInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations is True)
+        assert conn._use_ref_inst_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-argument
-            _ = [i for i in conn.IterReferenceInstances(  # noqa=F841
-                self.target_path('root/cimv2'))]
+            _ = list(conn.IterReferenceInstances(
+                self.target_path('root/cimv2')))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_ref_inst_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -645,21 +645,23 @@ class TestIterReferenceInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations == use_pull_param)
-        result = [inst for inst in
-                  conn.IterReferenceInstances(self.target_path(ns),
-                                              ResultClass=rc,
-                                              Role=ro,
-                                              IncludeQualifiers=iq,
-                                              IncludeClassOrigin=ico,
-                                              PropertyList=pl,
-                                              FilterQueryLanguage=fl,
-                                              FilterQuery=fq,
-                                              OperationTimeout=ot,
-                                              ContinueOnError=coe,
-                                              MaxObjectCount=moc)]
+        assert conn._use_ref_inst_pull_operations == use_pull_param
+
+        result = list(conn.IterReferenceInstances(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl,
+            FilterQueryLanguage=fl,
+            FilterQuery=fq,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc))
+
         conn.OpenReferenceInstances.assert_called_with(
             self.target_path(ns),
             ResultClass=rc,
@@ -673,9 +675,9 @@ class TestIterReferenceInstances(object):
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_ref_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -700,16 +702,16 @@ class TestIterReferenceInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_inst_pull_operations == use_pull_param)
+        assert conn._use_ref_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterReferenceInstances(
-            self.target_path('root/cimv2'))]
+        result = list(conn.IterReferenceInstances(
+            self.target_path('root/cimv2')))
 
-        assert(conn._use_ref_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_ref_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -724,11 +726,11 @@ class TestIterReferenceInstances(object):
         conn.References = Mock(return_value=tst_insts)
         conn.OpenReferenceInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
+
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterReferenceInstances(self.target_path('root/x'),
-                                                  MaxObjectCount=max_cnt)]
+            _ = list(conn.IterReferenceInstances(
+                self.target_path('root/x'),
+                MaxObjectCount=max_cnt))
 
 
 ########################################################################
@@ -784,22 +786,23 @@ class TestIterReferenceInstancePaths(object):
         conn.OpenReferenceInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations == use_pull_param)
+        assert conn._use_ref_path_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterReferenceInstancePaths(self.target_path(ns),
-                                                  ResultClass=rc,
-                                                  Role=ro)]
+        result = list(conn.IterReferenceInstancePaths(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro))
 
-        conn.ReferenceNames.assert_called_with(self.target_path(ns),
-                                               ResultClass=rc,
-                                               Role=ro)
+        conn.ReferenceNames.assert_called_with(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro)
 
-        assert(conn._use_ref_path_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_ref_path_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -815,21 +818,20 @@ class TestIterReferenceInstancePaths(object):
         conn.OpenReferenceInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations is True)
+        assert conn._use_ref_path_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-argument
-            _ = [i for i in conn.IterReferenceInstancePaths(  # noqa=F841
-                self.target_path('root/cimv2'))]
+            _ = list(conn.IterReferenceInstancePaths(
+                self.target_path('root/cimv2')))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_ref_path_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -869,18 +871,20 @@ class TestIterReferenceInstancePaths(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations == use_pull_param)
-        result = [inst for inst in
-                  conn.IterReferenceInstancePaths(self.target_path(ns),
-                                                  ResultClass=rc,
-                                                  Role=ro,
-                                                  FilterQueryLanguage=fl,
-                                                  FilterQuery=fq,
-                                                  OperationTimeout=ot,
-                                                  ContinueOnError=coe,
-                                                  MaxObjectCount=moc)]
+        assert conn._use_ref_path_pull_operations == use_pull_param
+
+        result = list(conn.IterReferenceInstancePaths(
+            self.target_path(ns),
+            ResultClass=rc,
+            Role=ro,
+            FilterQueryLanguage=fl,
+            FilterQuery=fq,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc))
+
         conn.OpenReferenceInstancePaths.assert_called_with(
             self.target_path(ns),
             ResultClass=rc,
@@ -892,9 +896,9 @@ class TestIterReferenceInstancePaths(object):
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_ref_path_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -919,16 +923,16 @@ class TestIterReferenceInstancePaths(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_ref_path_pull_operations == use_pull_param)
+        assert conn._use_ref_path_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterReferenceInstancePaths(
-            self.target_path('root/cimv2'))]
+        result = list(conn.IterReferenceInstancePaths(
+            self.target_path('root/cimv2')))
 
-        assert(conn._use_ref_path_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_ref_path_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -943,11 +947,11 @@ class TestIterReferenceInstancePaths(object):
         conn.ReferenceNames = Mock(return_value=tst_insts)
         conn.OpenReferenceInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
+
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterReferenceInstancePaths(self.target_path('dum'),
-                                                      MaxObjectCount=max_cnt)]
+            _ = list(conn.IterReferenceInstancePaths(
+                self.target_path('dum'),
+                MaxObjectCount=max_cnt))
 
 ########################################################################
 #
@@ -1010,32 +1014,33 @@ class TestIterAssociatorInstances(object):
         conn.OpenAssociatorInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations == use_pull_param)
+        assert conn._use_assoc_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterAssociatorInstances(self.target_path(ns),
-                                               AssocClass=ac,
-                                               ResultClass=rc,
-                                               Role=ro,
-                                               ResultRole=rr,
-                                               IncludeQualifiers=iq,
-                                               IncludeClassOrigin=ico,
-                                               PropertyList=pl)]
+        result = list(conn.IterAssociatorInstances(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl))
 
-        conn.Associators.assert_called_with(self.target_path(ns),
-                                            AssocClass=ac,
-                                            ResultClass=rc,
-                                            Role=ro,
-                                            ResultRole=rr,
-                                            IncludeQualifiers=iq,
-                                            IncludeClassOrigin=ico,
-                                            PropertyList=pl)
+        conn.Associators.assert_called_with(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl)
 
-        assert(conn._use_assoc_inst_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_assoc_inst_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -1051,21 +1056,20 @@ class TestIterAssociatorInstances(object):
         conn.OpenAssociatorInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations is True)
+        assert conn._use_assoc_inst_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-argument
-            _ = [i for i in conn.IterAssociatorInstances(  # noqa=F841
-                self.target_path('root/cimv2'))]
+            _ = list(conn.IterAssociatorInstances(
+                self.target_path('root/cimv2')))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_assoc_inst_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1114,23 +1118,25 @@ class TestIterAssociatorInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations == use_pull_param)
-        result = [inst for inst in
-                  conn.IterAssociatorInstances(self.target_path(ns),
-                                               AssocClass=ac,
-                                               ResultClass=rc,
-                                               Role=ro,
-                                               ResultRole=rr,
-                                               IncludeQualifiers=iq,
-                                               IncludeClassOrigin=ico,
-                                               PropertyList=pl,
-                                               FilterQueryLanguage=fl,
-                                               FilterQuery=fq,
-                                               OperationTimeout=ot,
-                                               ContinueOnError=coe,
-                                               MaxObjectCount=moc)]
+        assert conn._use_assoc_inst_pull_operations == use_pull_param
+
+        result = list(conn.IterAssociatorInstances(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr,
+            IncludeQualifiers=iq,
+            IncludeClassOrigin=ico,
+            PropertyList=pl,
+            FilterQueryLanguage=fl,
+            FilterQuery=fq,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc))
+
         conn.OpenAssociatorInstances.assert_called_with(
             self.target_path(ns),
             AssocClass=ac,
@@ -1146,9 +1152,9 @@ class TestIterAssociatorInstances(object):
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_assoc_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1173,16 +1179,16 @@ class TestIterAssociatorInstances(object):
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_inst_pull_operations == use_pull_param)
+        assert conn._use_assoc_inst_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterAssociatorInstances(
-            self.target_path('root/cimv2'))]
+        result = list(conn.IterAssociatorInstances(
+            self.target_path('root/cimv2')))
 
-        assert(conn._use_assoc_inst_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_insts)
+        assert conn._use_assoc_inst_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_insts
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -1197,11 +1203,11 @@ class TestIterAssociatorInstances(object):
         conn.Associators = Mock(return_value=tst_insts)
         conn.OpenAssociatorInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
+
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterAssociatorInstances(self.target_path('root/x'),
-                                                   MaxObjectCount=max_cnt)]
+            _ = list(conn.IterAssociatorInstances(
+                self.target_path('root/x'),
+                MaxObjectCount=max_cnt))
 
 ########################################################################
 #
@@ -1257,26 +1263,27 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
         conn.OpenAssociatorInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations == use_pull_param)
+        assert conn._use_assoc_path_pull_operations == use_pull_param
 
-        result = [inst for inst in
-                  conn.IterAssociatorInstancePaths(self.target_path(ns),
-                                                   AssocClass=ac,
-                                                   ResultClass=rc,
-                                                   Role=ro,
-                                                   ResultRole=rr)]
+        result = list(conn.IterAssociatorInstancePaths(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr))
 
-        conn.AssociatorNames.assert_called_with(self.target_path(ns),
-                                                AssocClass=ac,
-                                                ResultClass=rc,
-                                                Role=ro,
-                                                ResultRole=rr)
+        conn.AssociatorNames.assert_called_with(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr)
 
-        assert(conn._use_assoc_path_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_assoc_path_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     def test_operation_fail(self, tst_paths):
         # pylint: disable=no-self-use
@@ -1292,21 +1299,20 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
         conn.OpenAssociatorInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations is True)
+        assert conn._use_assoc_path_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-argument
-            _ = [i for i in conn.IterAssociatorInstancePaths(  # noqa=F841
-                self.target_path('root/cimv2'))]
+            _ = list(conn.IterAssociatorInstancePaths(
+                self.target_path('root/cimv2')))
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_assoc_path_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1346,20 +1352,22 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations == use_pull_param)
-        result = [inst for inst in
-                  conn.IterAssociatorInstancePaths(self.target_path(ns),
-                                                   AssocClass=ac,
-                                                   ResultClass=rc,
-                                                   Role=ro,
-                                                   ResultRole=rr,
-                                                   FilterQueryLanguage=fl,
-                                                   FilterQuery=fq,
-                                                   OperationTimeout=ot,
-                                                   ContinueOnError=coe,
-                                                   MaxObjectCount=moc)]
+        assert conn._use_assoc_path_pull_operations == use_pull_param
+
+        result = list(conn.IterAssociatorInstancePaths(
+            self.target_path(ns),
+            AssocClass=ac,
+            ResultClass=rc,
+            Role=ro,
+            ResultRole=rr,
+            FilterQueryLanguage=fl,
+            FilterQuery=fq,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc))
+
         conn.OpenAssociatorInstancePaths.assert_called_with(
             self.target_path(ns),
             AssocClass=ac,
@@ -1373,9 +1381,9 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
             MaxObjectCount=moc)
 
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_assoc_path_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1400,16 +1408,16 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
                                                      eos=True,
                                                      context=None))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations == use_pull_param)
+        assert conn._use_assoc_path_pull_operations == use_pull_param
 
-        result = [inst for inst in conn.IterAssociatorInstancePaths(
-            self.target_path('root/cimv2'))]
+        result = list(conn.IterAssociatorInstancePaths(
+            self.target_path('root/cimv2')))
 
-        assert(conn._use_assoc_path_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result == tst_paths)
+        assert conn._use_assoc_path_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result == tst_paths
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -1424,11 +1432,11 @@ class TestIterAssociatorInstancePaths(object):  # pylint: disable=invalid-name
         conn.AssociatorNames = Mock(return_value=tst_paths)
         conn.OpenAssociatorInstancePaths = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
+
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            result = [inst for inst in  # noqa F841
-                      conn.IterAssociatorInstancePaths(self.target_path('dum'),
-                                                       MaxObjectCount=max_cnt)]
+            _ = list(conn.IterAssociatorInstancePaths(
+                self.target_path('dum'),
+                MaxObjectCount=max_cnt))
 
 
 ########################################################################
@@ -1463,19 +1471,19 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
         conn.OpenQueryInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'Blah'))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations == use_pull_param)
+        assert conn._use_query_pull_operations == use_pull_param
 
         q_result = conn.IterQueryInstances(ql, query, namespace=ns)
-        result_insts = [inst for inst in q_result.generator]
+        result_insts = list(q_result.generator)
 
         conn.ExecQuery.assert_called_with(ql, query, namespace=ns)
 
-        assert(q_result.query_result_class is None)
-        assert(conn._use_query_pull_operations is False)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result_insts == tst_insts)
+        assert q_result.query_result_class is None
+        assert conn._use_query_pull_operations is False
+        assert conn.use_pull_operations == use_pull_param
+        assert result_insts == tst_insts
 
     def test_operation_fail(self, tst_insts):
         # pylint: disable=no-self-use
@@ -1491,21 +1499,19 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
         conn.OpenQueryInstances = \
             Mock(side_effect=CIMError(CIM_ERR_NOT_SUPPORTED, 'description'))
 
-        assert(conn.use_pull_operations is True)
+        assert conn.use_pull_operations is True
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations is True)
+        assert conn._use_query_pull_operations is True
 
         with pytest.raises(CIMError) as exec_info:
-            # pylint: disable=unused-variable
-            q_result = conn.IterQueryInstances(  # noqa=F841
-                'CQL', 'Select from *')
+            conn.IterQueryInstances('CQL', 'Select from *')
 
         exc = exec_info.value
-        assert(exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED')
+        assert exc.status_code_name == 'CIM_ERR_NOT_SUPPORTED'
 
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations is True)
-        assert(conn.use_pull_operations is True)
+        assert conn._use_query_pull_operations is True
+        assert conn.use_pull_operations is True
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1547,31 +1553,34 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
                                                       context=None,
                                                       query_result_class=qrc))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations == use_pull_param)
+        assert conn._use_query_pull_operations == use_pull_param
 
-        q_result = conn.IterQueryInstances(ql, query, namespace=ns,
-                                           ReturnQueryResultClass=rqrc_param,
-                                           OperationTimeout=ot,
-                                           ContinueOnError=coe,
-                                           MaxObjectCount=moc)
-
-        conn.OpenQueryInstances.assert_called_with(
-            ql, query, namespace=ns,
+        q_result = conn.IterQueryInstances(
+            ql, query,
+            namespace=ns,
             ReturnQueryResultClass=rqrc_param,
             OperationTimeout=ot,
             ContinueOnError=coe,
             MaxObjectCount=moc)
 
-        result_insts = [inst for inst in q_result.generator]
+        conn.OpenQueryInstances.assert_called_with(
+            ql, query,
+            namespace=ns,
+            ReturnQueryResultClass=rqrc_param,
+            OperationTimeout=ot,
+            ContinueOnError=coe,
+            MaxObjectCount=moc)
 
-        assert(q_result.query_result_class == qrc)
+        result_insts = list(q_result.generator)
+
+        assert q_result.query_result_class == qrc
 
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result_insts == tst_insts)
+        assert conn._use_query_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result_insts == tst_insts
 
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
@@ -1608,14 +1617,15 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
                                                       context=None,
                                                       query_result_class=qrc))
 
-        assert(conn.use_pull_operations == use_pull_param)
+        assert conn.use_pull_operations == use_pull_param
         # pylint: disable=protected-access
-        assert(conn._use_assoc_path_pull_operations == use_pull_param)
+        assert conn._use_assoc_path_pull_operations == use_pull_param
 
-        q_result = conn.IterQueryInstances('CQL', 'Select from *',
-                                           ReturnQueryResultClass=rqrc_param)
+        q_result = conn.IterQueryInstances(
+            'CQL', 'Select from *',
+            ReturnQueryResultClass=rqrc_param)
 
-        result_insts = [inst for inst in q_result.generator]
+        result_insts = list(q_result.generator)
 
         conn.OpenQueryInstances.assert_called_with(
             'CQL', 'Select from *',
@@ -1629,9 +1639,9 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
         # assert(q_result.query_result_class == rc)
 
         # pylint: disable=protected-access
-        assert(conn._use_query_pull_operations is True)
-        assert(conn.use_pull_operations == use_pull_param)
-        assert(result_insts == tst_insts)
+        assert conn._use_query_pull_operations is True
+        assert conn.use_pull_operations == use_pull_param
+        assert result_insts == tst_insts
 
     @pytest.mark.parametrize(
         "max_cnt", [0, -1]
@@ -1651,6 +1661,6 @@ class TestIterQueryInstances(object):  # pylint: disable=invalid-name
                                                       context=None,
                                                       query_result_class=None))
         with pytest.raises(ValueError):
-            # pylint: disable=unused-variable
-            q_result = conn.IterQueryInstances(  # noqa=F841
-                'CQL', 'Select from *', MaxObjectCount=max_cnt)
+            conn.IterQueryInstances(
+                'CQL', 'Select from *',
+                MaxObjectCount=max_cnt)

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -1377,51 +1377,54 @@ class BaseTestLexer(unittest.TestCase):
 
             if act_token is None and exp_token is None:
                 break  # successfully came to the end
-            elif act_token is None and exp_token is not None:
+
+            if act_token is None and exp_token is not None:
                 self.fail("Not enough tokens found, expected: %r" % exp_token)
-            elif act_token is not None and exp_token is None:
+
+            if act_token is not None and exp_token is None:
                 self.fail("Too many tokens found: %r" % act_token)
+
+            # We have both an expected and an actual token
+            if isinstance(exp_token, LexErrorToken):
+                # We expect an error
+                if self.last_error_t is None:
+                    self.fail("t_error() was not called as expected, "
+                              "actual token: %r" % act_token)
+
+                self.assertTrue(
+                    self.last_error_t.type == exp_token.type and
+                    self.last_error_t.value == exp_token.value,
+                    "t_error() was called with an unexpected "
+                    "token: %r (expected: %r)" %
+                    (self.last_error_t, exp_token))
+
             else:
-                # We have both an expected and an actual token
-                if isinstance(exp_token, LexErrorToken):
-                    # We expect an error
-                    if self.last_error_t is None:
-                        self.fail("t_error() was not called as expected, "
-                                  "actual token: %r" % act_token)
-                    else:
-                        self.assertTrue(
-                            self.last_error_t.type == exp_token.type and
-                            self.last_error_t.value == exp_token.value,
-                            "t_error() was called with an unexpected "
-                            "token: %r (expected: %r)" %
-                            (self.last_error_t, exp_token))
-                else:
-                    # We do not expect an error
-                    if self.last_error_t is not None:
-                        self.fail(
-                            "t_error() was unexpectedly called with "
-                            "token: %r" % self.last_error_t)
-                    else:
-                        self.assertTrue(
-                            act_token.type == exp_token.type,
-                            "Unexpected token type: %r (expected: %r) "
-                            "in token: %r" %
-                            (act_token.type, exp_token.type, act_token))
-                        self.assertTrue(
-                            act_token.value == exp_token.value,
-                            "Unexpected token value: %r (expected: %r) "
-                            "in token: %r" %
-                            (act_token.value, exp_token.value, act_token))
-                        self.assertTrue(
-                            act_token.lineno == exp_token.lineno,
-                            "Unexpected token lineno: %r (expected: %r) "
-                            "in token: %r" %
-                            (act_token.lineno, exp_token.lineno, act_token))
-                        self.assertTrue(
-                            act_token.lexpos == exp_token.lexpos,
-                            "Unexpected token lexpos: %r (expected: %r) "
-                            "in token: %r" %
-                            (act_token.lexpos, exp_token.lexpos, act_token))
+                # We do not expect an error
+                if self.last_error_t is not None:
+                    self.fail(
+                        "t_error() was unexpectedly called with "
+                        "token: %r" % self.last_error_t)
+
+                self.assertTrue(
+                    act_token.type == exp_token.type,
+                    "Unexpected token type: %r (expected: %r) "
+                    "in token: %r" %
+                    (act_token.type, exp_token.type, act_token))
+                self.assertTrue(
+                    act_token.value == exp_token.value,
+                    "Unexpected token value: %r (expected: %r) "
+                    "in token: %r" %
+                    (act_token.value, exp_token.value, act_token))
+                self.assertTrue(
+                    act_token.lineno == exp_token.lineno,
+                    "Unexpected token lineno: %r (expected: %r) "
+                    "in token: %r" %
+                    (act_token.lineno, exp_token.lineno, act_token))
+                self.assertTrue(
+                    act_token.lexpos == exp_token.lexpos,
+                    "Unexpected token lexpos: %r (expected: %r) "
+                    "in token: %r" %
+                    (act_token.lexpos, exp_token.lexpos, act_token))
 
 
 class TestLexerSimple(BaseTestLexer):

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -53,9 +53,9 @@ from pywbem_mock import FakedWBEMConnection
 
 # Ordered dict type created by yamlloader.ordereddict loaders
 if sys.version_info[0:2] >= (3, 7):
-    yaml_ordereddict = dict
+    yaml_ordereddict = dict  # pylint: disable=invalid-name
 else:
-    yaml_ordereddict = OrderedDict
+    yaml_ordereddict = OrderedDict  # pylint: disable=invalid-name
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -734,6 +734,7 @@ def capture():
 
 @pytest.fixture(scope='function')
 def test_client_recorder(request):
+    # pylint: disable=unused-argument
     """
     Fixture for a TestClientRecorder object that records to TEST_YAML_FILE and
     that is enabled.
@@ -776,7 +777,7 @@ def cleanup_recorder_yaml_file():
     if os.path.exists(TEST_YAML_FILE):
         try:
             os.remove(TEST_YAML_FILE)
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             # The file is still open at this point and on Windows,
             # a WindowsError is raised.
             warnings.warn(
@@ -932,8 +933,8 @@ def test_BaseOperationRecorder_open_file(testcase, text, exp_bytes):
     fp.close()
 
     with open(tmp_filename, 'rb') as fp:
-        bytes = fp.read()
-    assert bytes == exp_bytes
+        act_bytes = fp.read()
+    assert act_bytes == exp_bytes
 
     os.remove(tmp_filename)
 
@@ -1512,6 +1513,7 @@ TESTCASES_TESTCLIENTRECORDER_RECORD = [
 def test_TestClientRecorder_record(
         desc, op_name, op_kwargs, op_result, op_exc, exp_yaml_items,
         test_client_recorder):
+    # pylint: disable=redefined-outer-name
     """
     Record a single operation using the test client recorder and verify the
     generated YAML file.
@@ -1634,6 +1636,7 @@ class Test_LOR_Connections(BaseLogOperationRecorderTests):
     """
 
     def test_connection_1(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test log of a WBEMConnection object with default parameters.
         """
@@ -1668,6 +1671,7 @@ class Test_LOR_Connections(BaseLogOperationRecorderTests):
         )
 
     def test_connection_2(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test log of a WBEMConnection object with most parameters specified,
         and detail level 'all'.
@@ -1708,6 +1712,7 @@ class Test_LOR_Connections(BaseLogOperationRecorderTests):
         )
 
     def test_connection_summary(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test log of a WBEMConnection object with most parameters specified,
         and detail level 'summary'.
@@ -1747,6 +1752,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
     """
 
     def test_result_exception(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log None return, HTTPError exception.
         """
@@ -1765,6 +1771,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
         )
 
     def test_result_exception_all(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log None return, HTTPError exception.
         """
@@ -1785,6 +1792,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
         )
 
     def test_result_getinstance(self, capture, instancename_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Emulates call to getInstance to test parameter processing.
         Currently creates the pywbem_request component.
@@ -1817,6 +1825,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
     @pytest.mark.parametrize(
         "detail_level", [10, 1000, 'all'])
     def test_result_instance(self, capture, instance_tuple, detail_level):
+        # pylint: disable=redefined-outer-name
         """
         Test the staging of a CIM instance with different detail_level values.
         """
@@ -1845,6 +1854,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
         )
 
     def test_result_instance_paths(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the staging of a CIM instance with path with detail_level 'paths'.
         """
@@ -1863,6 +1873,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
         )
 
     def test_result_instances_paths(self, capture, instances_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the staging of multiple CIM instances with path with
         detail_level 'paths'.
@@ -1883,6 +1894,7 @@ class Test_LOR_PywbemResults(BaseLogOperationRecorderTests):
         )
 
     def test_result_pull_instances_paths(self, capture, instances_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the staging of multiple CIM instances with path with
         detail_level 'paths'.
@@ -1955,6 +1967,7 @@ class Test_LOR_HTTPRequests(BaseLogOperationRecorderTests):
         return url, target, method, headers, payload
 
     def test_stage_http_request_all(self, capture, instancename_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test stage of http_request log with detail_level='all'
         """
@@ -1980,6 +1993,7 @@ class Test_LOR_HTTPRequests(BaseLogOperationRecorderTests):
         )
 
     def test_stage_http_request_summary(self, capture, instancename_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test http request log record with summary as detail level
         """
@@ -2003,6 +2017,7 @@ class Test_LOR_HTTPRequests(BaseLogOperationRecorderTests):
         )
 
     def test_stage_http_request_int(self, capture, instancename_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test http log record with integer as detail_level
         """
@@ -2064,6 +2079,7 @@ class Test_LOR_HTTPResponses(BaseLogOperationRecorderTests):
         return body
 
     def test_stage_http_response_all(self, capture, instance_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test http response log record with 'all' detail_level
         """
@@ -2088,6 +2104,7 @@ class Test_LOR_HTTPResponses(BaseLogOperationRecorderTests):
         )
 
     def test_stage_http_response_summary(self, capture, instance_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test http response log record with 'all' detail_level
         """
@@ -2112,6 +2129,7 @@ class Test_LOR_HTTPResponses(BaseLogOperationRecorderTests):
         )
 
     def test_stage_http_response_int(self, capture, instance_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test http response log record with 'all' detail_level
         """
@@ -2143,6 +2161,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
     """
 
     def test_getinstance(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for get instance
         """
@@ -2176,6 +2195,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_getinstance_exception(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for get instance
         """
@@ -2209,6 +2229,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_getinstance_exception_all(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for get instance CIMError exception
         """
@@ -2240,6 +2261,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_getinstance_result_all(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for get instance
         """
@@ -2280,6 +2302,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_enuminstances_result(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for enumerate instances
         """
@@ -2314,6 +2337,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_enuminstancenames_result(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for enumerate instances
         """
@@ -2350,6 +2374,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_openenuminstances_result_all(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for enumerate instances. Returns no instances.
         """
@@ -2396,6 +2421,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_openenuminstances_all(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for enumerate instances paths with
         data in the paths component
@@ -2448,6 +2474,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_associators_result(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for Associators that returns nothing
         """
@@ -2482,6 +2509,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_associators_result_exception(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test the ops result log for associators that returns exception
         """
@@ -2500,6 +2528,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_invokemethod_int(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test invoke method log
         """
@@ -2532,6 +2561,7 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         )
 
     def test_invokemethod_summary(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Test invoke method log
         """
@@ -2581,6 +2611,7 @@ class TestExternLoggerDef(BaseLogOperationRecorderTests):
     """
 
     def test_root_logger(self, capture, instance_wp_tuple):
+        # pylint: disable=redefined-outer-name
         """
         Create a logger using logging.basicConfig and generate logs
         """
@@ -2624,6 +2655,7 @@ class TestExternLoggerDef(BaseLogOperationRecorderTests):
 
     @pytest.mark.skip("Test unreliable exception not always the same")
     def test_pywbem_logger(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test executing a connection with an externally created handler. Note
         that this test inconsistently reports the text of the exception
@@ -2738,6 +2770,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         return conn
 
     def test_1(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure the "pywbem.api" logger for summary information output to a
         file and activate that logger for all subsequently created
@@ -2798,6 +2831,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_2(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure and activate a single :class:`~pywbem.WBEMConnection` object
         logger for output of summary information for both "pywbem.api" and
@@ -2830,6 +2864,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_3(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a single pywbem connection with standard Python logger
         methods by defining the root logger with basicConfig
@@ -2867,6 +2902,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_4(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a single pywbem connection with standard Python logger
         methods by defining the root logger with basicConfig
@@ -2902,6 +2938,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_5(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a single pywbem connection with standard Python logger
         methods by defining the root logger with basicConfig
@@ -2938,6 +2975,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_6(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a http logger with detail_level='all' and
         a log config with just 'http'  (which produces no output because the
@@ -2984,6 +3022,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_7(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a http logger with detail_level='all', log_dest=none
         a log config with just 'http'  (which produces no output because the
@@ -3029,6 +3068,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_8(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a http logger with detail_level='all' and
         a log config with just 'http'  (which produces no output because the
@@ -3080,6 +3120,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_9(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a http logger with detail_level='all' and
         a log config with just 'http'  (which produces no output because the
@@ -3125,6 +3166,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_10(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Configure a http logger with detail_level='all' and
         a log config with just 'http'  (which produces no output because the
@@ -3169,6 +3211,7 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         )
 
     def test_err(self, capture):
+        # pylint: disable=redefined-outer-name
         """
         Test configure_logger exception
         """
@@ -3176,11 +3219,9 @@ class TestLoggingEndToEnd(BaseLogOperationRecorderTests):
         conn = self.build_repo(namespace)
 
         # Define the detail_level and WBEMConnection object to activate.
-        try:
+
+        with pytest.raises(ValueError):
             configure_logger('api', detail_level='blah', connection=conn,
                              propagate=True)
-            self.fail("Exception expected")
-        except ValueError:
-            pass
 
         capture.check()

--- a/tests/unittest/pywbem_mock/test_complexassoc.py
+++ b/tests/unittest/pywbem_mock/test_complexassoc.py
@@ -333,6 +333,7 @@ def test_complexref_classnames(conn, ns, target, r, rc, mof, exp_rslt,
     if ns is not None:
         target = CIMClassName(target, namespace=ns)
     if cond == 'pdb':
+        # pylint: disable=import-outside-toplevel
         import pdb
         pdb.set_trace()
 
@@ -484,6 +485,7 @@ def test_complexref_instnames(conn, ns, target, r, rc, mof, exp_rslt,
     conn.compile_mof_string(complex_assoc_mof + mof, namespace=ns)
 
     if cond == 'pdb':
+        # pylint: disable=import-outside-toplevel
         import pdb
         pdb.set_trace()
 
@@ -616,6 +618,7 @@ def test_complexassoc_classnames(conn, ns, target, r, rr, ac,
     if ns is not None:
         target = CIMClassName(target, namespace=ns)
     if cond == 'pdb':
+        # pylint: disable=import-outside-toplevel
         import pdb
         pdb.set_trace()
 
@@ -1140,6 +1143,7 @@ def test_complexassoc_instnames(conn, ns, target, r, rr, ac,
         pytest.skip("Condition for test case not met")
 
     if cond == 'pdb':
+        # pylint: disable=import-outside-toplevel
         import pdb
         pdb.set_trace()
 

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -166,11 +166,11 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
     rtn_obj = xxx_repo.get(name)
     assert rtn_obj == obj
 
-    names = [n for n in xxx_repo.iter_names()]
+    names = list(xxx_repo.iter_names())
     assert len(names) == 1
     assert names[0] == name
 
-    objs = [x for x in xxx_repo.iter_values()]
+    objs = list(xxx_repo.iter_values())
     assert len(objs) == 1
     assert objs[0] == obj
 

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -273,7 +273,7 @@ def assert_classes_equal(cls1, cls2):
     class generates data that is difficult to debug.
     """
     classes_equal(cls1, cls2)
-    assert(cls1 == cls2)
+    assert cls1 == cls2
 
 ###################################################################
 #
@@ -3370,32 +3370,34 @@ class TestInstanceOperations(object):
         assert len(rtn_insts) == exp_inst
 
         target_class = conn.GetClass(cln, namespace=ns, LocalOnly=False)
-        cl_props = [p.name for p in six.itervalues(target_class.properties)]
+        cl_props = sorted(list(target_class.properties.keys()))
 
         tst_class_names = conn.EnumerateClassNames(ns, DeepInheritance=True)
 
         for inst in rtn_insts:
             assert isinstance(inst, CIMInstance)
             assert inst.classname in tst_class_names
-            # TODO: This is overkill. Should just be all properties in inst
-            # The set makes us test for dups but should be None
-            inst_props = list(set([p for p in inst]))
-            if di is not True:   # inst props should match cl_props
+
+            # Test property names
+            inst_props = sorted(list(inst.properties.keys()))
+            if di is not True:
+                # inst_props should match cl_props
                 if len(inst_props) != len(cl_props):
                     # TODO: Still have issue with one test. and am therefore
                     # displaying the following as a reminder
-                    print('TODO props %s and %s should match.\nprops=%s\n'
-                          'clprops=%s' % (len(inst_props),
-                                          len(cl_props), inst_props, cl_props))
-
-                assert len(inst_props) == len(cl_props)
-                assert set(inst_props) == set(cl_props)
+                    print("TODO: test_enumerateinstances_di(): "
+                          "inst prop and class prop names should match:\n"
+                          "  inst  prop names ({}): {!r}\n"
+                          "  class prop names ({}): {!r}".
+                          format(len(inst_props), inst_props,
+                                 len(cl_props), cl_props))
+                assert inst_props == cl_props
             else:
                 di_class = conn.GetClass(inst.classname, namespace=ns,
                                          LocalOnly=False)
-                cl_props = [p.name for p in six.itervalues(di_class.properties)]
-                assert len(inst_props) == len(cl_props)
-                assert set(inst_props) == set(cl_props)
+                cl_props = sorted(list(di_class.properties.keys()))
+                assert inst_props == cl_props
+
             # TODO Test actual instance returned
 
     # TODO test for ico and iq
@@ -3581,7 +3583,7 @@ class TestInstanceOperations(object):
                 exp_prop = exp_inst.properties[prop_name]
                 rtn_prop = rtn_inst.properties[prop_name]
                 # assert case-sensitive match
-                assert(rtn_prop.name == exp_prop.name)
+                assert rtn_prop.name == exp_prop.name
 
         else:
             with pytest.raises(CIMError) as exec_info:

--- a/tests/unittest/utils/pytest_extensions.py
+++ b/tests/unittest/utils/pytest_extensions.py
@@ -122,6 +122,7 @@ def simplified_test_function(test_func):
             pytest.skip("Condition for test case not met")
 
         if condition == 'pdb':
+            # pylint: disable=import-outside-toplevel
             import pdb
 
         testcase = testcase_tuple(desc, kwargs, exp_exc_types, exp_warn_types,

--- a/tests/unittest/utils/unichr2.py
+++ b/tests/unittest/utils/unichr2.py
@@ -21,7 +21,7 @@ def unichr2(cp):
 
     Returns None for surrogsate code points.
     """
-    if cp >= SURROGATE_MIN_CP and cp <= SURROGATE_MAX_CP:
+    if SURROGATE_MIN_CP <= cp <= SURROGATE_MAX_CP:
         return None
 
     if sys.maxunicode == MAX_UNICODE_CP:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,11 +40,12 @@ def skip_if_moftab_regenerated():
     them out to the pywbem installation directory.
     """
 
-    test_installed = os.getenv('TEST_INSTALLED', False)
+    test_installed = os.getenv('TEST_INSTALLED')
 
     pywbem = import_installed('pywbem')
 
     try:
+        # pylint: disable=import-outside-toplevel
         from pywbem import _mofparsetab, _moflextab
     except ImportError:
         if test_installed:
@@ -113,7 +114,7 @@ def import_installed(module_name):
     The number of dots in `from ..utils` depends on where the test program
     containing this code is located, relative to the tests/utils.py file.
     """
-    test_installed = os.getenv('TEST_INSTALLED', False)
+    test_installed = os.getenv('TEST_INSTALLED')
     if test_installed:
 
         # Remove '' directory.


### PR DESCRIPTION
This time using Pylint 2.4.4 on Python 3.8, which finds more than the latest Pylint 1.9.5 we can use on Python 2.7.