### PR TITLE
Partly fixes #2253: Changed lists and dicts in mock support to use NocaseList

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -92,6 +92,10 @@ This documentation uses a few special terms to refer to Python types:
       The namespace is a component of other elements like namespace path used
       to access objects in the WBEM server.
 
+   NocaseList
+      A case-insensitive list class provided by the
+      `nocaselist package <https://pypi.org/project/nocaselist/>`_.
+
    interop namespace
       A :term:`CIM namespace`  is the interop namespace if it has one of the
       following names: DMTF definition; ('interop', 'root/interop') pywbem

--- a/makefile
+++ b/makefile
@@ -689,7 +689,8 @@ installtest: $(bdist_file) $(sdist_file) $(test_dir)/installtest/test_install.sh
 ifeq ($(PLATFORM),Windows_native)
 	@echo "makefile: Warning: Skipping install test on native Windows" >&2
 else
-	$(test_dir)/installtest/test_install.sh $(bdist_file) $(sdist_file) $(PYTHON_CMD)
+# TODO: Enable installtest again once nocaselist has been released to Pypi.
+	echo $(test_dir)/installtest/test_install.sh $(bdist_file) $(sdist_file) $(PYTHON_CMD)
 endif
 	@echo "makefile: Done running install tests"
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -93,8 +93,9 @@ PyYAML==5.3; python_version == '2.7'  # PyYAML 5.3 fixes narrow build error
 PyYAML==5.1; python_version >= '3.4'
 six==1.10.0; python_version < '3.8'
 six==1.12.0; python_version >= '3.8'  # required by virtualenv==20.0.0
-
 requests==2.20.1
+# TODO: Add nocaselist with final version once released to Pypi
+# nocaselist==1.0.0
 
 
 # Indirect dependencies for installation (not in requirements.txt)

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -272,16 +272,12 @@ class BaseRepository(object):
     @compatibleabstractproperty
     def namespaces(self):
         """
-        Read-only property that returns a list with the names of the
-        namespaces existing in this repository. Note that if there were any
-        leading or trailing slash ("/") characters in namespace parameters used
-        to add the namespaces to the repository, they will be removed from
-        the namespaces returned with this property.
+        :term:`NocaseList` of :term:`string`:
+        The names of the namespaces that exist in this CIM repository.
 
-        Returns:
-
-            list of :term:`string`: List containing the namespace names in this
-            repository.
+        Note that if there were any leading or trailing slash ("/") characters
+        in namespace parameters used to add the namespaces to the repository,
+        they will be removed from the namespaces returned with this property.
         """
         pass
 

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -40,6 +40,7 @@ from __future__ import absolute_import, print_function
 
 from copy import deepcopy
 import six
+from nocaselist import NocaseList
 
 from pywbem import CIMClass, CIMQualifierDeclaration, CIMInstance
 
@@ -270,7 +271,8 @@ class InMemoryRepository(BaseRepository):
     @property
     def namespaces(self):
         # pylint: disable=invalid-overridden-method
-        return list(self._repository)
+        # This puts just the dict keys (i.e. namespaces) into the list
+        return NocaseList(self._repository)
 
     def get_class_store(self, namespace):
         if namespace is None:

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -40,6 +40,7 @@ import uuid
 from collections import Counter
 from copy import deepcopy
 import six
+from nocaselist import NocaseList
 
 # pylint: disable=ungrouped-imports
 try:
@@ -50,13 +51,11 @@ except ImportError:
     from time import clock as delta_time
 # pylint: enable=ungrouped-imports
 
-
 from pywbem import CIMClass, CIMClassName, CIMInstanceName, \
     CIMQualifierDeclaration, CIMError, \
     CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, CIM_ERR_INVALID_CLASS, \
     CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_ENUMERATION_CONTEXT, \
     CIM_ERR_NOT_SUPPORTED, CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED
-from pywbem._nocasedict import NocaseDict
 from pywbem._utils import _format
 
 from pywbem_mock.config import IGNORE_INSTANCE_IQ_PARAM, \
@@ -454,14 +453,13 @@ class MainProvider(BaseProvider, ResolverMixin):
 
     def _get_subclass_list_for_enums(self, classname, namespace, class_store):
         """
-        Get class list (i.e names of subclasses for classname for the
-        enumerateinstance methods in a case-insenstive dictionary. The input
-        classname is included in this dictionary.
+        Return the class names of subclasses of the specified classname
+        in the specified namespace, including the specified classname itself.
 
         Returns:
 
-          NocaseDict where only the keys are important, This allows case
-          insensitive matches of the names with Python "for cln in clns".
+          :term:`NocaseList`: Class names of subclasses, including classname
+          itself.
 
         Raises:
 
@@ -475,13 +473,11 @@ class MainProvider(BaseProvider, ResolverMixin):
                 _format("Class {0!A} not found in namespace {1!A}.",
                         classname, namespace))
 
-        clnslist = self._get_subclass_names(classname, class_store, True)
-        clnsdict = NocaseDict()
-        for cln in clnslist:
-            clnsdict[cln] = cln
+        cln_list = self._get_subclass_names(classname, class_store, True)
 
-        clnsdict[classname] = classname
-        return clnsdict
+        result = NocaseList(cln_list)
+        result.append(classname)
+        return result
 
     @staticmethod
     def _validate_instancename_namespace(namespace, object_name):

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -231,19 +231,20 @@ class FakedWBEMConnection(WBEMConnection):
     @property
     def namespaces(self):
         """
-        list: List of namespaces in the CIM repository.
+        :term:`NocaseList` of :term:`string`:
+        The names of the namespaces that exist in the CIM repository.
         """
         return self._mainprovider.namespaces
 
     @property
     def interop_namespace_names(self):
         """
-        list of :term:`string`: List of the valid Interop namespace names.
+        :term:`NocaseList` of :term:`string`:
+        The valid Interop namespace names.
+
         Only these names may be the Interop namespace and only one
         Interop namespace may exist in a WBEM server environment.
         This list is defined in :attr:`pywbem.WBEMServer.INTEROP_NAMESPACES`.
-
-        Namespace names need to be considered case insensitive.
         """
         return self._mainprovider.interop_namespace_names
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,10 @@ requests>=2.20.0
 # is planing to remove python 2.7 support in next version.
 custom-inherit==2.2.2
 yamlloader>=0.5.5
-
+# TODO: Replace nocaselist with final version once released to Pypi
+# nocaselist>=1.0.0
+git+https://github.com/pywbem/nocaselist@andy/initial-code#egg=nocaselist
+# https://github.com/pywbem/nocaselist/tarball/andy%2Finitial-code#egg=nocaselist-1.0.0
 
 # Indirect dependencies are no longer specified here, but for testing with a
 # minimum version, they are listed in the minimum-constraints.txt file.

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,6 @@ install_requires = [req for req in requirements
                     if req and not re.match(r'[^:]+://', req)]
 dependency_links = [req for req in requirements
                     if req and re.match(r'[^:]+://', req)]
-
 test_requirements = get_requirements('test-requirements.txt')
 
 package_version = get_version(os.path.join('pywbem', '_version.py'))


### PR DESCRIPTION
See commit message.

Ready to be reviewed and tried out. The test fails only because of Pylint enforcement that is now active.

Update: The pylint issue has been introduced by this PR and has been fixed in the latest update.

This PR fixes issue #2253 only partly, because it installs the new nocaselist package from a branch of its repo, and it had to disable the installtest which does not work with dependency links. This needs to be changed in a subsequent PR to be installed from Pypi, once released.