### PR TITLE
Correct issues with InvokeMethod response handling

### DIFF
--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -114,7 +114,7 @@ class MethodProvider(BaseProvider):
           MethodName (:term:`string`):
             Name of the method to be invoked (case independent).
 
-          ObjectName:
+          ObjectName: (:class: `CIMInstanceName` or :term:`string`):
             The object path of the target object, as follows:
 
             * For instance-level use: The instance path of the target
@@ -123,19 +123,23 @@ class MethodProvider(BaseProvider):
               of the connection is used.
               Its `namespace`, and `host` attributes will be ignored.
 
-            * For class-level use: The class path of the target class, as a
-              :term:`string`:
+            * For class-level use: The class name of the target class, as a
+              :term:`string`. This should be one of the classes defined in
+              the class variable `classnames`.
 
-              The string is interpreted as a class name in the default
-              namespace of the connection (case independent).
+              The string is interpreted as a class name in the namespace defined
+              in the namespace parameter(case independent).
 
-          Params (:term:`py:iterable`):
-            An iterable of input parameter values for the CIM method. Each item
-            in the iterable is a single parameter value and is:
+          Params (:term:`py:NocaseDict`):
+            Each item in Params is a name/parameter-value for the CIM
+            method and is:
 
-            * :class:`~pywbem.CIMParameter` representing a parameter value. The
-              `name`, `value`, `type` and `embedded_object` attributes of this
-              object are used.
+            * :term:`string_types` - The case-insensitive name of the
+              parameter
+            * :class:`~pywbem.CIMParameter`  the item value representing a
+              parameter value. The `name`, `value`, `type` and
+              `embedded_object` attributes of this object are guaranteed
+              present..
 
         Returns:
 
@@ -146,6 +150,8 @@ class MethodProvider(BaseProvider):
               Return value of the CIM method.
             * outparams (:term:`py:iterable` of :class:`~pywbem.CIMParameter`):
               Each item represents a single output parameter of the CIM method.
+              If the iterable is a dictionary, the key is the parameter name
+              and the value is :class:`~pywbem.CIMParameter`.
               The :class:`~pywbem.CIMParameter` objects must have at least
               the following properties set:
 
@@ -155,9 +161,9 @@ class MethodProvider(BaseProvider):
 
         Raises:
 
-            :exc:`~pywbem.CIMError`: (CIM_ERR_METHOD_NOT_AVAILABLE) because the
-              default method is only a placeholder for the API and documentation
-              and not a real InvokeMethod action implementation.
+            :exc:`~pywbem.CIMError`: (CIM_ERR_METHOD_NOT_FOUND) because the
+              default method is only a placeholder for the API and
+              documentation and not a real InvokeMethod action implementation.
         """
         # No default MethodProvider is implemented because all method
         # providers define specific actions in their implementations.

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1961,18 +1961,21 @@ class FakedWBEMConnection(WBEMConnection):
                 CIM_ERR_FAILED,
                 _format("Invalid Response. Must be list or tuple)",
                         type(result)))
-        for param in result[1]:
-            if not isinstance(param, CIMParameter):
+
+        # Map output params to NocaseDict to be compatible with return
+        # from _methodcall. The input list is an iterable of CIMParameters
+        output_params = NocaseDict()
+        rtn_params = result[1]
+        rtn_params = rtn_params if isinstance(rtn_params, (tuple, list)) \
+            else rtn_params.values()
+        for param in rtn_params:
+            if isinstance(param, CIMParameter):
+                output_params[param.name] = param.value
+            else:
                 raise CIMError(
                     CIM_ERR_FAILED,
                     _format('Invalid response {0}. Must be CIMParameter. '
                             'Type {1} received',
                             param, type(param)))
-
-        # Map output params to NocaseDict to be compatible with return
-        # from _methodcall. The input list is just CIMParameters
-        output_params = NocaseDict()
-        for param in result[1]:
-            output_params[param.name] = param.value
 
         return (result[0], output_params)

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1963,14 +1963,14 @@ class FakedWBEMConnection(WBEMConnection):
                         type(result)))
 
         # Map output params to NocaseDict to be compatible with return
-        # from _methodcall. The input list is an iterable of CIMParameters
-        output_params = NocaseDict()
-        rtn_params = result[1]
-        rtn_params = rtn_params if isinstance(rtn_params, (tuple, list)) \
-            else rtn_params.values()
-        for param in rtn_params:
+        # from _methodcall. The input list (result[1]) is an iterable of
+        # CIMParameters
+        output_params_dict = NocaseDict()
+        result_params = result[1] if isinstance(result[1], (tuple, list)) \
+            else result[1].values()
+        for param in result_params:
             if isinstance(param, CIMParameter):
-                output_params[param.name] = param.value
+                output_params_dict[param.name] = param.value
             else:
                 raise CIMError(
                     CIM_ERR_FAILED,
@@ -1978,4 +1978,4 @@ class FakedWBEMConnection(WBEMConnection):
                             'Type {1} received',
                             param, type(param)))
 
-        return (result[0], output_params)
+        return (result[0], output_params_dict)


### PR DESCRIPTION
Corrects issue in pywbem_mock that was causing failures in tests with pywbemcli and pywbem version 1.0.0.

We were incorrectly processing the InvokeMethod response 