### PR TITLE
Partly fixes #2062: add namespace provider

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -170,6 +170,12 @@ Released: not yet
   namespace. If you miss a symbol in the pywbem namespace, it was likely a
   symbol that is not part of the public pywbem API. (See issue #1925)
 
+* Removed the method `add_method_callback()` and the FakeWBEMConnection
+  `methods` property from python_mock. This has been replaced by
+  the user-defined provider concept where the user defines and registers a
+  subclass to the class MethodProvider whichimplements the InvokeMethod
+  responder in that user-defined provider. (See issue #2062).
+
 **Deprecations:**
 
   Deprecated the method FakedWBEMConnection.compile_dmtf_schema in favor of

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -563,6 +563,14 @@ Released: not yet
 
 * Test: Converted WBEMListener tests from unittest to pytest. (See issue #2179)
 
+* Enhance FakeWBEMConnection to allow user-defined providers for specific
+  WBEM request operations.  This allows user-defined providers for selected
+  instance requests (CreateInstance, ModifyInstance, DeleteInstance) and for
+  the InvokeMethod.  Includes the capability to register these providers with
+  a method `register_provider` in Faked_WBEMConnection.  This also creates
+  a CIM_Namespace provider to handle the CIM_Namespace class in the interop
+  namespace.  See issue #2062)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -321,22 +321,22 @@ The following is an example for defining a method provider.
         def __init__(self, cimrepository):
             self.cimrepository = cimrepository
 
-        def InvokeMethod(self, namespace, methodname, objectname, Params):
+        def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
             """
             The parameters and return for Invoke method are defined in
             :meth:`~pywbem_mock.MethodProvider.InvokeMethod`
 
-            This acts as both a static (objectname is only classname) and dynamic
-            (objectname is an instance name) method provider
+            This acts as both a static (ObjectName is only classname) and dynamic
+            (ObjectName is an instance name) method provider
             """
             # validate namespace using method in BaseProvider
             self.validate_namespace(namespace)
 
             # get classname and validate. This provider uses only one class
-            if isinstance(objectname, six.string_types):
-                classname = objectname
+            if isinstance(ObjectName, six.string_types):
+                classname = ObjectName
             else:
-                classname = objectname.classname
+                classname = ObjectName.classname
             assert classname.lower() == 'tst_class'
 
             # Test if class exists.
@@ -346,17 +346,17 @@ The following is an example for defining a method provider.
                     _format("class {0|A} does not exist in CIM repository, "
                             "namespace {1!A}", classname, namespace))
 
-            if isinstance(objectname, CIMInstanceName):
+            if isinstance(ObjectName, CIMInstanceName):
                 instance_store = self.get_instance_store(namespace)
                 inst = self.find_instance(objectname, instance_store,
-                                          copy_inst=False)
+                                          copy=False)
                 if inst is None:
                     raise CIMError(
                         CIM_ERR_NOT_FOUND,
                         _format("Instance {0|A} does not exist in CIM repository, "
-                                "namespace {1!A}", objectname, namespace))
+                                "namespace {1!A}", ObjectName, namespace))
 
-            if methodname.lower() == 'method1':
+            if MethodName.lower() == 'method1':
 
                 rtn_parameters = [CIMParameter('OutputParam1', 'string',
                                                value=namespace)]
@@ -929,21 +929,8 @@ DMTF CIM schema download support
 config
 ------
 
-.. autoclass:: pywbem_mock.config
+.. automodule:: pywbem_mock.config
    :members:
-
-   .. rubric:: Methods
-
-   .. autoautosummary:: pywbem_mock.config
-      :methods:
-      :nosignatures:
-
-   .. rubric:: Attributes
-
-   .. autoautosummary:: pywbem_mock.config
-      :attributes:
-
-   .. rubric:: Details
 
 
 .. _`Mock CIM repository`:

--- a/docs/mocksupport.rst
+++ b/docs/mocksupport.rst
@@ -129,6 +129,8 @@ Pywbem mock supports:
 3. Gathering time statistics and delaying responses for a predetermined time.
 4. :class:`~pywbem.WBEMConnection` logging except that there are no HTTP entries
    in the log.
+5. Creating user-defined providers that can create specialized versions of
+   some of the responder methods.
 
 Pywbem mock does NOT support:
 
@@ -156,9 +158,7 @@ Pywbem mock does NOT support:
    HTTP requests or responses.
 7. Generating CIM indications.
 8. Some of the functionality that may be implemented in real WBEM servers such
-   as the `__Namespace__` class/provider or the `CIM_Namespace`
-   class/provider, because these are WBEM server-specific implementations and
-   not WBEM request level capabilities.  Note that such capabilities can be at
+   as the `__Namespace__` class/provider.  Note that such capabilities can be at
    least partly built on top of the existing capabilities by inserting
    corresponding CIM instances into the mock repository.
 
@@ -271,27 +271,26 @@ repository.
 Faked method invocation operation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. index:: single: User defined providers
+.. index:: single: User-defined providers
 
 The faked method invocation operation (`InvokeMethod`) behaves like
 :meth:`~pywbem.WBEMConnection.InvokeMethod`, but because of the nature of
 `InvokeMethod`, the user must provide an implementation of InvokeMethod
 based on the API defined in :meth:`~pywbem_mock.MethodProvider.InvokeMethod`.
 
-See :ref:`User provider interfaces`
+See :ref:`User-defined providers` for more information on writing a
+user-defined provider.
 
-The user method provider must have the signature defined in the
+The user-defined method provider must have the signature defined in the
 :class:`~pywbem_mock.MethodProvider` function and must be registered
 as a method provider
 :meth:`~pywbem_mock.FakedWBEMConnection.register_provider` for a particular
 combination of namespace, class, and CIM method name.
 
-When the user method provider is invoked on behalf of an `InvokeMethod` operation,
-the target object of the method invocation (class or instance) is provided to
-the InvokeMethod method, in addition to the method input parameters.
-
-The user provider can access the mock repository of the faked connection
-using the methods defined in :class:`~pywbem_mock.InMemoryRepository`
+When the user-defined method provider is invoked on behalf of an `InvokeMethod`
+operation, the target object of the method invocation (class or instance) is
+provided to the InvokeMethod method, in addition to the method input
+parameters.
 
 The user provider is expected to return a tuple consisting of two items:
 
@@ -299,7 +298,11 @@ The user provider is expected to return a tuple consisting of two items:
 * an iterable containing any output parameters as
   :class:`~pywbem.CIMParameter` objects.
 
