### PR TITLE
Fixes #2062: part4 compiler - refactor compiler interface in mocker

### DIFF
--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -734,7 +734,7 @@ def p_mp_createInstance(p):
     # p[1] is a list of instance and any alias defined in instanceDeclaration
     input = p[1]
     inst = input[0]
-    alias = input[1]
+    alias = input[1]  # alias may be valid alias or None
 
     if p.parser.verbose:
         p.parser.log(
@@ -742,7 +742,8 @@ def p_mp_createInstance(p):
     try:
         instpath = p.parser.handle.CreateInstance(inst)
         # Set the returned instance path into the alias table
-        p.parser.aliases[alias] = instpath
+        if alias:
+            p.parser.aliases[alias] = instpath
     except CIMError as ce:
         if ce.status_code == CIM_ERR_ALREADY_EXISTS:
             if p.parser.verbose:
@@ -1730,7 +1731,9 @@ def p_instanceDeclaration(p):
                     cname, pname, pval, ve),
                 parser_token=p)
 
-    # Returns both the created instance and either the alias name or None
+    # Returns the created instance and either the alias name or None
+    # This allows the alias to be created from the CreateInstance
+    # returned path rather than trying to build the path in the compiler.
     p[0] = [inst, alias]
 
 
@@ -1916,7 +1919,8 @@ class BaseRepositoryConnection(object):
     Raises:
 
       : Implementation classes should raise only exceptions derived from
-        :exc:`~pywbem.Error`. Other exceptions are considered programming
+        :exc:`~pywbem.Error` or use assert for methods that are not implemented.
+        Other exceptions are considered programming
         errors.
     """
 

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -38,6 +38,7 @@ from __future__ import absolute_import, print_function
 
 import uuid
 from collections import Counter
+from copy import deepcopy
 import six
 
 # pylint: disable=ungrouped-imports
@@ -101,6 +102,7 @@ class MainProvider(ResolverMixin, BaseProvider):
     """
 
     def __init__(self, host, disable_pull_operations, cimrepository):
