### PR TITLE
Fixes #2291: refactor base provider

### DIFF
--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -1002,8 +1002,9 @@ The following is an example of a method provider:
                             "namespace {1!A}", classname, namespace))
 
             if isinstance(ObjectName, CIMInstanceName):
-                instance_store = self.get_instance_store(namespace)
-                inst = self.find_instance(objectname, instance_store,
+                instance_store = self.cimrepository.get_instance_store(
+                    namespace)
+                inst = self.get_bare_instance(objectname, instance_store,
                                           copy=False)
                 if inst is None:
                     raise CIMError(

--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -62,9 +62,9 @@ class BaseProvider(object):
           cimrepository (:class:`~pywbem_mock.BaseRepository` or subclass):
             Defines the repository to be used by request responders.  The
             repository is fully initialized but contains only objects defined
-            by the :class:`pywbem_mock/FakedWbemConnection` methods that
+            by the :class:`~pywbem_mock.FakedWbemConnection` methods that
             create objects in the repository
-            (ex. :meth:`pywbem_mock/FakedWbemConnection.compile_file`)
+            (ex. :meth:`~pywbem_mock.FakedWbemConnection.compile_file`)
         """
         self._cimrepository = cimrepository
 
@@ -83,13 +83,13 @@ class BaseProvider(object):
         The CIM repository is the data store for CIM classes, CIM
         instances, and CIM qualifier declarations.  All access to the mocker
         CIM data must pass through this variable to the CIM repository.
-        See :class:`pywbem_mock/BaseRepository` for a description of
+        See :class:`~pywbem_mock.BaseRepository` for a description of
         the repository interface.
 
         The mocker may use subclasses of  :class:`~pywbem_mock.BaseRepository`
         for specific functionality.  Thus, :class:`~pywbem.InMemoryRepository`
         implements an InMemory CIM repository that must be initialized for
-        each :class:`pywbem_mock/FakedWbemConnection` construction.
+        each :class:`~pywbem_mock.FakedWbemConnection` construction.
         """
         return self._cimrepository
 

--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -169,7 +169,6 @@ A user-defined instance provider can be created as follows:
         provider = MyCIM_BlanInstanceWriteProvider(self.cimrepository)
         conn.register_provider(provider,
                                namespaces=['root/interop', 'root/cimv2'])
-
 """
 
 from __future__ import absolute_import, print_function
@@ -342,7 +341,7 @@ class InstanceWriteProvider(BaseProvider):
         new_instance = NewInstance
 
         self.validate_namespace(namespace)
-        instance_store = self.get_instance_store(namespace)
+        instance_store = self.cimrepository.get_instance_store(namespace)
 
         # Requires corresponding class to build path to be returned
         target_class = self.get_class(namespace,
@@ -468,7 +467,7 @@ class InstanceWriteProvider(BaseProvider):
         # get the namespace from the Modified instance
         namespace = ModifiedInstance.path.namespace
 
-        instance_store = self.get_instance_store(namespace)
+        instance_store = self.cimrepository.get_instance_store(namespace)
         modified_instance = deepcopy(ModifiedInstance)
 
         # Return if empty property list, nothing would be changed
@@ -495,9 +494,9 @@ class InstanceWriteProvider(BaseProvider):
 
         # Get original instance in datastore.
         # Copy because it will be modified.
-        orig_instance = self.find_instance(modified_instance.path,
-                                           instance_store,
-                                           copy=True)
+        orig_instance = self.get_bare_instance(modified_instance.path,
+                                               instance_store,
+                                               copy=True)
         if orig_instance is None:
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
@@ -642,7 +641,8 @@ class InstanceWriteProvider(BaseProvider):
             :exc:`~pywbem.CIMError`: (CIM_ERR_NOT_FOUND)
         """
 
-        instance_store = self.get_instance_store(InstanceName.namespace)
+        instance_store = self.cimrepository.get_instance_store(
+            InstanceName.namespace)
 
         # Handle namespace deletion, currently hard coded.
         # Issue #2062 TODO/AM 8/18 Generalize the hard coded handling into

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -401,7 +401,8 @@ class MainProvider(BaseProvider, ResolverMixin):
         """  # noqa: E501
         # pylint: enable=line-too-long
 
-        rtn_inst = self.find_instance(instance_name, instance_store, copy=True)
+        rtn_inst = self.get_bare_instance(instance_name, instance_store,
+                                          copy=True)
 
         if rtn_inst is None:
             raise CIMError(
@@ -1851,7 +1852,7 @@ class MainProvider(BaseProvider, ResolverMixin):
         # Get associated instance names
         rtn_instpaths = set()
         for ref_path in ref_paths:
-            inst = self.find_instance(ref_path, instance_store)
+            inst = self.get_bare_instance(ref_path, instance_store)
             for prop in six.itervalues(inst.properties):
                 if prop.type == 'reference':
                     if prop.value == inst_name:

--- a/pywbem_mock/_namespaceprovider.py
+++ b/pywbem_mock/_namespaceprovider.py
@@ -268,7 +268,8 @@ class CIMNamespaceProvider(InstanceWriteProvider):
         self.remove_namespace(remove_namespace)
 
         # Delete the instance from the CIM repository
-        instance_store = self.get_instance_store(InstanceName.namespace)
+        instance_store = self.cimrepository.get_instance_store(
+            InstanceName.namespace)
         instance_store.delete(InstanceName)
 
     def post_register_setup(self, conn):
@@ -285,7 +286,6 @@ class CIMNamespaceProvider(InstanceWriteProvider):
 
         1. Inserts instances of CIM_Namespace for every namespace in the
            CIM repository.
-
         """
         assert self.installed is False
 

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -183,11 +183,11 @@ class ProviderDispatcher(BaseProvider):
                         namespace))
 
         # Test original instance exists.