-TODO: Explain other mocker methods in BaseProvider that are available.
+The user-defined provider has access to:
+   * methods defined in it superclass
+   * methods defined in :class:~pywbem_mock.BaseProvider`
+   * methods to access the CIM repository using the methods defined in
+     :class:`~pywbem_mock.InMemoryRepository`
 
 The following is an example for defining a method provider.
 
@@ -864,6 +867,15 @@ This adds the instances to the repository display of the previous example:
     };
 
 
+
+.. _`User-defined providers`:
+
+User-defined providers
+----------------------
+
+TODO: Write this section. It should include defining them and registering them.
+
+
 .. _`FakedWBEMConnection`:
 
 FakedWBEMConnection
@@ -906,6 +918,29 @@ DMTF CIM schema download support
    .. rubric:: Attributes
 
    .. autoautosummary:: pywbem_mock.DMTFCIMSchema
+      :attributes:
+
+   .. rubric:: Details
+
+
+
+.. _`config`:
+
+config
+------
+
+.. autoclass:: pywbem_mock.config
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem_mock.config
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem_mock.config
       :attributes:
 
    .. rubric:: Details

--- a/pywbem_mock/__init__.py
+++ b/pywbem_mock/__init__.py
@@ -29,7 +29,8 @@ from ._resolvermixin import *              # noqa: F403,F401
 from ._mockmofwbemconnection import *      # noqa: F403,F401
 from ._baserepository import *             # noqa: F403,F401
 from ._inmemoryrepository import *         # noqa: F403,F401
-from ._baseprovider import *                # noqa: F403,F401
+from ._baseprovider import *               # noqa: F403,F401
 from ._mainprovider import *               # noqa: F403,F401
 from ._defaultinstanceprovider import *    # noqa: F403,F401
+from ._namespaceprovider import *          # noqa: F403,F401
 from ._utils import *                      # noqa: F403,F401

--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -21,21 +21,15 @@
 """
 A CIM provider creates WBEM server responses to operations defined in DSP0200.
 
-The BaseProvider WBEM server provider handles provider required data that
-is common to both the MainProvider, InstanceWriteProvider, and any
-registered instance providers including:
+The BaseProvider module contains methods required by both builtin
+providers and user-defined providers. This module includes methods for the
+following functionality:
 
-  * Access to the CIM repository
-  * Access to the Method repository
-  * Local provider methods that are common to both the main provider and other
-    providers.
-  * CIMInstance request operations except for selected operations that are
-    handled by the BaseInstanceProvider to allow for specialized
-    instance providers to be implemented.
-  * Associator request operations
-
-This provider uses a separate CIM repository for the objects maintained by
-the CIM repository and defined with the interfaces in `BaseRepository`.
+  * Managing namespaces in the CIM repository
+  * Methods that provide access to specific objects in the CIM repository
+    including the processing consistent with filtering the returned objects.
+    For example, `get_class(...) the internal equilavent of the GetClass
+    and `find_instance(...) the internal equivalent of GetInstance.
 """
 
 from __future__ import absolute_import, print_function
@@ -303,7 +297,7 @@ class BaseProvider(object):
 
         Returns:
 
-          List of :term:`string` containing the valid names for
+          List of :term:`string`: containing the valid names for
           namespaces that can be interop namespaces. Any name not on this list
           cannot be an interop provider
 
@@ -325,9 +319,9 @@ class BaseProvider(object):
                 The namespace name that is to be tested.
 
         Returns:
-            True: If the name is one of the valid interop namespace names
-            False: if the name is not an interop namespace valid name.
 
+            Bool: If the name is one of the valid interop namespace names if
+              `True` and is not a valid interop namespace name if `False`.
         """
         ns_lower = [ns.lower() for ns in self.interop_namespace_names()]
         return namespace.lower() in ns_lower
@@ -339,8 +333,8 @@ class BaseProvider(object):
         possible names is defined by the method `interop_namespace_names`.
 
         Returns:
-          The name of the interop namespace if one exists or None if there
-          is no interop namespace in the CIM repository.
+          :term:`string`: The name of the interop namespace if one exists or
+          `None` if there is no interop namespace in the CIM repository.
 
         """
         ns_dict = NocaseDict({ns: ns for ns in self.cimrepository.namespaces})
@@ -455,9 +449,9 @@ class BaseProvider(object):
 
         Returns:
 
-          Copy of the CIM class in the cim repository if found. Includes
-          superclass properties installed and filtered in accord with the the
-          local_only, etc. arguments.
+          :class:`~pywbem.CIMClass`: Copy of the CIM class in the CIM
+          repository if found. Includes superclass properties installed and
+          filtered in accord with the local_only, etc. arguments.
 
         Raises:
           :class:`~pywbem.CIMError`: (CIM_ERR_NOT_FOUND) if class not found in
@@ -539,10 +533,10 @@ class BaseProvider(object):
                     del obj.properties[pname]
 
     @staticmethod
-    def find_instance(instance_name, instance_store, copy_inst=None):
+    def find_instance(instance_name, instance_store, copy=None):
         """
         Find an instance in the CIM repository by `instance_name` and return
-        that instance. the `copy_inst` parameter controls whether the original
+        that instance. the `copy` parameter controls whether the original
         instance in the CIM repository is returned or a copy.  The
         only time the original should be returned is when the user is
         certain that the returned object WILL NOT be modified.
@@ -555,18 +549,20 @@ class BaseProvider(object):
           instance_store (:class:`~pywbem_mock.BaseObjectStore`):
             Instance store of the CIM repository to search for the instance
 
-          copy_inst (bool):
+          copy (bool):
             If True do copy of the instance and return the copy. Otherwise
             return the instance in the CIM repository
 
         Returns:
-            None if the instance defined by `instance_name` is not found.
+            :class:`~pywbem.CIMInstance`: the complete CIM instance or copy of
+            the CIM instance is returned if it is found in the cim repository
+            or `None` if the instance defined by `instance_name` is not found
+            in the CIM repository.
 
-            The complete CIM instance or copy of the CIMinstance
-            is returned if it is found in the cim repository.
+
         """
 
         if instance_store.object_exists(instance_name):
-            return instance_store.get(instance_name, copy=copy_inst)
+            return instance_store.get(instance_name, copy=copy)
 
         return None

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -73,6 +73,7 @@ classes) so that generally only the leaf CIM classes required for the
 repository need to be in the class list. This speeds up the process of
 compiling DMTF CIM classes for any test significantly.
 """
+
 import warnings
 import os
 from zipfile import ZipFile
@@ -93,12 +94,12 @@ __all__ = ['DMTFCIMSchema']
 def build_schema_mof(class_names, schema_pragma_file):
     """
     Build a string that includes the ``#include pragma`` statements for the
-    DMTF schema CIM classes defined in `class_names` using the DMTF CIM
-    schema defined by this object.
+    schema CIM classes defined in `class_names` using the CIM schema defined by
+    this object.
 
     The class names in `class_names` can be just leaf classes. The pywbem
     MOF compiler will search for dependent classes including superclasses,
-    and other classes referenced as the classes are compiled.
+    and other classes referenced as the defined classes are compiled.
 
     It builds a compilable MOF string in the form::
 
@@ -135,12 +136,12 @@ def build_schema_mof(class_names, schema_pragma_file):
         classes defined in the schema.
 
     Returns:
-        :term:`string`: Valid MOF containing pragma statements for
-        all of the classes in `schema_classes`.
+        :term:`string`: Valid MOF containing pragma statements from the
+        `CIM schema pragma file` for all of the classes in `schema_classes`.
 
     Raises:
         ValueError: If any of the classnames in `schema_classes` are not in
-        the DMTF CIM schema installed
+        the `CIM schema pragma file`.
     """
     if isinstance(class_names, six.string_types):
         class_names = [class_names]
@@ -167,7 +168,7 @@ def build_schema_mof(class_names, schema_pragma_file):
     classes_not_found = set(class_names) - set(found_classes)
     if classes_not_found:
         raise ValueError(
-            _format("Classes {0!A} not in DMTF CIM schema {1!A}",
+            _format("Classes {0!A} not in the CIM schema pragma file {1!A}",
                     ', '.join(classes_not_found), schema_pragma_file))
 
     # Sort the list so the result is in the same order as the pragmas
@@ -331,22 +332,23 @@ class DMTFCIMSchema(object):
     def schema_mof_file(self):
         """
         **Deprecated:** This attribute has been deprecated in pywbem 1.0.0
-        in favor of
-        :method:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`.
+        in favor of :meth:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`.
+
         :term:`string`: Path name of the schema pragma file
         which defines MOF pragmas to compile the complete CIM schema. This file
         contains the `#pragama include` statements for all of the classes in
         the schema and the qualifier declaration `#pragma include` statements
         to compile `qualifiers.mof` and `qualifiers_optional.mof`.
 