+        # pylint: disable=super-init-not-called
         """
         Parameters:
             conn(:class:`~pywbem_mock.FakedWBEMConnection`):
@@ -1018,7 +1020,8 @@ class MainProvider(ResolverMixin, BaseProvider):
                 _format("Class {0!A} already exists in namespace {1!A}.",
                         NewClass.classname, namespace))
 
-        new_class = NewClass.copy()
+        # Create copy because resolve_class modifies elements of class
+        new_class = deepcopy(NewClass)
 
         qualifier_store = self.get_qualifier_store(namespace)
         self._resolve_class(new_class, namespace, qualifier_store,
@@ -1068,9 +1071,6 @@ class MainProvider(ResolverMixin, BaseProvider):
                 _format("ModifyClass not valid CIMClass. Rcvd type={0}",
                         type(ModifiedClass)))
 
-        # Validate namespace in class store and get the class CIM repository
-        # for this namespace.
-        self.validate_namespace(namespace)
         class_store = self.get_class_store(namespace)
 
         if not class_store.object_exists(ModifiedClass.classname):
@@ -1079,13 +1079,14 @@ class MainProvider(ResolverMixin, BaseProvider):
                 _format("Class {0!A} does not exist in namespace {1!A}.",
                         ModifiedClass.classname, namespace))
 
-        modified_class = ModifiedClass.copy()
+        # create copy because resolve_class can modify elements of class
+        modified_class = deepcopy(ModifiedClass)
 
         qualifier_store = self.get_qualifier_store(namespace)
         self._resolve_class(modified_class, namespace, qualifier_store,
                             verbose=False)
 
-        # Add new class to CIM repository
+        # Update class in CIM repository
         class_store.update(modified_class.classname, modified_class)
 
     ####################################################################

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -448,6 +448,69 @@ class MainProvider(ResolverMixin, BaseProvider):
         clnsdict[classname] = classname
         return clnsdict
 
+def validate_modified_class(self, namespace, modified_class, original_class,
+                            super_class=None):
+    """
+    Validate and possibly modify the modified class against the original_class
+    and possibly against superclasses.
+
+    This method validates the modified class using the rules defined in
+    :term:`DSP0200`
+
+    Returns:
+        Update class ready to commit to repository
+
+    Raises:
+        TODO:
+    """
+
+    def clean_mod_class_objects(modified_dict, original_dict, classname,
+                                name_list = None):
+        """
+        For the objects collection defined (methods and properties)
+        validate and set the existing attributes. Insures that class_origin
+        is this class and that the entity is in the original class.
+        """
+        for name in modified_dict:
+            if name_list is not None and name in name_list or name_list is None:
+                value = modified_dict[name]
+                if name not in original_dict:
+                    del modified_dict[pname]
+                if value.class_origin != classname:
+                    value.class_origin = classname
+
+    def names_only_in_subclass(subclass_dict, super_class_dict)
+        """
+        Return list of object names only in the subclass dictionary for the
+        object
+        """
+        subc_names = [name for name in subclass_dict]
+        sc_names = [name for name in super_class_dict]
+        return list(set(subc_names) - set(sc_names))
+
+    if super_class:
+        # find and clean modified_class properties:
+        sub_class_only_pnames = names_only_in_subclass(
+            ModifiedClass.properties, superclass.properties)
+        clean_existing_attributes(ModifiedClass.properties,
+                                  original_class.properties, classname
+                                  subclcass_only_pnames)
+        sub_class_only_mnames = names_only_in_subclass(
+            ModifiedClass.methods, superclass.methods)
+        clean_existing_attributes(ModifiedClass.methods,
+                                  original_class.methods, classname,
+                                  sub_class_only_mnames)
+        # now process names that are in superclass
+        # class defined in superclass but not in subclass is inherited without
+        # modification.  This is the normal role of resolution.
+
+    else:
+        clean_existing_attributes(ModifiedClass.properties,
+                                  original_class.properties, classname)
+        clean_existing_attributes(ModifiedClass.methods,
+                                  original_class.methods, classname)
+
+
     ###############################################################
     #
     #   Access to the datastores (CIMClass, CIMInstance,
@@ -1060,11 +1123,35 @@ class MainProvider(ResolverMixin, BaseProvider):
 
             CIMError: CIM_ERR_NOT_SUPPORTED
         """
-
         self.validate_namespace(namespace)
-        raise CIMError(
-            CIM_ERR_NOT_SUPPORTED,
-            "Currently ModifyClass not supported in MainProvider")
+
+        # copy because we may modify the class
+        modified_class = deepcopy(ModifiedClass)
+
+        classname = ModifiedClass.classname
+
+        original_class = self.getclass(namespace, classname,
+                                       LocalOnly=False,
+                                       IncludeClassOrigin=True,
+                                       IncludeQualifiers=True)
+        if ModifiedClass.superclass:
+            superclass = self.getclass(namespace, ModifiecClass.superclass,
+                                       LocalOnly=False,
+                                       IncludeClassOrigin=True,
+                                       IncludeQualifiers=True)
+        else:
+            superclass = None
+
+        # validate and cleanup the modified class. This method may generate
+        # CIMError exceptions
+        modified_class = self.validate_modified_class(namespace,
+                                                      modified_class,
+                                                      original_class,
+                                                      superclass)
+
+
+        # Add new class to CIM repository
+        class_store.update(modified_class.classname, modified_class)
 
     ####################################################################
     #

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -41,17 +41,13 @@ from ._resolvermixin import ResolverMixin
 
 class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
     """
-    Create an adaption of the MOF compiler MOFWBEMConnection class so that to
-    directly use the attributes that represent the repository and implement a
-    modified CreateClass that resolves the new class. This directs the compiler
-    output directly  to the dictionaries for qualifiers, and instances in the
-    FakedWBEMConnection object and replaces the CreateClass with a local method
-    that allows resolving the created class before it is inserted into the
-    repository.
+    Create an adaption of the MOF compiler MOFWBEMConnection class to interface
+    through the client API to the FakedWBEMConnection acting as the
+    interface to the CIM repository
 
     This class adaption is private to pywbem_mock
     """
