### PR TITLE
Partly fixes #2062: Implement new schema compile method

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -172,6 +172,15 @@ Released: not yet
 
 **Deprecations:**
 
+  Deprecated the method FakedWBEMConnection.compile_dmtf_schema in favor of
+  a new method FakedWBEMConnection.compile_dmtf_classes that does not
+  directly use the DMTFCIMSchema class.
+
+  Deprecated the attribute name schema_mof_file in DMTFCIMSchema in favor of
+  the name schema_pragma_file since this is the file that contains all
+  of the MOF pragmas defining the locations of the class MOF files in a
+  set of directories.
+
 **Bug fixes:**
 
 * Dev/Test: Pinned lxml to <4.4.0 because that version removed Python 3.4
@@ -616,6 +625,9 @@ Released: not yet
   CreateInstance method defined in the compiler repo.  For the tests that
   means that the path creation is in MOFWBEMConnection.CreateInstance.
   (See issue # 1911)
+
+* Added a new method FakedWBEMConnection.compile_dmtf_classes that does not
+  directly use the DMTFCIMSchema class.  See the Deprecations section.
 
 **Known issues:**
 

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -15,15 +15,17 @@
 #
 #
 """
-A DMTF CIM schema is the collection of CIM qualifier declarations and CIM
-classes managed by the DMTF and released as a single tested, coherent package
-with a defined major, minor, update version number.  The MOF representation of
+A CIM schema is the collection of CIM qualifier declarations and CIM
+classes and available  a single tested, coherent package
+with a defined major, minor, update version number. The DMTF regularly
+releases updates to the DMTF CIM schema that represent all of the classes
+approved by the DMTF. The MOF representation of
 a DMTF schema release is packaged as a single zip file and is available on the
 DMTF web site ( https://www.dmtf.org/standards/cim ).
 
-Because the DMTF CIM schemas are the source of most of the classes that a WBEM
-server normally implements it was important to create a simple mechanism
-to include the DMTF CIM classes and qualifier declarations in the
+Because CIM schemas are the source of most of the classes that a WBEM server
+normally implements it was important to create a simple mechanism to include
+the DMTF CIM classes and qualifier declarations from a CIM schema in the
 :class:`~pywbem_mock.FakedWBEMConnection` mock repository.
 
 The :class:`~pywbem_mock.DMTFCIMSchema` class downloads the DMTF CIM schema
@@ -36,7 +38,7 @@ classes in the CIM schema having unique class names; this is always true for
 DMTF CIM schema releases to assure that they can be installed in the same
 namespace in a WBEM server repository.
 
-Once a DMTF CIM schema is extracted into the individual MOF files it consumes
+Once aCIM schema is extracted into the individual MOF files it consumes
 considerable space since it expands to almost 3000 files.  Therefore it is
 logical to remove all of the individual MOF files when not being used and also
 if the schema information is to be committed to be used in testing in an
@@ -63,19 +65,20 @@ Because it is usually necessary to compile only a subset of the DMTF CIM
 classes into a mock repository for any test, the
 :class:`~pywbem_mock.DMTFCIMSchema` class provides a
 :meth:`~pywbem_mock.FakedWBEMConnection.build_schema_mof` method to create a
-MOF include file that includes only a subset of the classes in the downloaded
-DMTF CIM Schema. The task of listing classes to be compiled is futher
+list of MOF pragmans that includes only a subset of the classes in the
+downloaded CIM Schema. The task of listing classes to be compiled is futher
 simplified because the pywbem MOF compiler searches the DMTF schema for
 prerequisite classes (superclasses, reference classes, and EmbeddedInstance
 classes) so that generally only the leaf CIM classes required for the
 repository need to be in the class list. This speeds up the process of
 compiling DMTF CIM classes for any test significantly.
 """
+import warnings
 import os
 from zipfile import ZipFile
 import shutil
-import six
 import re
+import six
 try:
     from urllib.request import urlopen
 except ImportError:  # py2
@@ -87,6 +90,98 @@ from pywbem._utils import _format
 __all__ = ['DMTFCIMSchema']
 
 
+def build_schema_mof(class_names, schema_pragma_file):
+    """
+    Build a string that includes the ``#include pragma`` statements for the
+    DMTF schema CIM classes defined in `class_names` using the DMTF CIM
+    schema defined by this object.
+
+    The class names in `class_names` can be just leaf classes. The pywbem
+    MOF compiler will search for dependent classes including superclasses,
+    and other classes referenced as the classes are compiled.
+
+    It builds a compilable MOF string in the form::
+
+        #pragma locale ("en_US")
+        #pragma include ("System/CIM_ComputerSystem.mof")
+        ...
+
+    with a ``#pragma include`` for each classname in the `class_names`
+    list.
+
+    The resulting set of #pragma statements is in the same order as the
+    original pragmas.  In some cases that could be important because the
+    DMTF list is ordered to missing dependencies and conflicts between
+    class mof compiles.
+
+    Parameters:
+
+      class_names (:term:`py:list` of :term:`string` or :term:`string`):
+        These must be class names of classes in the DMTF CIM schema represented
+        by the instance of :class:`~pywbem_mock.DMTFCIMSchema` object. This
+        parameter can be a string if there is only a single class name to be
+        included.
+
+        If the returned string is compiled, the MOF compiler will search the
+        directory defined by the path component of `schema_pragma_file` for
+        classes referenced by each for class in this list including super
+        classes, classed defined by reference properties, and classes defined
+        by an embedded-object.
+
+    schema_pragma_file (:term:`string`):
+        File path defining a CIM schema pragma file for the set of
+        CIM classes that make up a schema such as the DMTF schema.
+        This file must contain a pragma statement for each of the
+        classes defined in the schema.
+
+    Returns:
+        :term:`string`: Valid MOF containing pragma statements for
+        all of the classes in `schema_classes`.
+
+    Raises:
+        ValueError: If any of the classnames in `schema_classes` are not in
+        the DMTF CIM schema installed
+    """
+    if isinstance(class_names, six.string_types):
+        class_names = [class_names]
+
+    schema_lines = []
+    with open(schema_pragma_file, 'r') as f:
+        schema_lines = f.readlines()
+
+    # Build list  classname/line number pairs
+    classname_pattern = ' *#.*include.*/(.*)\\.mof'
+    class_names_lc = [cln.lower() for cln in class_names]
+    lines_list = []
+    found_classes = []
+    for line_no, line in enumerate(schema_lines, 0):
+        result = re.search(classname_pattern, line)
+        if result:
+            cln = result.group(1)
+            if cln.lower() in class_names_lc:
+                lines_list.append(line_no)
+                found_classes.append(cln)
+
+    # Create list of the line numbers in schema_lines containing
+    # pragmas that will be part of the build.
+    classes_not_found = set(class_names) - set(found_classes)
+    if classes_not_found:
+        raise ValueError(
+            _format("Classes {0!A} not in DMTF CIM schema {1!A}",
+                    ', '.join(classes_not_found), schema_pragma_file))
+
+    # Sort the list so the result is in the same order as the pragmas
+    # in the cim_schema pragma file.
+    lines_list.sort()
+
+    # Create list with line from pragma file for each entry in lines_list
+    output_lines = [schema_lines[line_number] for line_number in lines_list]
+
+    output_lines.insert(0, '#pragma locale ("en_US")\n')
+
+    return ''.join(output_lines)
+
+
 class DMTFCIMSchema(object):
     """
     :class:`DMTFCIMSchema` represents a DMTF CIM Schema downloaded from the
@@ -94,8 +189,9 @@ class DMTFCIMSchema(object):
 
     This class manages the download of the DMTF schema zip file and extraction
     of MOF files of DMTF CIM schema releases into a directory that can be used
-    by :class:`~pywbem_mock.FakedWBEMConnection` to compile a mock repository
-    with class and qualifier declarations.
+    by :meth:`~pywbem_mock.FakedWBEMConnection.compile_schema_classes` to
+    compile a mock repository with class and qualifier declarations from the
+    schema.
     """
     def __init__(self, schema_version, schema_root_dir, use_experimental=False,
                  verbose=False):
@@ -127,12 +223,12 @@ class DMTFCIMSchema(object):
           schema_root_dir (:term:`string`):
             Path name of the schema root directory into which the DMTF CIM
             schema zip file is downloaded and in which a subdirectory for the
-            extracted MOF files is created
+            extracted MOF files for the schema version defined is created
 
             Multiple DMTF CIM schemas may be maintained in the same
             `schema_root_dir` simultaneously because the MOF for each schema is
             extracted into a subdirectory identified by the schema version
-            information.
+            information See :attr:`schema_mof_dir`.
 
           use_experimental (:class:`py:bool`):
             If `True`, the experimental version of the defined DMTF schema is
@@ -154,7 +250,7 @@ class DMTFCIMSchema(object):
         """
         if not isinstance(schema_version, tuple):
             raise TypeError(
-                _format("schema_version {v!A} must be tuple",
+                _format("Schema_version {v!A} must be tuple",
                         v=schema_version))
         if len(schema_version) != 3:
             raise ValueError(
@@ -183,8 +279,8 @@ class DMTFCIMSchema(object):
         schema_mof_bld_name = cim_schema_version + '.mof'
 
         self._schema_zip_file = os.path.join(self._schema_root_dir, mof_zip_bn)
-        self._schema_mof_file = os.path.join(self.schema_mof_dir,
-                                             schema_mof_bld_name)
+        self._schema_pragma_file = os.path.join(self.schema_mof_dir,
+                                                schema_mof_bld_name)
 
         self.verbose = verbose
 
@@ -226,17 +322,21 @@ class DMTFCIMSchema(object):
         :term:`string`: Path name of the directory in which the DMTF CIM Schema
         MOF files are extracted from the downloaded zip file. This property can
         be used as the MOF compiler search path for compiling classes in the
-        DMTF CIM schema.
+        DMTF CIM schema. This directory should also contain the
+        schema mof pragma file.
         """
         return self._schema_mof_dir
 
     @property
     def schema_mof_file(self):
         """
-        :term:`string`: Path name of the DMTF CIM schema MOF top level file
-        which used to compile the complete CIM schema. This file
-        contains the `#pragama include` statements for all of the classes
-        in the schema and the qualifier declaration `#pragma include` statements
+        **Deprecated:** This attribute has been deprecated in pywbem 1.0.0
+        in favor of
+        :method:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`.
+        :term:`string`: Path name of the schema pragma file
+        which defines MOF pragmas to compile the complete CIM schema. This file
+        contains the `#pragama include` statements for all of the classes in
+        the schema and the qualifier declaration `#pragma include` statements
         to compile `qualifiers.mof` and `qualifiers_optional.mof`.
 
         This filename is of the general form::
@@ -245,7 +345,27 @@ class DMTFCIMSchema(object):
 
             ex: schemas/dmtf/moffinal2490/cim_schema_2.49.0.mof
         """
-        return self._schema_mof_file
+        warnings.warn("The attribute schema_mof_file has been deprecated. Use "
+                      " the attribute schema_pragma_file.",
+                      DeprecationWarning, stacklevel=2)
+        return self._schema_pragma_file
+
+    @property
+    def schema_pragma_file(self):
+        """
+        :term:`string`: Path name of the DMTF CIM schema pragma MOF file
+        which defines MOF pragmas to compile the complete CIM schema. This file
+        contains the `#pragama include` statements for all of the classes in
+        the schema and the qualifier declaration `#pragma include` statements
+        to compile `qualifiers.mof` and `qualifiers_optional.mof`.
+
+        This filename is of the general form::
+
+            <schema_mof_dir>/cim_schema_<schema_version_str>.mof
+
+            ex: schemas/dmtf/moffinal2490/cim_schema_2.49.0.mof
+        """
+        return self._schema_pragma_file
 
     @property
     def schema_zip_file(self):
@@ -273,11 +393,12 @@ class DMTFCIMSchema(object):
 
         return '{0}(schema_version_str={1}, schema_root_dir={2}, ' \
                'schema_mof_dir={3}, ' \
-               ' schema_mof_file={4})'.format(self.__class__.__name__,
-                                              self.schema_version_str,
-                                              self.schema_root_dir,
-                                              self.schema_mof_dir,
-                                              self.schema_mof_file)
+               'schema_pragma_file={4})'.format(
+                   self.__class__.__name__,
+                   self.schema_version_str,
+                   self.schema_root_dir,
+                   self.schema_mof_dir,
+                   self.schema_pragma_file)
 
     def __repr__(self):
         """
@@ -287,13 +408,13 @@ class DMTFCIMSchema(object):
         """
         return '{0}(schema_version={1}, schema_root_dir={2}, ' \
                'schema_zip_file={3}, schema_mof_dir={4}, ' \
-               'schema_mof_file={5}, schema_zip_url={6})' \
+               'schema_pragma_file={5}, schema_zip_url={6})' \
                .format(self.__class__.__name__,
                        self.schema_version,
                        self.schema_root_dir,
                        self.schema_zip_file,
                        self.schema_mof_dir,
-                       self.schema_mof_file,
+                       self.schema_pragma_file,
                        self.schema_zip_url)
 
     def _setup_dmtf_schema(self):
@@ -362,7 +483,7 @@ class DMTFCIMSchema(object):
                 _format("Creating directory for CIM Schema MOF files: {0}",
                         self.schema_mof_dir))
             os.mkdir(self.schema_mof_dir)