-        This filename is of the general form::
+        This file pathname is of the general form::
 
             <schema_mof_dir>/cim_schema_<schema_version_str>.mof
 
             ex: schemas/dmtf/moffinal2490/cim_schema_2.49.0.mof
+
         """
         warnings.warn("The attribute schema_mof_file has been deprecated. Use "
-                      " the attribute schema_pragma_file.",
+                      "the attribute schema_pragma_file.",
                       DeprecationWarning, stacklevel=2)
         return self._schema_pragma_file
 

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -376,8 +376,7 @@ class MainProvider(BaseProvider, ResolverMixin):
         """  # noqa: E501
         # pylint: enable=line-too-long
 
-        rtn_inst = self.find_instance(instance_name, instance_store,
-                                      copy_inst=True)
+        rtn_inst = self.find_instance(instance_name, instance_store, copy=True)
 
         if rtn_inst is None:
             raise CIMError(

--- a/pywbem_mock/_namespaceprovider.py
+++ b/pywbem_mock/_namespaceprovider.py
@@ -1,0 +1,401 @@
+#
+# (C) Copyright 2020 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+This module implements a user-defined provider for the class CIM_Namespace
+
+This  provider manages creation and deletion of the instances of the
+CIM_Namespace class and limits that activity to the server environment interop
+classname.  The CIM_Namespace class is a DMTF defined class that
+defines an instance for each namespace in the server environment and allows
+the creation and deletion of server CIM namespaces to be controlled through
+creation and deletion of instances of  the CIM_Namespace class.
+"""
+
+from copy import deepcopy
+
+from pywbem import CIMError, CIMInstance, CIM_ERR_NOT_SUPPORTED, \
+    CIM_ERR_INVALID_PARAMETER
+
+from pywbem._nocasedict import NocaseDict
+
+from pywbem._utils import _format
+
+# TODO: Should be able to import from pywbem_mock
+from ._defaultinstanceprovider import InstanceWriteProvider
+
+from .config import OBJECTMANAGERNAME, SYSTEMNAME, SYSTEMCREATIONCLASSNAME, \
+    OBJECTMANAGERCREATIONCLASSNAME
+
+
+def create_cimnamespace_instance(conn, namespace, interop_namespace, klass):
+    """
+    Build and execute CreateInstance for an instance of CIM_Namespace using
+    the `namespace` as the value of the name property in the instance. The
+    instance is created in the `interop_namespace`
+
+    Parameters:
+
+      namespace (:term:`string`):
+        Namespace that this instance defines.
+
+      interop_namespace (:term:`string`):
+        Interop namespace for this environment.
+
+      klass (:class:`CIM_Namespace`):
+        The CIM class CIM_Namespace which is used to define each instance.
+
+    Raises:
+
+        :exc:'~pywbem.CIMError':: For errors encountered with CreateInstance
+
+    """
+    properties = NocaseDict(
+        [('Name', namespace),
+         ('CreationClassName', klass.classname),
+         ('ObjectManagerName', OBJECTMANAGERNAME),
+         ('ObjectManagerCreationClassName', OBJECTMANAGERCREATIONCLASSNAME),
+         ('SystemName', SYSTEMNAME),
+         ('SystemCreationClassName', SYSTEMCREATIONCLASSNAME)])
+
+    new_instance = CIMInstance.from_class(klass, property_values=properties)
+    conn.CreateInstance(new_instance, interop_namespace)
+
+
+def create_cimnamespace_instances(conn, interop_namespace):
+    """
+    Create an instance of CIM_Namespace for every existing namespace
+
+    """
+    insts = conn.EnumerateInstances('CIM_Namespace',
+                                    namespace=interop_namespace,
+                                    LocalOnly=False,
+                                    DeepInheritance=False)
+    ns_dict = NocaseDict([(inst.name, None) for inst in insts])
+
+    # Get the current namespaces directly from the repository since the
+    # instances of CIM_Namespace not yet set up.
+    namespaces = conn.cimrepository.namespaces
+
+    classname = 'CIM_Namespace'
+    klass = conn.GetClass(classname, interop_namespace, LocalOnly=False,
+                          IncludeQualifiers=True,
+                          IncludeClassOrigin=True)
+
+    for ns in namespaces:
+        if ns not in ns_dict:
+            create_cimnamespace_instance(conn, ns, interop_namespace, klass)
+
+
+class CIMNamespaceProvider(InstanceWriteProvider):
+    # pylint: disable=line-too-long
+    """
+    Implements the user defined provider for the class CIM_Namespace.
+
+    This provider provides the create, modify, and delete methods for
+    adding an instance of the class CIM_Namspace when a namespace is created or
+    deleted in a pywbem mock environment.
+
+    This class and the instances of this class only exist in the WBEM server
+    interop namespace per DMTF definitions.
+
+    This class __init__ saves the  cimrepository variable used by methods in
+    this class and by methods of its superclasses (i.e.  InstanceWriteProvider).
+
+    The provider defines the class level attributes `provider_type` (this
+    is an instance provider )and `provider_classnames` (CIM_Namespace)
+
+    Attributes:
+
+          provider_type (:term:`string`):
+            Provided by the superclass.
+
+          provider_classnames (:term:`py:iterable` of :term:`string` or :term:`string`):
+            The classnames for the classes for which the provider is
+            responsible and for which it should be registered..
+
+            This attribute is supplied by the constructor of the provider
+            when the provider is registered.
+    """  # noqa: E501
+    # pylint: enable=line-too-long
+
+    # This class level attribute must exist to define the CIM classname(s) .
+    # for which this provider is responsible.
+
+    provider_classnames = 'CIM_Namespace'
+
+    def __init__(self, cimrepository):
+        """
+        Parameters:
+
+          cimrepository (:class:`~pywbem_mock.BaseRepository` or subclass):
+            Defines the CIM repository to be used by request responders.  The
+            repository is fully initialized except for CIM classes or instances
+            required by this user_defined provider.
+        """
+        super(CIMNamespaceProvider, self).__init__(cimrepository)
+
+    def __repr__(self):
+        return _format(
+            "CIMNamespaceProvider("
+            "provider_type={s.provider_type}, "
+            "provider_classnames={s.provider_classnames})",
+            s=self)
+
+    def CreateInstance(self, namespace, NewInstance):
+        """
+        Create an instance of the CIM_Namespace class in the interop namespace
+        with the required parameters.  If the namespace defined in
+        NewInstance.name does not exist, it creates the namespace in the
+        cimrepository.
+
+        The interop namespace must already exist in the CIM repository when
+        this method is executed.
+
+        If the namespace defined in the the NewInstance.Name property does
+        not exist in the CIM repository, that namespace is added to the
+        repository.
+
+        See `~pywbem_mock.InstanceWriteProvider.CreateInstance` for
+        documentation of the input parameters noting extra conditions defined
+        below:
+
+        Parameters:
+          namespace (:term:`string`):
+            The name of the interop namespace in the CIM repository (case
+            insensitive). Must not be `None`. Leading or trailing slash
+            characters are ignored.
+
+         NewInstance (:class:`~pywbem.CIMInstance`):
+            A representation of the CIM instance to be created.
+
+            Since this method is called by the ProviderDispatcher, the key
+            characteristics of the instance have been validated already.
+
+            This must be an instance of the class CIM_Instance. Note that
+            most of the properties are modified by this method.  The Name
+            property must exist since it defines the name of the namespace
+            which this instance will represent
+
+        Raises:
+            CIMError: CIM_ERR_INVALID_PARAMETER  if namespace is not the
+            the interop namespace in the CIM repository or the Name property
+            does not exist or the other properties cannot be added to the
+            instance.
+        """
+        self.validate_namespace(namespace)
+
+        new_instance = deepcopy(NewInstance)
+
+        if not self.is_interop_namespace(namespace):
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format(
+                    "Instances of {0!A} are only allowed in the interop "
+                    "namespace for the server. {1!A} is not an interop "
+                    "namespace. It must be one of {2!A} ",
+                    NewInstance.classname, namespace,
+                    ", ".join(self.cimrepository.interop_namespace_names())))
+
+        try:
+            new_namespace = new_instance['Name']
+        except KeyError:
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("Namespace creation via CreateInstance: "
+                        "Missing 'Name' property in the {0!A} instance ",
+                        new_instance.classname))
+
+        # Normalize the namespace name
+        new_namespace = new_namespace.strip('/')
+
+        # Write it back to the instance in case it was changed
+        new_instance['Name'] = new_namespace
+
+        # Validate the property values.
+        try:
+            ccn_prop = 'CreationClassName'
+            if new_instance[ccn_prop] != new_instance.classname:
+                raise CIMError(
+                    CIM_ERR_INVALID_PARAMETER,
+                    _format("CIM_Namespace CreateInstance: "
+                            "Invalid property {0|A} for CIM_Instance {1!A}",
+                            ccn_prop, new_instance))
+
+        except KeyError as ke:
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("Namespace creation via CreateInstance: "
+                        "Missing property {0|A}for CIM_Instance {0!A}. "
+                        "Exception: {1!A}", ccn_prop, new_instance, ke))
+
+        ns_dict = NocaseDict({ns: ns for ns in self.cimrepository.namespaces})
+        if new_namespace not in ns_dict:
+            self.cimrepository.add_namespace(new_namespace)
+
+        # Pass NewInstance to the default CreateInstance
+        # Default CreateInstance creates path, validates all key properties
+        # in instance and inserts instance into the repository.
+        return super(CIMNamespaceProvider, self).CreateInstance(namespace,
+                                                                new_instance)
+
+    def ModifyInstance(self, ModifiedInstance,
+                       IncludeQualifiers=None, PropertyList=None):
+        """
+        Modification of CIM_Namespace instance not allowed
+        """
+        raise CIMError(
+            CIM_ERR_NOT_SUPPORTED,
+            _format("Modification of CIM_Namespace {0!A} not allowed. ",
+                    ModifiedInstance.classname))
+
+    def DeleteInstance(self, InstanceName):
+        """
+        Delete the namespace defined by the `Name` keybinding in the
+        InstanceName parameter and remove the instance defined by InstanceName.
+
+        The namespace must be empty to be removed otherwise an exception is
+        generated.
+
+        This method does not allow removing the interop namespace.
+
+        Parameters:
+
+          InstanceName: (:class:`~pywbem.CIMInstanceName`):
+            The instance path of the instance to be deleted with the
+            following attributes:
+
+            * `classname`: Name of the creation class of the instance.
+            * `keybindings`: Keybindings of the instance. The keybinding
+              `Name` must exist. It defines the namespace to be removed.
+            * `namespace`: Name of the CIM namespace containing the instance.
+              Must not be None.
+            * `host`: value ignored.
+
+        Raises:
+            CIMError: CIM_ERR_INVALID_NAMESPACE if the namespace defined in
+              InstanceName does not exist in the CIM repository.
+            CIMError: CIM_ERR_INVALID_CLASS if the classname does not exist in
+              the CIM repository.
+            CIMError: CIM_ERR_NOT_FOUND if the instance to be deleted is not
+               found in the ICM repository.
+            CIMError: CIM_ERR_NAMESPACE_NOT_EMPTY if attempting
+              to delete the default connection namespace.  This namespace cannot
+              be deleted from the CIM repository
+        """
+
+        assert InstanceName.classname.lower() == \
+            CIMNamespaceProvider.provider_classnames.lower()
+
+        remove_namespace = InstanceName.keybindings['Name']
+
+        if self.is_interop_namespace(remove_namespace):
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("Namespace deletion of the interop namespace {0|A} "
+                        "is not allowed by the namespace provider.",
+                        remove_namespace))
+
+        # Reflect the namespace deletion in the CIM repository
+        # This will check the namespace for being empty.
+        self.remove_namespace(remove_namespace)
+
+        # Delete the instance from the CIM repository
+        instance_store = self.get_instance_store(InstanceName.namespace)
+        instance_store.delete(InstanceName)
+
+    @staticmethod
+    def install_provider(conn, interop_namespace, schema_pragma_file,
+                         verbose=None):
+        """
+        FakedWBEMConnection user method to install the namespace provider in
+        the interop namespace where the proposed interop_namespace is defined
+        by the parameter interop_namespace
+
+        Because this provider requires a set of classes from the
+        pragma file for the schema that contains CIM_Namespace is required.
+
+        This method:
+
+        1. Confirms that an interop namespace exists or adds an interop
+           namespace using the `interop_namespace` parameter.
+
+        2. Registers this provider with the connection.
+
+        3. Creates instances of CIM_Namespace for all existing namespaces.
+
+        This method should only be called once at the creation of the
+        mock environment.
+
+        Parameters:
+
+          conn (:class:`~pywbem_mock.FakedWBEMConnection`):
+            Defines the attributes of the connection. Used to issue requests to
+            create instances in the interop namespace for all existing
+            namespaces that do not have instances of CIM_Namespace defined
+
+          interop_namespace (:term:`string`):
+            The interop namespace defined for this environment.  This is
+            the namespace for which this provider is to be registered and
+            and where instances of CIM_Namespace are created and deleted
+            representing the set of existing namespaces in the CIM repository.
+
+          schema_pragma_file (:term:`string`):
+            File path defining a CIM schema pragma file for the set of
+            CIM classes that make up a schema such as the DMTF schema.
+            This file must contain a pragma statement for each of the
+            classes defined in the schema.
+
+            None: Assumes the schema in already installed, in particular
+            the CIM_Namespace class and its dependencies.
+
+          verbose (:class:`py:bool`):
+            If True, displays progress information as providers are installed.
+
+        """
+
+        # Determine if an interop namespace already exists and add it if
+        # it does not exist.
+        if not conn.is_interop_namespace(interop_namespace):
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("Namespace {0!A} is not a valid interop namespace. "
+                        "Valid interop namespace names are: {1!A}.",
+                        interop_namespace,
+                        ", ".join(conn.interop_namespace_names())))
+
+        # Directly call the cim_repositoory namespace method since the
+        # FakedWBEMConnection method will attempt to add the instance
+        # to the namespace and we do that below.
+        if interop_namespace not in conn.namespaces:
+            conn.mainprovider.add_namespace(interop_namespace)
+
+        # TODO: There is no check on the reuse of this method, i.e. multiple
+        # attempts to install the CIM_namespace provider.
+        # add test. If CIM_Namespace class exists, exception with KeyError
+
+        # Register the provider
+        conn.register_provider(
+            CIMNamespaceProvider(conn.cimrepository),
+            interop_namespace,
+            schema_pragma_files=schema_pragma_file, verbose=verbose)
+
+        # Create instance CIM_Namespace for each existing namespace
+        create_cimnamespace_instances(conn, interop_namespace)

--- a/pywbem_mock/_namespaceprovider.py
+++ b/pywbem_mock/_namespaceprovider.py
@@ -314,7 +314,8 @@ class CIMNamespaceProvider(InstanceWriteProvider):
                         remove_namespace))
 
         # Reflect the namespace deletion in the CIM repository
-        # This will check the namespace for being empty.
+        # This call implementes the CIM repository remove namespace which
+        # checks for empty namespace.
         self.remove_namespace(remove_namespace)
 
         # Delete the instance from the CIM repository

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -605,7 +605,6 @@ class FakedWBEMConnection(WBEMConnection):
             or issues with the cim repository.
 
           CIMError: Other errors relating to the target server environment.
-
         """  # noqa: E501
         # pylint: enable:line-too-long
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -154,10 +154,12 @@ class ProviderRegistry(object):
         Providers can only be registered for the following request response
         methods:
 
-        1. provider_type = 'instance': CreateInstance, ModifyInstance, and
-           DeleteInstance
+        1. provider_type = 'instance': defines methods for CreateInstance,
+           ModifyInstance, and DeleteInstance requests within a subclass of
+           the `InstanceWriteProvider` class.
 
-        2. provider_type = 'method': InvokeMethod.
+        2. provider_type = 'method': defines a InvokeMethod method within
+           a subclass of the `MethodProvider` class.
 
         Each classname in a particular namespace may have at most one provider
         registered
@@ -169,7 +171,7 @@ class ProviderRegistry(object):
             create instances in the interop namespace for all existing
             namespaces that do not have instances of CIM_Namespace defined
 
-          provider (instance of subclass of :class:`pywbem_mock:InstanceWriteProvider` or :class:`pywbem_mock:MethodProvider`):
+          provider (instance of subclass of :class:`pywbem_mock.InstanceWriteProvider` or :class:`pywbem_mock.MethodProvider`):
             The methods in this subclass override the corresponding methods in
             the superclass. The method call parameters must be the same
             as the default method in the superclass and it must return
@@ -186,15 +188,15 @@ class ProviderRegistry(object):
             the built-in default namespace
 .
           schema_pragma_files (:term:`py:iterable` of :term:`string` or :term:`string`):
-            File paths defining a schema pragma file MOF for the set of CIM
+            Path names of schema pragma files for the set of CIM
             classes that make up a schema such as the DMTF schema. These files
             must contain include pragams defining the file location of the
             classes to be compiled for the defined provider and for any
             dependencies required to compile those classes.  The directory
-            containing each pragma file is passed to the MOF compiler as the
-            search path for compile dependencies.
+            containing each schema pragma file is passed to the MOF compiler as
+            the search path for compile dependencies.
 
-            see :class:`pywbem.MofCompiler` for more information on the
+            see :class:`pywbem.MOFCompiler` for more information on the
             `search_paths` parameter.
 
         Raises:
@@ -292,7 +294,7 @@ class ProviderRegistry(object):
                         raise ValueError(
                             _format('Class "{0!A}" does not exist in '
                                     'namespace {1!A} of the CIM repository '
-                                    'and no pragma files',
+                                    'and no schema pragma files were specified',
                                     classname, namespace))
 
             # Insert this classname if not already there
@@ -851,10 +853,10 @@ class FakedWBEMConnection(WBEMConnection):
         """
         Compile the classes defined by `class_names`  and all of their
         dependences. The class names must be classes in the defined schema and
-        with pragma statements in a `schema_pragma_file`. Each
-        `schema_pragma_file` in the `pragma_files` parameter must be in a
+        with pragma statements in a schema pragma file. Each
+        schema pragma file in the `schema_pragma_files` parameter must be in a
         directory that also encompasses the MOF files for all of the classes
-        defined in the `schema_pragma_file` and the dependencies of those
+        defined in the schema pragma file and the dependencies of those
         classes. While the relative paths of all of the CIM class files is
         defined in the `schema_pragma_file` the pywbem MOF compiler may also
         search for dependencies (ex. superclasses, references, etc.) that are
@@ -1304,12 +1306,12 @@ class FakedWBEMConnection(WBEMConnection):
                           schema_pragma_files=None, verbose=None):
         # pylint: disable=line-too-long
         """
-        Register the provider object for specific namespaces and CIM classes.
+        Register the `provider` object for specific namespaces and CIM classes.
         Registering a provider tells the FakedWBEMConnection that the provider
         implementation provided with this method as the `provider` parameter is
         to be executed as the request response method for the namespaces
         defined in the `namespaces` parameter, the provider type defined in the
-        provider 'provider_type` attribute of the `provider` and the classes
+        provider 'provider_type` attribute of the `provider` and the class(es)
         defined in the provider `provider_classnames` attribute of the
         `provider`.
 
@@ -1319,9 +1321,9 @@ class FakedWBEMConnection(WBEMConnection):
         2. Validation that the superclass of the provider is consistent with
            the `provider_type` attribute defined in the provider.
         3. Installation of any CIM classes defined by the provider
-           (`provider_classnames` attribute) including installation of
-           dependencies for these classes using the `schema_pragma_files` to
-           locate the search directories for dependencies.
+           `provider_classnames` attribute including dependencies for these
+           classes using the `schema_pragma_files` parameter to define the MOF
+           compiler search directories for dependencies.
         4. Adding the provider to the registry of user_providers so that any
            of the request methods defined for the `provider_type` are
            passed to this provider in place of the default request processors.
@@ -1329,19 +1331,21 @@ class FakedWBEMConnection(WBEMConnection):
         Providers can only be registered for the following request response
         methods:
 
-        1. provider_type = 'instance': CreateInstance, ModifyInstance, and
-           DeleteInstance
+        1. provider_type = 'instance': defines methods for CreateInstance,
+           ModifyInstance, and DeleteInstance requests within a subclass of
+           the `InstanceWriteProvider` class.
 
-        2. provider_type = 'method': InvokeMethod.
+        2. provider_type = 'method': defines a InvokeMethod method within
+           a subclass of the `MethodProvider` class.
 
         Each classname in a particular namespace may have at most one provider
         registered
 
         Parameters:
 
-          provider (instance of subclass of :class:`pywbem_mock:InstanceWriteProvider`):
+          provider (instance of subclass of :class:`pywbem_mock.InstanceWriteProvider` or :class:`pywbem_mock.MethodProvider`):
             An instance of the user provider class which is a subclass of
-            :class:`pywbem_mock:InstanceWriteProvider`.  The methods in this
+            :class:`pywbem_mock.InstanceWriteProvider`.  The methods in this
             subclass override the corresponding methods in
             InstanceWriteProvider. The method call parameters must be the
             same as the defult method in InstanceWriteProvider and it must
@@ -1355,16 +1359,16 @@ class FakedWBEMConnection(WBEMConnection):
           schema_pragma_files  (:term:`string` or :class:`py:list` of :term:`string`):
             File paths defining a schema pragma file MOF for the set of CIM
             classes that make up a schema such as the DMTF schema. These files
-            must contain include pragams defining the file location of the
-            classes to be compiled for the defined provider and for any
+            must contain include pragma statements defining the file location
+            of the classes to be compiled for the defined provider and for any
             dependencies required to compile those classes.  The directory
-            containing each pragma file is passed to the MOF compiler as the
-            search path for compile dependencies.
+            containing each schema pragma file is passed to the MOF compiler as
+            the search path for compile dependencies.
 
-            See :class:`pywbem.MofCompiler` for more information on the
+            See :class:`pywbem.MOFCompiler` for more information on the
             `search_paths` parameter.
 
-          verbose ():
+          verbose (:class:`py:bool`):
             Flag to enable detailed display of actions
 
         Raises:
@@ -1372,7 +1376,7 @@ class FakedWBEMConnection(WBEMConnection):
                        provider_type does not match superlclass or the
                        namespace parameter is invalid.
 
-.           ValueError: Provider_type retrieved from provider is not a
+            ValueError: Provider_type retrieved from provider is not a
                         valid string.
 
             ValueError: Classnames parameter retrieved from provider not a

--- a/pywbem_mock/config.py
+++ b/pywbem_mock/config.py
@@ -1,0 +1,68 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+"""
+Pywbem_mock supports several variables that provide configuration and
+behavior control of the mock environment.
+
+These configuration variables can be modified by the user directly after
+importing pywbem. For example:
+
+::
+
+    import pywbem_mock
+    pywbem_mock.config.SYSTEMNAME = 'MyTestSystemName'
+
+Note that the pywbem source file defining these variables should not be changed
+by the user. Instead, the technique shown in the example above should be used to
+modify the configuration variables.
+"""
+
+# This module is meant to be safe for 'import *'.
+
+__all__ = ['OBJECTMANAGERNAME', 'SYSTEMNAME',
+           'SYSTEMCREATIONCLASSNAME', 'DEFAULT_MAX_OBJECT_COUNT',
+           'OPEN_MAX_TIMEOUT', 'OBJECTMANAGERCREATIONCLASSNAME']
+
+#: Name for the object manager It is used in defining user-defined provider
+#: properties for CIM_Namespace provider and CIM_ObjectManager provider if
+#: if they are defined.
+
+OBJECTMANAGERNAME = 'FakeObjectManager'
+
+#: Value for the CIM_ObjectManagerCreationClassName defined in the
+#: CIM_ObjectManager class.
+
+OBJECTMANAGERCREATIONCLASSNAME = 'CIM_ObjectManager'
+
+#: The name of the mock object. This string value becomes part of the
+#: CIM_ObjectNamager instance and CIM_Namespace instances
+
+SYSTEMNAME = 'MockSystem_WBEMServerTest'
+
+#: Name for the property SystemCreationClassname defined a number of
+#: CIM classes that are used by the pywbem_mock including CIM_Namespace
+
+SYSTEMCREATIONCLASSNAME = 'CIM_ComputerSystem'
+
+#: Default positive integer value for the Open... request responder default
+#: value for MaxObjectCount if the value was not provided by the request.
+
+DEFAULT_MAX_OBJECT_COUNT = 100
+
+#: Maximum timeout in seconds for pull operations if the OperationTimeout
+#: parameter is not included in the request
+
+OPEN_MAX_TIMEOUT = 40

--- a/pywbem_mock/config.py
+++ b/pywbem_mock/config.py
@@ -39,30 +39,24 @@ __all__ = ['OBJECTMANAGERNAME', 'SYSTEMNAME',
 #: Name for the object manager It is used in defining user-defined provider
 #: properties for CIM_Namespace provider and CIM_ObjectManager provider if
 #: if they are defined.
-
 OBJECTMANAGERNAME = 'FakeObjectManager'
 
 #: Value for the CIM_ObjectManagerCreationClassName defined in the
 #: CIM_ObjectManager class.
-
 OBJECTMANAGERCREATIONCLASSNAME = 'CIM_ObjectManager'
 
 #: The name of the mock object. This string value becomes part of the
 #: CIM_ObjectNamager instance and CIM_Namespace instances
-
 SYSTEMNAME = 'MockSystem_WBEMServerTest'
 
 #: Name for the property SystemCreationClassname defined a number of
 #: CIM classes that are used by the pywbem_mock including CIM_Namespace
-
 SYSTEMCREATIONCLASSNAME = 'CIM_ComputerSystem'
 
 #: Default positive integer value for the Open... request responder default
 #: value for MaxObjectCount if the value was not provided by the request.
-
 DEFAULT_MAX_OBJECT_COUNT = 100
 
 #: Maximum timeout in seconds for pull operations if the OperationTimeout
 #: parameter is not included in the request
-
 OPEN_MAX_TIMEOUT = 40

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -88,8 +88,8 @@ class TestServerClass(BaseMethodsForTests):
 
         assert server.url == 'http://FakedUrl:5988'
 
-        assert server.brand == "OpenPegasus"
-        assert server.version == "2.15.0"
+        assert server.brand == "Mock_Test"
+        # assert server.version == "2.15.0"
         assert server.interop_ns == tst_namespace
         assert set(server.namespaces) == set([tst_namespace])
 
@@ -143,7 +143,7 @@ class TestServerClass(BaseMethodsForTests):
         kb = NocaseDict([('SystemCreationClassName', 'CIM_ComputerSystem'),
                          ('SystemName', mock_wbemserver.system_name),
                          ('CreationClassName', 'CIM_ObjectManager'),
-                         ('Name', 'MyFakeObjectManager'), ])
+                         ('Name', 'FakeObjectManager'), ])
         assert insts[0] == CIMInstanceName('CIM_ObjectManager', keybindings=kb,
                                            namespace=tst_namespace,
                                            host=server.conn.host)
