### PR TITLE
Eliminate use of deprecated methods and properties in the mocker

### DIFF
--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -527,7 +527,7 @@ There are two ways to build a mock repository:
     qualifier declarations into the mock repository and allows setting up
     a partial class repository (i.e. selected classes) with a single
     method call. See section `DMTF CIM schema download support`_ and the
-    :meth:`~pywbem_mock.FakedWBEMConnection.compile_dmtf_schema` method.
+    :meth:`~pywbem_mock.FakedWBEMConnection.schema_pragma_file` method.
 
 It may take a combination of all of the above methods to build a schema
 that satisfies a particular usage requirement including:
@@ -552,7 +552,7 @@ to successfully execute client operations can mean understanding the CIM model
 dependencies, the pywbem MOF compiler provides support for:
 
 1. Automatically including all qualifier declarations if classes are added
-   with the method :meth:`~pywbem_mock.FakedWBEMConnection.compile_dmtf_schema`
+   with the method :meth:`~pywbem_mock.FakedWBEMConnection.schema_pragma_file`
    or the :class:`DMTFCIMSchema`.
 
 2. Adding dependent classes from the DMTF schema in the case where they are
@@ -599,8 +599,11 @@ declarations defined by the DMTF schema and any dependent classes
     # Compile dmtf schema version 2.49.0, the qualifier declarations and
     # the classes in 'leaf_classes' and all dependent classes and keep the
     # schema in directory my_schema_dir
-    conn.compile_dmtf_schema((2, 49, 0), "my_schema_dir", leaf_classes,
-                            verbose=True)
+
+    schema = DMTFCIMSchema(2, 49, 0), "my_schema_dir", leaf_classes,
+                           verbose=True)
+    conn.compile_schema_classes(leaf_classes, schema.schema_pragma_file
+                                verbose=True)
 
     # Display the resulting repository
     conn.display_repository()

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -563,7 +563,7 @@ class DMTFCIMSchema(object):
             ValueError: If any of the classnames in `schema_classes` are not in
               the DMTF CIM schema installed
         """
-        return build_schema_mof(class_names, self.schema_mof_file)
+        return build_schema_mof(class_names, self.schema_pragma_file)
 
     def clean(self):
         """

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -606,7 +606,7 @@ class FakedWBEMConnection(WBEMConnection):
                                namespace=None, verbose=False):
         # pylint: disable=line-too-long
         """
-        Compile the classes defined by `class_names`  and all of their
+        Compile the classes defined by `class_names` and all of their
         dependences. The class names must be classes in the defined schema and
         with pragma statements in a schema pragma file. Each
         schema pragma file in the `schema_pragma_files` parameter must be in a
@@ -623,7 +623,7 @@ class FakedWBEMConnection(WBEMConnection):
            `qualifiers.mof` defined within the directory defined by the
            `schema_mof_dir` parameter
 
-        2. The file `schema_mof_file` that defines the location of all
+        2. The file `schema_pragma_file` that defines the location of all
            of the CIM class files within the a schema mof directory
            hierarchy. This is the `schema_pragma_file` attribute of the
            DMTFCIMSchema class.
@@ -642,10 +642,10 @@ class FakedWBEMConnection(WBEMConnection):
             be a subset of the classes defined in `schema_pragma_file`.
 
           schema_pragma_files (:term:`string` or :class:`py:list` of :term:`string`):
-            Relative or absolute file path of schema pragma files that include
-            a MOF pragma include statement for each CIM class to be
+            Relative or absolute file path(s) of schema pragma files that
+            include a MOF pragma include statement for each CIM class to be
             compiled.  This file path is available from
-            :attr:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`
+            :attr:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`.
 
           namespace (:term:`string`):
             Namespace into which the classes and qualifier declarations will
@@ -684,7 +684,7 @@ class FakedWBEMConnection(WBEMConnection):
                             verbose=False):
         # pylint: disable:line-too-long
         """
-        Compile the classes defined by `schema_class_names` and their
+        Compile the classes defined by `class_names` and their
         dependent classes from the CIM schema version defined by
         `schema_version`. If the DMTF schema defined by
         `schema_version` is not installed in path `schema_root_dir`

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -2134,7 +2134,7 @@ class TestFullSchema(MOFTest):
 
         # original compile and write of output mof
         # start_time = time()
