### PR TITLE
0.17: Fixed raise error for invalid reference_direction in WBEMServer.get_central_instances()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,9 @@ Released: not yet
   builds. This could not be fixed for Python 2.6 since PyYAML 3.12 dropped
   support for Python 2.6 (See issue #2182)
 
+* Fixed raise error for invalid reference_direction in
+  WBEMServer.get_central_instances(). (See issue #2187)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -863,7 +863,7 @@ class WBEMServer(object):
         """
 
         if reference_direction not in ('dmtf', 'snia'):
-            ValueError(
+            raise ValueError(
                 _format("The reference_direction parameter must be 'dmtf' or "
                         "'snia', but is: {0!A}", reference_direction))
 

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -387,6 +387,18 @@ TESTCASES_GET_CENTRAL_INSTANCES = [
         ),
         None, None, True
     ),
+    (
+        "Invalid reference direction",
+        dict(
+            profile_name=('SNIA', 'Server', '1.2.0'),
+            central_class='XXX_StorageComputerSystem',
+            scoping_class=None,
+            scoping_path=None,
+            direction='foo',
+            exp_paths=None
+        ),
+        ValueError, None, True
+    ),
     # TODO add more central instance tests
 ]
 


### PR DESCRIPTION
Rolls back PR #2189 into 0.17.2.