### PR TITLE
Fixes #2244: Review Provider Manager

### DIFF
--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -52,7 +52,7 @@ A user-defined method provider is created as follows:
 
 from __future__ import absolute_import, print_function
 
-from pywbem import CIMError, CIM_ERR_METHOD_NOT_AVAILABLE
+from pywbem import CIMError, CIM_ERR_METHOD_NOT_FOUND
 
 from ._baseprovider import BaseProvider
 
@@ -161,4 +161,4 @@ class MethodProvider(BaseProvider):
         """
         # No default MethodProvider is implemented because all method
         # providers define specific actions in their implementations.
-        raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
+        raise CIMError(CIM_ERR_METHOD_NOT_FOUND)

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -474,18 +474,10 @@ class FakedWBEMConnection(WBEMConnection):
                                           self.disable_pull_operations,
                                           self.cimrepository)
 
-        # Initiate the InstanceWriteProvider with the cimrepository
-        self._defaultinstanceprovider = InstanceWriteProvider(
-            self._cimrepository)
-
-        # self.methodprovider = MethodProvider(self.cimrepository)
-
         # Initiate instance of the ProviderDispatcher with required
-        # parameters including the cimrepository
+        # parameters including the CIM repository
         self._providerdispatcher = ProviderDispatcher(
-            self._cimrepository,
-            self._provider_registry,
-            self._defaultinstanceprovider)
+            self._cimrepository, self._provider_registry)
 
         # Flag to allow or disallow the use of the Open... and Pull...
         # operations. Uses the setter method


### PR DESCRIPTION
**NOTE: Expect manual changes before committing because PR #2251 moves the same code that we are changing here to a new module.**

This pr generates the following changes In response to the questions we made the following changes:

1. Move the definition of the default InstanceWriteProvider and
MethodProvider to the ProviderDispatcher. This is done with a property
for each that only constructs the default provider when the property is used.

2. Remove the constructor for the default providers from _wbemconnection
so the only parameter for the construction of ProviderDispatcher is the
CIM repository.

3. Change the default MethodProvider behavior to actually call the
MethodProvider where that provider generates the required exception.
This maintains the same pattern as the other operations in the
ProviderDispatcher.

4. Change that exception to CIM_ERR_NOT_FOUND

No changes to tests or to changes.rst