### PR TITLE
Correct issues in pywbem_mock with Open/Pull

### DIFF
--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -153,16 +153,6 @@ def validate_inst_props(namespace, target_class, instance):
         if cprop_name != iprop_name:
             instance.properties[iprop_name].name = cprop_name
 
-        # If property not in instance, add it from class and use default value
-        # from class
-        add_props = dict()
-        for cprop_name in target_class.properties:
-            if cprop_name not in instance:
-                default_value = target_class.properties[cprop_name]
-                add_props[cprop_name] = default_value
-
-    instance.update(add_props)
-
 
 class InstanceWriteProvider(BaseProvider):
     """

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -1567,8 +1567,8 @@ class MainProvider(BaseProvider, ResolverMixin):
     def _return_assoc_class_tuples(self, rtn_classnames, namespace, iq, ico,
                                    pl):
         """
-        Creates the correct tuples of for associator and references class
-        level responses from a list of classnames.  This is special because
+        Creates the correct tuples for associator and references class
+        level responses from a list of classnames.  This is unique because
         the class level references and associators return a tuple of
         CIMClassName and CIMClass for every entry.
         """
@@ -2125,8 +2125,9 @@ class MainProvider(BaseProvider, ResolverMixin):
                                                         ResultClass, Role)
         # returns list of tuples of (CIMClassname, CIMClass)
         return self._return_assoc_class_tuples(rtn_classnames, namespace,
-                                               PropertyList, IncludeClassOrigin,
-                                               IncludeQualifiers)
+                                               IncludeQualifiers,
+                                               IncludeClassOrigin,
+                                               PropertyList)
 
     ####################################################################
     #
@@ -2329,8 +2330,9 @@ class MainProvider(BaseProvider, ResolverMixin):
                                                          ResultRole, Role)
         # returns list of tuples of (CIMClassname, CIMClass)
         return self._return_assoc_class_tuples(rtn_classnames, namespace,
-                                               PropertyList, IncludeClassOrigin,
-                                               IncludeQualifiers)
+                                               IncludeQualifiers,
+                                               IncludeClassOrigin,
+                                               PropertyList)
 
     #####################################################################
     #
@@ -2557,14 +2559,14 @@ class MainProvider(BaseProvider, ResolverMixin):
             eos = u'TRUE'
             rtn_objs_list = objs_list
             del self.enumeration_contexts[EnumerationContext]
-            context_id = ""
+            EnumerationContest = ""
         else:
             eos = u'FALSE'
             rtn_objs_list = objs_list[0: max_obj_cnt]
             del objs_list[0: max_obj_cnt]
 
-        # returns tuple of list of insts, eos, and context_id
-        return (rtn_objs_list, eos, context_id)
+        # returns tuple of list of insts, eos, and EnumerationContext
+        return (rtn_objs_list, eos, EnumerationContest)
 
     @staticmethod
     def _validate_open_params(FilterQueryLanguage, FilterQuery,

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -2508,8 +2508,7 @@ class MainProvider(BaseProvider, ResolverMixin):
 
         return(rtn_objects, eos, context_id)
 
-    def _pull_response(self, req_type, EnumerationContext,
-                       MaxObjectCount):
+    def _pull_response(self, req_type, EnumerationContext, MaxObjectCount):
         """
         Common method for all of the Pull methods. Since all of the pull
         methods operate independent of the type of data, this single function
@@ -2559,14 +2558,15 @@ class MainProvider(BaseProvider, ResolverMixin):
             eos = u'TRUE'
             rtn_objs_list = objs_list
             del self.enumeration_contexts[EnumerationContext]
-            EnumerationContest = ""
+            context_id = ""
         else:
             eos = u'FALSE'
             rtn_objs_list = objs_list[0: max_obj_cnt]
             del objs_list[0: max_obj_cnt]
+            context_id = EnumerationContext
 
