### PR TITLE
[WIP] Fixes #2065: Instance iq and ico variations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -176,6 +176,12 @@ Released: not yet
   subclass to the class MethodProvider whichimplements the InvokeMethod
   responder in that user-defined provider. (See issue #2062).
 
+* Added pywbem_mock/config.py variables to control use of the IncludeQualifiers
+  and IncludeClassOrigin arguments on the GetInstance and EnumerateInstances
+  operations.  The default is not to ignore the request variables and
+  never return either attribute in the return instances.  This may be
+  modified by modifying the config variables. ()See issue # 2065)
+
 **Deprecations:**
 
   Deprecated the method FakedWBEMConnection.compile_dmtf_schema in favor of

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -59,6 +59,8 @@ from pywbem import CIMClass, CIMClassName, CIMInstanceName, \
 from pywbem._nocasedict import NocaseDict
 from pywbem._utils import _format
 
+from pywbem_mock.config import IGNORE_INSTANCE_IQ_PARAM, \
+    IGNORE_INSTANCE_ICO_PARAM
 from pywbem_mock._baseprovider import BaseProvider
 
 from ._resolvermixin import ResolverMixin
@@ -360,12 +362,18 @@ class MainProvider(BaseProvider, ResolverMixin):
               If `False` or `None` class_origin is not included in the
               returned object
 
+              The value of this argument may be overridden by the
+              IGNORE_INSTANCE_ICO_PARAM config variable.
+
           include_qualifiers (:class:`pybool`):
               If `True`, any qualifiers in the stored instance the instance and
               properties are returned
 
               If `False` or None no qualifiers in the instance or properties
               are returned.
+
+              The value of this argument may be overridden by the
+              IGNORE_INSTANCE_IQ_PARAM config variable.
 
         Returns:
 
@@ -437,10 +445,10 @@ class MainProvider(BaseProvider, ResolverMixin):
 
         self.filter_properties(rtn_inst, property_list)
 
-        if not include_qualifiers:
+        if IGNORE_INSTANCE_IQ_PARAM or not include_qualifiers:
             self._remove_qualifiers(rtn_inst)
 
-        if not include_class_origin:
+        if IGNORE_INSTANCE_ICO_PARAM or not include_class_origin:
             self._remove_classorigin(rtn_inst)
         return rtn_inst
 

--- a/pywbem_mock/config.py
+++ b/pywbem_mock/config.py
@@ -34,7 +34,8 @@ modify the configuration variables.
 
 __all__ = ['OBJECTMANAGERNAME', 'SYSTEMNAME',
            'SYSTEMCREATIONCLASSNAME', 'DEFAULT_MAX_OBJECT_COUNT',
-           'OPEN_MAX_TIMEOUT', 'OBJECTMANAGERCREATIONCLASSNAME']
+           'OPEN_MAX_TIMEOUT', 'OBJECTMANAGERCREATIONCLASSNAME',
+           'IGNORE_INSTANCE_IQ_PARAM', 'IGNORE_INSTANCE_ICO_PARAM']
 
 #: Name for the object manager It is used in defining user-defined provider
 #: properties for CIM_Namespace provider and CIM_ObjectManager provider if
@@ -60,3 +61,38 @@ DEFAULT_MAX_OBJECT_COUNT = 100
 #: Maximum timeout in seconds for pull operations if the OperationTimeout
 #: parameter is not included in the request
 OPEN_MAX_TIMEOUT = 40