@@ -202,7 +202,6 @@ TESTCASES_CREATE_NAMESPACE = [
         ),
         CIMError, None, True
     ),
-
 ]
 
 
@@ -210,8 +209,7 @@ TESTCASES_CREATE_NAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CREATE_NAMESPACE)
 @simplified_test_function
-def test_create_namespace_2(testcase,
-                            new_namespace, exp_namespace):
+def test_create_namespace(testcase, new_namespace, exp_namespace):
     """
     Test creation of a namespace using approach 2.
     """

--- a/tests/unittest/pywbem_mock/test_system_providers.py
+++ b/tests/unittest/pywbem_mock/test_system_providers.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+#
+# (C) Copyright 2020 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+Test of of the installation and operation of the CIM_Namespace provider.
+
+"""
+from __future__ import absolute_import, print_function
+
+import os
+import six
+import pytest
+
+from ..utils.pytest_extensions import simplified_test_function
+
+from ...utils import skip_if_moftab_regenerated
+
+from ...utils import import_installed
+
+from pywbem import CIMError, WBEMServer
+
+pywbem = import_installed('pywbem')  # noqa: E402
+
+pywbem_mock = import_installed('pywbem_mock')
+from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema  # noqa: E402
+from ..utils.dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER  # noqa: E402
+
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+# Location of DMTF schema directory used by all tests.
+# This directory is permanent and should not be removed.
+TESTSUITE_SCHEMA_DIR = os.path.join('tests', 'schema')
+
+VERBOSE = False
+
+# test variables to allow selectively executing tests.
+OK = True
+RUN = True
+FAIL = False
+
+
+def test_interop_namespace_names():
+    """
+    Test the method interop_namespace_names. This is a single test
+    with no parameters because it is really a static operation.
+    """
+    conn = FakedWBEMConnection()
+
+    interop_ns = conn.interop_namespace_names()
+
+    # get valid set from WBEMServer.
+    interop_namespaces = WBEMServer.INTEROP_NAMESPACES
+
+    assert set(interop_ns) == set(interop_namespaces)
+    # confirm case interop_ns is case-insensitive iterable
+    for name in interop_namespaces:
+        assert name.lower() in [ns.lower() for ns in interop_ns]
+
+
+TESTCASES_IS_INTEROP_NAMESPACE = [
+    ("verify interop True",
+     dict(ns='interop', exp_rtn=True), None, None, OK),
+
+    ("verify root/interop True",
+     dict(ns='root/interop', exp_rtn=True), None, None, OK),
+
+    ("verify root/interop True",
+     dict(ns='root/pg_interop', exp_rtn=True), None, None, OK),
+
+    ("verify root/blah False",
+     dict(ns='root/blah', exp_rtn=False), None, None, OK),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_IS_INTEROP_NAMESPACE)
+@simplified_test_function
+def test_is_interop_namespace(testcase, ns, exp_rtn):
+    """
+    Test the method _is_interop_namespace() which should return True
+    or False depending on whether the tst_ns is a valid interop namespace
+    name returns correct result.
+    """
+    conn = FakedWBEMConnection()
+
+    assert conn.is_interop_namespace(ns) is exp_rtn
+    assert conn.is_interop_namespace(ns.upper()) is exp_rtn
+
+
+TESTCASES_FIND_INTEROP_NAMESPACE = [
+    # deflt - default-namespace, string or None
+    # nss = Other namespaces to add (String or list of strings)
+    # exp_ns = Expected namespace returned
+
+    ("Verify interop not in enviroment returns None",
+     dict(deflt=None, nss=None, exp_ns=None), None, None, OK),
+
+    ("Verify interop in enviroment returns interop",
+     dict(deflt=None, nss=['interop'], exp_ns='interop'), None, None, OK),
+
+    ("Verify INTEROP in enviroment returns INTEROP",
+     dict(deflt=None, nss=['INTEROP'], exp_ns='INTEROP'), None, None, OK),
+
+    ("Verify root/interop in enviroment returns interop",
+     dict(deflt=None, nss=['root/interop'], exp_ns='root/interop'), None,
+     None, OK),
+
+    ("Verify interop in enviroment with other ns returns interop",
+     dict(deflt=None, nss=['interop', 'root/blah'], exp_ns='interop'), None,
+     None, OK),
+
+    ("Verify interop in enviroment with other ns and default returns interop",
+     dict(deflt='root/cimv2', nss=['interop', 'root/blah'], exp_ns='interop'),
+     None, None, OK),
+
+    ("Verify interop in enviroment with other ns and default returns interop",
+     dict(deflt='root/cimv2', nss=['root/blah', 'interop'], exp_ns='interop'),
+     None, None, OK),
+
+    ("Verify interop as default can be found",
+     dict(deflt='interop', nss=None, exp_ns='interop'), None, None, OK),
+
+    ("Verify interop not in namespaces that has a namespace finds nothing",
+     dict(deflt=None, nss=['root/blah'], exp_ns=None), None, None, OK),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_FIND_INTEROP_NAMESPACE)
+@simplified_test_function
+def test_find_interop_namespace(testcase, deflt, nss, exp_ns):
+    """
+    Test the method
+    """
+    conn = FakedWBEMConnection(default_namespace=deflt)
+
+    if nss:
+        if isinstance(nss, six.string_types):
+            nss = [nss]
+        for name in nss:
+            conn.add_namespace(name)
+
+    rtnd_ns = conn.find_interop_namespace()
+
+    assert rtnd_ns == exp_ns
+
+
+TESTCASES_CIMNAMESPACE_PROVIDER = [
+
+    # Testcases for dictionary tests
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * obj: Object that has dictionary behavior, e.g. IMInstanceName.
+    #   * exp_dict: Expected dictionary items, for validation.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    (
+        "Test with interop as interop namespace name",
+        dict(
+            default_ns=None,
+            ns='interop',
+        ),
+        None, None, OK
+    ),
+    (
+        "Test with interop as interop namespace name and root/blah default",
+        dict(
+            default_ns='root/blah',
+            ns='interop',
+        ),
+        None, None, OK
+    ),
+    (
+        "Test with root/interop as interop namespace name",
+        dict(
+            default_ns=None,
+            ns='root/interop',
+        ),
+        None, None, OK
+    ),
+    (
+        "Test with invalid interop namespace name",
+        dict(
+            default_ns=None,
+            ns='root/interopx',
+        ),
+        CIMError, None, OK
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_CIMNAMESPACE_PROVIDER)
+@simplified_test_function
+def test_install_namespace_provider(testcase, default_ns, ns):
+    """
+    Test installation of the namespace provider
+    """
+    # setup the connection and schema
+    conn = FakedWBEMConnection(default_namespace=default_ns)
+
+    skip_if_moftab_regenerated()
+
+    schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
+                           verbose=False)
+    # code to be tested
+    conn.install_namespace_provider(ns, schema.schema_pragma_file)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    # Assert that the defined interop namespace is installed
+    assert ns in conn.namespaces
+
+    if default_ns:
+        assert default_ns in conn.namespaces
+
+    assert len(conn.EnumerateInstances("CIM_Namespace", ns)) == \
+        len(conn.namespaces)
+
+    for namespace in conn.namespaces:
+        if namespace != ns:
+            assert len(conn.EnumerateClasses(namespace=namespace)) == 0
+
+# TODO. Test add and remove namespaces more completely.

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -2181,7 +2181,7 @@ class UserMethodTestProvider(MethodProvider):
             "provider_classnames={s.provider_classnames})",
             s=self)
 
-    def InvokeMethod(self, namespace, methodname, objectname, Params):
+    def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
         """Test InvokeMethod provider with InvokeMethod"""
         # return return-value 0 and no output parameters
         return (0, None)
@@ -5833,7 +5833,7 @@ class Method1TestProvider(MethodProvider):
     def __init__(self, cimrepository):
         super(Method1TestProvider, self).__init__(cimrepository)
 
-    def InvokeMethod(self, namespace, methodname, objectname, Params):
+    def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
         """
         Simplistic test method. Validates methodname, objectname, Params
         and returns rtn value 0 and one parameter
