### PR TITLE
Fixes #2284: Removed deprecated compile_dmtf_schema() and schema_mof_file

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,20 @@ Released: not yet
 
 **Incompatible changes:**
 
+* Removed the deprecated `compile_dmtf_schema()` method in `FakedWBEMConnection`
+  in favor of a new method `compile_schema_classes()` that does not automatically
+  download the DMTF schema classes as a search path, but leaves the control
+  over where the search path schema comes from, to the user. (See issue #2284)
+
+  To migrate your existing use of `compile_dmtf_schema()` to the new approach,
+  the code would be something like::
+
+      schema = DMTFCIMSchema(...)
+      conn.compile_schema_classes(class_names, schema.schema_pragma_file, namespace)
+
+* Removed the deprecated `schema_mof_file` property in `DMTFCIMSchema`, in favor
+  of the `schema_pragma_file` property. (See issue #2284)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -322,9 +336,10 @@ below this list.
     are simple. (See issue #1959)
 
   * Changed the logging behavior of the MOF compilation methods
-    `FakedWBEMConnection.compile_mof_string()`, `compile_mof_file()` and
-    `compile_dmtf_schema()` to be able to do no logging, by specifying `None` for
-    the `log_func` init parameter of `MOFCompiler`. This is now the default.
+    `FakedWBEMConnection.compile_mof_string()` and `compile_mof_file()`
+    (consistent with the new `compile_schema_classes()` method) to be able to
+    do no logging, by specifying `None` for the `log_func` init parameter of
+    `MOFCompiler`. This is now the default.
 
     MOF compile errors no are longer printed to stdout by default. To continue
     printing the MOF compile errors to stdout, print the exception in your code.

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -74,7 +74,6 @@ repository need to be in the class list. This speeds up the process of
 compiling DMTF CIM classes for any test significantly.
 """
 
-import warnings
 import os
 from zipfile import ZipFile
 import shutil
@@ -330,34 +329,6 @@ class DMTFCIMSchema(object):
         schema pragma file.
         """
         return self._schema_mof_dir
-
-    @property
-    def schema_mof_file(self):
-        """
-        :term:`string`: Path name of the schema pragma file for the DMTF CIM
-        schema. This file contains `#pragama include` statements for all of
-        the classes and qualifier declarations of the schema.
-
-        **Deprecated:** This property has been deprecated in pywbem 1.0.0
-        in favor of :attr:`schema_pragma_file`.
-
-        The classes are represented with one file per class, and the qualifier
-        declarations are in the files `qualifiers.mof` and
-        `qualifiers_optional.mof`.
-
-        The path name of the schema pragma file is of the general form::
-
-            <schema_mof_dir>/cim_schema_<schema_version_str>.mof
-
-        Example::
-
-            schemas/dmtf/moffinal2490/cim_schema_2.49.0.mof
-        """
-        warnings.warn("Property pywbem_mock.DMTFCIMSchema.schema_mof_file is "
-                      "deprecated; it will be removed in a future pywbem "
-                      "release. Use schema_pragma_file instead.",
-                      DeprecationWarning, stacklevel=2)
-        return self._schema_pragma_file
 
     @property
     def schema_pragma_file(self):

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -28,7 +28,6 @@ For documentation, see mocksupport.rst.
 from __future__ import absolute_import, print_function
 
 import os
-import warnings
 import time
 import re
 from xml.dom import minidom
@@ -51,7 +50,7 @@ from ._providerregistry import ProviderRegistry
 
 from ._providerdispatcher import ProviderDispatcher
 
-from ._dmtf_cim_schema import DMTFCIMSchema, build_schema_mof
+from ._dmtf_cim_schema import build_schema_mof
 from ._utils import _uprint
 
 from ._namespaceprovider import CIMNamespaceProvider
@@ -678,112 +677,6 @@ class FakedWBEMConnection(WBEMConnection):
                                 namespace=namespace,
                                 search_paths=search_paths,
                                 verbose=verbose)
-
-    def compile_dmtf_schema(self, schema_version, schema_root_dir, class_names,
-                            use_experimental=False, namespace=None,
-                            verbose=False):
-        # pylint: disable:line-too-long
-        """
-        Compile the classes defined by `class_names` and their
-        dependent classes from the CIM schema version defined by
-        `schema_version`. If the DMTF schema defined by
-        `schema_version` is not installed in path `schema_root_dir`
-        it is first downloaded from the DMTF and installed in that directory.
-
-        **Deprecated:** This method has been deprecated in pywbem 1.0.0
-        in favor of :meth:`compile_schema_classes`.
-
-        This method uses the :class:`~pywbem_mock.DMTFCIMSchema` class to
-        download the DMTF CIM schema defined by `schema_version` from the DMTF,
-        into the `schema_root_dir` directory, extract the MOF files, create a
-        MOF file with the `#include pragma` statements for the files in
-        `schema_class_names`.
-
-        It automatically compiles all of the DMTF qualifier declarations that
-        are in the files `qualifiers.mof` and `qualifiers_optional.mof`.
-
-        The result of the compilation is added to the specified CIM namespace
-        of the mock repository.
-
-        If the namespace does not exist, :exc:`~pywbem.CIMError` with status
-        CIM_ERR_INVALID_NAMESPACE is raised.
-
-        Parameters:
-
-          schema_version (tuple of 3 integers (m, n, u):
-            Represents the DMTF CIM schema version where:
-
-            * m is the DMTF CIM schema major version
-            * n is the DMTF CIM schema minor version
-            * u is the DMTF CIM schema update version
-
-            This must represent a DMTF CIM schema that is available from the
-            DMTF web site.
-
-          schema_root_dir (:term:`string`):
-            Directory into which the DMTF CIM schema is installed or will be
-            installed.  A single `schema_dir` can be used for multiple
-            schema versions because subdirectories are uniquely defined by
-            schema version and schema_type (i.e. Final or Experimental).
-
-            Multiple DMTF CIM schemas may be maintained in the same
-            `schema_root_dir` simultaneously because the MOF for each schema is
-            extracted into a subdirectory identified by the schema version
-            information.
-
-          class_names (:term:`py:list` of :term:`string` or :term:`string`):
-            List of class names from the DMTF CIM Schema to be included in the
-            MOF compile and inserted into the CIM repository.
-
-            A single class may be defined as a single string.
-
-            These must be classes in the defined DMTF CIM schema and can be a
-            list of just the leaf classes required The MOF compiler will search
-            the DMTF CIM schema MOF classes for superclasses, classes defined
-            in reference properties, and classes defined in EmbeddedInstance
-            qualifiers  and compile them also.
-
-            This parameter corresponds to the `schema_classnames` parameter in
-            the method `compile_schema_classes`.
-
-          use_experimental (:class:`py:bool`):
-            If `True` the expermental version of the DMTF CIM Schema
-            is installed or to be installed.
-
-            If `False` (default) the final version of the DMTF
-            CIM Schema is installed or to be installed.
-
-          namespace (:term:`string`):
-            The name of the target CIM namespace in the mock repository. This
-            namespace is also used for lookup of any existing or dependent
-            CIM objects. If `None`, the default namespace of the connection is
-            used.
-
-          verbose (:class:`py:bool`):
-            If `True`, progress messages are output to stdout
-
-        Raises:
-
-          ValueError: The schema cannot be retrieved from the DMTF web
-            site, the schema_version is invalid, or a class name cannot
-            be found in the defined DMTF CIM schema.
-          TypeError: The 'schema_version' is not a valid tuple with 3
-            integer components
-          :exc:`~pywbem.MOFCompileError`: Compile error in the MOF.
-        """  # noqa: E501
-        # pylint: enable:line-too-long
-
-        warnings.warn(
-            "Method pywbem_mock.FakedWBEMConnection.compile_dmtf_schema() is "
-            "deprecated; it will be removed in a future pywbem release. "
-            "Use compile_schema_classes() instead",
-            DeprecationWarning, stacklevel=2)
-
-        schema = DMTFCIMSchema(schema_version, schema_root_dir,
-                               use_experimental=use_experimental,
-                               verbose=verbose)
-        self.compile_schema_classes(class_names, schema.schema_pragma_file,
-                                    verbose=verbose)
 
     ######################################################################
     #

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1857,9 +1857,6 @@ class TestRepoMethods(object):
         assert conn.cimrepository.get_qualifier_store(ns).len() == \
             TOTAL_QUALIFIERS
 
-    @ pytest.mark.parametrize(
-        # Test use of both compile_dmtf_schema and compile_schema_classes
-        "use_compile_dmtf_schema", [True, False])
     @pytest.mark.parametrize(
         # Description - Description of the test
         # classnames - List of classnames to compile
@@ -2027,13 +2024,11 @@ class TestRepoMethods(object):
              True],
         ]
     )