-        # returns tuple of list of insts, eos, and EnumerationContext
-        return (rtn_objs_list, eos, EnumerationContest)
+        # returns tuple of list of insts, eos, and context_id
+        return (rtn_objs_list, eos, context_id)
 
     @staticmethod
     def _validate_open_params(FilterQueryLanguage, FilterQuery,

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -35,7 +35,7 @@ import six
 
 from pywbem import CIMInstance, CIMInstanceName, CIMError, \
     CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, CIM_ERR_INVALID_CLASS, \
-    CIM_ERR_METHOD_NOT_AVAILABLE, CIM_ERR_METHOD_NOT_FOUND
+    CIM_ERR_METHOD_NOT_FOUND
 
 from pywbem._utils import _format
 
@@ -269,4 +269,4 @@ class ProviderDispatcher(BaseProvider):
 
         # There is no default method provider so no user InvokeMethod
         # is defined for namespace and class, exception raise.
-        raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
+        raise CIMError(CIM_ERR_METHOD_NOT_FOUND)

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -354,12 +354,9 @@ class TestRemove(MOFTest):
 
         # Remove the mof defined by the testfile
         # create rollback definition
-        conn_mof = MOFWBEMConnection(conn=conn)
-        conn_mof.default_namespace = conn.default_namespace
-        conn_mof.url = conn.url
 
         conn_mof_mofcomp = MOFCompiler(
-            conn_mof,
+            MOFWBEMConnection(conn=conn),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
             verbose=False,
             log_func=moflog)

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -4688,12 +4688,50 @@ class TestInstanceOperations(object):
 
 class TestPullOperations(object):
     """
-    Mock the open and pull operations
-        ClassName, namespace=None,
-        FilterQueryLanguage=None, FilterQuery=None,
-        OperationTimeout=None, ContinueOnError=None,
-        MaxObjectCount=None,
+    Test the Open and pull operations.
     """
+
+    @pytest.mark.parametrize(
+        "ns", EXPANDED_NAMESPACES + [None])
+    @pytest.mark.parametrize(
+        # src_class: Source instance definitions (classname and name property
+        # maxobj: Max object count for each operation
+        # exp_eos: If True, eos expected on open request
+        "src_class,  maxobj, exp_rslt, open_eos", [
+            ['TST_Person', 100, True],
+
+            ['TST_Person', 1, False],
+        ]
+    )
+    def test_openenumerateinstancepaths(self, conn, ns, src_class, maxobj,
+                                        exp_eos, tst_assoc_mof):
+        # pylint: disable=no-self-use,invalid-name
+        """
+        Test openenueratepaths for a variety of MaxObjectCount values.
+        """
+        skip_if_moftab_regenerated()
+
+        add_objects_to_repo(conn, ns, [tst_assoc_mof])
+
+        orig_rtnd_instnames = conn.EnumerateInstanceNames(source_inst_class)
+
+        rtnd_instnames = []
+
+        result_tuple = conn.OpenEnumerateInstancePaths(
+            source_inst_class, MaxObjectCount=maxobj)
+
+        rtnd_instnames.extend(result_tuple.paths)
+
+        assert result_tuple.eos = exp_eos
+
+        If exp_eos is False:
+            while result_tuple.eos is False:
+                result_tuple = conn.PullInstancesWithPath(result_tuple)
+                rtnd_instnames.extend(result_tuple.paths)
+
+        assert len(rtnd_instnames) == len(orig_rtnd_instnames)
+
+        assert set(rtnd_instnames)== set(orig_rtnd_instnames)
 
     @pytest.mark.parametrize(
         "ns", EXPANDED_NAMESPACES + [None])


### PR DESCRIPTION
Fixes 3 issues found in testing with pywbemcli.

1. a code error in MainProvider  Open and pull processing.  We had some parameters out of order in a local function call.  Since this was changes made in Pywbem 1.0.0, no back port necessary.  

In the process, I found that we did not have a test for what caused this issue so added two new tests for Open/Pull

2. We were inserting extra properties in instances.  My coding error. Removed that code.

3. Restored use of CIM_ERR_NOT_FOUND in place of CIM_ERR_NOT_AVAILABLE when method not found.  This is correct since NOT_FOUND is higher priority than NOT_AVAILABLE. I misread the spec when review code during the refactor.

pywbemcli now passes tests (with a number of changes to its tests) against pywbem 1.0.0. I have not submitted that PR yet.