### PR TITLE
Regularize use of deepcopy for objects xfrd to and from repository

### DIFF
--- a/pywbem_mock/_defaultinstanceprovider.py
+++ b/pywbem_mock/_defaultinstanceprovider.py
@@ -67,6 +67,8 @@ from __future__ import absolute_import, print_function
 
 import six
 
+from copy import deepcopy
+
 from pywbem import CIMInstance, CIMInstanceName, CIMError, \
     CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, CIM_ERR_INVALID_CLASS, \
     CIM_ERR_ALREADY_EXISTS, CIM_ERR_METHOD_NOT_AVAILABLE, \
@@ -620,7 +622,7 @@ class InstanceWriteProvider(BaseProvider):
         namespace = ModifiedInstance.path.namespace
 
         instance_store = self.get_instance_store(namespace)
-        modified_instance = ModifiedInstance.copy()
+        modified_instance = deepcopy(ModifiedInstance)
 
         # Return if empty property list, nothing would be changed
         if PropertyList is not None and not PropertyList:

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -35,9 +35,6 @@ from pywbem._mof_compiler import MOFWBEMConnection
 from pywbem._utils import _format
 from ._resolvermixin import ResolverMixin
 
-# Issue #2062 TODO/ks Remove this code and use the methods in _WBEMConnection
-# in their place
-
 
 class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
     """


### PR DESCRIPTION
Since the .copy method for CIMClass and CIMInstance does not do a deep
copy and we want to insure that we the objects in the dictionary are
truly different than the ones in the input and maintained in the
repository we changed to use deepcopy to copy all objects before they
are placed into the dictionary and for all objects that are extracted
from the dictionary with the copy property.

Note that we were doing extraneous copies in _baserepository and so
removed them.

Adds tests for cim repository to assure that the objects are copied
on create, modify, get with copy and iter_value with copy.