-        self.mofcomp.compile_file(TEST_DMTF_CIMSCHEMA.schema_mof_file,
+        self.mofcomp.compile_file(TEST_DMTF_CIMSCHEMA.schema_pragma_file,
                                   NAME_SPACE)
         # print('elapsed compile: %f  ' % (time() - start_time))
 

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1851,7 +1851,7 @@ class TestRepoMethods(object):
         # install the schema if necessary.
         dmtf_schema = install_test_dmtf_schema()
 
-        conn.compile_mof_file(dmtf_schema.schema_mof_file, namespace=ns,
+        conn.compile_mof_file(dmtf_schema.schema_pragma_file, namespace=ns,
                               search_paths=[dmtf_schema.schema_mof_dir])
 
         # pylint: disable=protected-access
@@ -6597,16 +6597,18 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '%s.%s.%s' % DMTF_TEST_SCHEMA_VER
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
-        assert os.path.isfile(schema.schema_mof_file)
         assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
+        # deprecated property schema_mof_file. These tests will be removed
+        # when that property is removed in the future
+        assert os.path.isfile(schema.schema_mof_file)
         assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
         assert schema.schema_mof_dir == test_schema_mof_dir
 
-        assert schema.schema_mof_file == \
+        assert schema.schema_pragma_file == \
             os.path.join(test_schema_mof_dir,
                          'cim_schema_%s.mof' % (schema.schema_version_str))
 
@@ -6650,16 +6652,18 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '%s.%s.%s' % DMTF_TEST_SCHEMA_VER
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
+        # deprecated property
         assert os.path.isfile(schema.schema_mof_file)
         assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
+        # schema_mof_file is deprecated
         assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(test_schema_root_dir, mof_dir)
         assert schema.schema_mof_dir == test_schema_mof_dir
 
-        assert schema.schema_mof_file == \
+        assert schema.schema_pragma_file == \
             os.path.join(test_schema_mof_dir,
                          'cim_schema_%s.mof' % (schema.schema_version_str))
 
@@ -6667,11 +6671,11 @@ class TestDMTFCIMSchema(object):
                                'schema_version=%s, ' \
                                'schema_root_dir=%s, schema_zip_file=%s, ' \
                                'schema_mof_dir=%s, ' \
-                               'schema_mof_file=%s, schema_zip_url=%s)' % \
+                               'schema_pragma_file=%s, schema_zip_url=%s)' % \
                                (DMTF_TEST_SCHEMA_VER, test_schema_root_dir,
                                 schema.schema_zip_file,
                                 schema.schema_mof_dir,
-                                schema.schema_mof_file,
+                                schema.schema_pragma_file,
                                 schema.schema_zip_url)
 
         schema_mof = schema.build_schema_mof(['CIM_ComputerSystem', 'CIM_Door'])
@@ -6701,20 +6705,23 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '%s.%s.%s' % DMTF_TEST_SCHEMA_VER
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
+        # This property is deprecated
         assert os.path.isfile(schema.schema_mof_file)
         assert schema.schema_root_dir == TESTSUITE_SCHEMA_DIR
         mof_dir = 'mofExperimental%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
         assert test_schema_mof_dir == mof_dir
 
-        assert schema.schema_mof_file == \
+        assert schema.schema_pragma_file == \
             os.path.join(test_schema_mof_dir,
                          'cim_schema_%s.mof' % (schema.schema_version_str))
 
         # remove the second schema and test to be sure removed.
         schema.remove()
         assert not os.path.isdir(test_schema_mof_dir)
+        # deprecated
         assert not os.path.isfile(schema.schema_mof_file)
+        assert not os.path.isfile(schema.schema_pragma_file)
         assert os.path.isdir(schema.schema_root_dir)
 
     def test_second_schema_load(self):
@@ -6732,6 +6739,7 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '2.50.0'
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
+        # deprecated
         assert os.path.isfile(schema.schema_mof_file)
 
         assert schema.schema_root_dir == TESTSUITE_SCHEMA_DIR
@@ -6739,7 +6747,7 @@ class TestDMTFCIMSchema(object):
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
         assert schema.schema_mof_dir == test_schema_mof_dir
 
-        assert schema.schema_mof_file == \
+        assert schema.schema_pragma_file == \
             os.path.join(test_schema_mof_dir,
                          'cim_schema_%s.mof' % (schema.schema_version_str))
 


### PR DESCRIPTION
This eliminates the use in pywbem code and pywbem tests of the property
`schema_mof_file` and the method `compile__dmtf_schema()` in favor of the
replacements.  

This pr DOES NOT remove the deprecated entities.