### PR TITLE
0.17: Increased min version of setuptools on py37

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,9 @@ Released: not yet
 * Increased minimum version of 'six' from 0.10.0 to 0.12.0 when on Python 3.8
   (or higher). (See issue #2150).
 
+* Increased minimum version of 'setuptools' on Python 3.7 from 33.1.1 to 38.4.1
+  to fix a bug with new format of .pyc files. (See issue #2167).
+
 **Cleanup:**
 
 **Known issues:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -43,8 +43,10 @@
 #   wheel       0.33.6
 
 # For Python up to Python 3.7, we use the versions from Ubuntu 17.04:
+# setuptools 38.4.1 fixes a bug on Python 3.7.
 pip==9.0.1; python_version <= '3.7'
-setuptools==33.1.1; python_version <= '3.7'
+setuptools==33.1.1; python_version < '3.7'
+setuptools==38.4.1; python_version == '3.7'
 wheel==0.29.0; python_version <= '3.7'
 
 # For Python 3.8 and above, we use the versions from Python 3.8.0:


### PR DESCRIPTION
Rolls back PR #2169 into 0.17.1.