-    def __init__(self, faked_conn_object, cimrepository):
+    def __init__(self, faked_conn_object):
         """
         Initialize the connection.
 
@@ -66,7 +62,8 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
 
         self.classes = NocaseDict()
 
-        self.repo = cimrepository
+        self.conn = faked_conn_object
+        self.conn_id = self.conn_id
 
     def _getns(self):
         """
@@ -75,9 +72,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         This method exists for compatibility. Use the :attr:`default_namespace`
         property instead.
         """
-        if self.conn is not None:
-            return self.conn.default_namespace
-        return self.__default_namespace
+        return self.conn.default_namespace
 
     def _setns(self, value):
         """
@@ -86,10 +81,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         This method exists for compatibility. Use the :attr:`default_namespace`
         property instead.
         """
-        if self.conn is not None:
-            self.conn.default_namespace = value
-        else:
-            self.__default_namespace = value
+        self.conn.default_namespace = value
 
     getns = _getns  # for compatibility
     setns = _setns  # for compatibility
@@ -140,10 +132,11 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         For a description of the parameters, see
         :meth:`pywbem.WBEMConnection.CreateInstance`.
         """
-        namespace = self.default_namespace
+
         inst = args[0] if args else kwargs['NewInstance']
 
         # Get list of properties in class defined for this instance
+        # TODO should this get from conn
         cln = inst.classname
         cls = self.GetClass(cln, IncludeQualifiers=True, LocalOnly=False)
 
@@ -160,21 +153,24 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                             pname, cln, str(inst)))
 
         # Build path from instance and class
-        if inst.path is None or not inst.path.keybindings:
-            inst.path = CIMInstanceName.from_instance(
-                cls, inst, namespace=self.default_namespace)
+        #if inst.path is None or not inst.path.keybindings:
+        #    inst.path = CIMInstanceName.from_instance(
+        #        cls, inst, namespace=self.default_namespace)
+        # Force CreateInstance to build path
+        inst.path = None
 
         # Exception if duplicate. NOTE: compiler overrides this with
         # modify instance.
-        instance_store = self.repo.get_instance_store(namespace)
-        if instance_store.object_exists(inst.path):
-            raise CIMError(
-                CIM_ERR_ALREADY_EXISTS,
-                _format('CreateInstance failed. Instance with path {0!A} '
-                        'already exists in mock repository', inst.path))
+
+        # TODO: CreateInstance actually covers the case where it exists.
+        # confirm error type return
+        #if self.conn.GetInstance(inst.path):
+        #    raise CIMError(
+        #        CIM_ERR_ALREADY_EXISTS,
+        #        _format('CreateInstance failed. Instance with path {0!A} '
+        #                'already exists in mock repository', inst.path))
         try:
-            # TODO: This should go through self.conn.CreateInstance
-            instance_store.create(inst.path, inst)
+            self.conn.CreateInstance(inst)
         except KeyError:
             raise
 