-        if not os.path.isfile(self._schema_mof_file):
+        if not os.path.isfile(self._schema_pragma_file):
             print_verbose(
                 _format("Unpacking CIM Schema archive: {0}",
                         self.schema_zip_file))
@@ -383,39 +504,43 @@ class DMTFCIMSchema(object):
                 if zfp:
                     zfp.close()
 
-    def build_schema_mof(self, schema_classes):
+    def build_schema_mof(self, class_names):
         """
-        Build a string that includes the ``#include pragma`` statements for the
-        DMTF schema CIM classes defined in `schema_classes` using the DMTF CIM
-        schema defined by this object.
+        Build a string that includes the ``#include pragma`` statement for the
+        CIM schema classes defined in `class_names` using the DMTF CIM
+        schema defined by this instance of the class.
 
-        The class names in this list can be just leaf classes. The pywbem
-        MOF compiler will search for dependent classes.
+        The class names in `class_names` can be just leaf classes within the
+        schema . The pywbem MOF compiler will search for dependent classes
+        including superclasses, and other classes referenced as the classes are
+        compiled.
 
         It builds a compilable MOF string in the form::
 
             #pragma locale ("en_US")
             #pragma include ("System/CIM_ComputerSystem.mof")
+            ...
 
-        with a ``#pragma include`` for each classname in the `schema_classes`
+        with a ``#pragma include`` for each class name in the `class_names`
         list.
 
         The resulting set of #pragma statements is in the same order as the
         original pragmas.  In some cases that could be important because the
-        DMTF list is ordered to missing dependencies and conflicts between
-        class mof compiles
+        cim schema pragma file is ordered to missing dependencies and conflicts
+        between class mof compiles
 
         Parameters:
 
-          schema_classes (:term:`py:list` of :term:`string` or :term:`string`):
+          class_names (:term:`py:list` of :term:`string` or :term:`string`):
             These must be class names of classes in the DMTF CIM schema
             represented by this :class:`~pywbem_mock.DMTFCIMSchema` object.
             This parameter can be a string if there is only a single class name
             to be included.
 
             If the returned string is compiled, the MOF compiler will search
-            the directory defined by `schema_mof_dir` for dependent classes
-            for each class in this list.
+            the directory defined by `schema_mof_dir` for classes referenced by
+            each class in this list including super classes, classed defined by
+            reference properties, and classes defined by an embedded-object.
 
         Returns:
             :term:`string`: Valid MOF containing pragma statements for
@@ -425,44 +550,7 @@ class DMTFCIMSchema(object):
             ValueError: If any of the classnames in `schema_classes` are not in
             the DMTF CIM schema installed
         """
