### PR TITLE
Fixed dictionary changed size during iteration on pypy (redo)

### DIFF
--- a/pywbem_mock/_defaultinstanceprovider.py
+++ b/pywbem_mock/_defaultinstanceprovider.py
@@ -138,10 +138,13 @@ def validate_inst_props(namespace, target_class, instance):
 
         # If property not in instance, add it from class and use default value
         # from class
+        add_props = dict()
         for cprop_name in target_class.properties:
             if cprop_name not in instance:
                 default_value = target_class.properties[cprop_name]
-                instance[cprop_name] = default_value
+                add_props[cprop_name] = default_value
+
+    instance.update(add_props)
 
 
 class ProviderDispatcher(BaseProvider):


### PR DESCRIPTION
PR #2220 was merged by mistake (it still contained a temp commit, and it was on top of an old version of PR #2215). I undid that merge by manually setting back the master branch to before that PR.

This PR here contains the commit that PR #2220 was supposed to contain, and basically redoes what it was supposed to do.