@@ -189,29 +185,33 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         each created instance include the instance path which means that
         the MOF must include the instance alias on each created instance.
         """
-        namespace = self.default_namespace
+        # namespace = self.default_namespace
         mod_inst = args[0] if args else kwargs['ModifiedInstance']
-        # pylint: disable=protected-access
-        instance_store = self.conn._get_instance_store(namespace)
+        # # pylint: disable=protected-access
+        # instance_store = self.conn._get_instance_store(namespace)
 
-        if self.default_namespace not in self.repo.namespaces:
-            raise CIMError(
-                CIM_ERR_INVALID_NAMESPACE,
-                _format('ModifyInstance failed. No instance repo exists. '
-                        'Use compiler instance alias to set path on '
-                        'instance declaration. inst: {0!A}', mod_inst))
+        # if self.default_namespace not in self.repo.namespaces:
+            # raise CIMError(
+                # CIM_ERR_INVALID_NAMESPACE,
+                # _format('ModifyInstance failed. No instance repo exists. '
+                        # 'Use compiler instance alias to set path on '
+                        # 'instance declaration. inst: {0!A}', mod_inst))
 
-        if not instance_store.object_exists(mod_inst.path):
-            raise CIMError(
-                CIM_ERR_NOT_FOUND,
-                _format('ModifyInstance failed. No instance exists. '
-                        'Use compiler instance alias to set path on '
-                        'instance declaration. inst: {0!A}', mod_inst))
+        # if not instance_store.object_exists(mod_inst.path):
+            # raise CIMError(
+                # CIM_ERR_NOT_FOUND,
+                # _format('ModifyInstance failed. No instance exists. '
+                        # 'Use compiler instance alias to set path on '
+                        # 'instance declaration. inst: {0!A}', mod_inst))
 
         # Update the instance in the repository from the modified inst
-        orig_inst = instance_store.get(mod_inst.path)
-        orig_inst.update(mod_inst.properties)
-        instance_store.update(mod_inst.path, orig_inst)
+        #orig_inst = instance_store.get(mod_inst.path)
+        #orig_inst.update(mod_inst.properties)
+        #instance_store.update(mod_inst.path, orig_inst)
+        # TODO: Do I have to do the update or does ModifyInstance
+        #orig_inst = self.conn.GetInstance(mod_inst.path)
+        #orig_inst.update(mod_inst.properties)
+        self.conn.ModifyInstance(mod_inst.path)
 
     def DeleteInstance(self, *args, **kwargs):
         """This method is only invoked by :meth:`rollback` (on the underlying
@@ -223,19 +223,18 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
             conn_id=self.conn_id)
 
     def GetClass(self, *args, **kwargs):
-        """Retrieve a CIM class from the local repository of this class.
+        """Retrieve a CIM class from the local classes store if it exists
+        there or from the cim repository reached through conn.
 
         For a description of the parameters, see
         :meth:`pywbem.WBEMConnection.GetClass`.
         """
+
         cname = args[0] if args else kwargs['ClassName']
 
         try:
             cc = self.classes[self.default_namespace][cname]
         except KeyError:
-            if self.conn is None:
-                ce = CIMError(CIM_ERR_NOT_FOUND, cname)
-                raise ce
             cc = self.conn.GetClass(*args, **kwargs)
             try:
                 self.classes[self.default_namespace][cc.classname] = cc
@@ -243,6 +242,8 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                 self.classes[self.default_namespace] = \
                     NocaseDict({cc.classname: cc})
 
+        # TODO: Do we even need this except for when we get class from
+        # the local store?
         if 'LocalOnly' in kwargs and not kwargs['LocalOnly']:
             if cc.superclass:
                 try:
@@ -271,8 +272,6 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         :meth:`pywbem.WBEMConnection.CreateClass`.
         """
         cc = args[0] if args else kwargs['NewClass']
-        namespace = self.default_namespace
-        class_store = self.repo.get_class_store(namespace)
 
         if cc.superclass:
             # Since this may cause additional GetClass calls
@@ -294,12 +293,13 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
 
         # Class created in local repo before tests because that allows
         # tests that may actually include this class to succeed in
-        # the test code below.
+        # the test code below without previously putting the class into
+        # the repository defined by conn.
         try:
             # The following generates an exception for each new ns
             self.classes[self.default_namespace][cc.classname] = cc
         except KeyError:
-            self.classes[namespace] = NocaseDict({cc.classname: cc})
+            self.classes[self.default_namespace] = NocaseDict({cc.classname: cc})
 
         # Validate that references and embedded instance properties, methods,
         # etc. have classes that exist in repo. This  also institates the
@@ -329,6 +329,8 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                                     obj.reference_class, obj.name,
                                     cc.classname, self.getns()),
                             conn_id=self.conn_id)
+                    # NOTE: Only delete when this is total failure
+                    del self.classes[self.conn.default_namespace][cc.classname]
                     raise
 
             elif obj.type == 'string':
@@ -351,20 +353,23 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                                         eiqualifier.value, obj.name,
                                         cc.classname, self.getns()),
                                 conn_id=self.conn_id)