-        if isinstance(schema_classes, six.string_types):
-            schema_classes = [schema_classes]
-
-        schema_lines = []
-        with open(self.schema_mof_file, 'r') as f:
-            schema_lines = f.readlines()
-
-        # Build list  classname/line number pairs
-        classname_pattern = ' *#.*include.*/(.*)\\.mof'
-        schema_classes_lc = [cln.lower() for cln in schema_classes]
-        lines_list = []
-        found_classes = []
-        for line_no, line in enumerate(schema_lines, 0):
-            result = re.search(classname_pattern, line)
-            if result:
-                cln = result.group(1)
-                if cln.lower() in schema_classes_lc:
-                    lines_list.append(line_no)
-                    found_classes.append(cln)
-            line_no += 1
-
-        # Create list of the line numbers in schema_lines containing
-        # pragmas that will be part of the build.
-        classes_not_found = set(schema_classes) - set(found_classes)
-        if classes_not_found:
-            raise ValueError(
-                _format("Classes {0!A} not in DMTF CIM schema {1!A}",
-                        ', '.join(classes_not_found), self.schema_mof_file))
-
-        # Sort the list so the result is in the same order as the pragmas
-        # in the cim_schema file.
-        lines_list.sort()
-
-        output_lines = [schema_lines[line_number] for line_number in lines_list]
-
-        output_lines.insert(0, '#pragma locale ("en_US")\n')
-
-        return ''.join(output_lines)
+        return build_schema_mof(class_names, self.schema_mof_file)
 
     def clean(self):
         """

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -1718,6 +1718,8 @@ class MainProvider(BaseProvider, ResolverMixin):
             CIM_ERR_NOT_SUPPORTED,
             "ExecQuery not implemented!")
 
+        return []
+
     #####################################################################
     #
     #  Faked WBEMConnection Reference and Associator methods

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1841,11 +1841,11 @@ class TestRepoMethods(object):
 
         # TODO test returned instance for match with what was created
 
-    def test_compile_dmtf_schema(self, conn):
+    def test_compile_complete_dmtf_schema(self, conn):
         # pylint: disable=no-self-use
         """
