### PR TITLE
Appveyor/tox: Fixed 32-bit CygWin envs; enabled py34 on native Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,15 +10,10 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
-# Note: Python 3.4 is disabled on Windows because lxml does not install anymore,
-#       it fails with missing include files from libxml2 and libxslt, although
-#       these packages are installed viy choco (and work with Python 3.5 and
-#       higher). Even if the include file paths are added via INCLUDE, it fails
-#       at the link step because libxslt.lib etc are needed but not part of
-#       the choco installation of libxml2 etc.
 #    - TOX_ENV: win64_py34_32
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
+
 #    - TOX_ENV: win64_py34_64
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
@@ -71,7 +66,6 @@ environment:
 #      PIP_CMD: pip
 #      CYGWIN_PYTHON_DEVEL: python27-devel
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py36
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.6
@@ -88,7 +82,6 @@ environment:
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py37
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.7
@@ -105,7 +98,6 @@ environment:
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py38
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,11 @@ envlist =
     win64_py38_64
     cygwin32_py27
     cygwin64_py27
+    cygwin32_py36
     cygwin64_py36
+    cygwin32_py37
     cygwin64_py37
+    cygwin32_py38
     cygwin64_py38
 
 # For Appveyor, missing interpreters should fail. For local use, you may
@@ -114,6 +117,14 @@ basepython = C:\Python27\python.exe
 platform = win32
 basepython = C:\Python27-x64\python.exe
 
+[testenv:win64_py34_32]
+platform = win32
+basepython = C:\Python34\python.exe
+
+[testenv:win64_py34_64]
+platform = win32
+basepython = C:\Python34-x64\python.exe
+
 [testenv:win64_py35_32]
 platform = win32
 basepython = C:\Python35\python.exe
@@ -154,13 +165,25 @@ basepython = python2.7
 platform = cygwin
 basepython = python2.7
 
+[testenv:cygwin32_py36]
+platform = cygwin
+basepython = python3.6
+
 [testenv:cygwin64_py36]
 platform = cygwin
 basepython = python3.6
 
+[testenv:cygwin32_py37]
+platform = cygwin
+basepython = python3.7
+
 [testenv:cygwin64_py37]
 platform = cygwin
 basepython = python3.7
+
+[testenv:cygwin32_py38]
+platform = cygwin
+basepython = python3.8
 
 [testenv:cygwin64_py38]
 platform = cygwin


### PR DESCRIPTION
No review needed.