### PR TITLE
Appveyor: Cleaned up non-support of py34 on native Windows and 32-bit CygWin envs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,12 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
-#    - TOX_ENV: win64_py34_32
-#      UNIX_PATH: none
-#      PYTHON_CMD: python
-
-#    - TOX_ENV: win64_py34_64
-#      UNIX_PATH: none
-#      PYTHON_CMD: python
+# Note: Python 3.4 is does not work on Windows because lxml does not install.
+#       It fails with missing include files from libxml2 and libxslt, although
+#       these packages are installed viy choco (and work with Python 3.5 and
+#       higher). Even if the include file paths are added via INCLUDE, it fails
+#       at the link step because libxslt.lib etc are needed but not part of
+#       the choco installation of libxml2 etc.
 
 #    - TOX_ENV: win64_py35_32
 #      UNIX_PATH: none
@@ -52,27 +51,17 @@ environment:
 
 # Note: On CygWin with Python 3.x, LC_ALL/LANG need to be set to utf-8 for Click to install/work
 
-# TODO: Disabled because python2.7 with cygwin 32-bit fails with:
-#       "virtualenv is not compatible with this system or executable"
-#    - TOX_ENV: cygwin32_py27
-#      UNIX_PATH: C:\cygwin\bin
-#      PYTHON_CMD: python2.7
-#      PIP_CMD: pip
-#      CYGWIN_PYTHON_DEVEL: python27-devel
+# Note: The 32-bit versions of CygWin do not work and have been removed from
+# appveyor.yml and tox.ini:
+# - Python 2.7 with cygwin 32-bit fails with "virtualenv is not compatible with
+#   this system or executable".
+# - On Python 3.6 and upwards, Tox returns success but does not do anything.
 
 #    - TOX_ENV: cygwin64_py27
 #      UNIX_PATH: C:\cygwin64\bin
 #      PYTHON_CMD: python2.7
 #      PIP_CMD: pip
 #      CYGWIN_PYTHON_DEVEL: python27-devel
-
-#    - TOX_ENV: cygwin32_py36
-#      UNIX_PATH: C:\cygwin\bin
-#      PYTHON_CMD: python3.6
-#      PIP_CMD: pip
-#      CYGWIN_PYTHON_DEVEL: python36-devel
-#      LC_ALL: C.UTF-8
-#      LANG: C.UTF-8
 
 #    - TOX_ENV: cygwin64_py36
 #      UNIX_PATH: C:\cygwin64\bin
@@ -82,27 +71,11 @@ environment:
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 
-#    - TOX_ENV: cygwin32_py37
-#      UNIX_PATH: C:\cygwin\bin
-#      PYTHON_CMD: python3.7
-#      PIP_CMD: pip
-#      CYGWIN_PYTHON_DEVEL: python37-devel
-#      LC_ALL: C.UTF-8
-#      LANG: C.UTF-8
-
 #    - TOX_ENV: cygwin64_py37
 #      UNIX_PATH: C:\cygwin64\bin
 #      PYTHON_CMD: python3.7
 #      PIP_CMD: pip
 #      CYGWIN_PYTHON_DEVEL: python37-devel
-#      LC_ALL: C.UTF-8
-#      LANG: C.UTF-8
-
-#    - TOX_ENV: cygwin32_py38
-#      UNIX_PATH: C:\cygwin\bin
-#      PYTHON_CMD: python3.8
-#      PIP_CMD: pip
-#      CYGWIN_PYTHON_DEVEL: python38-devel
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -130,26 +130,29 @@ readme-renderer>=23.0; python_version >= '3.5'
 # Python 3.4.
 jupyter>=1.0.0; python_version != '3.4' or sys_platform != 'win32'
 ipython>=5.1.0,<6.0; python_version == '2.7'
-ipython>=6.0,<7.0; python_version == '3.4'
+ipython>=6.0,<7.0; python_version == '3.4' and sys_platform != 'win32'
 ipython>=7.0,<7.10; python_version == '3.5'
 ipython>=7.10; python_version >= '3.6'
