### PR TITLE
0.17: Improved support for array-typed elements in ValueMapping

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,10 +17,13 @@ funcsigs>=1.0.2; python_version < '3.3'
 unittest2>=1.1.0; python_version == '2.6'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=3.1.0,<3.3.0; python_version == '2.6'
+pytest>=3.2.0,<3.3.0; python_version == '2.6'
 pytest>=4.3.1,<5.0.0; python_version > '2.6' and python_version < '3.5'
 pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
 pytest>=4.4.0; python_version >= '3.7'
+# py version is determined by pytest:
+py>=1.4.34,<1.5; python_version == '2.6'
+py>=1.5.1; python_version > '2.6'
 # testfixtures 6.0.0 no longer supports py26 and fails on py26 with syntax error
 testfixtures>=4.3.3,<6.0.0; python_version == '2.6'
 testfixtures>=6.9.0; python_version > '2.6'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Added support for array-typed elements to pywbem.ValueMapping.
+  (See issue #2304)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,11 @@ Released: not yet
 
 **Bug fixes:**
 
+* On Python 2.6, increased minimum versions of pytest from 3.1.0 to 3.2.0, and
+  of py from 1.4.32 to 1.4.34, in order for ValueMapping tests not to catch the
+  pytest Skipped exception.
+  (Related to issue #2304)
+
 **Enhancements:**
 
 * Added support for array-typed elements to pywbem.ValueMapping.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -115,9 +115,12 @@ typing==3.6.1  # from M2Crypto
 packaging==16.6
 funcsigs==1.0.2; python_version < '3.3'
 unittest2==1.1.0; python_version == '2.6'
-pytest==3.1.0; python_version == '2.6'
+pytest==3.2.0; python_version == '2.6'
 pytest==4.3.1; python_version >= '2.7' and python_version <= '3.6'
 pytest==4.4.0; python_version >= '3.7'
+# py version is determined by pytest:
+py==1.4.34; python_version == '2.6'
+py==1.5.1; python_version > '2.6'
 testfixtures==4.3.3; python_version == '2.6'
 testfixtures==6.9.0; python_version > '2.6'
 httpretty==0.8.14; python_version == '2.6'
@@ -262,9 +265,6 @@ pickleshare==0.7.4
 pkginfo==1.4.1
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
-# py version is determined by pytest:
-py==1.4.32; python_version == '2.6'
-py==1.5.1; python_version > '2.6'
 pyzmq==16.0.4
 qtconsole==4.2.1
 requests-toolbelt==0.7.0

--- a/tests/unittest/pywbem/test_valuemapping.py
+++ b/tests/unittest/pywbem/test_valuemapping.py
@@ -51,6 +51,15 @@ def element_kind(request):
 
 
 @pytest.fixture(params=[
+    False,
+    True,
+], scope='module')
+def is_array(request):
+    """Fixture controlling whether the CIM element is scalar or array"""
+    return request.param
+
+
+@pytest.fixture(params=[
     'server',
     'conn',
 ], scope='module')
@@ -71,12 +80,14 @@ class Test_ValueMapping(object):
         # pylint: disable=attribute-defined-outside-init
         self.server = WBEMServer(self.conn)
 
-    def setup_for_property(self, server, type_, valuemap, values):
+    def setup_for_property(self, server, integer_type, is_array,
+                           valuemap, values):
         """
         Return a new ValueMapping object that is set up for a CIM property
         with the specified data type and valuemap and values qualifiers.
         """
-        test_prop = CIMProperty(PROPNAME, value=None, type=type_)
+        test_prop = CIMProperty(PROPNAME, value=None, type=integer_type,
+                                is_array=is_array)
         if valuemap is not None:
             test_prop.qualifiers['ValueMap'] = \
                 CIMQualifier('ValueMap', valuemap, 'string')
@@ -90,12 +101,15 @@ class Test_ValueMapping(object):
         vm = ValueMapping.for_property(server, NAMESPACE, CLASSNAME, PROPNAME)
         return vm
 
-    def setup_for_method(self, server, type_, valuemap, values):
+    def setup_for_method(self, server, integer_type, is_array,
+                         valuemap, values):
         """
         Return a new ValueMapping object that is set up for a CIM method
         with the specified data type and valuemap and values qualifiers.
         """
-        test_meth = CIMMethod(METHNAME, return_type=type_)
+        if is_array:
+            pytest.skip("CIM methods cannot return arrays")
+        test_meth = CIMMethod(METHNAME, return_type=integer_type)
         if valuemap is not None:
             test_meth.qualifiers['ValueMap'] = \
                 CIMQualifier('ValueMap', valuemap, 'string')
@@ -109,12 +123,13 @@ class Test_ValueMapping(object):
         vm = ValueMapping.for_method(server, NAMESPACE, CLASSNAME, METHNAME)
         return vm
 
-    def setup_for_parameter(self, server, type_, valuemap, values):
+    def setup_for_parameter(self, server, integer_type, is_array,
+                            valuemap, values):
         """
         Return a new ValueMapping object that is set up for a CIM parameter
         with the specified data type and valuemap and values qualifiers.
         """
-        test_parm = CIMParameter(PARMNAME, type=type_)
+        test_parm = CIMParameter(PARMNAME, type=integer_type, is_array=is_array)
         if valuemap is not None:
             test_parm.qualifiers['ValueMap'] = \
                 CIMQualifier('ValueMap', valuemap, 'string')
@@ -131,8 +146,8 @@ class Test_ValueMapping(object):
                                         PARMNAME)
         return vm
 
-    def setup_for_element(self, element_kind, server_arg, type_, valuemap,
-                          values):
+    def setup_for_element(self, element_kind, server_arg, integer_type,
+                          is_array, valuemap, values):
         # pylint: disable=redefined-outer-name
         """
         Return a new ValueMapping object that is set up for a CVIM element of
@@ -143,7 +158,7 @@ class Test_ValueMapping(object):
         setup_func_name = 'setup_for_%s' % element_kind
         setup_func = getattr(self, setup_func_name)
 
-        vm = setup_func(server, type_, valuemap, values)
+        vm = setup_func(server, integer_type, is_array, valuemap, values)
 
         return vm
 
@@ -171,26 +186,26 @@ class Test_ValueMapping(object):
         assert re.match(".*outside of the set defined by its Values "
                         "qualifier.*", exc_msg) is not None
 
-    def test_empty(self, element_kind, server_arg, integer_type):
+    def test_empty(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test empty ValueMapping"""
         valuemap = []
         values = []
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, 0)
         self.assertOutsideValues(vm, 'x')
 
