### PR TITLE
Addressed Pylint issues in _recorder.py and mocker test

### DIFF
--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -657,11 +657,10 @@ class LogOperationRecorder(BaseOperationRecorder):
 
             else:    # format result
                 # test if type is tuple (subclass of tuple but not type tuple)
-                # pylint: disable=unidiomatic-typecheck
                 qrc = ""
                 # format open/pull response
-                if isinstance(ret, tuple) and \
-                        type(ret) is not tuple:  # pylint: disable=C0123
+                # pylint: disable=unidiomatic-typecheck
+                if isinstance(ret, tuple) and type(ret) is not tuple:
                     try:    # test if field instances or paths
                         rtn_data = ret.instances
                         data_str = 'instances'

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -2256,7 +2256,7 @@ class TestUserDefinedProviders(object):
     def test_register_provider(self, conn, ns, desc, inputs,
                                exp_exec, condition,
                                tst_classeswqualifiersandinsts):
-        # pylint: disable=no-self-use
+        # pylint: disable=no-self-use,unused-argument
         """
         Test register_provider method.
         """
@@ -2294,10 +2294,8 @@ class TestUserDefinedProviders(object):
                       conn._provider_registry.provider_namespaces()]
             for _ns in tst_ns:
                 assert _ns.lower() in reg_ns
-
-            exp_clns = [c.lower() for c in
-                        conn._provider_registry.provider_classes(_ns)]
-            for _ns in tst_ns:
+                exp_clns = [c.lower() for c in
+                            conn._provider_registry.provider_classes(_ns)]
                 for cln in provider_classnames:
                     assert cln.lower() in exp_clns
 
@@ -2768,7 +2766,7 @@ class TestUserDefinedProviders(object):
 
             def post_register_setup(self, conn):
                 """Sets flag to show method run"""
-                # pylint: disable unused_argument
+                # pylint: disable=unused-argument
                 self.postregistersetup = True
 
         skip_if_moftab_regenerated()


### PR DESCRIPTION
Brings the result back to our current low water mark:

```
+-----------------------+------------+
|message id             |occurrences |
+=======================+============+
|fixme                  |173         |
+-----------------------+------------+
|redefined-builtin      |11          |
+-----------------------+------------+
|using-constant-test    |8           |
+-----------------------+------------+
|protected-access       |2           |
+-----------------------+------------+
|no-value-for-parameter |2           |
+-----------------------+------------+
```