### PR TITLE
Fixes #2173: Added the pywbem_os_setup.* scripts to the source dist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@ include README.rst
 include README_PYPI.rst
 include INSTALL.md
 include requirements.txt
+include pywbem_os_setup.sh
+include pywbem_os_setup.bat
 include setup.py
 include build_moftab.py
 include mof_compiler

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,12 @@ Released: not yet
   versions that support a particular Python versions beyond that.
   This only affects development of pywbem. (See issue #2174)
 
+* Setup: Added the scripts for installing OS-level dependencies
+  (pywbem_os_setup.sh/.bat) to the source distribution archive. Note that
+  starting with the upcoming pywbem 1.0.0, these scripts are no longer needed,
+  so this change will not be rolled forward into 1.0.0.
+  (See issue #2173)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/makefile
+++ b/makefile
@@ -287,6 +287,8 @@ dist_manifest_in_files := \
     README_PYPI.rst \
     INSTALL.md \
     requirements.txt \
+    pywbem_os_setup.sh \
+    pywbem_os_setup.bat \
     setup.py \
     build_moftab.py \
     mof_compiler \
@@ -305,6 +307,8 @@ dist_dependent_files := \
     README_PYPI.rst \
     INSTALL.md \
     requirements.txt \
+    pywbem_os_setup.sh \
+    pywbem_os_setup.bat \
     setup.py \
     build_moftab.py \
     mof_compiler \


### PR DESCRIPTION
See commit message.

Note, this fixes the part of issue #2173 where the pywbem_os_setup.* scripts were missing from the source distribution archive. The failure with the openssl/err.h file could not be reproduced.