### PR TITLE
Issue #2062 - Change name from DefaultInstanceProvider to InstanceWriteProvider

### DIFF
--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -22,7 +22,7 @@
 A CIM provider creates WBEM server responses to operations defined in DSP0200.
 
 The BaseProvider WBEM server provider handles provider required data that
-is common to both the MainProvider, DefaultInstanceProvider, and any
+is common to both the MainProvider, InstanceWriteProvider, and any
 registered instance providers including:
 
   * Access to the CIM repository
@@ -76,7 +76,7 @@ class BaseProvider(object):
     """
     BaseProvider is the top level class in the provider hiearchy and includes
     methods required by the subclasses such as MainProvider and
-    DefaultInstanceProvider.  This class is not intended to be executed
+    InstanceWriteProvider.  This class is not intended to be executed
     directly.
     """
 
@@ -85,6 +85,7 @@ class BaseProvider(object):
         Set up dummy instance variables.
         """
         self.cimrepository = None
+        self.provider_registry = None
 
     @property
     def disable_pull_operations(self):
@@ -497,7 +498,7 @@ class BaseProvider(object):
         """
         If there is a provider registered for this namespace, provider_type,
         and classname return that object (the instance of the
-        DefaultInstanceProvider subclass).
+        InstanceWriteProvider subclass).
 
         If no provider is registered, return None.
 

--- a/pywbem_mock/_defaultinstanceprovider.py
+++ b/pywbem_mock/_defaultinstanceprovider.py
@@ -26,39 +26,39 @@ of the mocker for special processing for certain classes to be mocked.
 This module contains two classes:
 
 1. ProviderDispatcher - Routes the calls for request methods that allow
-user-defined providers either to the default method in DefaultInstanceProvider
+user-defined providers either to the default method in InstanceWriteProvider
 or to a user defined method in the provider registry.
 
-2. DefaultInstanceProvider - The default implementation for the request
+2. InstanceWriteProvider - The default implementation for the request
 responders that may include user defined providers.  This is the method that
 will be called if there is no provider registered for a namespace and class
 name.
 
 User defined providers may be created for specific CIM classes and specific
 namespaces to override one or more of the operation request methods defined in
-:class:`~pywbem_mock:DefaultInstanceProvider` with user methods defined in a
-subclass of :class:`~pywbem_mock:DefaultInstanceProvider`.
+:class:`~pywbem_mock:InstanceWriteProvider` with user methods defined in a
+subclass of :class:`~pywbem_mock:InstanceWriteProvider`.
 
 A user defined provider is created as follows:
 
-1. Define the subclass of :class:`~pywbem_mock:DefaultInstanceProvider` with an
+1. Define the subclass of :class:`~pywbem_mock:InstanceWriteProvider` with an
 __init__ method and the methods that will override any of the request methods
-defined in :class:`~pywbem_mock:DefaultInstanceProvider`.  Note that not all of
-the requests methods in :class:`~pywbem_mock:DefaultInstanceProvider` need to
+defined in :class:`~pywbem_mock:InstanceWriteProvider`.  Note that not all of
+the requests methods in :class:`~pywbem_mock:InstanceWriteProvider` need to
 be implemented, just those for which user provider will manipulate the incoming
 request parameters.
 
 Thus, a user provider can override the
-:meth:`~pywbem_mock:DefaultInstanceProviderCreateInstance` method to modify the
+:meth:`~pywbem_mock:InstanceWriteProvider.CreateInstance` method to modify the
 ``NewInstance`` input parameter to change properties, etc. and either submit it
 to the CIM repository within the user provider or call the