@@ -5845,10 +5845,10 @@ class Method1TestProvider(MethodProvider):
         self.validate_namespace(namespace)
 
         # get classname and validate. This provider uses only one class
-        if isinstance(objectname, six.string_types):
-            classname = objectname
+        if isinstance(ObjectName, six.string_types):
+            classname = ObjectName
         else:
-            classname = objectname.classname
+            classname = ObjectName.classname
         assert classname.lower() == 'cim_foo_sub_sub'
 
         # Test if class exists.
@@ -5858,15 +5858,14 @@ class Method1TestProvider(MethodProvider):
                 _format("class {0|A} does not exist in CIM repository, "
                         "namespace {1!A}", classname, namespace))
 
-        if isinstance(objectname, CIMInstanceName):
+        if isinstance(ObjectName, CIMInstanceName):
             instance_store = self.get_instance_store(namespace)
-            inst = self.find_instance(objectname, instance_store,
-                                      copy_inst=False)
+            inst = self.find_instance(ObjectName, instance_store, copy=False)
             if inst is None:
                 raise CIMError(
                     CIM_ERR_NOT_FOUND,
                     _format("Instance {0|A} does not exist in CIM repository, "
-                            "namespace {1!A}", objectname, namespace))
+                            "namespace {1!A}", ObjectName, namespace))
         # This method expects a single parameter input
         # Used to test the inputs.  The single input parameter is a string
         # and the value determines the method actions:
