### PR TITLE
0.17: Fixed raise error for missing ports in WBEMListener.__init__()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,9 @@ Released: not yet
 * Fixed raise error for invalid reference_direction in
   WBEMServer.get_central_instances(). (See issue #2187)
 
+* Fixed raise error for missing ports in WBEMListener.__init__().
+  (See issue #2188)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -685,7 +685,7 @@ class WBEMListener(object):
             self._keyfile = None
 
         if self._http_port is None and self._https_port is None:
-            ValueError("Listener requires at least one active port")
+            raise ValueError("Listener requires at least one active port")
 
         self._http_server = None  # ThreadedHTTPServer for HTTP
         self._http_thread = None  # Thread for HTTP


### PR DESCRIPTION
Rolls back PR #2191 into 0.17.2.