-        Test Compiling DMTF CIM schema. This test compiles the
-        complete DMTF schema that is defined in the test suite.
+        Test Compiling the complete DMTF CIM schema. This test compiles all
+        classes of  the DMTF schema that is defined in the test suite.
         """
         skip_if_moftab_regenerated()
 
@@ -1860,6 +1860,9 @@ class TestRepoMethods(object):
         assert conn._get_class_store(ns).len() == TOTAL_CLASSES
         assert conn._get_qualifier_store(ns).len() == TOTAL_QUALIFIERS
 
+    @ pytest.mark.parametrize(
+        # Test use of both compile_dmtf_schema and compile_schema_classes
+        "use_compile_dmtf_schema", [True, False])
     @pytest.mark.parametrize(
         # Description - Description of the test
         # classnames - List of classnames to compile
@@ -2027,9 +2030,10 @@ class TestRepoMethods(object):
              True],
         ]
     )
-    def test_compile_dmtf_schema_method(self, conn, description, classnames,
-                                        extra_exp_classnames, exp_class,
-                                        run_tst):
+    def test_compile_partial_dmtf_schema(self, conn, use_compile_dmtf_schema,
+                                         description, classnames,
+                                         extra_exp_classnames, exp_class,
+                                         run_tst):
         # pylint: disable=no-self-use,unused-argument
         """
         Test Compiling DMTF CIM schema using the compile_dmtf_schema method.
