### PR TITLE
Modify mock code to change method name exists to object_exists

### DIFF
--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -438,7 +438,7 @@ class BaseProvider(object):
         Exception if the namespace does not exist
         """
         class_store = self.get_class_store(namespace)
-        return class_store.exists(classname)
+        return class_store.object_exists(classname)
 
     @staticmethod
     def filter_properties(obj, property_list):
@@ -487,7 +487,7 @@ class BaseProvider(object):
 
         """
 
-        if instance_store.exists(instance_name):
+        if instance_store.object_exists(instance_name):
             if copy_inst:
                 return instance_store.get(instance_name).copy()
             return instance_store.get(instance_name)

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -96,7 +96,7 @@ class BaseObjectStore(object):
         self._cim_object_type = cim_object_type
 
     @abstractmethod
-    def exists(self, name):
+    def object_exists(self, name):
         """
         Test if the CIM object identified by name exists in the object store.
 

--- a/pywbem_mock/_defaultinstanceprovider.py
+++ b/pywbem_mock/_defaultinstanceprovider.py
@@ -293,7 +293,7 @@ class ProviderDispatcher(BaseProvider):
                         InstanceName.classname, namespace, InstanceName))
 
         instance_store = self.get_instance_store(namespace)
-        if not instance_store.exists(InstanceName):
+        if not instance_store.object_exists(InstanceName):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format("Instance {0!A} not found in CIM repository namespace "

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -101,7 +101,7 @@ class InMemoryObjectStore(BaseObjectStore):
                        self._cim_object_type, type(self._data),
                        len(self._data))
 
-    def exists(self, name):
+    def object_exists(self, name):
         return name in self._data
 
     def get(self, name, copy=True):

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -434,7 +434,7 @@ class MainProvider(ResolverMixin, BaseProvider):
             CIMError: (CIM_ERR_INVALID_CLASS) if classname not in CIM repository
         """
 