@@ -5874,7 +5873,7 @@ class Method1TestProvider(MethodProvider):
         # value = 'methodname' return the method name in output parameter
         # value = 'objectname' return the object name in output parameter
         # value = 'returnvalue' return value 1
-        if methodname.lower() == 'method1':
+        if MethodName.lower() == 'method1':
             if Params:
                 # This should not be an assert.
                 assert len(Params) == 1
@@ -5901,10 +5900,10 @@ class Method1TestProvider(MethodProvider):
                                                value=namespace)]
                 elif val == 'methodname':
                     rtn_params = [CIMParameter('OutputParam1', 'string',
-                                               value=methodname)]
+                                               value=MethodName)]
                 elif val == 'objectname':
                     rtn_params = [CIMParameter('OutputParam1', 'string',
-                                               value=objectname)]
+                                               value=ObjectName)]
                 elif val == 'returnvalue':
                     return_value = 1
                     rtn_params = [CIMParameter('OutputParam1', 'string',


### PR DESCRIPTION
Adds the first system provider, the namespace provider. This includes the implementation of the user defined provider, and  a method to FakedWBEMConnection, install_privileged_providers() that serves as the interface to install providers that are considered privileged to be installed.

TODO 

Figure out where we put the initialization code for user-defined providers to a) make insitialization simple, b) allow the different user providers to accomplish all if the initialization tasks in a common way.