@@ -2044,10 +2048,20 @@ class TestRepoMethods(object):
         skip_if_moftab_regenerated()
 
         ns = 'root/cimv2'
-        conn.compile_dmtf_schema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
-                                 class_names=classnames, verbose=True)
+        if use_compile_dmtf_schema:
+            conn.compile_dmtf_schema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
+                                     class_names=classnames,
+                                     verbose=True)
 
-        # test the set of created classnames for match to exp_classnames
+        else:  # use compile_schema_classes
+            schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
+                                   verbose=True)
+
+            conn.compile_schema_classes(classnames,
+                                        schema.schema_pragma_file,
+                                        verbose=True)
+
+        # Test the set of created classnames for match to exp_classnames
         exp_classnames = classnames
         exp_classnames.extend(extra_exp_classnames)
         rslt_classnames = conn.EnumerateClassNames(DeepInheritance=True,
@@ -6129,7 +6143,9 @@ class TestDMTFCIMSchema(object):
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
         assert os.path.isfile(schema.schema_mof_file)
+        assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
+        assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
@@ -6143,12 +6159,13 @@ class TestDMTFCIMSchema(object):
                                'schema_version=%s, ' \
                                'schema_root_dir=%s, schema_zip_file=%s, ' \
                                'schema_mof_dir=%s, ' \
-                               'schema_mof_file=%s, schema_zip_url=%s)' % \
+                               'schema_pragma_file=%s, ' \
+                               'schema_zip_url=%s)' % \
                                (DMTF_TEST_SCHEMA_VER,
                                 TESTSUITE_SCHEMA_DIR,
                                 schema.schema_zip_file,
                                 test_schema_mof_dir,
-                                schema.schema_mof_file,
+                                schema.schema_pragma_file,
                                 schema.schema_zip_url)
 
         schema_mof = schema.build_schema_mof(['CIM_ComputerSystem', 'CIM_Door'])
@@ -6158,9 +6175,6 @@ class TestDMTFCIMSchema(object):
                   '#pragma include ("System/CIM_ComputerSystem.mof")\n'
 
         assert schema_mof == exp_mof
-
-        assert os.path.isfile(schema.schema_zip_file)
-        assert os.path.isfile(schema.schema_mof_file)
 
     def test_schema_final_load(self, test_schema_root_dir):
         # pylint: disable=no-self-use
@@ -6182,7 +6196,9 @@ class TestDMTFCIMSchema(object):
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
         assert os.path.isfile(schema.schema_mof_file)
+        assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
+        assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(test_schema_root_dir, mof_dir)
@@ -6206,8 +6222,8 @@ class TestDMTFCIMSchema(object):
         schema_mof = schema.build_schema_mof(['CIM_ComputerSystem', 'CIM_Door'])
 
         exp_mof = '#pragma locale ("en_US")\n' \
-                  '#pragma include ("System/CIM_ComputerSystem.mof")\n' \
-                  '#pragma include ("Device/CIM_Door.mof")\n'
+                  '#pragma include ("Device/CIM_Door.mof")\n' \
+                  '#pragma include ("System/CIM_ComputerSystem.mof")\n'
 
         assert schema_mof == exp_mof
 

--- a/tests/unittest/utils/wbemserver_mock.py
+++ b/tests/unittest/utils/wbemserver_mock.py
@@ -7,7 +7,7 @@ from __future__ import print_function, absolute_import
 
 import os
 
-from .dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
+from .dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER, DMTFCIMSchema
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -193,9 +193,13 @@ class WbemServerMock(object):
         FakedWBEMConnection._reset_logging_config()
         conn = FakedWBEMConnection(default_namespace=default_namespace)
 
-        conn.compile_dmtf_schema(
-            self.dmtf_schema_ver, self.schema_dir,
-            class_names=self.server_mock_data['class_names'], verbose=False)
+        schema = DMTFCIMSchema(self.dmtf_schema_ver, self.schema_dir,
+                               verbose=False)
+
+        conn.compile_schema_classes(
+            self.server_mock_data['class_names'],
+            schema.schema_pragma_file,
+            verbose=False)
 
         for fn in self.pg_schema_files:
             pg_file = os.path.join(self.pg_schema_dir, fn)


### PR DESCRIPTION
Currently in 3 commits, 1. original, 2. fixes to comments, 3. modify we use schema_mof_pragma_file 
as the input parameter to compile_schema_classes.

The original method for compiling parts of a DMTF schema was
compile_dmtf_schema() which compiled a specific set of classes from the
DMTF schema defined by a DMTF schema version number and the directory
where a local version of that DMTF was supposed to be located.

This change separates the compile of classes of the schema from the process
of downloading and installing the schema.

Thus, originally, the FakedWBEMConnection method to create a mock
repository with some classes from the schema was:

conn.compile_dmtf_schema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
                         class_names=[CIM_Namespace,'CIM_ObjectManager'],
                         verbose=True)

the separation functionality yields:

schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
                       verbose=False)

conn.compile_dmtf_classes(schema.schema_mof_pragma_file
         schema_classnames=[CIM_Namespace,'CIM_ObjectManager'],
         namespace=True)

In addition we changed the internal name in DMTFCIMSchema class from
schema_mof_file to schema_mof_pragma_file.  Note that the property
schema_mof_file is retained but marked deprecated.  This helps to
clarify the meaning of this file.

Added tests for the new method to compile DMTF classes. This
was a very small change, just extending the test class for the original
compile_dmtf_schema to execute both the original compile and the new
compile.