### PR TITLE
Partly fixes #2261: provider type names

### DIFF
--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -869,14 +869,14 @@ can be executed for each provider type.
 
 .. table:: Pywbem_mock provider types
 
-    ====================== ============ ========================  ================================
-    Provider Type          type name    CIM Request Operations    Default provider class
-    ====================== ============ ========================  ================================
-    method                 "method"      InvokeMethod             :ref:`Method Provider`
-    instance write         "instance"    CreateInstance           :ref:`Instance Write Provider`
-    instance write         "instance"    ModifyInstance           :ref:`Instance Write Provider`
-    instance write         "instance"    DeleteInstance           :ref:`Instance Write Provider`
-    ====================== ============ ========================  ================================
+    ====================== =================== ========================  ================================
+    Provider Type          type name           CIM Request Operations    Default provider class
+    ====================== =================== ========================  ================================
+    method                 "method"            InvokeMethod             :ref:`Method Provider`
+    instance write         "instance-write"    CreateInstance           :ref:`Instance Write Provider`
+    instance write         "instance-write"    ModifyInstance           :ref:`Instance Write Provider`
+    instance write         "instance-write"    DeleteInstance           :ref:`Instance Write Provider`
+    ====================== ============ ====== ========================  ================================
 
 Each user-defined provider is a Python class which is a subclass
 of the corresponding default provider for the provider type as defined in

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -190,7 +190,7 @@ class InMemoryRepository(BaseRepository):
         # namespaces in the repository. The keys of this dictionary
         # are namespace names and the values are dictionaries
         # defining the CIM classes, CIM instances, and CIM qualifier
-        # declarations where the keys are "classes", "instance", and
+        # declarations where the keys are "classes", "instances", and
         # "qualifiers" and the value for each is an instance of the
         # class InMemoryObjectStore that containe the CIM objects.
         self._repository = NocaseDict()

--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -264,7 +264,7 @@ class InstanceWriteProvider(BaseProvider):
 
     #: :term:`string`: Keyword defining the type of request the provider will
     #: service. The type for this provider class is predefined as 'instance'.
-    provider_type = 'instance'
+    provider_type = 'instance-write'
 
     def __init__(self, cimrepository=None):
         """

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -122,7 +122,7 @@ class ProviderDispatcher(BaseProvider):
                         NewInstance.classname, namespace))
 
         provider = self.provider_registry.get_registered_provider(
-            namespace, 'instance', NewInstance.classname)
+            namespace, 'instance-write', NewInstance.classname)
 
         # Execute the method in the provider if the method exists. Otherwise
         # fall back to the default provider
@@ -195,7 +195,7 @@ class ProviderDispatcher(BaseProvider):
                         ModifiedInstance.path, namespace))
 
         provider = self.provider_registry.get_registered_provider(
-            namespace, 'instance', ModifiedInstance.classname)
+            namespace, 'instance-write', ModifiedInstance.classname)
 
         # Execute the method in the provider if the method exists. Otherwise
         # fall back to the default provider
@@ -244,7 +244,7 @@ class ProviderDispatcher(BaseProvider):
                         "{1!A}", InstanceName, namespace))
 
         provider = self.provider_registry.get_registered_provider(
-            InstanceName.namespace, 'instance', InstanceName.classname)
+            InstanceName.namespace, 'instance-write', InstanceName.classname)
 
         # Execute the method in the provider if the method exists. Otherwise
         # fall back to the default provider

--- a/pywbem_mock/_providerregistry.py
+++ b/pywbem_mock/_providerregistry.py
@@ -51,7 +51,7 @@ class ProviderRegistry(object):
     namespace, and provider_type.
     """
     #: Allowed provider types
-    PROVIDER_TYPES = ["instance", "method"]
+    PROVIDER_TYPES = ["instance-write", "method"]
 
     def __init__(self):
         # Dictionary of registered providers.
