### PR TITLE
0.17: Fixed docs of CIMInstanceName.keys(), values(), items() for py3

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Docs: Fixed the description of return values of the keys(), values() and
+  items() methods of CIMInstanceName to state that they return lists on
+  Python 2, but dictionary views on Python 3. (See issue #2373)
+
 **Enhancements:**
 
 **Cleanup:**
@@ -49,7 +53,7 @@ Released: 2020-07-24
 * Test: Fixed issue with Swig when installing M2Crypto on native Windows
   in the Appveyor CI, reporting mssing files swig.swg and python.swg.
   This was fixed by pinning the swig version to 4.0.1. (See issue #2359)
-  
+
 
 pywbem 0.17.3
 -------------

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -1547,18 +1547,24 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def keys(self):
         """
-        Return a copied list of the keybinding names of this CIM instance path.
+        Return the keybinding names of this CIM instance path.
 
-        The keybinding names have their original lexical case.
+        The type of the returned object is consistent with the behavior of
+        the corresponding method of the built-in dict class: On Python 2, a
+        list is returned; on Python 3, a dictionary view is returned.
 
-        The order of keybindings is preserved.
+        The keybinding names have their original lexical case and the order of
+        keybindings is preserved.
         """
         return self.keybindings.keys()
 
     def values(self):
         """
-        Return a copied list of the keybinding values
-        of this CIM instance path.
+        Return the keybinding values of this CIM instance path.
+
+        The type of the returned object is consistent with the behavior of
+        the corresponding method of the built-in dict class: On Python 2, a
+        list is returned; on Python 3, a dictionary view is returned.
 
         The order of keybindings is preserved.
         """
@@ -1566,13 +1572,15 @@ class CIMInstanceName(_CIMComparisonMixin):
 
     def items(self):
         """
-        Return a copied list of the keybinding names and values
-        of this CIM instance path.
+        Return the keybinding items as a tuple (name, value) of this
+        CIM instance path.
 
-        Each item in the returned list is a tuple of keybinding name (in the
-        original lexical case) and keybinding value.
+        The type of the returned object is consistent with the behavior of
+        the corresponding method of the built-in dict class: On Python 2, a
+        list is returned; on Python 3, a dictionary view is returned.
 
-        The order of keybindings is preserved.
+        The keybinding names have their original lexical case and the order of
+        keybindings is preserved.
         """
         return self.keybindings.items()
 


### PR DESCRIPTION
Rolls back PR #2374 into 0.17.5.