+
+#: Use of the IncludeQualifiers parameter on instance requests is DEPRECATED in
+#: DMTF DSP0200. The definition of IncludeQualifiers is ambiguous and when this
+#: parameter is set to true, WBEM clients cannot be assured that any qualifiers
+#: will be returned. A WBEM client should always set this parameter to false. To
+#: minimize the impact of this recommendation on WBEM clients, a WBEM server may
+#: choose to treat the value of IncludeQualifiers as false for all requests.
+#:
+#: The following variable forces pywbem_mock to ignore the client supplied
+#: variable and not return qualifiers on EnumerateInstances and GetInstance
+#: responses.
+#:
+#: * True (default): pywbem_mock always removes qualifiers from instances
+#:   in responses
+#: * False: pywbem_mock uses value of input parameter or its default to
+#:   determine if qualifiers are to be removed
+IGNORE_INSTANCE_IQ_PARAM = True
+
+#: Use of the IncludeClassOrigin parameter on instance requests is DEPRECATED. A
+#: WBEM server may choose to treat the value of IncludeClassOrigin parameter as
+#: false for all requests, otherwise the implementation shall support the
+#: original behavior as defined in the rest of this paragraph. If the
+#: IncludeClassOrigin input parameter is true, the CLASSORIGIN attribute shall
+#: be present on all appropriate elements in each returned Instance. If it is
+#: false, no CLASSORIGIN attributes are present.
+#:
+#: The following variable forces pywbem_mock to ignore the client supplied
+#: variable and not return qualifiers on EnumerateInstances and GetInstance
+#: responses.
+#:
+#: * True (default): pywbem_mock always removes class origin attributes from
+#:   instances in responses
+#: * False: pywbem_mock uses value of input parameter or its default to
+#:   determine if class origin attributes are to be removed
+IGNORE_INSTANCE_ICO_PARAM = True

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -3744,15 +3744,15 @@ class TestInstanceOperations(object):
             # verify class and instance in default, use default
             [DEFAULT_NAMESPACE, 'CIM_Foo', 'CIM_Foo1', None, None],
             # verify works with explicit tst_ns
-            [DEFAULT_NAMESPACE, 'CIM_Foo', 'CIM_Foo1', DEFAULT_NAMESPACE, None],
+            [DEFAULT_NAMESPACE, 'CIM_Foo', 'CIM_Foo1', None, None],
             [DEFAULT_NAMESPACE, 'CIM_Foo', 'badid', DEFAULT_NAMESPACE,
              CIM_ERR_NOT_FOUND],
             [DEFAULT_NAMESPACE, 'CIM_Foo', 'CIM_Foo1', 'BadNamespace',
              CIM_ERR_INVALID_NAMESPACE],
             [DEFAULT_NAMESPACE, 'CIM_Foox', 'CIM_Foo1', None,
              CIM_ERR_INVALID_CLASS],
-            # class and instance in ns. test different tst_ns fails
-            [NOT_DEFAULT_NS, 'CIM_Foo', 'CIM_Foo1', DEFAULT_NAMESPACE,
+            # Invalid classname on instance
+            [DEFAULT_NAMESPACE, 'CIM_Foox', 'CIM_Foo1', None,
              CIM_ERR_INVALID_CLASS],
         ]
     )
@@ -3767,18 +3767,41 @@ class TestInstanceOperations(object):
             conn.add_namespace(ns)
         conn.add_cimobjects(tst_classeswqualifiers, namespace=ns)
         conn.add_cimobjects(tst_instances, namespace=ns)
-
         req_inst_path = CIMInstanceName(cln, {'InstanceID': inst_id},
-                                        namespace=tst_ns)
+                                        namespace=ns)
+
         if not exp_status:
             inst = conn.GetInstance(req_inst_path)
-            req_inst_path.namespace = ns
+
+            # Get the original instance inserted into the repository
+            req_instance = None
+            req_inst_path.namespace = None
+            for inst in tst_instances:
+                if inst.path == req_inst_path:
+                    req_instance = inst
+                    break
+            if not req_instance:
+                print("req_path %s\ninst_id %s" % (req_inst_path, inst_id))
+            assert req_instance is not None  # Must find to execute test
+
             assert inst.path == req_inst_path