-:meth:`~pywbem_mock:DefaultInstanceProviderCreateInstance` in the superclass to
+:meth:`~pywbem_mock:InstanceWriteProviderCreateInstance` in the superclass to
 complete submission of the ``NewInstance``.
 
 2. Define registraton of the user provider using
 :meth:`~pywbem_mock:WBEMConnection.register_provider' to define the namespaces
 and classes for which the user provider will override the corresponding method
-in the :class:`~pywbem_mock:DefaultInstanceProvider`.  The registration of the
+in the :class:`~pywbem_mock:InstanceWriteProvider`.  The registration of the
 user provider must occur after the namespaces and classnames defined in the
 registration have been added to the CIM repository.
 """
@@ -78,7 +78,7 @@ from ._baseprovider import BaseProvider
 # None of the request method names conform since they are camel case
 # pylint: disable=invalid-name
 
-__all__ = ['DefaultInstanceProvider']
+__all__ = ['InstanceWriteProvider']
 
 
 def validate_inst_props(namespace, target_class, instance):
@@ -146,7 +146,7 @@ def validate_inst_props(namespace, target_class, instance):
 class ProviderDispatcher(BaseProvider):
     """
     This class dispatches requests destined for the instance provider methods
-    defined in DefaultInstanceProvider  to the either the default instance
+    defined in InstanceWriteProvider  to the either the default instance
     provder method or the provider defined for processing the defined class in
     the defined namespace.
     """
@@ -159,7 +159,7 @@ class ProviderDispatcher(BaseProvider):
         self.cimrepository = cimrepository
         self.provider_registry = provider_registry
 
-        # defines the instance of DefaultInstanceProvider that will
+        # defines the instance of InstanceWriteProvider that will
         # be called to dispatch operation to default provider.
         self.default_instance_provider = default_instance_provider
 
@@ -310,7 +310,7 @@ class ProviderDispatcher(BaseProvider):
             InstanceName)
 
 
-class DefaultInstanceProvider(BaseProvider):
+class InstanceWriteProvider(BaseProvider):
     """
     This class defines those instance provider methods that may have user-
     defined providers that override the default provider implementation in this

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -48,7 +48,7 @@ from ._inmemoryrepository import InMemoryRepository
 from ._mockmofwbemconnection import _MockMOFWBEMConnection
 
 from ._defaultinstanceprovider import ProviderDispatcher, \
-    DefaultInstanceProvider
+    InstanceWriteProvider
 
 from ._dmtf_cim_schema import DMTFCIMSchema
 from ._utils import _uprint
@@ -307,8 +307,8 @@ class FakedWBEMConnection(WBEMConnection):
                                          self.disable_pull_operations,
                                          self.cimrepository)
 
-        # Initiate the DefaultInstanceProvider with the cimrepository
-        self.defaultinstanceprovider = DefaultInstanceProvider(
+        # Initiate the InstanceWriteProvider with the cimrepository
+        self.defaultinstanceprovider = InstanceWriteProvider(
             self.cimrepository)
 
         # Initiate instance of the ProviderDispatcher with required
@@ -1046,16 +1046,16 @@ class FakedWBEMConnection(WBEMConnection):
           provider_type (:term:`string`):
             Keyword defining the type of request the provider will service.
             The allowed types are instance (keyword 'instance') which responds
-            to the request responder methods defined in DefaultInstanceProvider
+            to the request responder methods defined in InstanceWriteProvider
             (ex. CreateInstance) and method (keyword 'method') which responds
             to the InvokeMethod.
 
-          provider (subclass of :class::class:`pywbem_mock:DefaultInstanceProvider`):
+          provider (subclass of :class::class:`pywbem_mock:InstanceWriteProvider`):
             The user provider class which is a subclass of
-            :class:`pywbem_mock:DefaultInstanceProvider`.  The methods in this
+            :class:`pywbem_mock:InstanceWriteProvider`.  The methods in this
             subclass override the corresponding methods in
-            DefaultInstanceProvider. The method call parameters must be the
-            same as the defult method in DefaultInstanceProvider and it must
+            InstanceWriteProvider. The method call parameters must be the
+            same as the defult method in InstanceWriteProvider and it must
             return data in the same format if the default method returns data.
         """  # noqa: E501
         # pylint: enable=line-too-long
@@ -1068,10 +1068,10 @@ class FakedWBEMConnection(WBEMConnection):
                              "Valid provider types are {1!A}.", provider_type,
                              provider_types)
 
-        if not issubclass(provider, DefaultInstanceProvider):
+        if not issubclass(provider, InstanceWriteProvider):
             raise TypeError(
                 _format("provider argument {0!A} is not a "
-                        "valid subclass of DefaultInstanceProvider. ",
+                        "valid subclass of InstanceWriteProvider. ",
                         provider))
 
         if classnames is None:
@@ -1217,12 +1217,12 @@ class FakedWBEMConnection(WBEMConnection):
     #####################################################################
     #
     #  The following methods map the imethodcall interface (dictionary of
-    #  the method parameters to the arguments required by each correspondin
-    #  gmethod in the MainProvider  or DefaultInstanceProvider and call that
+    #  the method parameters to the arguments required by each corresponding
+    #  method in the MainProvider  or InstanceWriteProvider and call that
     #  method. the resultsare mapped back to be compatible with imethodcall
     #  return tuple.
     #  Methods that allow user providers are routed to the
-    #  DefaultInstanceProvider. All other methods are rounted to the
+    #  InstanceWriteProvider. All other methods are rounted to the
     #  MainProvider.
     #
     #####################################################################

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -58,7 +58,7 @@ from pywbem._utils import _format
 from pywbem._cim_operations import pull_path_result_tuple
 pywbem_mock = import_installed('pywbem_mock')  # noqa: E402
 from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema, \
-    DefaultInstanceProvider
+    InstanceWriteProvider
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
 
@@ -812,7 +812,7 @@ def tst_assoc_mof(tst_assoc_qualdecl_mof, tst_assoc_class_mof):
     return tst_assoc_qualdecl_mof + tst_assoc_class_mof + instances
 
 
-class UserProviderTest(DefaultInstanceProvider):
+class UserProviderTest(InstanceWriteProvider):
     """
     Basic user provider implements CreateInstance and DeleteInstance
     """
@@ -825,12 +825,11 @@ class UserProviderTest(DefaultInstanceProvider):
 
     def CreateInstance(self, namespace, NewInstance):
         """Test Create instance just calls super class method"""
-        return DefaultInstanceProvider.CreateInstance(namespace,
-                                                      NewInstance)
+        return InstanceWriteProvider.CreateInstance(namespace, NewInstance)
 
     def DeleteInstance(self, InstanceName):
         """Test Create instance just calls super class method"""
-        return DefaultInstanceProvider.DeleteInstance(InstanceName)
+        return InstanceWriteProvider.DeleteInstance(InstanceName)
 
 
 # Counts of instances for tests of tst_assoc_mof fixture.
@@ -2350,7 +2349,7 @@ class TestProviderRegisterMethods(object):
                 assert rtn is None
             if exp_rslt is True:
                 assert rtn
-                assert issubclass(rtn, DefaultInstanceProvider)
+                assert issubclass(rtn, InstanceWriteProvider)
 
         else:
             with pytest.raises(exp_rslt):
@@ -2362,7 +2361,7 @@ class TestProviderRegisterMethods(object):
         """
         Test execution with a user provider and CreateInstance.
         """
-        class CIM_FooUserProvider(DefaultInstanceProvider):
+        class CIM_FooUserProvider(InstanceWriteProvider):
             """
             Define the user provider with only CreateInstance supported
             """
@@ -2413,7 +2412,7 @@ class TestProviderRegisterMethods(object):
         Test with a single user defined provider using CIM_Foo_sub as the
         class and handles ModifyInstance only
         """
-        class CIM_FooSubUserProvider(DefaultInstanceProvider):
+        class CIM_FooSubUserProvider(InstanceWriteProvider):
             """
             Define the user provider
             """


### PR DESCRIPTION
Note that this does not change the name of the file _defaultinstanceprovider.py.  That is for later.

Depends on pr # 2186