### PR TITLE
Fixes #2314: slow performance for mock enumerate classes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,9 @@ Released: not yet
   1.0.0b1. This reduces the change log entries shown for 1.0.0b1 to just the
   changes relative to 0.17.2. (See issue #2303)
 
+* Fixed slow performance for EnumerateClasses operation in mock WBEM server.
+  (See issue #2314)
+
 **Enhancements:**
 
 * Added support for array-typed elements to pywbem.ValueMapping.

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -272,11 +272,11 @@ class MainProvider(BaseProvider, ResolverMixin):
 
         if classname is None:
             rtn_classnames = [
-                c.classname for c in class_store.iter_values()
+                c.classname for c in class_store.iter_values(copy=False)
                 if c.superclass is None]
         else:
             rtn_classnames = [
-                c.classname for c in class_store.iter_values()
+                c.classname for c in class_store.iter_values(copy=False)
                 if c.superclass and c.superclass.lower() == classname.lower()]
 
         # Recurse for next level of class hierarchy


### PR DESCRIPTION
Fixes issue where we were repeatedly copying from the repo rather than
just itering causing very large slowdown of enumerate classes mock
operation.

NOTE: This should have an entry in changes.rst for b2 but this commit is to master.

    fixes issue #2314, mock enumerate classes --di very slow with large sets of classes.

Marked rollback for rollback to beta2

Marked priority because it makes it impossible to use the mocker with more than about 150 classes because of the speed of EnumerateClasses.

NOTE: I did not include a specific test. I will add one before the 1.0.0 release but that will take more time and the fix works with manual tests.