-            # TODO test returned instance. Right now only comparing
-            # the paths
+            inst.classname == req_instance.classname
+            assert not inst.qualifiers
+            for pname in inst.properties:
+                pvalue = inst.properties[pname]
+                reqvalue = req_instance.properties[pname]
+                assert not pvalue.qualifiers
+                assert not pvalue.class_origin
+                assert pvalue.name == reqvalue.name
+                assert pvalue.value == reqvalue.value
+                assert pvalue.value == reqvalue.value
+                assert pvalue.type == reqvalue.type
+                assert pvalue.array_size == reqvalue.array_size
+                assert pvalue.reference_class == reqvalue.reference_class
 
         else:
             with pytest.raises(CIMError) as exec_info:
+                req_inst_path.namespace = tst_ns
                 conn.GetInstance(req_inst_path)
             exc = exec_info.value
             assert exc.status_code == exp_status
@@ -3787,32 +3810,70 @@ class TestInstanceOperations(object):
         "ns", INITIAL_NAMESPACES + [None]
     )
     @pytest.mark.parametrize(
+        "inst_id", ['CIM_Foo1', 'CIM_Foo2']
+    )
+    @pytest.mark.parametrize(
         "lo, iq, ico", [
             [None, None, None],
             [None, True, None],
             [None, True, True],
         ]
     )
-    def test_getinstance_opts(self, conn, ns, lo, iq, ico,
+    def test_getinstance_opts(self, conn, ns, inst_id, lo, iq, ico,
                               tst_classeswqualifiers, tst_instances):
         # pylint: disable=no-self-use
         """
         Test getting an instance from the repository with GetInstance and
-        the options set
+        the various request options set
         """
-        # TODO extend to test lo and iq
+
         conn.add_cimobjects(tst_classeswqualifiers, namespace=ns)
         conn.add_cimobjects(tst_instances, namespace=ns)
 
-        request_inst_path = CIMInstanceName(
-            'CIM_Foo', {'InstanceID': 'CIM_Foo1'}, namespace=ns)
+        req_inst_path = CIMInstanceName(
+            'CIM_Foo', {'InstanceID': inst_id}, namespace=ns)
 
-        inst = conn.GetInstance(request_inst_path, LocalOnly=lo,
+        inst = conn.GetInstance(req_inst_path, LocalOnly=lo,
                                 IncludeClassOrigin=ico, IncludeQualifiers=iq)
 
         inst.path.namespace = ns
-        assert inst.path == request_inst_path
-        # TODO test complete instances returned. Now only testing paths
+        assert inst.path == req_inst_path
+
+        # Because of the config variables qualifiers and classorigin are always
+        # removed.
+        for prop_value in inst.properties.values():
+            assert not prop_value.qualifiers
+
+        assert not inst.qualifiers
+
+        req_instance = None
+        req_inst_path.namespace = None
+
+        # find the original instance that went into the repository
+        for inst in tst_instances:
+            if inst.path == req_inst_path:
+                req_instance = inst
+                break
+        if not req_instance:
+            print("req_path %s\ninst_id %s" % (req_inst_path, inst_id))
+        assert req_instance is not None  # Must find to execute test
+
+        for prop_value in inst.properties.values():
+            assert not prop_value.class_origin
+            assert inst.path == req_inst_path
+            inst.classname == req_instance.classname
+            assert not inst.qualifiers
+            for pname in inst.properties:
+                pvalue = inst.properties[pname]
+                reqvalue = req_instance.properties[pname]
+                assert not pvalue.qualifiers
+                assert not pvalue.class_origin
+                assert pvalue.name == reqvalue.name
+                assert pvalue.value == reqvalue.value
+                assert pvalue.value == reqvalue.value
+                assert pvalue.type == reqvalue.type
+                assert pvalue.array_size == reqvalue.array_size
+                assert pvalue.reference_class == reqvalue.reference_class
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None]


### PR DESCRIPTION
Adds config variables to define if the instance request
IncludeQualifiers and IncludeClassOrigin are honored in the pywbem_mock
GetInstance and EnumerateInstance response generators since these
request parameters have been deprecated in DMTF 0200 with the proposed
solution being to not return either qualifiers or class origin.