### PR TITLE
Fixes #2267: Refactor changes.rst incompatibilities section

### DIFF
--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -869,14 +869,14 @@ can be executed for each provider type.
 
 .. table:: Pywbem_mock provider types
 
-    ====================== =================== ========================  ================================
-    Provider Type          type name           CIM Request Operations    Default provider class
-    ====================== =================== ========================  ================================
+    ====================== =================== ======================== ================================
+    Provider Type          type name           CIM Request Operations   Default provider class
+    ====================== =================== ======================== ================================
     method                 "method"            InvokeMethod             :ref:`Method Provider`
     instance write         "instance-write"    CreateInstance           :ref:`Instance Write Provider`
     instance write         "instance-write"    ModifyInstance           :ref:`Instance Write Provider`
     instance write         "instance-write"    DeleteInstance           :ref:`Instance Write Provider`
-    ====================== ============ ====== ========================  ================================
+    ====================== =================== ======================== ================================
 
 Each user-defined provider is a Python class which is a subclass
 of the corresponding default provider for the provider type as defined in

--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -228,8 +228,8 @@ class MethodProvider(BaseProvider):
             Each item in ``Params`` is a name/parameter-value for the CIM
             method and is:
 
-            * :term:`string` The case-insensitive name of the parameter.
-            * :class:`~pywbem.CIMParameter`  The item value representing a
+            * :term:`string`: The case-insensitive name of the parameter.
+            * :class:`~pywbem.CIMParameter`: The item value representing a
               parameter value. The `name`, `value`, `type` and
               `embedded_object` attributes of this object are guaranteed
               present.

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -259,7 +259,7 @@ class FakedWBEMConnection(WBEMConnection):
         The CIM repository instance  is the data store for CIM classes, CIM
         instances, and CIM qualifier declarations.  All access to the mocker
         CIM data must pass through this variable to the CIM repository.
-        See :py:class:`pywbem_mock/InmemoryRepository` for a description of
+        See :class:`pywbem_mock/InmemoryRepository` for a description of
         the repository interface.
         """
         if self._cimrepository is None:


### PR DESCRIPTION
Broke into two sections, one for summary of the incompatibilities and
the second for details

Fixed issue in _methodprovider.py with misnamed doc label.

DISCUSSION: This set of changes is so big it might be better to add another layer of subsctions rather than just the bold headings