@@ -142,7 +142,7 @@ class ProviderRegistry(object):
         Providers can only be registered for the following request response
         methods:
 
-        1. provider_type = 'instance': defines methods for CreateInstance,
+        1. provider_type = 'instance-write': defines methods for CreateInstance,
            ModifyInstance, and DeleteInstance requests within a subclass of
            the `InstanceWriteProvider` class.
 
@@ -214,7 +214,7 @@ class ProviderRegistry(object):
                 _format("Attributes provider_type and provider_classnames "
                         "required in provider. exception {}",
                         ae))
-        if provider_type == 'instance':
+        if provider_type == 'instance-write':
             if not isinstance(provider, InstanceWriteProvider):
                 raise TypeError(
                     _format("Provider argument {0!A} is not a "
@@ -324,8 +324,8 @@ class ProviderRegistry(object):
             The namespace in which the request will be executed.
 
           provider_type (:term:`string`):
-            String containing keyword ('instance' or 'method') defining the
-            type of provider.
+            String containing keyword ('instance-write' or 'method') defining
+            the type of provider.
 
           classname (:term:`string`):
             Name of the class defined for the operation
@@ -419,8 +419,8 @@ class ProviderRegistry(object):
             Name of the class defined for the operation.
 
           provider_type (:term:`string`):
-            String containing keyword ('instance' or 'method') defining the
-            type of provider.
+            String containing keyword ('instance-write' or 'method') defining
+            the type of provider.
 
         Returns:
             The registered object

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1388,7 +1388,6 @@ class FakedWBEMConnection(WBEMConnection):
 
           Error: Exceptions from the call
         """
-
         modified_instance = params['ModifiedInstance']
         assert modified_instance.path.namespace is None
         modified_instance.path.namespace = namespace

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -2245,11 +2245,13 @@ class TestUserDefinedProviders(object):
         "desc,  inputs, exp_exec, condition",
         [
             ["validate ns='root/cimv2', etc.",
-             [["root/cimv3", UserInstanceTestProvider, 'CIM_Foo', 'instance']],
+             [["root/cimv3", UserInstanceTestProvider, 'CIM_Foo',
+               'instance-write']],
              None, OK],
 
             ["validate  ns='root/cimv2x' fails",
-             [["root/cimv2x", UserInstanceTestProvider, 'CIM_Foo', 'instance']],
+             [["root/cimv2x", UserInstanceTestProvider, 'CIM_Foo',
+               'instance-write']],
              ValueError, OK],
         ]
     )
@@ -2278,7 +2280,7 @@ class TestUserDefinedProviders(object):
                 provider = item[1]
                 conn.register_provider(provider(conn.cimrepository), tst_ns)
 
-            assert provider.provider_type == 'instance'
+            assert provider.provider_type == 'instance-write'
             provider_classnames = provider.provider_classnames
 
             if not isinstance(provider_classnames, (list, tuple)):
@@ -2320,7 +2322,7 @@ class TestUserDefinedProviders(object):
         #         * classnames - classname or list of classnames to register
         #           for provider
         #         * provider_type - String defining provider type
-        #           ('instance', etc.)
+        #           ('instance-write', etc.)
         #         * provider - Class that contains the user provider.
         # get_ns - namespace parameter for get_registered_provider
         # get_cln - classname parameter for get_registered_provider
@@ -2331,14 +2333,14 @@ class TestUserDefinedProviders(object):
         [
             ["Verify registry empty returns nothing",
              [],
-             'root/cimv2', 'CIM_Foo', 'instance',
+             'root/cimv2', 'CIM_Foo', 'instance-write',
              None, True],
 
             ["Register single good instance provider and test good result",
              [
                  ["root/cimv2", UserInstanceTestProvider],
              ],
-             'root/cimv2', 'CIM_Foo', 'instance',
+             'root/cimv2', 'CIM_Foo', 'instance-write',
              True, True],
 
             ["Register single good instance provider and test good result "
@@ -2346,21 +2348,21 @@ class TestUserDefinedProviders(object):
              [
                  ["root/cimv2", UserInstanceTestProvider],
              ],
-             'root/cimv2', 'cim_foo', 'instance',
+             'root/cimv2', 'cim_foo', 'instance-write',
              True, True],
 
             ["Verify get returns None namespace not found",
              [
                  ["root/cimv2", UserInstanceTestProvider],
              ],
-             'root/cimv2x', 'CIM_Foo', 'instance',
+             'root/cimv2x', 'CIM_Foo', 'instance-write',
              None, True],
 
             ["Verify get returns None classname  not found",
              [
                  ["root/cimv2", UserInstanceTestProvider],
              ],
-             'root/cimv2', 'CIM_Foo_sub_sub', 'instance',
+             'root/cimv2', 'CIM_Foo_sub_sub', 'instance-write',
              None, True],
 
             ["Verify get v provider type does not match",
@@ -2376,22 +2378,22 @@ class TestUserDefinedProviders(object):
              [
                  ["root/cimv2", UserInstanceTestProvider],
              ],
-             'root/cimv2', 'CIM_Foo_sub_sub', 'instance',
+             'root/cimv2', 'CIM_Foo_sub_sub', 'instance-write',
              True, None],
 
             ["Verify multiple providers registered, returns OK",
              [["root/cimv2", UserInstanceTestProvider]],
-             'root/cimv2', 'CIM_Foo', 'instance',
+             'root/cimv2', 'CIM_Foo', 'instance-write',
              True, True],
 
             ["Verify test, multiple classes registered, returns OK",
              [["root/cimv2", UserInstanceTestProvider]],
-             'root/cimv2', 'CIM_Foo', 'instance',
+             'root/cimv2', 'CIM_Foo', 'instance-write',
              True, OK],
 
             ["Verify test, register with None as namespace, returns OK",
              [[None, UserInstanceTestProvider]],
-             'root/cimv2', 'CIM_Foo', 'instance',
+             'root/cimv2', 'CIM_Foo', 'instance-write',
              True, OK],
         ]
     )
@@ -2455,7 +2457,7 @@ class TestUserDefinedProviders(object):
              ],
              "\nRegistered Providers:\n"
              "namespace: root/cimv2\n"
-             "  CIM_Foo  instance  UserInstanceTestProvider\n",
+             "  CIM_Foo  instance-write  UserInstanceTestProvider\n",
              OK],
 
             ["validate snamespace is None, etc.",
@@ -2464,7 +2466,7 @@ class TestUserDefinedProviders(object):
              ],
              "\nRegistered Providers:\n"
              "namespace: root/cimv2\n"
-             "  CIM_Foo  instance  UserInstanceTestProvider\n",
+             "  CIM_Foo  instance-write  UserInstanceTestProvider\n",
              OK],
 
             ["validate multiple namespaces , etc.",
@@ -2473,9 +2475,9 @@ class TestUserDefinedProviders(object):
              ],
              '\nRegistered Providers:\n'
              'namespace: root/cimv2\n'
-             '  CIM_Foo  instance  UserInstanceTestProvider\n'
+             '  CIM_Foo  instance-write  UserInstanceTestProvider\n'
              'namespace: root/cimv3\n'
-             '  CIM_Foo  instance  UserInstanceTestProvider\n',
+             '  CIM_Foo  instance-write  UserInstanceTestProvider\n',
              OK],
 
             ["validate ns='root/cimv2, root/cimv3', etc.",
@@ -2485,9 +2487,9 @@ class TestUserDefinedProviders(object):
              ],
              '\nRegistered Providers:\n'
              'namespace: root/cimv2\n'
-             '  CIM_Foo  instance  UserInstanceTestProvider\n'
+             '  CIM_Foo  instance-write  UserInstanceTestProvider\n'
              'namespace: root/cimv3\n'
-             '  CIM_Foo  instance  UserInstanceTestProvider\n',
+             '  CIM_Foo  instance-write  UserInstanceTestProvider\n',
              OK],
 
             ["validate single existing ns, provider with multiple classnames",
@@ -2496,8 +2498,8 @@ class TestUserDefinedProviders(object):
              ],
              '\nRegistered Providers:\n'
              'namespace: root/cimv2\n'
-             '  CIM_Foo      instance  UserInstanceTestProvider2\n'
-             '  CIM_Foo_Sub  instance  UserInstanceTestProvider2\n',
+             '  CIM_Foo      instance-write  UserInstanceTestProvider2\n'
+             '  CIM_Foo_Sub  instance-write  UserInstanceTestProvider2\n',
              OK],
 
             ["validate multiple  ns, provider with multiple classnames",
@@ -2506,11 +2508,11 @@ class TestUserDefinedProviders(object):
              ],
              '\nRegistered Providers:\n'
              'namespace: root/cimv2\n'
-             '  CIM_Foo      instance  UserInstanceTestProvider2\n'
-             '  CIM_Foo_Sub  instance  UserInstanceTestProvider2\n'
+             '  CIM_Foo      instance-write  UserInstanceTestProvider2\n'
+             '  CIM_Foo_Sub  instance-write  UserInstanceTestProvider2\n'
              'namespace: root/cimv3\n'
-             '  CIM_Foo      instance  UserInstanceTestProvider2\n'
-             '  CIM_Foo_Sub  instance  UserInstanceTestProvider2\n',
+             '  CIM_Foo      instance-write  UserInstanceTestProvider2\n'
+             '  CIM_Foo_Sub  instance-write  UserInstanceTestProvider2\n',
              OK],
 
         ]
@@ -2643,7 +2645,7 @@ class TestUserDefinedProviders(object):
 
         class CIM_FooSubUserProvider(InstanceWriteProvider):
             """
-            Define the user provider
+            Define the user provider. Only implements ModifyInstance
             """
             # CIM classes this provider serves
             provider_classnames = 'CIM_Foo_Sub'
@@ -2660,10 +2662,14 @@ class TestUserDefinedProviders(object):
                 My user ModifyInstance.  Will change the value of the
                 property as a flag
                 """
-
                 # modify a None key property.
                 assert ModifiedInstance.get("InstanceID") == 'origid'
-                ModifiedInstance.properties["cimfoo_sub"].value = "ModProperty"
+                # modify the defined property value
+                assert ModifiedInstance.properties["cimfoo_sub"].value == \
+                    "ModProperty"
+
+                ModifiedInstance.properties["cimfoo_sub"].value = \
+                    "ModProperty2"
 
                 # send back to the superclass to complete insertion into
                 # the repository.
@@ -2671,7 +2677,6 @@ class TestUserDefinedProviders(object):
                     ModifiedInstance)
 
         skip_if_moftab_regenerated()
-
         ns = conn.default_namespace
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
         conn.register_provider(CIM_FooSubUserProvider(conn.cimrepository), ns)
@@ -2686,15 +2691,13 @@ class TestUserDefinedProviders(object):
 
         # Modify the cimfoo_sub property and put modification in repository
         mod_instance = deepcopy(rtnd_instance)
-        mod_instance.update_existing([('cimfoo_sub',
-                                       CIMProperty('cimfoo_sub',
-                                                   'ModProperty'))])
+        mod_instance.update_existing([('cimfoo_sub', 'ModProperty')])
         conn.ModifyInstance(mod_instance)
 
         # Get modified instance and compare property for change
         rtnd_modified_instance = conn.GetInstance(rtnd_path)
         assert rtnd_modified_instance.properties["cimfoo_sub"].value == \
-            "ModProperty"
+            "ModProperty2"
 
         assert rtnd_instance.path == rtnd_path
 


### PR DESCRIPTION
Changes name of provider from 'instance" to "instance-write"

Based on pr #2232, mock documentation update because the name of the provider type changed in the documentation also