-ipykernel>=4.5.2
-ipython_genutils>=0.1.0
-ipywidgets>=5.2.2
-jupyter_console>=5.0.0,<6.0.0; python_version <= '3.4'
+ipykernel>=4.5.2; python_version != '3.4' or sys_platform != 'win32'
+ipython_genutils>=0.1.0; python_version != '3.4' or sys_platform != 'win32'
+ipywidgets>=5.2.2; python_version != '3.4' or sys_platform != 'win32'
+jupyter_console>=5.0.0,<6.0.0; python_version == '2.7'
+jupyter_console>=5.0.0,<6.0.0; python_version == '3.4' and sys_platform != 'win32'
 jupyter_console>=6.0.0; python_version >= '3.5'
-jupyter_client>=4.4.0
-jupyter_core>=4.2.1
-nbconvert>=5.0.0
-nbformat>=4.2.0
-notebook>=4.3.1
+jupyter_client>=4.4.0; python_version != '3.4' or sys_platform != 'win32'
+jupyter_core>=4.2.1; python_version != '3.4' or sys_platform != 'win32'
+nbconvert>=5.0.0; python_version != '3.4' or sys_platform != 'win32'
+nbformat>=4.2.0; python_version != '3.4' or sys_platform != 'win32'
+notebook>=4.3.1; python_version != '3.4' or sys_platform != 'win32'
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 226 needs to be excluded, see issue #1946.
 # Pywin32 version 222 is inconsistent in its 32-bit/64-bit support on py37
 # Pywin32 version 225+ provides wheel files for py38, but does not advertise
 # py38 on Pypi. That causes pywin32==225 to fail but pywin32>=225 to work.
-pywin32>=222,!=226; sys_platform == 'win32' and python_version <= '3.6'
+# There is no version of pywin32 for py34.
+pywin32>=222,!=226; sys_platform == 'win32' and python_version == '2.7'
+pywin32>=222,!=226; sys_platform == 'win32' and python_version >= '3.5' and python_version <= '3.6'
 pywin32>=223,!=226; sys_platform == 'win32' and python_version == '3.7'
 # TODO: Re-enable once pywin32 fixes its Python version advertising on Pypi
 #       (see issue #1975).

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -178,21 +178,25 @@ twine==1.8.1
 readme-renderer==23.0
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
-jupyter==1.0.0
+# The jupyter package is not installed on Python 3.4 on Windows, because its
+# (indirectly) dependent pywin32 package is not available on Pypi for
+# Python 3.4.
+jupyter==1.0.0; python_version != '3.4' or sys_platform != 'win32'
 ipython==5.1.0; python_version == '2.7'
-ipython==6.0; python_version == '3.4'
+ipython==6.0; python_version == '3.4' and sys_platform != 'win32'
 ipython==7.0; python_version == '3.5'
 ipython==7.10; python_version >= '3.6'
-ipykernel==4.5.2
-ipython_genutils==0.1.0
-ipywidgets==5.2.2
-jupyter_console==5.0.0; python_version <= '3.4'
+ipykernel==4.5.2; python_version != '3.4' or sys_platform != 'win32'
+ipython_genutils==0.1.0; python_version != '3.4' or sys_platform != 'win32'
+ipywidgets==5.2.2; python_version != '3.4' or sys_platform != 'win32'
+jupyter_console==5.0.0; python_version == '2.7'
+jupyter_console==5.0.0; python_version == '3.4' and sys_platform != 'win32'
 jupyter_console==6.0.0; python_version >= '3.5'
