### PR TITLE
Fixes #2333:  Fixed py38 upgrade issue on macOS on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 
 #    - os: osx
+#      osx_image: xcode9.4  # macOS 10.13.6 with python2 @ 2.7.17
 #      language: generic
 #      python:
 #      env:
@@ -133,6 +134,7 @@ matrix:
 #        - PACKAGE_LEVEL=minimum
 
 #    - os: osx
+#      osx_image: xcode9.4  # macOS 10.13.6 with python2 @ 2.7.17
 #      language: generic
 #      python:
 #      env:
@@ -140,6 +142,7 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 
 #    - os: osx
+#      osx_image: xcode12  # macOS 10.15.5 with python3 @ 3.7.7, upgraded to 3.8.3
 #      language: generic
 #      python:
 #      env:
@@ -147,6 +150,7 @@ matrix:
 #        - PACKAGE_LEVEL=minimum
 
 #    - os: osx
+#      osx_image: xcode12  # macOS 10.15.5 with python3 @ 3.7.7, upgraded to 3.8.3
 #      language: generic
 #      python:
 #      env:
@@ -154,6 +158,11 @@ matrix:
 #        - PACKAGE_LEVEL=latest
 
 before_install:
+
+  # Debug original Python versions on macOS
+  - sh -c "which python; python --version"
+  - sh -c "which python2; python2 --version"
+  - sh -c "which python3; python3 --version"
 
   - git --version
 


### PR DESCRIPTION
No review needed.
The Travis runs have been verified with py3 on macOS: https://travis-ci.org/github/pywbem/pywbem/builds/707445552