Initialization tasks:

1.  Install user classes required by the provider

2. Install schema classes required by the provider (This and 1 may not be mutually exclusive)

3. Allow the provider to do any other setup (ex. Namespace provider would insure that there is an instance of CIM_Namespace for every namespace already in the  cim repository.


SEE DISCUSSION ITEM BELOW

Questions: **DISCUSSION**

1. Is there a reason for a public method remove_namespace? **DONE. Yes there is**

2. There is an interesting issue here in our implementation concept. We really have two information sources for namespace information, the repository itself and the CIM_Namespace class/instances in the repository.  To avoid that duplication, we really should be building the CIM_Instance instances dynamitally rather than putting them into the repository. But that would mean extending the user-defined provider to get_instance and possibly to enumerate_instances. **DONE: we are past this question**

3. I removed PG_Namespace completely.  That was a Pegasus thing that we did largely because we were trying to add pegasus specific functionality (also we were ahead of the whole CIM_Namespace definition effort) and did not want to interfer with anything that could be general.  **DONE. We agree there is not**

4. The implementation of the method add_namespace (which simply calls the cim_repository to remove the namespace) is actually base_provider which is completely disconnected from the ability to sync CIM_namespace instances with the actual repository. That method is available to user-defined providers but does not have any means execute a client CreateInstance or DeleteInstance. In short I have made it difficult to completely synchroize the existence of the instances with the existence of the namespaces.