-jupyter_client==4.4.0
-jupyter_core==4.2.1
-nbconvert==5.0.0
-nbformat==4.2.0
-notebook==4.3.1
+jupyter_client==4.4.0; python_version != '3.4' or sys_platform != 'win32'
+jupyter_core==4.2.1; python_version != '3.4' or sys_platform != 'win32'
+nbconvert==5.0.0; python_version != '3.4' or sys_platform != 'win32'
+nbformat==4.2.0; python_version != '3.4' or sys_platform != 'win32'
+notebook==4.3.1; python_version != '3.4' or sys_platform != 'win32'
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 226 needs to be excluded, see issue #1946.
@@ -200,7 +204,9 @@ notebook==4.3.1
 # Pywin32 version 225+ provides wheel files for py38, but does not advertise
 # py38 on Pypi. That causes pip to fail with any use of it in the constraints
 # file.
-pywin32==222; sys_platform == 'win32' and python_version <= '3.6'
+# There is no version of pywin32 for py34.
+pywin32==222; sys_platform == 'win32' and python_version == '2.7'
+pywin32==222; sys_platform == 'win32' and python_version >= '3.5' and python_version <= '3.6'
 pywin32==223; sys_platform == 'win32' and python_version == '3.7'
 # TODO: Re-enable once pywin32 fixes its Python version advertising on Pypi
 #       (see issue #1975).

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,12 @@
 #   OS-X
 #   Windows (native and in UNIX-like environments)
 
+# Note: The 32-bit versions of cygwin do not work and have been removed from
+# appveyor.yml and tox.ini:
+# - Python 2.7 with cygwin 32-bit fails with "virtualenv is not compatible with
+#   this system or executable".
+# - On Python 3.6 and upwards, Tox returns success but does not do anything.
+
 [tox]
 minversion = 2.0
 envlist =
@@ -25,13 +31,9 @@ envlist =
     win64_py37_64
     win64_py38_32
     win64_py38_64
-    cygwin32_py27
     cygwin64_py27
-    cygwin32_py36
     cygwin64_py36
-    cygwin32_py37
     cygwin64_py37
-    cygwin32_py38
     cygwin64_py38
 
 # For Appveyor, missing interpreters should fail. For local use, you may
@@ -117,13 +119,12 @@ basepython = C:\Python27\python.exe
 platform = win32
 basepython = C:\Python27-x64\python.exe
 
-[testenv:win64_py34_32]
-platform = win32
-basepython = C:\Python34\python.exe
-
-[testenv:win64_py34_64]
-platform = win32
-basepython = C:\Python34-x64\python.exe
+# Note: Python 3.4 is does not work on Windows because lxml does not install.
+#       It fails with missing include files from libxml2 and libxslt, although
+#       these packages are installed viy choco (and work with Python 3.5 and
+#       higher). Even if the include file paths are added via INCLUDE, it fails
+#       at the link step because libxslt.lib etc are needed but not part of
+#       the choco installation of libxml2 etc.
 
 [testenv:win64_py35_32]
 platform = win32
@@ -157,33 +158,23 @@ basepython = C:\Python38\python.exe
 platform = win32
 basepython = C:\Python38-x64\python.exe
 
-[testenv:cygwin32_py27]
-platform = cygwin
-basepython = python2.7
+# Note: The 32-bit versions of CygWin do not work and have been removed from
+# appveyor.yml and tox.ini:
+# - Python 2.7 with cygwin 32-bit fails with "virtualenv is not compatible with
+#   this system or executable".
+# - On Python 3.6 and upwards, Tox returns success but does not do anything.
 
 [testenv:cygwin64_py27]
 platform = cygwin
 basepython = python2.7
 
-[testenv:cygwin32_py36]
-platform = cygwin
-basepython = python3.6
-
 [testenv:cygwin64_py36]
 platform = cygwin
 basepython = python3.6
 
-[testenv:cygwin32_py37]
-platform = cygwin
-basepython = python3.7
-
 [testenv:cygwin64_py37]
 platform = cygwin
 basepython = python3.7
-
-[testenv:cygwin32_py38]
-platform = cygwin
-basepython = python3.8
 
 [testenv:cygwin64_py38]
 platform = cygwin


### PR DESCRIPTION
No review needed.