-        instance_store = self.get_instance_store(namespace)
+        instance_store = self.cimrepository.get_instance_store(namespace)
         # Do not copy because not modified or passed on
-        orig_instance = self.find_instance(ModifiedInstance.path,
-                                           instance_store,
-                                           copy=False)
+        orig_instance = self.get_bare_instance(ModifiedInstance.path,
+                                               instance_store,
+                                               copy=False)
         if orig_instance is None:
             raise CIMError(
                 CIM_ERR_NOT_FOUND,
@@ -236,7 +236,7 @@ class ProviderDispatcher(BaseProvider):
                         "Cannot delete instance {2!A}",
                         InstanceName.classname, namespace, InstanceName))
 
-        instance_store = self.get_instance_store(namespace)
+        instance_store = self.cimrepository.get_instance_store(namespace)
         if not instance_store.object_exists(InstanceName):
             raise CIMError(
                 CIM_ERR_NOT_FOUND,

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -253,13 +253,13 @@ class FakedWBEMConnection(WBEMConnection):
     @property
     def cimrepository(self):
         """
-        :class:`~pywbem.InMemoryRepository`: CIM instance of class
-        `InMemoryRepository`  that represents the CIM repository instance.
+        :class:`~pywbem.InMemoryRepository`: Instance of class
+        `InMemoryRepository`  that represents the CIM repository.
 
-        The CIM repository instance  is the data store for CIM classes, CIM
+        The CIM repository instance is the data store for CIM classes, CIM
         instances, and CIM qualifier declarations.  All access to the mocker
         CIM data must pass through this variable to the CIM repository.
-        See :class:`pywbem_mock/InmemoryRepository` for a description of
+        See :class:`pywbem_mock/BaseRepository` for a description of
         the repository interface.
         """
         if self._cimrepository is None:
@@ -883,8 +883,8 @@ class FakedWBEMConnection(WBEMConnection):
                     self.cimrepository.get_instance_store(namespace)
                 try:
                     # pylint: disable=protected-access
-                    if self._mainprovider.find_instance(inst.path,
-                                                        instance_store):
+                    if self._mainprovider.get_bare_instance(inst.path,
+                                                            instance_store):
                         raise ValueError(
                             _format("The instance {0!A} already exists in "
                                     "namespace {1!A}", inst, namespace))

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -259,7 +259,7 @@ class FakedWBEMConnection(WBEMConnection):
         The CIM repository instance is the data store for CIM classes, CIM
         instances, and CIM qualifier declarations.  All access to the mocker
         CIM data must pass through this variable to the CIM repository.
-        See :class:`pywbem_mock/BaseRepository` for a description of
+        See :class:`~pywbem_mock.BaseRepository` for a description of
         the repository interface.
         """
         if self._cimrepository is None:

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -484,7 +484,7 @@ class TestAliases(MOFTest):
         };
         """
 
-        def find_instance(path, repo):
+        def confirm_instance_path(path, repo):
             """Local method confirms paths found for all created instances."""
             for inst in repo:
                 if inst.path == path:
@@ -525,7 +525,7 @@ class TestAliases(MOFTest):
         ]
 
         for path in exp_paths:
-            self.assertTrue(find_instance(path, instances))
+            self.assertTrue(confirm_instance_path(path, instances))
 
 
 class TestSchemaError(MOFTest):

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1256,9 +1256,8 @@ class TestRepoMethods(object):
             ['CIM_Foo_sub', 'CIM_Foo_sub99', False],
         ]
     )
-    def test_find_instance(self, conn, tst_classeswqualifiers, tst_instances,
-                           tst_instances_mof, ns, mof,
-                           cln, key, exp_ok):
+    def test_get_bare_instance(self, conn, tst_classeswqualifiersandinsts,
+                               tst_instances_mof, ns, mof, cln, key, exp_ok):
         # pylint: disable=no-self-use
         """
         Test the find instance repo method with both compiled and add
@@ -1268,8 +1267,7 @@ class TestRepoMethods(object):
             skip_if_moftab_regenerated()
             conn.compile_mof_string(tst_instances_mof, namespace=ns)
         else:
-            conn.add_cimobjects(tst_classeswqualifiers, namespace=ns)
-            conn.add_cimobjects(tst_instances, namespace=ns)
+            add_objects_to_repo(conn, ns, tst_classeswqualifiersandinsts)
 
         instance_store = conn.cimrepository.get_instance_store(ns)
 
@@ -1278,7 +1276,7 @@ class TestRepoMethods(object):
                                 namespace=ns)
 
         # pylint: disable=protected-access
-        inst = conn._mainprovider.find_instance(iname, instance_store)
+        inst = conn._mainprovider.get_bare_instance(iname, instance_store)
 
         if exp_ok:
             assert isinstance(inst, CIMInstance)
@@ -6292,7 +6290,8 @@ class Method1TestProvider(MethodProvider):
 
         if isinstance(ObjectName, CIMInstanceName):
             instance_store = self.cimrepository.get_instance_store(namespace)
-            inst = self.find_instance(ObjectName, instance_store, copy=False)
+            inst = self.get_bare_instance(ObjectName, instance_store,
+                                          copy=False)
             if inst is None:
                 raise CIMError(
                     CIM_ERR_NOT_FOUND,


### PR DESCRIPTION
Refactor issues documented in issue # 2291 as follows:

* cimrepository attribute: Change to define as a property  in
BaseProvider with documentation

* find_instance() method: Changed method name to get_bare_instance()

* find_interop_namespace() method: No change.  See issue for comments.

* get_instance_store() method and get_qualifier_store method: Removed
them both and modified tests and examples to show difference.