-        if not class_store.exists(classname):
+        if not class_store.object_exists(classname):
             raise CIMError(
                 CIM_ERR_INVALID_CLASS,
                 _format("Class {0!A} not found in namespace {1!A}.",
@@ -785,7 +785,7 @@ class MainProvider(ResolverMixin, BaseProvider):
 
         if ClassName:
             assert(isinstance(ClassName, six.string_types))
-            if not class_store.exists(ClassName):
+            if not class_store.object_exists(ClassName):
                 raise CIMError(
                     CIM_ERR_INVALID_CLASS,
                     _format("The class {0!A} defined by 'ClassName' parameter "
@@ -867,7 +867,7 @@ class MainProvider(ResolverMixin, BaseProvider):
 
         if ClassName:
             assert(isinstance(ClassName, six.string_types))
-            if not class_store.exists(ClassName):
+            if not class_store.object_exists(ClassName):
                 raise CIMError(
                     CIM_ERR_INVALID_CLASS,
                     _format("The class {0!A} defined by 'ClassName' parameter "
@@ -1012,7 +1012,7 @@ class MainProvider(ResolverMixin, BaseProvider):
         self.validate_namespace(namespace)
         class_store = self.get_class_store(namespace)
 
-        if class_store.exists(NewClass.classname):
+        if class_store.object_exists(NewClass.classname):
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format("Class {0!A} already exists in namespace {1!A}.",
@@ -1104,7 +1104,7 @@ class MainProvider(ResolverMixin, BaseProvider):
         class_store = self.get_class_store(namespace)
         instance_store = self.get_instance_store(namespace)
 
-        if not class_store.exists(ClassName):
+        if not class_store.object_exists(ClassName):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format("Class {0!A} in namespace {1!A} not in CIM repository. "
@@ -1312,7 +1312,7 @@ class MainProvider(ResolverMixin, BaseProvider):
         self.validate_namespace(namespace)
         qualifier_store = self.get_qualifier_store(namespace)
 
-        if qualifier_store.exists(QualifierName):
+        if qualifier_store.object_exists(QualifierName):
             qualifier_store.delete(QualifierName)
         else:
             raise CIMError(
@@ -1853,7 +1853,7 @@ class MainProvider(ResolverMixin, BaseProvider):
         class_store = self.get_class_store(namespace)
 
         # DSP0200 specifies INVALID_PARAMETER and not INVALID_CLASS
-        if not class_store.exists(instname.classname):
+        if not class_store.object_exists(instname.classname):
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
                 _format("Class {0!A} not found in namespace {1!A}.",

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -167,7 +167,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         # Exception if duplicate. NOTE: compiler overrides this with
         # modify instance.
         instance_store = self.repo.get_instance_store(namespace)
-        if instance_store.exists(inst.path):
+        if instance_store.object_exists(inst.path):
             raise CIMError(
                 CIM_ERR_ALREADY_EXISTS,
                 _format('CreateInstance failed. Instance with path {0!A} '
@@ -201,7 +201,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                         'Use compiler instance alias to set path on '
                         'instance declaration. inst: {0!A}', mod_inst))
 
-        if not instance_store.exists(mod_inst.path):
+        if not instance_store.object_exists(mod_inst.path):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
                 _format('ModifyInstance failed. No instance exists. '
@@ -360,7 +360,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         # If the class exists, update it. Otherwise create it
         # TODO: Validate that this is correct behavior. That is what the
         # original MOFWBEMConnection does.
-        if class_store.exists(ccr.classname):
+        if class_store.object_exists(ccr.classname):
             class_store.update(ccr.classname, ccr)
         else:
             class_store.create(ccr.classname, ccr)

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -81,7 +81,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
         """
         if qualifier_store is None:
             return
-        if not qualifier_store.exists(qualifier.name):
+        if not qualifier_store.object_exists(qualifier.name):
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
                 _format("Qualifier declaration {0!A} required by CreateClass "
@@ -101,7 +101,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
         5. Whether the qualifier should be propagated to the subclass.
         """
         for qname, qvalue in qualifier_list.items():
-            if not qualifier_store.exists(qname):
+            if not qualifier_store.object_exists(qname):
                 raise CIMError(
                     CIM_ERR_INVALID_PARAMETER,
                     _format("Qualifier {0!A} used in new class {1!A} "
@@ -151,7 +151,7 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
         Initialize the flavors of a qualifier declaration if they are not
         already set.
         """
-        assert qualifier_store.exists(qualifier_decl.name)
+        assert qualifier_store.object_exists(qualifier_decl.name)
         if qualifier_decl.tosubclass is None:
             qualifier_decl.tosubclass = True
         if qualifier_decl.overridable is None:

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -157,7 +157,7 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
     xxx_repo.create(name, obj)
 
     # confirm that exists works
-    assert xxx_repo.exists(name)
+    assert xxx_repo.object_exists(name)
 
     # Test len()
     assert xxx_repo.len() == 1
@@ -183,7 +183,7 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
 
     # Test valid delete of object
     xxx_repo.delete(name)
-    assert not xxx_repo.exists(name)
+    assert not xxx_repo.object_exists(name)
     assert xxx_repo.len() == 0
 
     # Test errors
@@ -209,7 +209,7 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
         pass
 
     # Test exists; entity should not exist
-    assert not xxx_repo.exists(name)
+    assert not xxx_repo.object_exists(name)
 
     # Test create with existing object
     xxx_repo.create(name, obj)
@@ -421,8 +421,8 @@ def test_repository_valid_methods(desc, args, condition, capsys):
     for type_dict, obj_dict in input_items.items():
         xxx_repo = repos[type_dict]
         for name, obj in obj_dict.items():
-            assert xxx_repo.exists(name), '{} exists() fail {}'.format(desc,
-                                                                       name)
+            assert xxx_repo.object_exists(name), '{} exists() fail {}' \
+                .format(desc, name)
 
             rtnd_obj = xxx_repo.get(name)
             assert rtnd_obj == input_items[type_dict][name]

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1705,15 +1705,15 @@ class TestRepoMethods(object):
         # pylint: disable=protected-access
         qual_repo = conn._get_qualifier_store(exp_ns)
 
-        assert qual_repo.exists('Association')
+        assert qual_repo.object_exists('Association')
         conn.compile_mof_string(q2, ns)
 
         qual_repo = conn._get_qualifier_store(exp_ns)
         # pylint: enable=protected-access
 
-        assert qual_repo.exists('Association')
-        assert qual_repo.exists('Description')
-        assert qual_repo.exists('Key')
+        assert qual_repo.object_exists('Association')
+        assert qual_repo.object_exists('Description')
+        assert qual_repo.object_exists('Key')
 
         assert conn.GetQualifier('Association', namespace=ns)
         assert conn.GetQualifier('Description', namespace=ns)


### PR DESCRIPTION
Changes the method name in BaseObjectStore for exists(...) to
object_exists(...).  This was because we both confused the behavior to
mean that the object_store exists rather than the object itself.

Thus:

  if not class_store.exists(classname)

becomes:

if not class_store.object_exists(classname)