### PR TITLE
Fixes #2231: Rename the provider files and separate classes

### DIFF
--- a/pywbem_mock/__init__.py
+++ b/pywbem_mock/__init__.py
@@ -1,5 +1,5 @@
 #
-# (C) Copyright 2003-2007 InovaDevelopment.com
+# (C) Copyright 2003-2020 InovaDevelopment.com
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -31,6 +31,8 @@ from ._baserepository import *             # noqa: F403,F401
 from ._inmemoryrepository import *         # noqa: F403,F401
 from ._baseprovider import *               # noqa: F403,F401
 from ._mainprovider import *               # noqa: F403,F401
+from ._providerdispatcher import *         # noqa: F403,F401
 from ._defaultinstanceprovider import *    # noqa: F403,F401
+from ._defaultmethodprovider import *      # noqa: F403,F401
 from ._namespaceprovider import *          # noqa: F403,F401
 from ._utils import *                      # noqa: F403,F401

--- a/pywbem_mock/_defaultmethodprovider.py
+++ b/pywbem_mock/_defaultmethodprovider.py
@@ -1,0 +1,160 @@
+"""
+This module adds support for user-defined method providers.  User defined
+method providers may be created within pywbem_mock to extend the capability
+of the mocker for special processing for selected classes using CIM
+extrensic methods (the `InvokeMethod` client request).
+
+Since there is no concept of a default method provider (all CIM methods
+imply actions that are specific to the method). The default provide returns
+an exception.
+
+User defined providers may be created for specific CIM classes and namespaces
+to override the InvokeMethod in :class:`~pywbem_mock.MethodProvider` with user
+methods defined in a subclass of :class:`~pywbem_mock.MethodProvider`.
+
+This module contains the default MethodProvider class which provides the
+following:
+
+1. Definition of the provider type (`provider_type = method`).
+2. Definition of the API and return for the `InvokeMethod` method required in
+   the user-defined subclass
+
+A user-defined method provider is created as follows:
+
+1. Create the subclass of :class:`~pywbem_mock.MethodProvider` with an
+   __init__ method, an optional `post_registration_setup` method and the
+   `InvokeMethod that will override the same method defined in
+   :class:`~pywbem_mock.MethodProvider`.  The input parameters for the
+   InvokeMethod will have been already validated in
+   :class:`~pywbem_mock.ProviderDispatcher.ProviderDispatcher`
+
+   The user-defined class must include the following class variables:
+
+   * `provider_classnames` (:term:`string` or list of :term`string`): defines
+     the class(es) that this provider will serve.
+
+   Thus, a user-defined method provider defines a subclass to
+   :class:`~pywbem_mock.MethodProvider and defines a `InvokeMethod` method in
+   the user-defined subclass to override
+   :meth:`~pywbem_mock.MethodProvider.InvokeMethod`.
+
+2. Register the user-defined method provider using
+   :meth:`~pywbem_mock.FakedWBEMConnection.register_provider` to define the
+   namespaces for which the user provider will override
+   :class:`~pywbem_mock.InstanceWriteProvider`.  The registration of the user
+   provider must occur after the namespaces defined in the registration have
+   been added to the CIM repository.
+"""
+
+from __future__ import absolute_import, print_function
+
+from pywbem import CIMError, CIM_ERR_METHOD_NOT_AVAILABLE
+
+from ._baseprovider import BaseProvider
+
+# None of the request method names conform since they are camel case
+# pylint: disable=invalid-name
+
+__all__ = ['MethodProvider']
+
+
+class MethodProvider(BaseProvider):
+    """
+    This class defines the provider class that handles the default InvokeMethod.
+
+    User  method providers are defined by creating a subclass of this class and
+    defining an InvokeMethod based on the method in this class.
+    """
+    #:  provider_type (:term:`string`):
+    #:    Keyword defining the type of request the provider will service.
+    #:    The type for this class is predefined as 'method'
+    provider_type = 'method'
+
+    def __init__(self, cimrepository=None):
+        """
+        Parameters:
+
+          cimrepository (:class:`~pywbem_mock.BaseRepository` or subclass):
+            Defines the repository to be used by request responders.  The
+            repository is fully initialized.
+        """
+        super(MethodProvider, self).__init__(cimrepository)
+
+    ####################################################################
+    #
+    #   Server responder for InvokeMethod.
+    #
+    ####################################################################
+
+    def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
+        # pylint: disable=invalid-name
+        """
+        Defines the API and return for a mock WBEM server responder for
+        :meth:`~pywbem.WBEMConnection.InvokeMethod` for both static (ObjectName
+        is a class name) and dynamic (ObjectName is a CIMInstanceName) methods
+
+        This method should never be called because there is no concept of a
+        default InvokeMethod in WBEM.  All method providers specify specific
+        actions.
+
+        This responder calls a function defined by an entry in the methods
+        repository. The return from that function is returned to the user.
+
+        Parameters:
+
+          namespace  (:term:`string`):
+            The name of the CIM namespace in the CIM repository (case
+            insensitive). Must not be `None`. Leading or trailing slash
+            characters are ignored.
+
+          MethodName (:term:`string`):
+            Name of the method to be invoked (case independent).
+
+          ObjectName:
+            The object path of the target object, as follows:
+
+            * For instance-level use: The instance path of the target
+              instance, as a :class:`~pywbem.CIMInstanceName` object.
+              If this object does not specify a namespace, the default namespace
+              of the connection is used.
+              Its `namespace`, and `host` attributes will be ignored.
+
+            * For class-level use: The class path of the target class, as a
+              :term:`string`:
+
+              The string is interpreted as a class name in the default
+              namespace of the connection (case independent).
+
+          Params (:term:`py:iterable`):
+            An iterable of input parameter values for the CIM method. Each item
+            in the iterable is a single parameter value and is:
+
+            * :class:`~pywbem.CIMParameter` representing a parameter value. The
+              `name`, `value`, `type` and `embedded_object` attributes of this
+              object are used.
+
+        Returns:
+
+            A :func:`py:tuple` of (returnvalue, outparams), with these
+            tuple items:
+
+            * returnvalue (:term:`CIM data type`):
+              Return value of the CIM method.
+            * outparams (:term:`py:iterable` of :class:`~pywbem.CIMParameter`):
+              Each item represents a single output parameter of the CIM method.
+              The :class:`~pywbem.CIMParameter` objects must have at least
+              the following properties set:
+
+                * name (:term:`string`): Parameter name (case independent).
+                * type (:term:`string`): CIM data type of the parameter.
+                * value (:term:`CIM data type`): Parameter value.
+
+        Raises:
+
+          :exc:`~pywbem.CIMError`: CIM_ERR_METHOD_NOT_AVAILABLE because the
+          default method is only a placeholder for the API and documentation
+          and not a real InvokeMethod action implementation.
+        """
+        # No default MethodProvider is implemented because all method
+        # providers define specific actions in their implementations.
+        raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -1,0 +1,251 @@
+#
+# (C) Copyright 2020 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+This module is part of the support for user-defined providers.  User-defined
+providers may be created within pywbem_mock to extend the capability
+of the mocker for special processing for selected classes.
+
+This module contains the ProviderDispatcher class which routes request methods
+that allow user-defined providers either to the default method  or if a
+user-defined provider is registered to the user-defined method for the
+provider class defined in the provider registry.
+"""
+
+from __future__ import absolute_import, print_function
+
+import six
+
+from pywbem import CIMInstance, CIMInstanceName, CIMError, \
+    CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, CIM_ERR_INVALID_CLASS, \
+    CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_METHOD_NOT_FOUND
+
+from pywbem._utils import _format
+
+from ._baseprovider import BaseProvider
+
+
+class ProviderDispatcher(BaseProvider):
+    """
+    This class dispatches requests destined for the instance provider methods
+    defined in InstanceWriteProvider  to the either the default instance
+    provder method or the provider defined for processing the defined class in
+    the defined namespace.
+    """
+
+    def __init__(self, cimrepository, provider_registry,
+                 default_instance_provider):
+        """
+        Set instance parameters passed from FakedWBEMConnection
+        """
+        super(ProviderDispatcher, self).__init__(cimrepository)
+
+        self.provider_registry = provider_registry
+
+        # Defines the instance of InstanceWriteProvider that will
+        # be called to dispatch operation to default provider.
+        self.default_instance_provider = default_instance_provider
+
+    def CreateInstance(self, namespace, NewInstance):
+        """
+        Dispatcher for CreateInstance.
+
+        This method validates input parameters against the repository and
+        provider required parameter types and if successful, routes the method
+        either to the default provider or to a provider registered for the
+        namespace and class in InstanceName
+        """
+        # Validate input parameters
+
+        self.validate_namespace(namespace)
+
+        if not isinstance(NewInstance, CIMInstance):
+            raise TypeError(
+                _format("NewInstance parameter is not a valid CIMInstance. "
+                        "Rcvd type={0}", type(NewInstance)))
+
+        if not self.class_exists(namespace, NewInstance.classname):
+            raise CIMError(
+                CIM_ERR_INVALID_CLASS,
+                _format("Cannot create instance because its creation "
+                        "class {0!A} does not exist in namespace {1!A}.",
+                        NewInstance.classname, namespace))
+
+        provider = self.provider_registry.get_registered_provider(
+            namespace, 'instance', NewInstance.classname)
+
+        if provider:
+            return provider.CreateInstance(namespace, NewInstance)
+
+        return self.default_instance_provider.CreateInstance(
+            namespace, NewInstance)
+
+    def ModifyInstance(self, ModifiedInstance,
+                       IncludeQualifiers=None, PropertyList=None):
+        """
+        Dispatcher for the ModifyInstance method.
+
+        This method validates input parameters against the repository and
+        provider required types and if successful, routes the method either to
+        the default provider or to a provider registered for the namespace and
+        class in ModifiedInstance.
+
+        Validates basic characteristics of parameters including:
+
+        1. Namespace xists.
+        2. Modified instance is valid instance.
+        3. ClassName same in instance and instance.path
+        4. Class exists in repository
+        5. Instance exists in repository.
+        """
+
+        namespace = ModifiedInstance.path.namespace
+        self.validate_namespace(namespace)
+
+        if not isinstance(ModifiedInstance, CIMInstance):
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("The ModifiedInstance parameter is not a valid "
+                        "CIMInstance. Rcvd type={0}", type(ModifiedInstance)))
+
+        # Classnames in instance and path must match
+        if ModifiedInstance.classname.lower() != \
+                ModifiedInstance.path.classname.lower():
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("ModifyInstance classname in path and instance do "
+                        "not match. classname={0!A}, path.classname={1!A}",
+                        ModifiedInstance.classname,
+                        ModifiedInstance.path.classname))
+
+        if not self.class_exists(namespace, ModifiedInstance.classname):
+            raise CIMError(
+                CIM_ERR_INVALID_CLASS,
+                _format("ModifyInstance classn {0!A} does not exist in"
+                        "CIM repository for namespace {1!A}.",
+                        ModifiedInstance.classname,
+                        namespace))
+
+        # Test original instance exists.
+        instance_store = self.get_instance_store(namespace)
+        # Do not copy because not modified or passed on
+        orig_instance = self.find_instance(ModifiedInstance.path,
+                                           instance_store,
+                                           copy=False)
+        if orig_instance is None:
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                _format("Original Instance {0!A} not found in namespace {1!A}",
+                        ModifiedInstance.path, namespace))
+
+        provider = self.provider_registry.get_registered_provider(
+            namespace, 'instance', ModifiedInstance.classname)
+
+        if provider:
+            return provider.ModifyInstance(
+                ModifiedInstance,
+                IncludeQualifiers=IncludeQualifiers,
+                PropertyList=PropertyList)
+
+        return self.default_instance_provider.ModifyInstance(
+            ModifiedInstance,
+            IncludeQualifiers=IncludeQualifiers,
+            PropertyList=PropertyList)
+
+    def DeleteInstance(self, InstanceName):
+        """
+        Dispatcher for the DeleteInstance method.
+
+        This method validates input parameters against the repository and
+        provider required types and if successful, routes the method either to
+        the default provider or to a provider registered for the namespace and
+        class in InstanceName
+        """
+
+        # Validate input parameters
+        namespace = InstanceName.namespace
+        self.validate_namespace(namespace)
+
+        # Test if corresponding class and instance already exist
+        if not self.class_exists(namespace, InstanceName.classname):
+            raise CIMError(
+                CIM_ERR_INVALID_CLASS,
+                _format("Class {0!A} in namespace {1!A} not found. "
+                        "Cannot delete instance {2!A}",
+                        InstanceName.classname, namespace, InstanceName))
+
+        instance_store = self.get_instance_store(namespace)
+        if not instance_store.object_exists(InstanceName):
+            raise CIMError(
+                CIM_ERR_NOT_FOUND,
+                _format("Instance {0!A} not found in CIM repository namespace "
+                        "{1!A}", InstanceName, namespace))
+
+        provider = self.provider_registry.get_registered_provider(
+            InstanceName.namespace, 'instance', InstanceName.classname)
+
+        if provider:
+            return provider.DeleteInstance(InstanceName)
+
+        return self.default_instance_provider.DeleteInstance(
+            InstanceName)
+
+    def InvokeMethod(self, namespace, methodname, objectname, Params):
+        """
+        Default Method provider.
+        NOTE: There is no default method provider because all method
+        providers provide specific functionality and there is no way
+        to do that in a default method provider.
+        """
+        # Validate input parameters
+        self.validate_namespace(namespace)
+
+        assert isinstance(objectname, (CIMInstanceName, six.string_types))
+
+        classname = objectname.classname \
+            if isinstance(objectname, CIMInstanceName) else objectname
+
+        # This raises CIM_ERR_NOT_FOUND or CIM_ERR_INVALID_NAMESPACE
+        # Uses local_only = False to get characteristics from super classes
+        # and include_class_origin to get origin of method in hierarchy
+        cc = self.get_class(namespace, classname,
+                            local_only=False,
+                            include_qualifiers=True,
+                            include_classorigin=True)
+
+        # Determine if method defined in classname defined in
+        # the classorigin of the method
+        try:
+            cc.methods[methodname].class_origin
+        except KeyError:
+            raise CIMError(
+                CIM_ERR_METHOD_NOT_FOUND,
+                _format("Method {0!A} not found in class {1!A}.",
+                        methodname, classname))
+
+        provider = self.provider_registry.get_registered_provider(
+            namespace, 'method', classname)
+        if provider:
+            return provider.InvokeMethod(namespace, methodname,
+                                         objectname, Params)
+
+        # There is no default method provider so no user InvokeMethod
+        # is defined for namespace and class, exception raise.
+        raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -47,8 +47,11 @@ from ._inmemoryrepository import InMemoryRepository
 
 from ._mockmofwbemconnection import _MockMOFWBEMConnection
 
-from ._defaultinstanceprovider import ProviderDispatcher, \
-    InstanceWriteProvider, MethodProvider
+from ._providerdispatcher import ProviderDispatcher
+
+from ._defaultinstanceprovider import InstanceWriteProvider
+
+from ._defaultmethodprovider import MethodProvider
 
 from ._dmtf_cim_schema import DMTFCIMSchema, build_schema_mof
 from ._utils import _uprint


### PR DESCRIPTION
1. Create new _defaultmethodprovider.py
2. Create new file _providerdispatcher.py
3. Modify imports, etc. to use the new files.

I kept the name defaultinstanceprovider because I am uncomfortable
creating separate providers in the future for instancewrite and
instanceread.  DISCUSSION.