### PR TITLE
Fixed pywbem,pywbem_mock imports into mocker testcases

### DIFF
--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -20,15 +20,19 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from pywbem import CIMClass, CIMInstance, CIMInstanceName, CIMProperty, \
-    CIMQualifierDeclaration, CIMQualifier
-
-from pywbem._nocasedict import NocaseDict
-
-from pywbem_mock import InMemoryRepository
-from pywbem_mock._inmemoryrepository import InMemoryObjectStore
-
 from ..utils.pytest_extensions import simplified_test_function
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ...utils import import_installed
+pywbem = import_installed('pywbem')
+from pywbem import CIMClass, CIMInstance, CIMInstanceName, CIMProperty, \
+    CIMQualifierDeclaration, CIMQualifier  # noqa: E402
+from pywbem._nocasedict import NocaseDict  # noqa: E402
+pywbem_mock = import_installed('pywbem_mock')
+from pywbem_mock import InMemoryRepository  # noqa: E402
+from pywbem_mock._inmemoryrepository import InMemoryObjectStore  # noqa: E402
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
 
 ########################################################################
 #

--- a/tests/unittest/pywbem_mock/test_system_providers.py
+++ b/tests/unittest/pywbem_mock/test_system_providers.py
@@ -30,20 +30,17 @@ import six
 import pytest
 
 from ..utils.pytest_extensions import simplified_test_function
-
+from ..utils.dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
 from ...utils import skip_if_moftab_regenerated
 
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
-
-from pywbem import CIMError, WBEMServer
-
-pywbem = import_installed('pywbem')  # noqa: E402
-
+pywbem = import_installed('pywbem')
+from pywbem import CIMError, WBEMServer  # noqa: E402
 pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema  # noqa: E402
-from ..utils.dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER  # noqa: E402
-
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
 # Location of DMTF schema directory used by all tests.
 # This directory is permanent and should not be removed.
 TESTSUITE_SCHEMA_DIR = os.path.join('tests', 'schema')


### PR DESCRIPTION
Some of the mocker testcases did not use the concept of dynamically importing pywbem or pywbem_mock.