### PR TITLE
Fixes #2264: Changed format 'standard' of CIMInstanceName.to_wbem_uri() to sort the   keys

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -593,6 +593,9 @@ Released: not yet
   a CIM_Namespace provider to handle the CIM_Namespace class in the interop
   namespace.  See issue #2062)
 
+* Changed format 'standard' of `CIMInstanceName.to_wbem_uri()` to sort the
+  keys in the resulting WBEM URI. (See issue #2264)
+
 **Cleanup:**
 
 * Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04)

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -1986,11 +1986,13 @@ class CIMInstanceName(_CIMComparisonMixin):
 
             * ``"standard"`` - Standard format that is conformant to untyped
               WBEM URIs for instance paths defined in :term:`DSP0207`.
+              The order of keybindings is in lexical order of the original
+              keybinding names.
 
             * ``"canonical"`` - Like ``"standard"``, except that the following
               items have been converted to lower case: host, namespace,
-              classname, and the names of any keybindings, and except that the
-              order of keybindings is in lexical order of the (lower-cased)
+              classname, and the names of any keybindings.
+              The order of keybindings is in lexical order of the lower-cased
               keybinding names.
               This format guarantees that two instance paths that are
               considered equal according to :term:`DSP0004` result in equal
@@ -2047,7 +2049,7 @@ class CIMInstanceName(_CIMComparisonMixin):
         Raises:
 
           TypeError: Invalid type in keybindings
-          ValueError: Invalid format
+          ValueError: Invalid format argument
         """
 
         ret = []
@@ -2061,8 +2063,9 @@ class CIMInstanceName(_CIMComparisonMixin):
         def case_sorted(keys):
             """Return the keys in the correct order for the format."""
             if format == 'canonical':
-                case_keys = [case(k) for k in keys]
-                keys = sorted(case_keys)
+                return sorted([case(k) for k in keys])
+            if format == 'standard':
+                return sorted(keys)
             return keys
 
         if format not in ('standard', 'canonical', 'cimobject', 'historical'):

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -15,7 +15,7 @@ except ImportError:
     from ordereddict import OrderedDict  # pylint: disable=import-error
 import pytest
 import six
-import packaging
+from packaging.version import parse as parse_version
 
 from ..utils.validate import validate_cim_xml_obj
 from ..utils.pytest_extensions import simplified_test_function, ignore_warnings
@@ -89,7 +89,7 @@ unimplemented = pytest.mark.skipif(True, reason="test not implemented")
 #   the next patch version, which was not always the intended next version.
 # - Starting with 0.15.0, dev versions of an upcoming version always show the
 #   intended next version.
-version_info = packaging.version.parse(__version__).release
+version_info = parse_version(__version__).release
 
 # Controls whether the new behavior for CIM objects in 0.12 is checked.
 # Because of the behavior for dev versions described above, a dev version of
@@ -5025,7 +5025,8 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
         None, None, CHECK_0_12_0
     ),
     (
-        "multiple keys (bool) in non-alphabetical order, standard format",
+        "multiple keys (bool) in non-alphabetical order in lower case, "
+        "standard format",
         dict(
             obj=CIMInstanceName(
                 classname=u'C',
@@ -5035,7 +5036,23 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
             kwargs=dict(
                 format='standard',
             ),
-            exp_uri='/n:C.k2=TRUE,k1=FALSE',
+            exp_uri='/n:C.k1=FALSE,k2=TRUE',
+        ),
+        None, None, CHECK_0_12_0
+    ),
+    (
+        "multiple keys (bool) in non-alphabetical order in mixed case, "
+        "standard format",
+        dict(
+            obj=CIMInstanceName(
+                classname=u'C',
+                keybindings=NocaseDict([('K2', True), ('k1', False)]),
+                namespace=u'n',
+                host=None),
+            kwargs=dict(
+                format='standard',
+            ),
+            exp_uri='/n:C.K2=TRUE,k1=FALSE',
         ),
         None, None, CHECK_0_12_0
     ),
@@ -5060,12 +5077,12 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
         dict(
             obj=CIMInstanceName(
                 classname=u'C',
-                keybindings=NocaseDict([('k1', 0), ('k2', -1), ('k3', -32769),
+                keybindings=NocaseDict([('k1', 0), ('k3', -32769), ('k2', -1),
                                         ('k4', 42), ('k5', 42),
-                                        ('kmax32', 4294967295),
                                         ('kmin32', -4294967296),
-                                        ('kmax64', 9223372036854775807),
+                                        ('kmax32', 4294967295),
                                         ('kmin64', -9223372036854775808),
+                                        ('kmax64', 9223372036854775807),
                                         ('klong', 9223372036854775808)]),
                 namespace=u'n',
                 host=None),
@@ -5073,11 +5090,11 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
                 format='standard',
             ),
             exp_uri='/n:C.k1=0,k2=-1,k3=-32769,k4=42,k5=42,'
+            'klong=9223372036854775808,'
             'kmax32=4294967295,'
-            'kmin32=-4294967296,'
             'kmax64=9223372036854775807,'
-            'kmin64=-9223372036854775808,'
-            'klong=9223372036854775808',
+            'kmin32=-4294967296,'
+            'kmin64=-9223372036854775808',
         ),
         None, None, CHECK_0_12_0
     ),
@@ -5086,12 +5103,12 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
         dict(
             obj=CIMInstanceName(
                 classname=u'C',
-                keybindings=NocaseDict([('k1', 0.0), ('k2', -0.1), ('k3', 0.1),
+                keybindings=NocaseDict([('k1', 0.0), ('k3', 0.1), ('k2', -0.1),
                                         ('k4', 31.4E-1), ('k5', 0.4E1),
-                                        ('kmax32', 3.402823466E38),
                                         ('kmin32', 1.175494351E-38),
-                                        ('kmax64', 1.7976931348623157E308),
-                                        ('kmin64', 2.2250738585072014E-308)]),
+                                        ('kmax32', 3.402823466E38),
+                                        ('kmin64', 2.2250738585072014E-308),
+                                        ('kmax64', 1.7976931348623157E308)]),
                 namespace=u'n',
                 host=None),
             kwargs=dict(
@@ -5099,8 +5116,8 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
             ),
             exp_uri='/n:C.k1=0.0,k2=-0.1,k3=0.1,k4=3.14,k5=4.0,'
             'kmax32=3.402823466e+38,'
-            'kmin32=1.175494351e-38,'
             'kmax64=1.7976931348623157e+308,'
+            'kmin32=1.175494351e-38,'
             'kmin64=2.2250738585072014e-308',
         ),
         None, None, CHECK_0_12_0
@@ -5195,7 +5212,7 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
             kwargs=dict(
                 format='standard',
             ),
-            exp_uri='/n:C.k1="a",k3="\\"",k2="1",k4="\'",k5="\\\\"',
+            exp_uri='/n:C.k1="a",k2="1",k3="\\"",k4="\'",k5="\\\\"',
         ),
         None, None, CHECK_0_12_0
     ),


### PR DESCRIPTION
For details, see the commit message.