### PR TITLE
Fixed Pylint issues except for pywbem_mock

### DIFF
--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -27,9 +27,9 @@ import inspect
 from string import Formatter
 import six
 try:
-    from builtins import ascii
+    from builtins import ascii as _ascii
 except ImportError:  # py2
-    from future_builtins import ascii
+    from future_builtins import ascii as _ascii
 try:
     from collections.abc import Mapping, Set, MutableSequence, Sequence
 except ImportError:  # py2
@@ -255,7 +255,7 @@ def _ascii2(value):
 
     if isinstance(value, six.text_type):
 
-        ret = ascii(value)  # returns type str in py2 and py3
+        ret = _ascii(value)  # returns type str in py2 and py3
         if ret.startswith('u'):
             ret = ret[1:]
 
@@ -269,7 +269,7 @@ def _ascii2(value):
                      r'\\u00\1', ret)
 
     elif isinstance(value, six.binary_type):
-        ret = ascii(value)  # returns type str in py2 and py3
+        ret = _ascii(value)  # returns type str in py2 and py3
         if ret.startswith('b'):
             ret = ret[1:]
 
@@ -283,7 +283,7 @@ def _ascii2(value):
         ret = str(value)
 
     else:
-        ret = ascii(value)  # returns type str in py2 and py3
+        ret = _ascii(value)  # returns type str in py2 and py3
 
     return ret
 
@@ -310,7 +310,7 @@ class _Ascii2Formatter(Formatter):
         elif conversion == 'r':
             return repr(value)
         elif conversion == 'a':
-            return ascii(value)
+            return _ascii(value)
         elif conversion == 'A':
             return _ascii2(value)
         raise ValueError(

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -71,13 +71,13 @@ def wbem_connection(request, server_definition):
     # pylint: disable=redefined-outer-name, unused-argument
     """
     Fixture representing the set of WBEMConnection objects to use for the
-    end2end tests.  This fixture uses the  server_definition
+    end2end tests.  This fixture uses the
     implementation_namespace item from the server_definition as the
     default namespace if that item exists in the server_definition.
 
     Returns the `WBEMConnection` object of each server to test against.
     """
-    sd = server_definition
+    sd = server_definition  # ServerDefinition object
 
     # Skip this server if we had a skip reason in an earlier attempt
     skip_msg = getattr(sd, 'skip_msg', None)
@@ -99,9 +99,8 @@ def wbem_connection(request, server_definition):
         ca_certs=sd.ca_certs,
         no_verification=sd.no_verification,
         default_namespace=sd.implementation_namespace,
-        timeout=10)
-
-    conn.server_definition = sd
+        timeout=10,
+        server_definition=sd)
 
     # Check that the server can be reached and authenticated with, by issuing
     # some quick operation. Operation failures are tolerated (e.g. GetQualifier

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -230,6 +230,21 @@ class WBEMConnectionAsserted(WBEMConnection):
     specifying keyword argument `asserted=True`.
     """
 
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters:
+
+          server_definition(ServerDefinition): Server to test against
+            (required keyword argument)
+
+          All other positional and keyword arguments are passed to the
+          superclass init.
+        """
+        server_definition = kwargs['server_definition']
+        del kwargs['server_definition']
+        super(WBEMConnectionAsserted, self).__init__(*args, **kwargs)
+        self.server_definition = server_definition
+
     def _call_op(self, funcname, *args, **kwargs):
         """
         Call the specified operation function of the base class.

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -582,8 +582,8 @@ def process_indication(indication, host):
     """
 
     # Note: Global variables that are modified must be declared global
-    global RCV_COUNT
-    global RCV_ERRORS
+    global RCV_COUNT  # pylint: disable=global-statement
+    global RCV_ERRORS  # pylint: disable=global-statement
 
     try:
         if VERBOSE_DETAILS:
@@ -603,7 +603,7 @@ def process_indication(indication, host):
 
         RCV_COUNT += 1
 
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         print("Error in process_indication(): {}: {}".
               format(exc.__class__.__name__, exc))
         sys.stdout.flush()
