### PR TITLE
Fixes #2337: On Python 3.8, upgraded the minimum version of lxml

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Test: On Python 3.8, upgraded the minimum version of lxml from 4.4.1 to 4.4.3,
+  in order to fix an XMLSyntaxError raised when encountering UCS-4 characters.
+  (See issue #2337)
+
 **Enhancements:**
 
 * Test: Added support for testing from Pypi/GitHub source distribution archives.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -133,7 +133,7 @@ FormEncode==1.3.1
 
 # Lxml
 lxml==4.2.4; python_version <= '3.7'
-lxml==4.4.1; python_version >= '3.8'
+lxml==4.4.3; python_version >= '3.8'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==4.5.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -51,7 +51,7 @@ FormEncode>=1.3.1
 lxml>=4.2.4; python_version == '2.7'
 lxml>=4.2.4,<4.4.0; python_version == '3.4'
 lxml>=4.2.4; python_version >= '3.5' and python_version <= '3.7'
-lxml>=4.4.1; python_version >= '3.8'
+lxml>=4.4.3; python_version >= '3.8'
 
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.


### PR DESCRIPTION
See commit message.

Travis run with py38 on macos enabled: https://travis-ci.org/github/pywbem/pywbem/builds/707632980