-    def test_attrs_property(self, server_arg, integer_type):
+    def test_attrs_property(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM property"""
         valuemap = ['42']
         values = ['forty-two']
 
         vm = self.setup_for_element('property', server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.conn is self.conn
 
@@ -205,14 +220,14 @@ class Test_ValueMapping(object):
         assert prop.name == PROPNAME
         assert prop.type == integer_type
 
-    def test_attrs_method(self, server_arg, integer_type):
+    def test_attrs_method(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM method"""
         valuemap = ['42']
         values = ['forty-two']
 
         vm = self.setup_for_element('method', server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.conn is self.conn
 
@@ -227,14 +242,14 @@ class Test_ValueMapping(object):
         assert meth.name == METHNAME
         assert meth.return_type == integer_type
 
-    def test_attrs_parameter(self, server_arg, integer_type):
+    def test_attrs_parameter(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM parameter"""
         valuemap = ['42']
         values = ['forty-two']
 
         vm = self.setup_for_element('parameter', server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.conn is self.conn
 
@@ -249,14 +264,14 @@ class Test_ValueMapping(object):
         assert parm.name == PARMNAME
         assert parm.type == integer_type
 
-    def test_repr(self, element_kind, server_arg, integer_type):
+    def test_repr(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test ValueMapping.__repr__()"""
         valuemap = ['1']
         values = ['one']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         r = repr(vm)
 
@@ -288,7 +303,7 @@ class Test_ValueMapping(object):
         # We don't check the internal data attributes.
 
     def test_invalid_valuemap_format(self, element_kind, server_arg,
-                                     integer_type):
+                                     integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test invalid ValueMap format"""
         valuemap = ['0x']
@@ -296,7 +311,7 @@ class Test_ValueMapping(object):
 
         with pytest.raises(Exception) as exc_info:
             self.setup_for_element(element_kind, server_arg, integer_type,
-                                   valuemap, values)
+                                   is_array, valuemap, values)
         exc = exc_info.value
         assert isinstance(exc, ValueError)
         exc_msg = exc.args[0]
@@ -304,7 +319,7 @@ class Test_ValueMapping(object):
                         "ValueMap entry.*",
                         exc_msg) is not None
 
-    def test_invalid_element_type(self, element_kind, server_arg):
+    def test_invalid_element_type(self, element_kind, server_arg, is_array):
         # pylint: disable=redefined-outer-name
         """Test invalid type for the element"""
         valuemap = ['0']
@@ -312,7 +327,7 @@ class Test_ValueMapping(object):
 
         with pytest.raises(Exception) as exc_info:
             self.setup_for_element(element_kind, server_arg, 'string',
-                                   valuemap, values)
+                                   is_array, valuemap, values)
         exc = exc_info.value
         assert isinstance(exc, TypeError)
         exc_msg = exc.args[0]
@@ -320,14 +335,14 @@ class Test_ValueMapping(object):
                         exc_msg) is not None
 
     def test_invalid_tovalues_type(self, element_kind, server_arg,
-                                   integer_type):
+                                   integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test tovalues() with invalid type"""
         valuemap = ['0']
         values = ['zero']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         with pytest.raises(Exception) as exc_info:
             vm.tovalues('0')
@@ -338,14 +353,14 @@ class Test_ValueMapping(object):
                         exc_msg) is not None
 
     def test_invalid_tobinary_type(self, element_kind, server_arg,
-                                   integer_type):
+                                   integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test tobinary() with invalid type"""
         valuemap = ['0']
         values = ['zero']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         with pytest.raises(Exception) as exc_info:
             vm.tobinary(0)
@@ -355,7 +370,8 @@ class Test_ValueMapping(object):
         assert re.match(".*is not string-typed.*",
                         exc_msg) is not None
 
-    def test_no_values_qualifier(self, element_kind, server_arg, integer_type):
+    def test_no_values_qualifier(self, element_kind, server_arg, integer_type,
+                                 is_array):
         # pylint: disable=redefined-outer-name
         """Test element without Values qualifier"""
         valuemap = ['0']
@@ -363,14 +379,15 @@ class Test_ValueMapping(object):
 
         with pytest.raises(Exception) as exc_info:
             self.setup_for_element(element_kind, server_arg, integer_type,
-                                   valuemap, values)
+                                   is_array, valuemap, values)
         exc = exc_info.value
         assert isinstance(exc, ValueError)
         exc_msg = exc.args[0]
         assert re.match(".*has no Values qualifier defined.*",
                         exc_msg) is not None
 
-    def test_valuemap_default(self, element_kind, server_arg, integer_type):
+    def test_valuemap_default(self, element_kind, server_arg, integer_type,
+                              is_array):
         # pylint: disable=redefined-outer-name
         """Test default if no ValueMap qualifier is defined"""
         valuemap = None
@@ -378,7 +395,7 @@ class Test_ValueMapping(object):
         values = ['zero', 'one', 'two']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, -1)
         assert vm.tovalues(0) == 'zero'
@@ -397,7 +414,7 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_zero(self, element_kind, server_arg, integer_type):
+    def test_zero(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 0"""
         valuemap = ['0']
@@ -405,7 +422,7 @@ class Test_ValueMapping(object):
         values = ['zero']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'zero'
         self.assertOutsideValueMap(vm, 1)
@@ -419,7 +436,7 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_one(self, element_kind, server_arg, integer_type):
+    def test_one(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 1"""
         valuemap = ['1']
@@ -427,7 +444,7 @@ class Test_ValueMapping(object):
         values = ['one']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, 0)
         assert vm.tovalues(1) == 'one'
@@ -443,31 +460,32 @@ class Test_ValueMapping(object):
         assert items == exp_items
 
     def test_tovalues_with_cimtype(self, element_kind, server_arg,
-                                   integer_type):
+                                   integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test tovalues() with argument of CIM type"""
         valuemap = ['1']
         values = ['one']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         cimtype = type_from_name(integer_type)
         assert vm.tovalues(cimtype(1)) == 'one'
 
     def test_tobinary_with_unicode(self, element_kind, server_arg,
-                                   integer_type):
+                                   integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test tobinary() with argument unicode string"""
         valuemap = ['1']
         values = ['one']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tobinary(u'one') == 1
 
-    def test_singles(self, element_kind, server_arg, integer_type):
+    def test_singles(self, element_kind, server_arg, integer_type,
+                     is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with multiple non-range values"""
         valuemap = ['0', '1', '9']
@@ -475,7 +493,7 @@ class Test_ValueMapping(object):
         values = ['zero', 'one', 'nine']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'zero'
         assert vm.tovalues(1) == 'one'
@@ -495,7 +513,8 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_singles_ranges(self, element_kind, server_arg, integer_type):
+    def test_singles_ranges(self, element_kind, server_arg, integer_type,
+                            is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with ranges"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9']
@@ -503,7 +522,7 @@ class Test_ValueMapping(object):
         values = ['zero', 'one', 'two-four', 'five-six', 'seven-eight', 'nine']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'zero'
         assert vm.tovalues(1) == 'one'
@@ -531,7 +550,8 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_unclaimed(self, element_kind, server_arg, integer_type):
+    def test_unclaimed(self, element_kind, server_arg, integer_type,
+                       is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with unclaimed marker '..'"""
         valuemap = ['..']
@@ -539,7 +559,7 @@ class Test_ValueMapping(object):
         values = ['unclaimed']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'unclaimed'
         assert vm.tovalues(1) == 'unclaimed'
@@ -554,7 +574,7 @@ class Test_ValueMapping(object):
         assert items == exp_items
 
     def test_singles_ranges_unclaimed(self, element_kind, server_arg,
-                                      integer_type):
+                                      integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with combination of singles, ranges, unclaimed"""
         valuemap = ['0', '1', '2..4', '..6', '7..', '9', '..']
@@ -563,7 +583,7 @@ class Test_ValueMapping(object):
                   'unclaimed']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'zero'
         assert vm.tovalues(1) == 'one'
@@ -593,7 +613,7 @@ class Test_ValueMapping(object):
         assert items == exp_items
 
     def test_singles_ranges_unclaimed2(self, element_kind, server_arg,
-                                       integer_type):
+                                       integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test singles, ranges, unclaimed"""
         valuemap = ['0', '2..4', '..6', '7..', '9', '..']
@@ -602,7 +622,7 @@ class Test_ValueMapping(object):
                   'unclaimed']
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         assert vm.tovalues(0) == 'zero'
         assert vm.tovalues(1) == 'unclaimed'  # '..' fills this gap
@@ -630,7 +650,8 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_min_max_single(self, element_kind, server_arg, integer_type):
+    def test_min_max_single(self, element_kind, server_arg, integer_type,
+                            is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with single min and max values of integer type"""
 
@@ -648,7 +669,7 @@ class Test_ValueMapping(object):
             values.append('val %s' % v)
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, minvalue - 1)
         assert vm.tovalues(minvalue) == values[0]
@@ -669,7 +690,7 @@ class Test_ValueMapping(object):
         assert items == exp_items
 
     def test_min_max_closed_ranges(self, element_kind, server_arg,
-                                   integer_type):
+                                   integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with two closed ranges at min and max of int type"""
 
@@ -687,7 +708,7 @@ class Test_ValueMapping(object):
             values.append('val %s' % v)
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, minvalue - 1)
         assert vm.tovalues(minvalue) == values[0]
@@ -711,7 +732,8 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_min_max_open_range1(self, element_kind, server_arg, integer_type):
+    def test_min_max_open_range1(self, element_kind, server_arg, integer_type,
+                                 is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with open range 1 of min and max of integer type"""
 
@@ -732,7 +754,7 @@ class Test_ValueMapping(object):
             values.append('val %s' % v)
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, minvalue - 1)
         assert vm.tovalues(minvalue) == values[0]
@@ -758,7 +780,8 @@ class Test_ValueMapping(object):
             items.append(item)
         assert items == exp_items
 
-    def test_min_max_open_range2(self, element_kind, server_arg, integer_type):
+    def test_min_max_open_range2(self, element_kind, server_arg, integer_type,
+                                 is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with open range 2 of min and max of integer type"""
 
@@ -777,7 +800,7 @@ class Test_ValueMapping(object):
             values.append('val %s' % v)
 
         vm = self.setup_for_element(element_kind, server_arg, integer_type,
-                                    valuemap, values)
+                                    is_array, valuemap, values)
 
         self.assertOutsideValueMap(vm, minvalue - 1)
         assert vm.tovalues(minvalue) == values[0]
@@ -869,8 +892,9 @@ class Test_ValueMapping(object):
         testcases_integer_representations
     )
     def test_integer_representations(
-            self, desc, integer_type, values_str_list, valuemap_str_list,
-            exp_valuemap_list, exp_exc_type, exp_exc_msg_pattern, condition):
+            self, desc, integer_type, is_array, values_str_list,
+            valuemap_str_list, exp_valuemap_list, exp_exc_type,
+            exp_exc_msg_pattern, condition):
         # pylint: disable=redefined-outer-name,unused-argument
         """Test tobinary() in valuemap with different integer represent."""
 
@@ -879,7 +903,8 @@ class Test_ValueMapping(object):
 
         if exp_exc_type is None:
             vm = self.setup_for_element('property', 'conn', integer_type,
-                                        valuemap_str_list, values_str_list)
+                                        is_array, valuemap_str_list,
+                                        values_str_list)
             for i, values_str in enumerate(values_str_list):
                 exp_valuemap = exp_valuemap_list[i]
                 valuemap = vm.tobinary(values_str)
@@ -887,10 +912,43 @@ class Test_ValueMapping(object):
         else:
             with pytest.raises(exp_exc_type) as exec_info:
                 vm = self.setup_for_element('property', 'conn', integer_type,
-                                            valuemap_str_list, values_str_list)
+                                            is_array, valuemap_str_list,
+                                            values_str_list)
             if exp_exc_msg_pattern:
                 exc = exec_info.value
                 exc_msg = str(exc)
                 one_line_exc_msg = exc_msg.replace('\n', '\\n')
                 assert re.search(exp_exc_msg_pattern, one_line_exc_msg), \
                     "Unexpected exception message:\n" + exc_msg
+
+    @pytest.mark.parametrize(
+        "element_value",
+        [
+            [1, 2],
+            (1, 2),
+        ]
+    )
+    def test_tovalues_multiple_values(
+            self, element_value, element_kind, server_arg, integer_type,
+            is_array):
+        # pylint: disable=redefined-outer-name
+        """Test tovalues() with multiple element values"""
+        valuemap = ['1', '2']
+        values = ['one', 'two']
+
+        vm = self.setup_for_element(element_kind, server_arg, integer_type,
+                                    is_array, valuemap, values)
+        result = vm.tovalues(element_value)
+        assert result == ['one', 'two']
+
+    def test_tovalues_none(
+            self, element_kind, server_arg, integer_type, is_array):
+        # pylint: disable=redefined-outer-name
+        """Test tovalues() with element value of None"""
+        valuemap = ['1', '2']
+        values = ['one', 'two']
+
+        vm = self.setup_for_element(element_kind, server_arg, integer_type,
+                                    is_array, valuemap, values)
+        result = vm.tovalues(None)
+        assert result is None


### PR DESCRIPTION
This rolls back PR #2304 into 0.17.3.

An additional commit was needed to address issues specific to Python 2.6.

Note that the exception indicating a non-integer type of the CIM element is still TypeError, consistent with pre-1.0.0. In 1.0.0, this gets changed to ModelError.