### PR TITLE
Fixes #2232: user-defined provider documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Pywbem provides the following Python APIs:
 * `MOF Compiler`_ - An API for compiling MOF files or strings into a CIM
   repository (e.g. on a WBEM server), or for test-compiling MOF.
 
-* `Mock Support`_ - An API for setting up a mocked WBEM server that is used
+* `Mock WBEM server`_ - An API for setting up a mocked WBEM server that is used
   instead of a real WBEM server. This allows setting up well-defined WBEM
   servers locally that can be used for example for prototyping or testing user
   applications.

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -95,7 +95,7 @@ This documentation uses a few special terms to refer to Python types:
    interop namespace
       A :term:`CIM namespace`  is the interop namespace if it has one of the
       following names: DMTF definition; ('interop', 'root/interop') pywbem
-      implementation; ('interop', 'root/interop', 'root/PG_Interop''),
+      implementation; ('interop', 'root/interop', 'root/PG_Interop'),
       Only one interop namespace is allowed in a WBEM Server. The interop
       namespace contains CIM classes that the client needs to discover
       characteristics of the WBEM server (namespaces, coniguration of server

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -86,6 +86,23 @@ This documentation uses a few special terms to refer to Python types:
    CIM object
       one of the types listed in :ref:`CIM objects`.
 
+   CIM namespace
+      an object that is accessible through a WBEM server and is a naming
+      space for CIM classes, CIM instances and CIM qualifier declarations.
+      The namespace is a component of other elements like namespace path used
+      to access objects in the WBEM server.
+
+   interop namespace
+      A :term:`CIM namespace`  is the interop namespace if it has one of the
+      following names: DMTF definition; ('interop', 'root/interop') pywbem
+      implementation; ('interop', 'root/interop', 'root/PG_Interop''),
+      Only one interop namespace is allowed in a WBEM Server. The interop
+      namespace contains CIM classes that the client needs to discover
+      characteristics of the WBEM server (namespaces, coniguration of server
+      components like indications) and the registered profiles implemented by
+      that server.
+
+
    keybindings input object
       a Python object used as input for initializing an ordered list of
       keybindings in a parent object (i.e. a :class:`~pywbem.CIMInstanceName`
@@ -280,6 +297,25 @@ This documentation uses a few special terms to refer to Python types:
       :class:`~pywbem.CIMProperty` objects that were provided in the input
       collection. Therefore, a caller must be careful to not accidentally
       modify the provided :class:`~pywbem.CIMProperty` objects.
+
+   provider
+      An element of a WBEM server that responds to requests for selected
+      classes. A WBEM server normally contains a main provider that may
+      interface with a CIM respository and provides responses to client
+      requests for which no specific provider is defined and providers which
+      providers that allow specialized responses for selected classes and
+      request types (communicate with managed components) or manipulate the
+      objects being managed.
+
+      NOTE: In the SNIA terminology, a provider may also be a complete
+      WBEM server implementation.
+
+   user-defined provider
+      A :term:provider that can be defined independently of the WBEM server
+      and attached dynamically to the WBEM server.  In pywbem, user-defined
+      providers can be defined as subclasses of specific default provider
+      types and attached to the server by registering them with the
+      connection.
 
    qualifiers input object
       a Python object used as input for initializing an ordered list of

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ https://pywbem.github.io/.
    indication.rst
    subscription.rst
    compiler.rst
-   mocksupport.rst
+   mockwbemserver.rst
    utilities.rst
    development.rst
    appendix.rst

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -53,7 +53,7 @@ Pywbem provides the following Python APIs:
   An API for compiling MOF files or strings into a CIM repository (e.g. on a
   WBEM server), or for test-compiling MOF.
 
-* :ref:`Mock support` -
+* :ref:`Mock WBEM server` -
   An API for setting up a mocked WBEM server that is used instead of a real
   WBEM server. This allows setting up well-defined WBEM servers locally that
   can be used for example for prototyping or testing user applications.
@@ -322,7 +322,7 @@ to the standards:
 
   Limitations:
 
-  - The mock support of pywbem (see :ref:`Mock support`) does not support the
+  - The mock support of pywbem (see :ref:`Mock WBEM server`) does not support the
     ``ModifyClass`` operation. Note that in its implementation of the CIM-XML
     protocol, pywbem does support the ``ModifyClass`` operation.
 

--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -125,7 +125,7 @@ Pywbem mock supports:
 1. All of the :class:`~pywbem.WBEMConnection` operation methods that communicate
    with the WBEM server (see below for list of operations supported and their
    limitations) except for specific limitations
-   (``DeleteClass and ``ExecQuery``).
+   (``DeleteClass`` and ``ExecQuery``).
 2. Multiple CIM namespaces and a default namespace on the faked connection.
 3. Gathering time statistics and delaying responses for a predetermined time.
 4. :class:`~pywbem.WBEMConnection` logging except that there are no HTTP entries
@@ -848,9 +848,10 @@ that somewhere an instance the class must be created each time a namespace is
 created or the responder must get the set of namespaces from the CIM repository
 to generate responses to ``GetInstance``, ``EnumerateInstance``, etc.
 
-Also, the :meth:`pywbem_mock.FakedWBEMConnection.InvokeMethod` client operation
-depends on a specific responder method in the WBEM server since the behavior of
-WBEM server methods is dependent on the specific method.
+Also, the :meth:`pywbem_mock.WBEMConnection.InvokeMethod` on
+:class:`pywbem_mock.FakedWBEMConnection` client operation depends on a specific
+responder method in the WBEM server since the behavior of WBEM server methods
+is dependent on the specific method.
 
 To meet these needs, pywbem_mock has implemented the capability to create
 :term:`user-defined providers <user-defined provider>` that become request
@@ -886,21 +887,21 @@ the previous table.
 
 Creating user-defined instance providers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- Instance user-defined providers can override the default implementations for
- the methods defined in the above table (``CreateInstance``, `ModifyInstance``,
+ User-defined instance providers can override the default implementations for
+ the methods defined in the above table (``CreateInstance``, ``ModifyInstance``,
  and ``DeleteInstance``). These methods are defined in a user-defined class
  that subclasses :class:`pywbem_mock.InstanceWriteProvider`. The details of
  defining this provider are in section :ref:`Instance Write Provider`.
 
-The following is a simple exaple of a user-defined InstanceWriteProvider
+The following is a simple example of a user-defined instance write provider
+
+.. code-block:: python
 
     import pywbem
     import pywbem_mock
 
     from pywbem_mock import InstanceWriteProvider, CIMError, \
         CIM_ERR_METHOD_NOT_SUPPORTED
-
-.. code-block:: python
 
     class CIMFooUserInstanceProvider(InstanceWriteProvider):
         """
@@ -1196,7 +1197,6 @@ Instance Write Provider
 Method Provider
 ^^^^^^^^^^^^^^^
 
-
 .. automodule:: pywbem_mock._methodprovider
 
 .. autoclass:: pywbem_mock.MethodProvider
@@ -1211,6 +1211,30 @@ Method Provider
    .. rubric:: Attributes
 
    .. autoautosummary:: pywbem_mock.MethodProvider
+      :attributes:
+
+   .. rubric:: Details
+
+
+.. _`Base Provider`:
+
+Base Provider
+^^^^^^^^^^^^^
+
+.. automodule:: pywbem_mock._baseprovider
+
+.. autoclass:: pywbem_mock.BaseProvider
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem_mock.BaseProvider
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem_mock.BaseProvider
       :attributes:
 
    .. rubric:: Details

--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -1,7 +1,7 @@
-.. _`Mock support`:
+.. _`Mock WBEM server`:
 
-Mock support
-============
+Mock WBEM server
+================
 
 **Experimental:** *New in pywbem 0.12.0 as experimental.*
 
@@ -11,51 +11,51 @@ Overview
 --------
 
 The pywbem package contains the ``pywbem_mock`` subpackage which provides mock
-support that enables usage of the pywbem library without a WBEM server.
-This subpackage is used for testing the pywbem library itself and can be used
-for the development and testing of Python programs that use the pywbem library.
+WBEM server support that enables using the pywbem library without a WBEM
+server. This subpackage is useful for testing the pywbem library itself as well
+as for the development and testing of Python programs that use the pywbem
+library.
 
-The pywbem mock support contains the :class:`pywbem_mock.FakedWBEMConnection`
+pywbem_mock  contains the :class:`pywbem_mock.FakedWBEMConnection`
 class that establishes a *faked connection*. That class is a subclass of
 :class:`pywbem.WBEMConnection` and replaces its internal methods that use
-HTTP/HTTPS to communicate with a WBEM server with methods that instead operate
-on a local in-memory repository of CIM objects (the *mock repository*).
+HTTP/HTTPS to communicate with a WBEM server with methods that communicate
+with  an in-process in-memory repository of CIM objects (the *mock repository*).
 
-As a result, the operation methods of :class:`~pywbem_mock.FakedWBEMConnection`
-are those inherited from :class:`~pywbem.WBEMConnection`, so they have the
-exact same input parameters, output parameters, return values, and even most of
-the raised exceptions, as when being invoked on a
-:class:`~pywbem.WBEMConnection` object against a WBEM server.
+:class:`~pywbem_mock.FakedWBEMConnection` acts as both the client API and a
+in-process fake WBEM server. It includes methods to establish, configure, and
+visualize this fake WBEM server.  As a result, the operation methods of
+:class:`~pywbem_mock.FakedWBEMConnection` are those inherited from
+:class:`~pywbem.WBEMConnection`, so they have exactly the same input
+parameters, output parameters, return values, and even most of the raised
+exceptions, as when invoked on a :class:`~pywbem.WBEMConnection` object against
+a WBEM server.
 
-Each :class:`~pywbem_mock.FakedWBEMConnection` object has its own mock
-repository.
-The mock repository contains the same kinds of CIM objects a WBEM server
-repository contains: CIM classes, CIM instances, and CIM qualifier types
-(declarations), all contained in CIM namespaces.
-
-Because :class:`~pywbem_mock.FakedWBEMConnection` operates only on the mock
-repository, the class does not have any connection- or security-related
-constructor parameters.
+Each :class:`~pywbem_mock.FakedWBEMConnection` object creates its own mock
+repository that contains the same kinds of CIM objects a WBEM
+server repository contains: CIM classes, CIM instances, and CIM qualifier
+declarations types contained in CIM namespaces. Because
+:class:`~pywbem_mock.FakedWBEMConnection` operates only on the mock repository,
+the class does not have any connection or security-related constructor
+parameters.
 
 Like :class:`~pywbem.WBEMConnection`, :class:`~pywbem_mock.FakedWBEMConnection`
-has a default CIM namespace that can be set upon object creation.
+has a default CIM namespace that is created upon
+:class:`~pywbem_mock.FakedWBEMConnection` instance creation;
+:class:`~pywbem.WBEMConnection` allows defining additional namespaces with
+:meth:`~pywbem_mock.FakedWBEMConnection.add_namespace()` .
 
-:class:`~pywbem_mock.FakedWBEMConnection` has some additional methods that
+:class:`~pywbem_mock.FakedWBEMConnection` has additional methods that
 provide for adding CIM classes, instances and qualifier types to its mock
-repository. See :ref:`Building the mock repository` for details.
+repository. See :ref:`Building a mock repository` for details.
 
-There are no setup methods to remove or modify CIM objects in the mock
-repository. However, if needed, that can be done by using operation methods
-such as :meth:`~pywbem.WBEMConnection.DeleteClass` or
-:meth:`~pywbem.WBEMConnection.ModifyInstance`.
-
-.. _`mock repository operation modes`:
-
-The repository contains the classes and qualifier types that
-are needed for the operations that are invoked. This results in a behavior of
-the faked operations that is close to the behavior of the operations of a
-real WBEM server.
-
+The repository must contain the CIM classes, CIM instances and CIM qualifier
+declaration types that are needed for the operations that are invoked. This
+results in a behavior of the faked operations that is close to the behavior of
+the operations of a real WBEM server. The CIM repository can be build from
+pywbem python classes for CIMClass, CIMInstance or CIMQualifier using methods
+in :class:`~pywbem_mock.FakedWBEMConnection` as defined in section
+:ref:`Building a mock repository`.
 
 The following example demonstrates setting up a faked connection, adding
 several CIM objects defined in a MOF string to its mock repository, and
@@ -124,52 +124,95 @@ Pywbem mock supports:
 
 1. All of the :class:`~pywbem.WBEMConnection` operation methods that communicate
    with the WBEM server (see below for list of operations supported and their
-   limitations) except for specific limitations documented.
+   limitations) except for specific limitations
+   (``DeleteClass and ``ExecQuery``).
 2. Multiple CIM namespaces and a default namespace on the faked connection.
 3. Gathering time statistics and delaying responses for a predetermined time.
 4. :class:`~pywbem.WBEMConnection` logging except that there are no HTTP entries
    in the log.
-5. Creating user-defined providers that can create specialized versions of
-   some of the responder methods.
+5. User-defined providers that replace the WBEM  server responder for specific
+   request methods, CIM classes, and namespaces. See :ref:`User-defined
+   providers`.
 
 Pywbem mock does NOT support:
 
 1. CIM-XML protocol security and security constructor parameters of
    :class:`~pywbem.WBEMConnection`.
-2. Dynamic WBEM server providers in that the data for responses is from the
-   mock repository that is built before the request rather than from resources
-   accessed by such providers. This means there is no dynamic determination of
-   property values for newly created CIM instances. Therefore, creating CIM
-   instances requires that all keybinding values as well as all other property
-   values must be provided as input to the
-   :meth:`~pywbem.WBEMConnection.CreateInstance` operation by the user.
-3. Processing of queries defined for :meth:`~pywbem.WBEMConnection.ExecQuery`
+2. Processing of queries defined for :meth:`~pywbem.WBEMConnection.ExecQuery`
    in languages like CQL and WQL. The mocked operation parses only the very
    general portions of the query for class/instance name and properties.
-4. Filter processing of the FQL (see :term:`DSP0212`) Filter Query Language
-   parameter QueryFilter used by the Open... operations because it does not
+3. Filter processing of FQL (see :term:`DSP0212`) the Filter Query Language
+   parameter ``QueryFilter`` used by the Open... operations because it does not
    implement the parser/processor for the FQL language.  It returns the same
    data as if the filter did not exist.
-5. Providing data in the trace variables for last request and last reply in
-   :class:`~pywbem.WBEMConnection`: `last_request`, `last_raw_request`,
-   `last_reply`, `last_raw_reply`, `last_request_len`, or `last_reply_len`.
-6. Log entries for HTTP request and response in the logging support of
+4. Providing data in the trace variables for last request and last reply in
+   :class:`~pywbem.WBEMConnection`: ``last_request``, ``last_raw_request``,
+   ``last_reply``, ``last_raw_reply``, ``last_request_len``, or
+   ``last_reply_len``.
+5. Log entries for HTTP request and response in the logging support of
    :class:`~pywbem.WBEMConnection`, because it does not actually build the
    HTTP requests or responses.
-7. Generating CIM indications.
-8. Some of the functionality that may be implemented in real WBEM servers such
-   as the `__Namespace__` class/provider.  Note that such capabilities can be at
-   least partly built on top of the existing capabilities by inserting
-   corresponding CIM instances into the mock repository.
+6. Generating CIM indications.
+7. Some of the functionality that may be implemented in real WBEM servers such
+   as the `__Namespace__` class/provider .  Note that such capabilities can be at
+   least partly built on top of the existing capabilities by implementing
+   user-defined providers.  Thus the CIM_Namespace class is supported with
+   the user defined provider in the pywbem_mock directory but only registered
+   if the user wants to use the provider.
 
+.. code-block:: text
+
+    +----------------------------------+
+    |                                  |
+    | +------------------------------+ |           +-------------+
+    | |                              | |           |             |
+    | | WBEM Server Mock Methods     | |           | Main        |
+    | |                              | |           | Provider    |
+    | |            All other Requests+------------>+             |
+    | |  CreateInstance, ModifyInst  +------+      | Class ,assoc|
+    | |  DeleteInstance, InvokeMeth  | |    |      | some inst   |
+    | +------------^-----------------+ |    |      | requests    +--+
+    |              |                   |    |      +-------------+  |
+    | +------------+-----------------+ |    |                       |
+    | | WBEM Server Mock Interface   | |    |      +-------------+  |     +-----------+
+    | |                              | |    |      |             |  |     | Instance  |
+    | +------------^-----------------+ |    |      | Provider    |  |     | Write     |
+    |              |                   |    |      | Dispatcher  |  |     | Provider  |
+    |              |                   |    |      |             +------->+ (Default) |
+    |              |                   |    |      | Dispatches  |  |     +-|---|-----+       +----------+
+    | +------------+-----------------+ |    |      | methods to  |  | +-----|   |-------------+ User     |
+    | |                              | |    +----->+ default or  +----------------------------> Instance |
+    | |  Client API request methods  | |           | registered  |  | |                       | Providers|
+    | |  from WBEM Connection        | |           | user        |  | |   +------------+      |          +-----+
+    | |                              | |           | providers   |  | |   |            |      +----------+     |
+    | |   *CreateClass, etc.         | |           |             +------->+ Method     |                       |
+   --->                              | |           |             |  | |   | Provider   |                       |
+    | |                              | |           |             |  | |   | (Default)  |                       |
+    | |                              | |           +-----------+-+  | |   +-----|------+                       |
+    | +------------------------------+ |                       |    | |         |------------------------+     |
+    | +------------------------------+ |                       +-------------------------------> User    |     |
+    | |  Mock Environment management | |                            | |                        | Method  |     |
+    | |  methods                     | |                            | |                        | Providers     |
+    | |  * Mof Compiler, add objects | |                            | |                        |         |     |
+    | |  * Manage namespaces         | |                            | |                        +---------+     |
+    | |  * Register user providers   +---------+    +---------------v-V----------------------------------+     |
+    | +------------------------------+ |       |    |                                                    |     |
+    |  FakeWBEMConnection              |       +---->          CIM Repository                            <-----+
+    +----------------------------------+            |                                                    |
+                                                    +----------------------------------------------------+
+
+Diagram of flow of requests operations through mocker
 
 .. _`Faked WBEM operations`:
 
 Faked WBEM operations
 ---------------------
 
-The :class:`pywbem_mock.FakedWBEMConnection` class supports the same WBEM
-operations that are supported by the :class:`pywbem.WBEMConnection` class.
+The :class:`pywbem_mock.FakedWBEMConnection`  class supports the same WBEM
+operations that are supported by the :class:`pywbem.WBEMConnection` class and
+in addition a set of methods to execute WBEM server responders for each of these
+client methods using an internal CIM repository of CIM classes, CIM instances,
+and CIM qualifier declarations.
 
 These faked operations generally adhere to the behavior requirements defined in
 :term:`DSP0200` for handling input parameters and returning a result.
@@ -194,7 +237,7 @@ effects of the operation modes of the mock repository.
 Faked instance operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The operations that retrieve objects require instances in the
+The operations that retrieve instances require instances in the
 repository for the instances to be recovered and that the classes
 for these instances exist in the repository.
 
@@ -204,33 +247,45 @@ for these instances exist in the repository.
 
 - **EnumerateInstances:** Behaves like
   :meth:`~pywbem.WBEMConnection.EnumerateInstances`, returning all instances
-  of the cim class defined on input and subclasses of this class filtered
+  of the CIM class defined on input and subclasses of this class filtered
   by the optional attributes for property names, etc.
 
 - **EnumerateInstanceNames:** Behaves like
-  :meth:`~pywbem.WBEMConnection.EnumerateInstances`, Returns the instance
-  name of all instances of the cimclass defined on input and subclasses of this
-  class.
+  :meth:`~pywbem.WBEMConnection.EnumerateInstances`, Returns the instance name
+  of all instances of the :class:`pywbem.CIMClass` defined on input and
+  subclasses of this class.
 
 - **CreateInstance**: Behaves like
   :meth:`~pywbem.WBEMConnection.CreateInstance`.
-  This operation requires that all key properties are specified in
-  the new instance since the mock repository has no support for dynamically
-  setting key properties as a dynamic provider for the class in a real WBEM
-  server might and all key properties are required to get the newly defined
-  instance with other requests.
+
+  Creates the defined instance in the CIM repository.
+
+  If there is no user-defined provider (see :ref:`User-defined providers`)for
+  the class defined in the ``NewInstance`` parameter operation requires that
+  all key properties be specified in the new instance since the CIM repository
+  has no support for dynamically setting key properties and all key properties
+  are required to get the newly defined instance with other requests.  If a
+  user-defined provider exists for the class, the behavior depends on that
+  provider.
 
 - **ModifyInstance**: Behaves like
   :meth:`~pywbem.WBEMConnection.ModifyInstance`. Modifies the instance
   defined by the instance name provided on input if that instance exists in
   the repository. It modifies only the properties defined by the instance
-  provided and will not modify any key properties.
+  provided and will not modify any key properties. If there is a user-defined
+  provider defined for this operation, that provider may modify the default
+  behavior.
 
 - **DeleteInstance**: Behaves like
   :meth:`~pywbem.WBEMConnection.DeleteInstance`. Deletes the instance defined
-  by the instance name provided on input if that instance exists.
+  by the instance name provided on input if that instance exists. If there is a
+  user-defined provider defined for this operation, that provider may modify
+  the default behavior.
 
 - **ExecQuery**: This operation is not currently implemented.
+
+See :ref:`User-defined providers` for more information on writing a
+user-defined provider.
 
 
 .. _`Faked association operations`:
@@ -278,146 +333,11 @@ The faked method invocation operation (`InvokeMethod`) behaves like
 `InvokeMethod`, the user must provide an implementation of InvokeMethod
 based on the API defined in :meth:`~pywbem_mock.MethodProvider.InvokeMethod`.
 
+NOTE: InvokeMethod is the method name pywbem and other clients and WBEM
+servers use for what the DMTF defines as extrinsic methods.
+
 See :ref:`User-defined providers` for more information on writing a
 user-defined provider.
-
-The user-defined method provider must have the signature defined in the
-:class:`~pywbem_mock.MethodProvider` function and must be registered
-as a method provider
-:meth:`~pywbem_mock.FakedWBEMConnection.register_provider` for a particular
-combination of namespace, class, and CIM method name.
-
-When the user-defined method provider is invoked on behalf of an `InvokeMethod`
-operation, the target object of the method invocation (class or instance) is
-provided to the InvokeMethod method, in addition to the method input
-parameters.
-
-The user provider is expected to return a tuple consisting of two items:
-
-* the CIM method return value, as a :term:`CIM data type` value.
-* an iterable containing any output parameters as
-  :class:`~pywbem.CIMParameter` objects.
-
-The user-defined provider has access to:
-   * methods defined in it superclass
-   * methods defined in :class:~pywbem_mock.BaseProvider`
-   * methods to access the CIM repository using the methods defined in
-     :class:`~pywbem_mock.InMemoryRepository`
-
-The following is an example for defining a method provider.
-
-.. code-block:: python
-
-    import pywbem
-    import pywbem_mock
-
-    from pywbem_mock import MethodProvider, CIMParameter, CIMError, \
-        CIM_ERR_NOT_FOUND, CIM_ERR_METHOD_NOT_AVAILABLE
-
-    class Method1TestProvider(MethodProvider):
-        """
-        User method provider for InvokeMethod using CIM_Foo_sub_sub and method1.
-        """
-        def __init__(self, cimrepository):
-            self.cimrepository = cimrepository
-
-        def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
-            """
-            The parameters and return for Invoke method are defined in
-            :meth:`~pywbem_mock.MethodProvider.InvokeMethod`
-
-            This acts as both a static (ObjectName is only classname) and dynamic
-            (ObjectName is an instance name) method provider
-            """
-            # validate namespace using method in BaseProvider
-            self.validate_namespace(namespace)
-
-            # get classname and validate. This provider uses only one class
-            if isinstance(ObjectName, six.string_types):
-                classname = ObjectName
-            else:
-                classname = ObjectName.classname
-            assert classname.lower() == 'tst_class'
-
-            # Test if class exists.
-            if not self.class_exists(namespace, classname):
-                raise CIMError(
-                    CIM_ERR_NOT_FOUND,
-                    _format("class {0|A} does not exist in CIM repository, "
-                            "namespace {1!A}", classname, namespace))
-
-            if isinstance(ObjectName, CIMInstanceName):
-                instance_store = self.get_instance_store(namespace)
-                inst = self.find_instance(objectname, instance_store,
-                                          copy=False)
-                if inst is None:
-                    raise CIMError(
-                        CIM_ERR_NOT_FOUND,
-                        _format("Instance {0|A} does not exist in CIM repository, "
-                                "namespace {1!A}", ObjectName, namespace))
-
-            if MethodName.lower() == 'method1':
-
-                rtn_parameters = [CIMParameter('OutputParam1', 'string',
-                                               value=namespace)]
-                else:
-                    rtn_params = None
-
-                return (return_value, rtn_params)
-
-            else:
-                raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
-
-    def run_invokemethod():
-        mof = '''
-            Qualifier In : boolean = true,
-                Scope(parameter),
-                Flavor(DisableOverride, ToSubclass);
-
-            Qualifier Key : boolean = false,
-                Scope(property, reference),
-                Flavor(DisableOverride, ToSubclass);
-
-            Qualifier Out : boolean = false,
-                Scope(parameter),
-                Flavor(DisableOverride, ToSubclass);
-
-            Qualifier Static : boolean = false,
-                Scope(property, method),
-                Flavor(DisableOverride, ToSubclass);
-
-            class TST_Class {
-
-                string InstanceID;
-
-                  [Static,
-                   Description("Static method with input and output parameters")]
-                uint32 Method1(
-                    [IN, Description("Input param 1")]
-                  string IP1,
-                    [IN (false), OUT, Description("Output param 1")]
-                  string OP1);
-            };
-        '''
-
-        # Create a faked connection
-        conn = pywbem_mock.FakedWBEMConnection(default_namespace='root/cimv2')
-
-        # Compile the MOF string and add its CIM objects to the default namespace
-        # of the mock repository
-        conn.compile_mof_string(mof)
-
-        # Register the method callback function to the mock repository, for the
-        # default namespace of the connection
-        conn.register_provider(conn.default_namespace, 'TST_Class', 'method',
-                               )
-
-        # Invoke static method Method1
-        params = [('IP1', 'someData')]
-        result = conn.InvokeMethod('Method1', 'TST_Class', Params=params)
-
-        print('Return value: %r' % result[0])
-        print('Output parameters: %r' % (result[1],))
 
 
 .. _`Faked pull operations`:
@@ -495,7 +415,7 @@ Faked iter operations
 
 The iter operations on a faked connection are in fact the iter operations
 on :class:`~pywbem.WBEMConnection`, because they do not directly issue requests
-and responses on the connection, but instead are simply a layer on top of
+and responses on the connection, but instead are a layer on top of
 underlying operations. For example, `IterEnumerateInstances`
 invokes either pull operations (i.e. `OpenEnumerateInstances` followed by
 `PullInstancesWithPath`) or traditional operations (i.e. `EnumerateInstances`).
@@ -545,13 +465,12 @@ Class operations only work if the mock repository is in full operation mode.
 - **ModifyClass:** Not currently implemented.
 
 
-.. _`Faked qualifier operations`:
+.. _`Faked qualifier declaration operations`:
 
-Faked qualifier operations
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Faked qualifier declaration operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Qualifier operations only work if the mock repository is in full operation
-mode.
+Qualifier operations declaration include the following.
 
 - **SetQualifier:** Behaves like :meth:`~pywbem.WBEMConnection.SetQualifier`.
   Requires that the specified qualifier type is in the mock repository.
@@ -566,59 +485,56 @@ mode.
 - **DeleteQualifier:** - Not implemented.
 
 
-.. _`Building the mock repository`:
+.. _`Building a mock repository`:
 
-Building the mock repository
-----------------------------
+Building a mock repository
+--------------------------
 
-The mock repository should contain the CIM qualifier declarations, CIM classes,
-CIM instances, and CIM methods to be used in the mock environment. The
-mock user creates a repository that contains the CIM objects required for
-the operations to be executed in the mock environment. Thus, if the user only
-requires CIM_ComputerSystem, only that class and its dependent classes need
-be in the repository along with instances of the classes that will satisfy
-the methods called
+The mock repository should contain CIM qualifier declarations, CIM classes,
+and CIM instances to be required by the user. These are created as part of
+the setup of any particular pywbem mock environment. Thus, if the user only
+requires CIM_ComputerSystem, only that class and its dependent classes and
+qualifier declarations need be in the repository along with instances of the
+classes that will satisfy the client methods executed.
 
-:class:`~pywbem_mock.FakedWBEMConnection` and
+The classes :class:`~pywbem_mock.FakedWBEMConnection` and
 :class:`~pywbem_mock.DMTFCIMSchema` provide the tools to build the mock
 repository.
 
 There are two ways to build a mock repository:
 
 * Directly from pywbem CIM objects (:class:`~pywbem.CIMClass`,
-  :class:`~pywbem.CIMInstance`, etc). See
-  :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects`
+  :class:`~pywbem.CIMInstance` or :class:`~pywbem.CIMQualifierDeclaration`,
+  etc). The method :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects`
+  installs these objects into the CIM repository
 
-* From MOF definitions of the objects (which can be a string or a file, in
-  and  with MOF pragma include statements).
-
-  There are two methods to help building the repository from MOF:
+* From MOF definitions of the objects (which can be a string or a file):
 
   * Build from MOF definitions of the objects which are compiled into the
     repository. See :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_string`
-    and See :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_file`.
-    If instances are compiled (i.e. "instance of ...") they must be
-    compiled with the instance alias (ex:"instance of CIM_xxx as $xxx {") which
-    adds the keybindings of the CIMInstanceName from the key
-    properties to the instance path. If a compiled instances duplicates the
-    path of an existing instance in the repository, the existing instance will
-    modified. When defining new instances in MOF, the corresponding class must
-    exist in the repository but not necessarily in the current MOF file.
+    and :meth:`~pywbem_mock.FakedWBEMConnection.compile_mof_file`.
+
+    If an instance compiled with the MOF compiler duplicates the path of an
+    existing instance in the repository, the existing instance will modified
+    because the MOF compiler uses ModifyInstance on the request if the
+    CreateInstance fails. When defining new instances in MOF, the corresponding
+    class must exist in the repository but not necessarily in the current MOF
+    file.
 
   * Build MOF qualifier declarations and classes directly from the DMTF
     CIM schema by downloading the schema from the DMTF and selecting all
     or part of the schema to compile. This automatically compiles all
-    qualifiers declarations into the mock repository and allows setting up
-    a partial class repository (i.e. just selected classes) in a single
-    method. See section `DMTF CIM schema download support`_ and the
+    qualifier declarations into the mock repository and allows setting up
+    a partial class repository (i.e. selected classes) with a single
+    method call. See section `DMTF CIM schema download support`_ and the
     :meth:`~pywbem_mock.FakedWBEMConnection.compile_dmtf_schema` method.
 
-It may take a combination of all three of the above methods to build a schema
-that satisfies a particular requirement including:
+It may take a combination of all of the above methods to build a schema
+that satisfies a particular usage requirement including:
 
-1. Build the DMTF CIM Classes from the DMTF schema. This is easy to code,
-   and eliminates errors defining components. It also loads all qualifier
-   declarations.
+1. Build the DMTF CIM classes and CIM qualifier declarations from the
+   DMTF schema. This is easy to code, and eliminates errors defining
+   components. It also loads all qualifier declarations.
 
 2. Build non-DMTF classes (subclasses, etc.) by defining either MOF for the
    classes and compiling or directly building the pywbem CIM classes.
@@ -628,13 +544,14 @@ that satisfies a particular requirement including:
    simplifies the definition of association instances with the instance
    alias.
 
-4. Add the definition of any CIM methods for which the mock server is expected
-   to respond. add_method_callback.  See
-   :meth:`~pywbem_mock.FakedWBEMConnection. add_method_callback`.
+4. Register user-defined providers for which the mock server
+   is expected to respond. See :ref:`User-defined providers`
 
-The pywbem MOF compiler provides support for:
+Since building a working CIM repository with all of the required elements
+to successfully execute client operations can mean understanding the CIM model
+dependencies, the pywbem MOF compiler provides support for:
 
-1. Automatically including all qualifier declaractions if classes are added
+1. Automatically including all qualifier declarations if classes are added
    with the method :meth:`~pywbem_mock.FakedWBEMConnection.compile_dmtf_schema`
    or the :class:`DMTFCIMSchema`.
 
@@ -646,15 +563,24 @@ The pywbem MOF compiler provides support for:
    user does not have to track down those dependent classes to be able to
    create a working mock repository.
 
+This means that the user creating a mock repository only needs to know the DMTF
+schema to be used and the leaf classes required. All qualifier declarations and
+classes upon which these leaf classes depends are automatically installed into the
+CIM repository. It also means that there is normally no reason to compile the
+complete DMTF schema which is much larger than the classes required for most
+test environments.
+
+
 .. _`Example: Set up qualifier types and classes DMTF CIM schema`:
 
 Example: Set up qualifier types and classes in DMTF CIM schema
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This example creates a faked connection and compiles the classes defined in the
-list 'classes' from DMTF schema version 2.49.0 into the repository along with
-all of the qualifier declarations defined by the DMTF schema and any dependent
-classes (superclasses, etc.).
+This example creates a faked connection using ``root/interop`` as the default
+namespace and compiles the classes defined in the list 'classes' from DMTF
+schema version 2.49.0 into the repository along with all of the qualifier
+declarations defined by the DMTF schema and any dependent classes
+(superclasses, etc.).
 
 .. code-block:: python
 
@@ -671,9 +597,9 @@ classes (superclasses, etc.).
                     'CIM_ReferencedProfile']
 
     # Compile dmtf schema version 2.49.0, the qualifier declarations and
-    # the classes in 'classes' and all dependent classes and keep the
+    # the classes in 'leaf_classes' and all dependent classes and keep the
     # schema in directory my_schema_dir
-    conn.compile_dmtf_schema((2, 49, 0), "my_schema_dir", classes,
+    conn.compile_dmtf_schema((2, 49, 0), "my_schema_dir", leaf_classes,
                             verbose=True)
 
     # Display the resulting repository
@@ -788,7 +714,8 @@ Example: Set up instances from single CIM objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Based on the mock repository content of the previous example, this example
-adds two class instances and one association instance from their CIM objects.
+adds two class instances and one association instance from their CIM objects
+using the ``add-cimobjects`` method.
 
 .. code-block:: python
 
@@ -867,13 +794,236 @@ This adds the instances to the repository display of the previous example:
     };
 
 
+.. _`Mocking multiple CIM namespaces`:
+
+Mocking multiple CIM namespaces
+-------------------------------
+
+Pywbem_mock allows creating multiple namespaces in the repository and installing
+elements in some or all of those namespaces.
+
+There is a default-namespace created when
+:class:`pywbem_mock.FakedWBEMConnection` is created from either the
+`default_namespace` of the constructor or with the system default of
+`root/cimv2`
+
+However, a working WBEM environment normally includes at least two namespaces
+
+1. An :term:`interop namespace` which contains the parts of the model that deal
+   with the WBEM server itself (ex. CIM_Namespace, CIM_ObjectManager, etc.) and
+   which must be publically discoverable without the user knowing what CIM
+   namespaces exist in the WBEM server The DM
+
+2. A user namespace where the CIM classes for the user model
+
+Pywbem_mock includes a user-defined provider for the CIM_Namespace class that
+can be enabled by adding code similar to the following to the setup of a
+mock environment.
+
+.. code-block:: text
+
+    # install the CIM_Namespace class either by directly compiling the class
+    # or using the DMTFCIMSchema class to compile the class
+
+    provider = CIMNamespaceProvider(self.cimrepository)
+    interop_namespace = "interop"   # or root/interop
+    conn.add_namespace(interop_namespace)
+    conn.register_provider, namespaces=interop_namespace)
+
 
 .. _`User-defined providers`:
 
 User-defined providers
 ----------------------
 
-TODO: Write this section. It should include defining them and registering them.
+Within the fake  WBEM server the response to client requests is normally
+determined by standard server responder methods that use data in the CIM
+repository to generate responses (ex. ``GetInstance`` gets the instances from the
+repository, possibly filters properties and attributes and returns the
+instance). However, it is expected that the user may want specific classes to
+generate responses that have side effects, or manage the returns differently
+than the normal responses.  Thus, for example, the DMTF defined CIM_Namespace
+class returns instances of each of the namespaces in the CIM repository. That means
+that somewhere an instance the class must be created each time a namespace is
+created or the responder must get the set of namespaces from the CIM repository
+to generate responses to ``GetInstance``, ``EnumerateInstance``, etc.
+
+Also, the :meth:`pywbem_mock.FakedWBEMConnection.InvokeMethod` client operation
+depends on a specific responder method in the WBEM server since the behavior of
+WBEM server methods is dependent on the specific method.
+
+To meet these needs, pywbem_mock has implemented the capability to create
+:term:`user-defined providers <user-defined provider>` that become request
+responders for defined classes and operations which can can manipulate the
+client input and generate responses specific for defined CIM classes.
+
+User-defined providers can be written by the user by defining subclasses of
+specific provider classes used by the fake WBEM server and registering these
+classes as providers using
+:meth:`~pywbem_mock.FakedWBEMConnection.register_provider`.
+
+Pywbem defines user-defined provider types so that specific request operations
+can be executed for each provider type.
+
+
+.. table:: Pywbem_mock provider types
+
+    ====================== ============ ========================  ================================
+    Provider Type          type name    CIM Request Operations    Default provider class
+    ====================== ============ ========================  ================================
+    method                 "method"      InvokeMethod             :ref:`Method Provider`
+    instance write         "instance"    CreateInstance           :ref:`Instance Write Provider`
+    instance write         "instance"    ModifyInstance           :ref:`Instance Write Provider`
+    instance write         "instance"    DeleteInstance           :ref:`Instance Write Provider`
+    ====================== ============ ========================  ================================
+
+Each user-defined provider is a Python class which is a subclass
+of the corresponding default provider for the provider type as defined in
+the previous table.
+
+
+.. _`Creating user-defined instance providers`:
+
+Creating user-defined instance providers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ Instance user-defined providers can override the default implementations for
+ the methods defined in the above table (``CreateInstance``, `ModifyInstance``,
+ and ``DeleteInstance``). These methods are defined in a user-defined class
+ that subclasses :class:`pywbem_mock.InstanceWriteProvider`. The details of
+ defining this provider are in section :ref:`Instance Write Provider`.
+
+The following is a simple exaple of a user-defined InstanceWriteProvider
+
+    import pywbem
+    import pywbem_mock
+
+    from pywbem_mock import InstanceWriteProvider, CIMError, \
+        CIM_ERR_METHOD_NOT_SUPPORTED
+
+.. code-block:: python
+
+    class CIMFooUserInstanceProvider(InstanceWriteProvider):
+        """
+        Simplistic user provider implements CreateInstance and DeleteInstance.
+        This example modifies a specific property for CreateInstance, does not
+        allow modify instance. For DeleteInstance it simply calls the default
+        processor
+        """
+
+        # The provider will serve the CIM_Foo and CIM_FooFoo classes
+        provider_classnames = ['CIM_Foo', 'CIM_FooFoo']
+
+        def __init__(self, cimrepository):
+            """
+            Initialize the cimrepository
+            """
+            super(UserInstanceTestProvider, self).__init__(cimrepository)
+
+        def CreateInstance(self, namespace, NewInstance):
+            """Create instance just calls super class method"""
+
+            NewInstance.properties["myproperty"] = "Fixed"
+
+            return super(UserInstanceTestProvider, self).CreateInstance(
+                namespace, NewInstance)
+
+        def ModifyInstance(self, ModifiedInstance, IncludeQualifiers=None,
+                           PropertyList=None):
+            """Disallows ModifyInstance"""
+
+            raise CIMError('CIM_ERR_NOT_SUPPORTED',
+                           "{0} provider does not allow ModifyInstance.".format(
+                           self.__class__.__name__))
+
+        def DeleteInstance(self, InstanceName):
+            """Test Create instance just calls super class method"""
+            # pylint: disable=useless-super-delegation
+            return super(UserInstanceTestProvider, self).DeleteInstance(
+                InstanceName)
+
+    def post_register_setup(self, conn):
+        """Execute setup code after provider is registered."""
+        pass
+
+
+.. _`Creating user-defined method providers`:
+
+Creating user-defined method providers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A user-defined method provider provides a server responder for specific
+CIM classes and namespaces.  If no user-defined method provider exists for
+the requested CIM class and namespace, the default is an exception since there
+is not normal behavior for a method
+
+The detailed requirements for implementing a user-defined method provider are
+in section :ref:`Method Provider`.
+
+The following is an example of a method provider:
+
+.. code-block:: python
+
+    import pywbem
+    import pywbem_mock
+
+    from pywbem_mock import MethodProvider, CIMParameter, CIMError, \
+        CIM_ERR_NOT_FOUND, CIM_ERR_METHOD_NOT_AVAILABLE
+
+    class MyMethodProvider(MethodProvider):
+
+        provider_classname = 'CIM_Foo_sub_sub'
+        """
+        User method provider for InvokeMethod using CIM_Foo_sub_sub and method1.
+        """
+        def __init__(self, cimrepository):
+            super(MyMethodProvider, self).__init__(cimrepository)
+
+        def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
+            """
+            The parameters and return for Invoke method are defined in
+            :meth:`~pywbem_mock.MethodProvider.InvokeMethod`
+
+            This acts as both a static (ObjectName is only classname) and
+            dynamic (ObjectName is an instance name) method provider.
+            """
+            # Validate namespace using method in BaseProvider
+            self.validate_namespace(namespace)
+
+            # Get classname and validate. This provider uses only one class
+            if isinstance(ObjectName, six.string_types):
+                classname = ObjectName
+            else:
+                classname = ObjectName.classname
+            assert classname.lower() == 'tst_class'
+
+            # Test if class exists.
+            if not self.class_exists(namespace, classname):
+                raise CIMError(
+                    CIM_ERR_NOT_FOUND,
+                    _format("class {0|A} does not exist in CIM repository, "
+                            "namespace {1!A}", classname, namespace))
+
+            if isinstance(ObjectName, CIMInstanceName):
+                instance_store = self.get_instance_store(namespace)
+                inst = self.find_instance(objectname, instance_store,
+                                          copy=False)
+                if inst is None:
+                    raise CIMError(
+                        CIM_ERR_NOT_FOUND,
+                        _format("Instance {0|A} does not exist in CIM repository, "
+                                "namespace {1!A}", ObjectName, namespace))
+
+            if MethodName.lower() == 'method1':
+
+                rtn_parameters = [CIMParameter('OutputParam1', 'string',
+                                               value=namespace)]
+                else:
+                    rtn_params = None
+
+                return (return_value, rtn_params)
+
+            else:
+                raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
 
 
 .. _`FakedWBEMConnection`:
@@ -1017,24 +1167,10 @@ Mock CIM repository
 User provider interfaces
 ------------------------
 
-.. automodule:: pywbem_mock._baseprovider
+.. _`Instance Write Provider`:
 
-.. autoclass:: pywbem_mock.BaseProvider
-   :members:
-
-   .. rubric:: Methods
-
-   .. autoautosummary:: pywbem_mock.BaseProvider
-      :methods:
-      :nosignatures:
-
-   .. rubric:: Attributes
-
-   .. autoautosummary:: pywbem_mock.BaseProvider
-      :attributes:
-
-   .. rubric:: Details
-
+Instance Write Provider
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pywbem_mock._instancewriteprovider
 
@@ -1053,6 +1189,13 @@ User provider interfaces
       :attributes:
 
    .. rubric:: Details
+
+
+.. _`Method Provider`:
+
+Method Provider
+^^^^^^^^^^^^^^^
+
 
 .. automodule:: pywbem_mock._methodprovider
 

--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -1,12 +1,32 @@
-"""
-This module adds support for user-defined method providers.  User defined
-method providers may be created within pywbem_mock to extend the capability
-of the mocker for special processing for selected classes using CIM
-extrensic methods (the `InvokeMethod` client request).
+#
+# (C) Copyright 2020 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
 
-Since there is no concept of a default method provider (all CIM methods
-imply actions that are specific to the method). The default provide returns
-an exception.
+"""
+The MethodProvider module adds support for user-defined method providers.  User
+defined method providers may be created within pywbem_mock to extend the
+capability of the mocker for processing methods defined in CIM classes using
+WBEM extrensic methods (the `InvokeMethod` client request).
+
+Since there is no concept of a default method provider (all CIM methods imply
+actions that are specific to the method), the default method provider always
+returns an exception (CIM_ERR_NOT_FOUND).
 
 User defined providers may be created for specific CIM classes and namespaces
 to override the InvokeMethod in :class:`~pywbem_mock.MethodProvider` with user
@@ -15,24 +35,100 @@ methods defined in a subclass of :class:`~pywbem_mock.MethodProvider`.
 This module contains the default MethodProvider class which provides the
 following:
 
-1. Definition of the provider type (`provider_type = method`).
-2. Definition of the API and return for the `InvokeMethod` method required in
-   the user-defined subclass
+1. Definition of the provider type (``provider_type = "method"``).
+2. Definition of the API and return for the ``InvokeMethod`` method required in
+   the user-defined subclass.
 
-A user-defined method provider is created as follows:
+A user-defined method provider can be created as follows:
 
-1. Create the subclass of :class:`~pywbem_mock.MethodProvider` with an
-   __init__ method, an optional `post_registration_setup` method and the
-   `InvokeMethod that will override the same method defined in
-   :class:`~pywbem_mock.MethodProvider`.  The input parameters for the
-   InvokeMethod will have been already validated in
-   :class:`~pywbem_mock.ProviderDispatcher.ProviderDispatcher`.
+1. Implement the subclass of :class:`~pywbem_mock.MethodProvider` with:
+
+   a. Constructor:
+      `__init__()` that takes as input at least the cimrepository
+      object parameter and passes it to the superclass and any other
+      constructor parameters the user-defined provider requires.  Since the
+      user creates the instance.
+
+      .. code-block:: python
+
+         def __init__(self, cimrepository):
+             super(UserMethodTestProvider, self).__init__(cimrepository)
+
+   b. Definition of the CIM class the provider supports as a class variable.
+
+      .. code-block:: python
+
+        provider_classnames = 'CIM_Foo'
+
+   c. Definition and implementation of the WBEM operations supported by the
+      provider from the set of request operations defined in the table above
+      for a specific provider type. This must be a subset of the methods
+      defined for the provider type. Methods that do not exist in the
+      user-defined provider default to the default method. Each of these
+      methods may:
+
+      * provide parameter or cim repository validation in addition to the normal
+        request validation,
+      * modify parameters of the request.
+      * generate an CIMError exception for the operation.
+      * make modifications to the cim repository.
+
+      The request may be completed by the user provider method calling the
+      superclass corresponding method to complete its final validation and
+      modify the repository or by the provider directly modifying the repository
+      based on the method and parameters.
+
+      The user-defined providers have access to:
+        * methods defined in their superclass
+        * methods defined in :class:~pywbem_mock.BaseProvider`
+        * methods to access the CIM repository using the methods defined in
+          :class:`~pywbem_mock.InMemoryRepository`
+
+      .. code-block:: python
+
+        def CreateInstance(self, namespace, NewInstance):
+            \"\"\"Test Create instance just calls super class method\"\"\"
+
+            # Simply calls the default responder method for CreateInstance
+            return super(UserInstanceTestProvider, self).CreateInstance(
+                namespace, NewInstance)
+
+   d. Optional method
+      The provider may include
+      (:meth:`~pywbem_mock.MethodProvider.post_register-setup()`) that
+      :meth:`~pywbem_mock.FakedWBEMConnection.register_provider` will call as
+      after the provider registration is successful.  This allows the provider
+      to do any special setup it desires uses its own methods. This method
+      includes the current connection as a parameter so that client methods can
+      be executed directly.
+
+      .. code-block:: python
+
+          def post_register_setup(self, conn):
+            # code that performs post registration setup for the provider
+
+
+   The input parameters for the user defined invoke_method InvokeMethod will
+   have been already validated in
+   :class:`~pywbem_mock.ProviderDispatcher.ProviderDispatcher` including:
+
+   a. The namespace defined in the namespace parameter exists.
+
+   b. The classname defined in the ObjectName parameter exists in the
+      namespace
+
+   c. The method defined in the MethodName parameter exists.
+
+   d. The method provider is registered for this classname in this namespace.
+
+   The correspondence between parameters in the Params argument and in
+   the class have not be verified.
 
    The created method should implement any exceptions based on
    :class:`pywbem.CIMError` using the error codes defined in :term:`DSP0200`
    which will be passed back to the client.
 
-   The user-defined class must include the following class variables:
+   The user-defined class must include the following class variable:
 
    * `provider_classnames` (:term:`string` or list of :term`string`): defines
      the class(es) that this provider will serve.
@@ -41,6 +137,12 @@ A user-defined method provider is created as follows:
    :class:`~pywbem_mock.MethodProvider and defines a `InvokeMethod` method in
    the user-defined subclass to override
    :meth:`~pywbem_mock.MethodProvider.InvokeMethod`.
+
+   The user-defined provider has access to:
+       * methods defined in the superclass :class:~pywbem_mock.MethodProvider`
+       * methods defined in :class:~pywbem_mock.BaseProvider`
+       * methods to access the CIM repository using the methods defined in
+         :class:`~pywbem_mock.InMemoryRepository`
 
 2. Register the user-defined method provider using
    :meth:`~pywbem_mock.FakedWBEMConnection.register_provider` to define the
@@ -130,16 +232,15 @@ class MethodProvider(BaseProvider):
               The string is interpreted as a class name in the namespace defined
               in the namespace parameter(case independent).
 
-          Params (:term:`py:NocaseDict`):
-            Each item in Params is a name/parameter-value for the CIM
+          Params (:class:`py:NocaseDict`):
+            Each item in ``Params`` is a name/parameter-value for the CIM
             method and is:
 
-            * :term:`string_types` - The case-insensitive name of the
-              parameter
-            * :class:`~pywbem.CIMParameter`  the item value representing a
+            * :term:`string` The case-insensitive name of the parameter.
+            * :class:`~pywbem.CIMParameter`  The item value representing a
               parameter value. The `name`, `value`, `type` and
               `embedded_object` attributes of this object are guaranteed
-              present..
+              present.
 
         Returns:
 

--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -113,25 +113,17 @@ A user-defined method provider can be created as follows:
    :class:`~pywbem_mock.ProviderDispatcher.ProviderDispatcher` including:
 
    a. The namespace defined in the namespace parameter exists.
-
    b. The classname defined in the ObjectName parameter exists in the
-      namespace
-
+      namespace.
    c. The method defined in the MethodName parameter exists.
-
    d. The method provider is registered for this classname in this namespace.
 
-   The correspondence between parameters in the Params argument and in
-   the class have not be verified.
+   The correspondence between parameters in the ``Params`` argument and in
+   the class have not been verified.
 
    The created method should implement any exceptions based on
-   :class:`pywbem.CIMError` using the error codes defined in :term:`DSP0200`
-   which will be passed back to the client.
-
-   The user-defined class must include the following class variable:
-
-   * `provider_classnames` (:term:`string` or list of :term`string`): defines
-     the class(es) that this provider will serve.
+   :class:`pywbem.CIMError` (as a server would) using the error codes defined
+   in :term:`DSP0200` which will be passed back to the client.
 
    Thus, a user-defined method provider defines a subclass to
    :class:`~pywbem_mock.MethodProvider and defines a `InvokeMethod` method in
@@ -197,14 +189,12 @@ class MethodProvider(BaseProvider):
         """
         Defines the API and return for a mock WBEM server responder for
         :meth:`~pywbem.WBEMConnection.InvokeMethod` for both static (ObjectName
-        is a class name) and dynamic (ObjectName is a CIMInstanceName) methods
+        is a class name) and dynamic (ObjectName is a CIMInstanceName) CIM
+        methods.
 
         This method should never be called because there is no concept of a
-        default InvokeMethod in WBEM.  All method providers specify specific
+        default InvokeMethod in CIM.  All method providers specify specific
         actions.
-
-        This responder calls a function defined by an entry in the methods
-        repository. The return from that function is returned to the user.
 
         Parameters:
 
@@ -214,7 +204,9 @@ class MethodProvider(BaseProvider):
             characters are ignored.
 
           MethodName (:term:`string`):
-            Name of the method to be invoked (case independent).
+            Name of the method to be invoked (case independent) The method
+            name must be a method of the class defined in the ``ObjectName``
+            parameter.
 
           ObjectName: (:class: `CIMInstanceName` or :term:`string`):
             The object path of the target object, as follows:

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -259,7 +259,7 @@ class FakedWBEMConnection(WBEMConnection):
         The CIM repository instance  is the data store for CIM classes, CIM
         instances, and CIM qualifier declarations.  All access to the mocker
         CIM data must pass through this variable to the CIM repository.
-        See :py:module:`pywbem_mock/inmemoryrepository` for a description of
+        See :py:class:`pywbem_mock/InmemoryRepository` for a description of
         the repository interface.
         """
         if self._cimrepository is None:


### PR DESCRIPTION
Refactor the documentation section on Mock Support to define writing a
user provider and give examples.