-    def test_compile_partial_dmtf_schema(self, conn, use_compile_dmtf_schema,
-                                         description, classnames,
-                                         extra_exp_classnames, exp_class,
-                                         run_tst):
+    def test_compile_schema_classes(self, conn, description, classnames,
+                                    extra_exp_classnames, exp_class, run_tst):
         # pylint: disable=no-self-use,unused-argument
         """
-        Test Compiling DMTF CIM schema using the compile_dmtf_schema method.
+        Test Compiling DMTF CIM schema using the compile_schema_classes method.
         Optionally compare one of the returned classes against the
         class defined in exp_class.  This test is specifically to assure
         that things like propagated, etc. are correct as compiled and
@@ -2045,18 +2040,12 @@ class TestRepoMethods(object):
         skip_if_moftab_regenerated()
 
         ns = 'root/cimv2'
-        if use_compile_dmtf_schema:
-            conn.compile_dmtf_schema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
-                                     class_names=classnames,
-                                     verbose=True)
+        schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
+                               verbose=True)
 
-        else:  # use compile_schema_classes
-            schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, TESTSUITE_SCHEMA_DIR,
-                                   verbose=True)
-
-            conn.compile_schema_classes(classnames,
-                                        schema.schema_pragma_file,
-                                        verbose=True)
+        conn.compile_schema_classes(classnames,
+                                    schema.schema_pragma_file,
+                                    verbose=True)
 
         # Test the set of created classnames for match to exp_classnames
         exp_classnames = classnames
@@ -6596,10 +6585,6 @@ class TestDMTFCIMSchema(object):
         assert os.path.isdir(schema.schema_mof_dir)
         assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
-        # deprecated property schema_mof_file. These tests will be removed
-        # when that property is removed in the future
-        assert os.path.isfile(schema.schema_mof_file)
-        assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
@@ -6649,12 +6634,8 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '%s.%s.%s' % DMTF_TEST_SCHEMA_VER
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
-        # deprecated property
-        assert os.path.isfile(schema.schema_mof_file)
         assert os.path.isfile(schema.schema_pragma_file)
         assert os.path.isfile(schema.schema_zip_file)
-        # schema_mof_file is deprecated
-        assert schema.schema_mof_file == schema.schema_pragma_file
 
         mof_dir = 'mofFinal%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(test_schema_root_dir, mof_dir)
@@ -6702,8 +6683,6 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '%s.%s.%s' % DMTF_TEST_SCHEMA_VER
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
-        # This property is deprecated
-        assert os.path.isfile(schema.schema_mof_file)
         assert schema.schema_root_dir == TESTSUITE_SCHEMA_DIR
         mof_dir = 'mofExperimental%s' % schema.schema_version_str
         test_schema_mof_dir = os.path.join(TESTSUITE_SCHEMA_DIR, mof_dir)
@@ -6716,8 +6695,6 @@ class TestDMTFCIMSchema(object):
         # remove the second schema and test to be sure removed.
         schema.remove()
         assert not os.path.isdir(test_schema_mof_dir)
-        # deprecated
-        assert not os.path.isfile(schema.schema_mof_file)
         assert not os.path.isfile(schema.schema_pragma_file)
         assert os.path.isdir(schema.schema_root_dir)
 
@@ -6736,8 +6713,6 @@ class TestDMTFCIMSchema(object):
         assert schema.schema_version_str == '2.50.0'
         assert os.path.isdir(schema.schema_root_dir)
         assert os.path.isdir(schema.schema_mof_dir)
-        # deprecated
-        assert os.path.isfile(schema.schema_mof_file)
 
         assert schema.schema_root_dir == TESTSUITE_SCHEMA_DIR
         mof_dir = 'mofFinal%s' % schema.schema_version_str


### PR DESCRIPTION
This removes the `compile_dmtf_schema()` method and `schema_mof_file` property that were deprecated in 1.0.0b1.
For details, see the commit message.
Please review for inclusion into 1.0.0 final (i.e. not into potential further beta versions).
If approved, the merging of this PR needs to wait until we are sure that there are no more beta versions before 1.0.0 final.