+                        # Only delete when total failure
+                        del self.classes[self.default_namespace][cc.classname]
                         raise
 
         # TODO: Review this. Changed from conn to repo
-        ccr = self.repo._resolve_class(  # pylint: disable=protected-access
-            cc, namespace, self.repo.get_qualifier_store(namespace))
+        # ccr = self.repo._resolve_class(  # pylint: disable=protected-access
+            # cc, namespace, self.repo.get_qualifier_store(namespace))
 
-        # If the class exists, update it. Otherwise create it
-        # TODO: Validate that this is correct behavior. That is what the
-        # original MOFWBEMConnection does.
-        if class_store.object_exists(ccr.classname):
-            class_store.update(ccr.classname, ccr)
-        else:
-            class_store.create(ccr.classname, ccr)
-        self.classes[namespace][ccr.classname] = ccr
+        # # If the class exists, update it. Otherwise create it
+        # # TODO: Validate that this is correct behavior. That is what the
+        # # original MOFWBEMConnection does.
+        # if class_store.object_exists(ccr.classname):
+            # class_store.update(ccr.classname, ccr)
+        # else:
+            # class_store.create(ccr.classname, ccr)
+        # self.classes[namespace][ccr.classname] = ccr
+        self.conn.CreateClass(cc)
 
     def EnumerateQualifiers(self, *args, **kwargs):
         """Enumerate the qualifier types in the local repository of this class.
@@ -373,10 +378,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         :meth:`pywbem.WBEMConnection.EnumerateQualifiers`.
         """
 
-        if self.conn is not None:
-            rv = self.conn.EnumerateQualifiers(*args, **kwargs)
-        else:
-            rv = []
+        rv = self.conn.EnumerateQualifiers(*args, **kwargs)
         try:
             rv += list(self.qualifiers[self.default_namespace].values())
         except KeyError:
@@ -391,11 +393,11 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         """
 
         qualname = args[0] if args else kwargs['QualifierName']
-        namespace = self.default_namespace
         try:
             # TODO: This should get from real repo I think
-            qualifier_store = self.repo.get_qualifier_store(namespace)
-            qual = qualifier_store.get(qualname)
+            #qualifier_store = self.repo.get_qualifier_store(namespace)
+            #qual = qualifier_store.get(qualname)
+            qual = self.conn.GetQualifier(qualname)
         except KeyError:
             raise
         return qual
@@ -407,18 +409,10 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         For a description of the parameters, see
         :meth:`pywbem.WBEMConnection.SetQualifier`.
         """
-        namespace = self.default_namespace
+        #namespace = self.default_namespace
         qual = args[0] if args else kwargs['QualifierDeclaration']
-        qualifier_store = self.repo.get_qualifier_store(namespace)
-        try:
-            qualifier_store.create(qual.name, qual)
-        except KeyError:
-            # If qualifier already in repo, update it. This is defined
-            # specification behavior
-            qualifier_store.update(qual.name, qual)
-            # raise
-            # self.qualifiers[self.default_namespace] = \
-            #    # NocaseDict({qual.name: qual})
+        #qualifier_store = self.repo.get_qualifier_store(namespace)
+        self.conn.SetQualifier(qual)
 
     def DeleteQualifier(self, *args, **kwargs):
         """This method is only invoked by :meth:`rollback` (on the underlying
@@ -436,6 +430,7 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
         This method is just rename of GetClass to support same method
         with both MOFWBEMConnection and FakedWBEMConnection
         """
