### PR TITLE
Partly fixes issue #2261, define post_register_setup in defaults

### DIFF
--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -569,3 +569,20 @@ class InstanceWriteProvider(BaseProvider):
 
         # Delete the instance from the CIM repository
         instance_store.delete(InstanceName)
+
+    def post_register_setup(self, conn):
+        """
+        Method called by provider registration after registation of provider
+        is successful. Using this method is optional for registration cases
+        where the provider must execute some activity (ex. modify the
+        CIM repository after successful provider registration).
+
+        Override this method in the user-defined provider subclass to execute
+        this method.
+
+        Parameters:
+
+          conn (:class:`~pywbem.WBEMConnection`):
+            Current connection which allows client methods to be executed
+            from within this method.
+        """

--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -168,3 +168,21 @@ class MethodProvider(BaseProvider):
         # No default MethodProvider is implemented because all method
         # providers define specific actions in their implementations.
         raise CIMError(CIM_ERR_METHOD_NOT_FOUND)
+
+    def post_register_setup(self, conn):
+        """
+        Method called by provider registration after registation of provider
+        is successful. Using this method is optional for registration cases
+        where the provider must execute some activity (ex. modify the
+        CIM repository after successful provider registration).
+
+        Override this method in the user-defined provider subclass to execute
+        this method.
+
+        Parameters:
+
+          conn (:class:`~pywbem.WBEMConnection`):
+            Current connection which allows client methods to be executed
+            from within this method.
+        """
+        pass

--- a/pywbem_mock/_providerregistry.py
+++ b/pywbem_mock/_providerregistry.py
@@ -305,11 +305,10 @@ class ProviderRegistry(object):
                     ", ".join(provider_classnames),
                     provider_type, ", ".join(namespaces))
 
-        try:
-            provider.post_register_setup(conn)
-        except AttributeError:
-            if verbose:
-                _format("Register_Provider post_register_setup not found")
+        # Call post_register_setup.  Since this method is defined in the
+        # default provider methods (MethodProvider, etc.) any exception is
+        # caught as an error.
+        provider.post_register_setup(conn)
 
     def get_registered_provider(self, namespace, provider_type, classname):
         """


### PR DESCRIPTION
Defines the post_register_setup method in the default providers
(MethodProvider and InstanceWriteProvider so that:

1. There is a model to work from when provider writers write their
providers subclassing MethodProvider and InstanceWriteProvider have a
defined API to override.

2. Any exception upon the execution of this method when the provider is
registered is considered an error whereas initially attribute error was
ignored because the method might not exist in the subclass.