@@ -637,8 +637,8 @@ def test_WBEMListener_send_indications(send_count):
     """
 
     # Note: Global variables that are modified must be declared global
-    global RCV_COUNT
-    global RCV_ERRORS
+    global RCV_COUNT  # pylint: disable=global-statement
+    global RCV_ERRORS  # pylint: disable=global-statement
 
     host = 'localhost'
     http_port = 50000
@@ -874,6 +874,7 @@ WBEMLISTENER_INCORRECT_HEADERS_TESTCASES = [
     "desc, headers, exp_status, exp_headers",
     WBEMLISTENER_INCORRECT_HEADERS_TESTCASES)
 def test_WBEMListener_incorrect_headers(desc, headers, exp_status, exp_headers):
+    # pylint: disable=unused-argument
     """
     Verify that WBEMListener send fails when incorrect HTTP headers are used
     (along with the correct POST method).
@@ -959,7 +960,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES = [
         400,
         {
             'CIMErrorDetails': r'Element .CIM. missing required '
-            r'child element .*.MESSAGE..*',
+                               r'child element .*.MESSAGE..*',
             'CIMError': r'request-not-well-formed',
             'CIMExport': r'MethodResponse',
         }
@@ -974,7 +975,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES = [
         400,
         {
             'CIMErrorDetails': r'Element .MESSAGE. missing required '
-            r'child element .*.SIMPLEEXPREQ..*',
+                               r'child element .*.SIMPLEEXPREQ..*',
             'CIMError': r'request-not-well-formed',
             'CIMExport': r'MethodResponse',
         }
@@ -991,7 +992,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES = [
         400,
         {
             'CIMErrorDetails': r'Element .SIMPLEEXPREQ. missing required '
-            r'child element .*.EXPMETHODCALL..*',
+                               r'child element .*.EXPMETHODCALL..*',
             'CIMError': r'request-not-well-formed',
             'CIMExport': r'MethodResponse',
         }
@@ -1014,7 +1015,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES = [
         400,
         {
             'CIMErrorDetails': r'Element .EXPPARAMVALUE. has invalid child '
-            r'element.*INSTANCENAME.*',
+                               r'element.*INSTANCENAME.*',
             'CIMError': r'request-not-well-formed',
             'CIMExport': r'MethodResponse',
         }
@@ -1027,6 +1028,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES = [
     WBEMLISTENER_INCORRECT_PAYLOAD1_TESTCASES)
 def test_WBEMListener_incorrect_payload1(
         desc, payload, exp_status, exp_headers):
+    # pylint: disable=unused-argument
     """
     Verify that WBEMListener send fails with HTTP error when incorrect HTTP
     payload is used that triggers HTTP errors.
@@ -1191,6 +1193,7 @@ WBEMLISTENER_INCORRECT_PAYLOAD2_TESTCASES = [
     WBEMLISTENER_INCORRECT_PAYLOAD2_TESTCASES)
 def test_WBEMListener_incorrect_payload2(
         desc, payload, exp_status, exp_headers, exp_payload):
+    # pylint: disable=unused-argument
     """
     Verify that WBEMListener send fails with export response indicating error
     when incorrect HTTP payload is used that triggers that.


### PR DESCRIPTION
This PR does not address Pylint issues in pywbem_mock because that is currently restructured.
Current Pylint results after this PR (with Pylint 2.4.4 on Python 3.8):
Note that most of them are related to pywbem_mock.
```
+--------------------------+------------+
|message id                |occurrences |
+==========================+============+
|fixme                     |182         |
+--------------------------+------------+
|redefined-builtin         |11          |
+--------------------------+------------+
|using-constant-test       |8           |
+--------------------------+------------+
|unused-argument           |7           |
+--------------------------+------------+
|try-except-raise          |3           |
+--------------------------+------------+
|protected-access          |3           |
+--------------------------+------------+
|invalid-name              |3           |
+--------------------------+------------+
|no-value-for-parameter    |2           |
+--------------------------+------------+
|no-self-use               |2           |
+--------------------------+------------+
|invalid-overridden-method |1           |
+--------------------------+------------+
|assignment-from-no-return |1           |
+--------------------------+------------+
|arguments-differ          |1           |
+--------------------------+------------+
```