### PR TITLE
Fixes #2277:  MOF compiler ignores EmbeddedObject instance property

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -73,6 +73,14 @@ Released: not yet
 * Reworked the documentation about the mock WBEM server, specifically the
   sections about user-defined providers (See issue #2290).
 
+* Enhance MOF compiler to correctly process MOF that contains instance
+  definitions with properties that have EmbeddedObject or EmbeddedInstance
+  qualifiers.  In this case, the property value is defined in the MOF as
+  a string or array of strings that compiles to a CIMInstance.  This
+  change does not compile CIMClass definitions.
+  Originally these compiled objects were passed through the compiler as 
+  strings. (See issue # 2277).
+
 **Cleanup:**
 
 * Document the TODOs in pywbem_mock and

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -578,6 +578,14 @@ def p_mp_createClass(p):
 
     ns = p.parser.target_namespace
     cc = p[1]
+
+    # Compile class invalid when in mode to compile embedded instance
+    if p.parser.embedded_objects is not None:
+        raise MOFParseError(
+            msg=_format(
+                "Invalid compile of CIMClass {0}. "
+                "Compiler in mode to compile embedded instance and"
+                "compile of other types is invalid", cc))
     try:
         fixedNS = fixedRefs = fixedSuper = False
         while not fixedNS or not fixedRefs or not fixedSuper:
@@ -785,6 +793,12 @@ def p_mp_createInstance(p):
 def p_mp_setQualifier(p):
     """mp_setQualifier : qualifierDeclaration"""
     qualdecl = p[1]
+    if p.parser.embedded_objects is not None:
+        raise MOFParseError(
+            msg=_format(
+                "Invalid compile of CIMQualifierDeclaration {0}. "
+                "Compiler in mode to compile Embedded instance and"
+                "compile of other types is invalid", qualdecl))
     ns = p.parser.target_namespace
     if p.parser.verbose:
         p.parser.log(
@@ -1738,12 +1752,13 @@ def p_instanceDeclaration(p):
             if 'EmbeddedInstance' in cprop.qualifiers:
                 allowed_types = (CIMInstance)
                 embedded_object_type = "instance"
-                # The compiler does not test if the classname
-                # in EmbeddedObject is the same or a superclass of the
-                # embedded instance classname.
+                # Issue: 2340: Extend to test with is_subclass from
+                # base repository when that is committed
+                # qclass = cprop.qualifiers['EmbeddedInstance'].value
+                # if qclass:
+                #   if not is_subclass(cprop, qclass):
+                #       raise MOFDependencyError ...
             elif 'EmbeddedObject' in cprop.qualifiers:
-                # Issue: 2340: Compiler does not support EmbeddedObject where
-                # value is class definition.
                 allowed_types = (CIMInstance)
                 embedded_object_type = "object"
 

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -172,18 +172,6 @@ class ProviderDispatcher(BaseProvider):
                             pn, prop_inst.is_array, prop_cls.is_array,
                             NewInstance.classname, namespace))
 
-            if prop_inst.embedded_object != prop_cls.embedded_object:
-                raise CIMError(
-                    CIM_ERR_INVALID_PARAMETER,
-                    _format("Property {0!A} in new instance has incorrect "
-                            "embedded_object={1!A}, but should have "
-                            "embedded_object={2!A} "
-                            "according to its creation class {3!A} in "
-                            "namespace {4!A} of the CIM repository",
-                            pn, prop_inst.embedded_object,
-                            prop_cls.embedded_object,
-                            NewInstance.classname, namespace))
-
         # The providers are guaranteed to get a deep copy of the original
         # new instance since they may update properties.
         # TODO: Consolidate this deep copy with the shallow copy in

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -78,7 +78,7 @@ class MOFTest(unittest.TestCase):
         self.mofcomp = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
-            verbose=True,
+            verbose=False,
             log_func=moflog)
 
         self.partial_schema_file = None
@@ -3009,18 +3009,23 @@ def test_embedded_object_property_compile(testcase, iid, pname, pstr, exp_dict):
         inst_mof = embed_inst_template.format(iid, pname, pstr)
 
     conn = FakedWBEMConnection()
-    conn.compile_mof_string(embedded_instance_test_mof, verbose=True)
+    conn.compile_mof_string(embedded_instance_test_mof, verbose=False)
 
-    # code to test - Compile the instance of TST_Container
+    # Code to test - Compile the instance of TST_Container defined for the test
     conn.compile_mof_string(inst_mof)