+        # TODO: Should we delete this???
         return self.GetClass(superclass,
                              namespace=namespace,
                              local_only=local_only,

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -28,7 +28,7 @@ For documentation, see mocksupport.rst.
 from __future__ import absolute_import, print_function
 
 from pywbem import CIMError, CIM_ERR_INVALID_PARAMETER, \
-    CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, CIM_ERR_INVALID_SUPERCLASS
+    CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_SUPERCLASS
 from pywbem._nocasedict import NocaseDict
 from pywbem._mof_compiler import BaseRepositoryConnection
 from pywbem._utils import _format
@@ -40,9 +40,9 @@ from ._resolvermixin import ResolverMixin
 
 class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
     """
-    Create an adaption of the MOF compiler MOFWBEMConnection class to interface
-    through the client API to the FakedWBEMConnection acting as the
-    interface to the CIM repository
+    Create an adaption of the MOF compiler BaseRepositoryConnection class to
+    interface through the client API to the FakedWBEMConnection acting as the
+    interface to the CIM repository for mocking a WBEM server
 
     This class adaption is private to pywbem_mock
     """
@@ -53,9 +53,8 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
           Parameters:
 
             faked_conn_object (FakedWBEMConnection):
-              The instance of _FakeWBEMConnection to which this is attached.
-              This allows us to use the same objects for qualifiers, instances
-              and classes as that object
+              The instance of :class:~`pywbem_mock._FakeWBEMConnection`
+              which provides the WBEM connection for access to CIM objects.
         """
 
         self.classes = NocaseDict()
@@ -81,8 +80,7 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         """
         self.conn.default_namespace = value
 
-    getns = _getns  # for compatibility
-    setns = _setns  # for compatibility
+    getns = _getns  # for compatibility, used in the MOF compiler
 
     default_namespace = property(
         _getns, _setns, None,
@@ -106,13 +104,11 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         Not Implemented because not used with the MOF compiler.
         """
 
-        raise CIMError(
-            CIM_ERR_FAILED, 'EnumerateInstanceNames not implemented!',
-            conn_id=self.conn_id)
+        assert False, 'EnumerateInstanceNames not implemented!'
 
     def CreateInstance(self, *args, **kwargs):
         """
-        Create a CIM instance through the connected client.
+        Create a CIM instance in the connected client.
 
         This method:
 
@@ -129,7 +125,6 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         inst = args[0] if args else kwargs['NewInstance']
 
         # Get list of properties in class defined for this instance
-        # TODO should this get from conn
         cln = inst.classname
         cls = self.GetClass(cln, IncludeQualifiers=True, LocalOnly=False)
 
@@ -152,11 +147,10 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         inst.path = None
 
         try:
-            self.conn.CreateInstance(inst)
+            path = self.conn.CreateInstance(inst)
         except KeyError:
             raise
-
-        return inst.path
+        return path
 
     def ModifyInstance(self, *args, **kwargs):
         """
@@ -177,10 +171,7 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         """
         Not implemented because not used by the MOF compiler
         """
-
-        raise CIMError(
-            CIM_ERR_FAILED, 'DeleteInstance not implemented!',
-            conn_id=self.conn_id)
+        assert False, 'DeleteInstance not implemented!'
 
     def GetClass(self, *args, **kwargs):
         """Retrieve a CIM class from the local classes store if it exists
@@ -338,9 +329,7 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         Not implemented because not called from the MOF compiler
         """
 
-        raise CIMError(
-            CIM_ERR_FAILED, 'DeleteClass not implemented!',
-            conn_id=self.conn_id)
+        assert False, 'DeleteClass not implemented!'
 
     def EnumerateQualifiers(self, *args, **kwargs):
         """Enumerate the qualifier types throught the connected client.
@@ -381,6 +370,4 @@ class _MockMOFWBEMConnection(BaseRepositoryConnection, ResolverMixin):
         Not implemented because not called from the MOF compiler
         """
 
-        raise CIMError(
-            CIM_ERR_FAILED, 'DeleteQualifier not implemented!',
-            conn_id=self.conn_id)
+        assert False, 'DeleteQualifier not implemented!'

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -152,23 +152,11 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                             'class {1!A} but not in new_instance: {2!A}',
                             pname, cln, str(inst)))
 
-        # Build path from instance and class
-        #if inst.path is None or not inst.path.keybindings:
-        #    inst.path = CIMInstanceName.from_instance(
-        #        cls, inst, namespace=self.default_namespace)
-        # Force CreateInstance to build path
-        inst.path = None
-
-        # Exception if duplicate. NOTE: compiler overrides this with
-        # modify instance.
-
-        # TODO: CreateInstance actually covers the case where it exists.
-        # confirm error type return
-        #if self.conn.GetInstance(inst.path):
-        #    raise CIMError(
-        #        CIM_ERR_ALREADY_EXISTS,
-        #        _format('CreateInstance failed. Instance with path {0!A} '
-        #                'already exists in mock repository', inst.path))
+	# insure inst.path is empty before calling CreateInstance so that
+        # the path is built by CreateInstance. This is logical because
+        # the mock environment always requires a complete path to insert
+        # an instance into the repository.
+	inst.path = None
         try:
             self.conn.CreateInstance(inst)
         except KeyError:
@@ -357,18 +345,6 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
                         del self.classes[self.default_namespace][cc.classname]
                         raise
 
-        # TODO: Review this. Changed from conn to repo
-        # ccr = self.repo._resolve_class(  # pylint: disable=protected-access
-            # cc, namespace, self.repo.get_qualifier_store(namespace))
-
-        # # If the class exists, update it. Otherwise create it
-        # # TODO: Validate that this is correct behavior. That is what the
-        # # original MOFWBEMConnection does.
-        # if class_store.object_exists(ccr.classname):
-            # class_store.update(ccr.classname, ccr)
-        # else:
-            # class_store.create(ccr.classname, ccr)
-        # self.classes[namespace][ccr.classname] = ccr
         self.conn.CreateClass(cc)
 
     def EnumerateQualifiers(self, *args, **kwargs):
@@ -394,9 +370,6 @@ class _MockMOFWBEMConnection(MOFWBEMConnection, ResolverMixin):
 
         qualname = args[0] if args else kwargs['QualifierName']
         try:
-            # TODO: This should get from real repo I think
-            #qualifier_store = self.repo.get_qualifier_store(namespace)
-            #qual = qualifier_store.get(qualname)
             qual = self.conn.GetQualifier(qualname)
         except KeyError:
             raise

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -242,11 +242,9 @@ class FakedWBEMConnection(WBEMConnection):
         # operations. Uses the setter method
         self.disable_pull_operations = disable_pull_operations
 
-        # Defines the connection for the compiler.  The compiler uses
-        # its local repo for work but sends new objects back to the
-        # methods in the mainprovider attached to this class.
-        self._mofwbemconnection = _MockMOFWBEMConnection(self,
-                                                         self.mainprovider)
+        # Defines the connection for the compiler. The compiler uses this
+        # instance of this class as the client interface.
+        self._mofwbemconnection = _MockMOFWBEMConnection(self)
 
         # The CIM methods with callback in the mock repository.
         # This is a dictionary of dictionaries of dictionaries, where the top

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -64,8 +64,6 @@ class BaseMethodsForTests(object):
         """
         skip_if_moftab_regenerated()
 
-        import pdb; pdb.set_trace()
-
         server = WbemServerMock(interop_ns='interop')
         # pylint: disable=attribute-defined-outside-init
         self.conn = server.wbem_server.conn

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -64,6 +64,8 @@ class BaseMethodsForTests(object):
         """
         skip_if_moftab_regenerated()
 
+        import pdb; pdb.set_trace()
+
         server = WbemServerMock(interop_ns='interop')
         # pylint: disable=attribute-defined-outside-init
         self.conn = server.wbem_server.conn

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -829,11 +829,11 @@ def add_objects_to_repo(conn, namespace, objects_list):
         conn.add_namespace(namespace)
     assert isinstance(objects_list, (list, tuple))
 
-    for object in objects_list:
-        if isinstance(object, six.string_types):
-            conn.compile_mof_string(object, namespace=namespace)
+    for obj in objects_list:
+        if isinstance(obj, six.string_types):
+            conn.compile_mof_string(obj, namespace=namespace)
         else:
-            conn.add_cimobjects(object, namespace=namespace)
+            conn.add_cimobjects(obj, namespace=namespace)
 
 
 #########################################################################
@@ -1272,8 +1272,7 @@ class TestRepoMethods(object):
             conn.add_cimobjects(tst_classeswqualifiers, namespace=ns)
             conn.add_cimobjects(tst_instances, namespace=ns)
 
-        instance_store = \
-            conn._get_instance_store(ns)  # pylint: disable=protected-access
+        instance_store = conn.mainprovider.get_instance_store(ns)
 
         iname = CIMInstanceName(cln,
                                 keybindings={'InstanceID': key},
@@ -1810,8 +1809,8 @@ class TestRepoMethods(object):
         assert 'TST_Person' in clns
         assert 'TST_Lineage' in clns
         assert 'TST_Personsub' in clns
-        assert 'TST_MemberOfFamilyCollection'
-        assert 'TST_FamilyCollection'
+        assert 'TST_MemberOfFamilyCollection' in clns
+        assert 'TST_FamilyCollection' in clns
         assert len(clns) == 5
 
         inst_names = conn.EnumerateInstanceNames('TST_Person', namespace=ns)
@@ -2147,7 +2146,7 @@ class UserMethodProviderTest(MethodProvider):
         """
         Init of test provider
         """
-        super(UserProviderTest, self).__init__()
+        super(UserMethodProviderTest, self).__init__()
         self.cimrepository = cimrepository
 
     def InvokeMethod(self, namespace, methodname, objectname, Params):
@@ -2219,16 +2218,16 @@ class TestProviderRegisterMethods(object):
 
         if condition == "pdb":
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
 
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
 
         if exp_exec is None:
-            for input in inputs:
-                tst_ns = input[0]
-                clns = input[1]
-                provider_type = input[2]
-                provider = input[3]
+            for item in inputs:
+                tst_ns = item[0]
+                clns = item[1]
+                provider_type = item[2]
+                provider = item[3]
                 conn.register_provider(tst_ns, clns, provider_type, provider)
 
             pr = conn.provider_registry
@@ -2245,11 +2244,11 @@ class TestProviderRegisterMethods(object):
 
         else:
             with pytest.raises(exp_exec):
-                for input in inputs:
-                    tst_ns = input[0]
-                    clns = input[1]
-                    provider_type = input[2]
-                    provider = input[3]
+                for item in inputs:
+                    tst_ns = item[0]
+                    clns = item[1]
+                    provider_type = item[2]
+                    provider = item[3]
 
                     conn.register_provider(tst_ns, clns, provider_type,
                                            provider)
@@ -2350,17 +2349,17 @@ class TestProviderRegisterMethods(object):
 
         if condition == "pdb":
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
 
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
 
         # Register multiple providers.  All registrations are must be
         # accepted
-        for input in inputs:
-            tst_ns = input[0]
-            clns = input[1]
-            provider_type = input[2]
-            provider = input[3]
+        for item in inputs:
+            tst_ns = item[0]
+            clns = item[1]
+            provider_type = item[2]
+            provider = item[3]
 
             conn.register_provider(tst_ns, clns, provider_type, provider)
 
@@ -4306,7 +4305,7 @@ class TestInstanceOperations(object):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
 
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
 

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -4134,10 +4134,7 @@ class TestInstanceOperations(object):
             # Mocker builds path
             ['instance of TST_Person { name = "Mike"; };',
              ('TST_Person', {'name': "Mike"}), None],
-            # Works because mock repo allows modification of existing instance
-            ['instance of TST_Person { name = "Mike"; };\n'
-             'instance of TST_Person { name = "Mike"; };',
-             ('TST_Person', {'name': "Mike"}), None],
+
             # Fails, because key property not in new instance
             ['instance of TST_Person {extraProperty = "Blah"; };',
              ('TST_Person', {}),

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -3376,7 +3376,9 @@ class TestClassOperations(object):
                         else:
                             assert mvalue.propagated is False
                             assert mvalue.class_origin == rtn_class.classname
-                # TODO test each parameter also
+                # TODO test each parameter also. Currently we stop at methods
+
+    # Issue # 2210, implement a specifc test for ModifyClass
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])


### PR DESCRIPTION
Refactored the code in _MockMOFWBEMConnection to add things and get them from the cim repository through the WBEMConnection client interfaces (before we were communicating directly through the cim repository interface).

See commit message for details.

Waiting commit of pr #2215