-    # Validate instance created and property value correct
-    path = CIMInstanceName("TST_Container",
-                           keybindings=dict(InstanceID=iid))
+
+    # Validate instance(s) created
+
+    path = CIMInstanceName("TST_Container", keybindings=dict(InstanceID=iid))
     rtn_inst = conn.GetInstance(path)
     rtn_property = rtn_inst.properties[pname]
+
+    # Validate returned property type and embedded_object attribute
     assert rtn_property.type == 'string'
     rtn_property_value = rtn_property.value
     assert exp_dict['EmbeddedObject'] == rtn_property.embedded_object
+
+    # Test for embedded object type, number of items, and classname
     if exp_dict['Array']:
         assert exp_dict['Size'] == len(rtn_property_value)
         for pvalue in rtn_property_value:

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-#
-
-""" Test the mof compiler against both locally defined mof and
+""" Test the mof compiler against both locally defined MOF and
     a version of the DMTF released Schema.
 """
 
@@ -9,6 +6,7 @@ from __future__ import print_function, absolute_import
 
 import os
 import unittest
+import pytest
 import re
 import six
 from ply import lex
@@ -21,18 +19,18 @@ from ...utils import skip_if_moftab_regenerated
 from ..utils.unittest_extensions import CIMObjectMixin
 from ..utils.dmtf_mof_schema_def import install_test_dmtf_schema, \
     TOTAL_QUALIFIERS, TOTAL_CLASSES
+from ..utils.pytest_extensions import simplified_test_function
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
-from pywbem._cim_operations import CIMError  # noqa: E402
 from pywbem._mof_compiler import MOFCompiler, MOFWBEMConnection, \
     MOFParseError, MOFDependencyError  # noqa: E402
 from pywbem._cim_constants import CIM_ERR_ALREADY_EXISTS, \
     CIM_ERR_INVALID_NAMESPACE, CIM_ERR_NOT_FOUND  # noqa: E402
 from pywbem._cim_obj import CIMClass, CIMProperty, CIMQualifier, \
     CIMQualifierDeclaration, CIMDateTime, CIMInstanceName  # noqa: E402
-from pywbem import _mof_compiler  # noqa: E402
+from pywbem import _mof_compiler, CIMInstance, CIMError  # noqa: E402
 from pywbem._utils import _format  # noqa: E402
 from pywbem._nocasedict import NocaseDict  # noqa: E402
 pywbem_mock = import_installed('pywbem_mock')
@@ -80,7 +78,7 @@ class MOFTest(unittest.TestCase):
         self.mofcomp = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
-            verbose=False,
+            verbose=True,
             log_func=moflog)
 
         self.partial_schema_file = None
@@ -2731,6 +2729,306 @@ class TestNamespacePragma(MOFTest):
         self.assertEqual(cl.properties['name'].type, 'string')
 
         self.assertEqual(len(repo.instances[NAME_SPACE]), 2)
+
+
+embedded_instance_test_mof = """
+
+    Qualifier Key : boolean = false,
+        Scope(property, reference),
+        Flavor(DisableOverride, ToSubclass);
+
+    Qualifier Description : string = null,
+        Scope(any),
+        Flavor(EnableOverride, ToSubclass, Translatable);
+
+    Qualifier EmbeddedInstance : string = null,
+        Scope(property, method, parameter),
+        Flavor(DisableOverride, ToSubclass);
+
+    Qualifier EmbeddedObject : boolean = false,
+        Scope(property, method, parameter),
+        Flavor(DisableOverride, ToSubclass);
+
+    class TST_Embedded1 {
+        boolean Bool1;
+
+        string Str1;
+
+            [Description ( "Recursive embed" ),
+                EmbeddedInstance ( "TST_Embedded1" )]
+        string RecursedEmbed;
+    };
+
+         [Description ("Test class that contains embedded properties")]
+    class TST_Container {
+            [Key, Description ("Key property")]
+        string InstanceID;
+
+            [Description ( "Scalar Embedded Instance Property" ),
+                EmbeddedInstance ( "TST_Embedded1" )]
+        string EmbedInstanceScalar;
+
+            [Description ( "Scalar Embedded Object Property" ),
+                EmbeddedObject]
+        string EmbedObjectScalar;
+
+            [Description ( "Array Embedded Instance Property" ),
+                EmbeddedInstance ( "TST_Embedded1" )]
+        string EmbedInstanceArray[];
+
+            [Description ( "Array Embedded Object Property" ),
+                EmbeddedObject]
+        string EmbedObjectArray[];
+    };
+
+    // See issue # 2330. EOL in embedded instance fails
+    //instance of TST_Container {
+    //    InstanceID = "AllWaysCompiled";
+    //    EmbedInstanceScalar = "instance of TST_Embedded1 {"
+    //              "Bool1 = true;"
+    //              "};";
+    //};
+"""
+
+OK = True
+RUN = True
+FAIL = False
+
+TESTCASES_EMBEDDED_OBJECT_PROP_COMPILE = [
+
+    # Testcases for EmbeddedObject Property compile tests
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * id: The value of the InstanceID property
+    #   * prname: name of the embedded instance property
+    #   * pstr: String containing mof for property
+    #   * exp_dict:
+    #           EmbeddedObject: Expected embedded_object attrribute value
+    #           Array: True if Array property
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    (
+        "Test creation of Scalar EmbeddedInstance property",
+        dict(
+            iid='TSTScalarInstance',
+            pname='EmbedInstanceScalar',
+            pstr="instance of TST_Embedded1 {"
+                 "Bool1 = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='instance',
+                Array=False,
+            ),
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test creation of EmbeddedInstance property Array type, one property",
+        dict(
+            iid='TSTArrayInstance',
+            pname='EmbedInstanceArray',
+            pstr=['instance of TST_Embedded1 {'
+                  'Bool1 = false;'
+                  '};'],
+            exp_dict=dict(
+                EmbeddedObject='instance',
+                Array=True,
+                Size=1
+            ),
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test creation of EmbeddedInstance property Array type  more props",
+        dict(
+            iid='TSTArrayInstance',
+            pname='EmbedInstanceArray',
+            pstr=["instance of TST_Embedded1 {"
+                  "Bool1 = false;"
+                  "};",
+                  "instance of TST_Embedded1 {"
+                  "Bool1 = true;"
+                  "};", ],
+            exp_dict=dict(
+                EmbeddedObject='instance',
+                Array=True,
+                Size=2
+            ),
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test creation of simple EmbeddedObject property",
+        dict(
+            iid='tst1',
+            pname='EmbedObjectScalar',
+            pstr="instance of TST_Embedded1 {"
+                 "Bool1 = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='object',
+                Array=False,
+            ),
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test for compile error in embedded instance string",
+        dict(
+            iid='tst1',
+            pname='EmbedObjectScalar',
+            pstr="instancex of TST_Embedded1 {"
+                 "Bool1 = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='object',
+                Array=False,
+            ),
+        ),
+        MOFParseError, None, OK
+    ),
+
+    (
+        "Test for Classname not found error in compile",
+        dict(
+            iid='tst1',
+            pname='EmbedObjectScalar',
+            pstr="instance of TST_NoClass {"
+                 "Bool1 = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='object',
+                Array=False,
+            ),
+        ),
+        MOFDependencyError, None, OK
+    ),
+
+    (
+        "Test for embeddedproperty not found error in compile",
+        dict(
+            iid='tst1',
+            pname='EmbedObjectScalar',
+            pstr="instancex of TST_Embedded1 {"
+                 "Bool1NotFound = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='object',
+                Array=False,
+            ),
+        ),
+        MOFParseError, None, OK
+    ),
+
+    (
+        "Test for property not found error in compile",
+        dict(
+            iid='tst1',
+            pname='EmbedObjectScalarNOTFOUND',
+            pstr="instancex of TST_Embedded1 {"
+                 "Bool1NotFound = true;"
+                 "};",
+            exp_dict=dict(
+                EmbeddedObject='object',
+                Array=False,
+            ),
+        ),
+        MOFDependencyError, None, OK
+    ),
+
+    (
+        "Test creation compile fails arrayness mismatch",
+        dict(
+            iid='TSTScalarInstanceError',
+            pname='EmbedInstanceScalar',
+            pstr=["instance of TST_Embedded1 {"
+                  "Bool1 = false;"
+                  "};",
+                  "instance of TST_Embedded1 {"
+                  "Bool1 = true;"
+                  "};", ],
+            exp_dict=dict(
+                EmbeddedObject='instance',
+                Array=False,
+            ),
+        ),
+        MOFParseError, None, OK
+    ),
+
+    (
+        "Test creation compile class fails arrayness mismatch",
+        dict(
+            iid='TSTScalarInstanceError',
+            pname='EmbedInstanceScalar',
+            pstr="class blah{"
+                  "boolean Bool1"
+                  "};",
+            exp_dict=dict(
+                EmbeddedObject='instance',
+                Array=False,
+            ),
+        ),
+        MOFParseError, None, OK
+    ),
+
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_EMBEDDED_OBJECT_PROP_COMPILE)
+@simplified_test_function
+def test_embedded_object_property_compile(testcase, iid, pname, pstr, exp_dict):
+    """OK
+    Test embedded object instances
+    """
+    # Create the instance mof from the following template of a property with
+    # embedded instance value (i.e. scalar with one string or array with
+    # multiple strings)
+    embed_inst_template = 'instance of TST_Container {{ ' \
+                          'InstanceID = {0}; ' \
+                          '{1} = {2};' \
+                          '}};'
+    if exp_dict['Array']:
+        array_strings = []
+        for strx in pstr:
+            array_strings.append('"{0}"'.format(strx))
+
+        embedd_inst_value = "{{ {0} }}".format(", ".join(array_strings))
+        inst_mof = embed_inst_template.format(iid, pname, embedd_inst_value)
+    else:
+        pstr = '"{0}"'.format(pstr)
+        inst_mof = embed_inst_template.format(iid, pname, pstr)
+
+    conn = FakedWBEMConnection()
+    conn.compile_mof_string(embedded_instance_test_mof, verbose=True)
+
+    # code to test - Compile the instance of TST_Container
+    conn.compile_mof_string(inst_mof)
+    # Validate instance created and property value correct
+    path = CIMInstanceName("TST_Container",
+                           keybindings=dict(InstanceID=iid))
+    rtn_inst = conn.GetInstance(path)
+    rtn_property = rtn_inst.properties[pname]
+    assert rtn_property.type == 'string'
+    rtn_property_value = rtn_property.value
+    assert exp_dict['EmbeddedObject'] == rtn_property.embedded_object
+    if exp_dict['Array']:
+        assert exp_dict['Size'] == len(rtn_property_value)
+        for pvalue in rtn_property_value:
+            assert isinstance(pvalue, CIMInstance)
+            assert pvalue.classname == 'TST_Embedded1'
+    else:
+        assert isinstance(rtn_property_value, CIMInstance)
+        assert rtn_property_value.classname == 'TST_Embedded1'
 
 
 if __name__ == '__main__':

--- a/tests/unittest/pywbem/testmofs/test_instance.mof
+++ b/tests/unittest/pywbem/testmofs/test_instance.mof
@@ -5,7 +5,7 @@
 #pragma include("test_types.mof")
 
 
-// TODO: Uncomment this to work on issues with embedded instance MOF
+//
 instance of EX_AllTypes as $inner
 {
     k1 = 9921;
@@ -46,8 +46,9 @@ instance of EX_AllTypes as $outer
     pc    = 'a';
     pb    = true;
     pdt   = "20160409061213.123456+120";
-//    peo   = $inner;
-//    pei   = $inner;
+    // TODO add the peo and pe1 EmbeddedInstance and EmbeddedObject
+    // values to to this test mof. That means creating a string definition
+    // based on the instance of Ex_AllTypes as $inner below.
 };
 
 instance of EX_AllTypes as $values1

--- a/tests/unittest/pywbem/testmofs/test_instance.mof
+++ b/tests/unittest/pywbem/testmofs/test_instance.mof
@@ -5,7 +5,7 @@
 #pragma include("test_types.mof")
 
 
-// TODO: Uncomment this to work on issues with instance MOF
+// TODO: Uncomment this to work on issues with embedded instance MOF
 instance of EX_AllTypes as $inner
 {
     k1 = 9921;


### PR DESCRIPTION
WARNING: This removes code in providerdispatcher that compares cls.embedded_object with instance.embedded_object.

LIMITATIONS;

1. Does not handle embedded class although that is only a few lines of code now.

2. Does not have test for recursive embedded.


Fixes #2277: MOF compiler ignores EmbeddedObject instance property.

The DMTF definition of the value of instance property MOF is one
or more strings containing the MOF that would be compiled into
CIM instances.

Originally the compiler simply passed the string through the compiler so
what went into a repository was simply a string for the value of the property.

The MOF compiler was extended to compile properties with the
EmbeddedInstance or EmbeddedObject qualifiers into CIMInstance
object(s).

The enhanced compiler creates CIMInstance objects so that the
instance compiled has a one or an  array of CIMInstance objects
corresponding

Limitations: The defintion of EmbeddedObject either an instance
or a class.  Since there are not instances of classes as
EmbeddedObject properties in the DMTF schema the compiler only
supports compiling instances.