### PR TITLE
0.17: Excluded pytest 6.0.0 from test dependencies to fix not-callable issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,10 +17,11 @@ funcsigs>=1.0.2; python_version < '3.3'
 unittest2>=1.1.0; python_version == '2.6'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
+# pytest 6.0.0 causes pylint to report "not-callable" issues
 pytest>=3.2.0,<3.3.0; python_version == '2.6'
 pytest>=4.3.1,<5.0.0; python_version > '2.6' and python_version < '3.5'
-pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
-pytest>=4.4.0; python_version >= '3.7'
+pytest>=4.3.1,!=6.0.0; python_version >= '3.5' and python_version <= '3.6'
+pytest>=4.4.0,!=6.0.0; python_version >= '3.7'
 # py version is determined by pytest:
 py>=1.4.34,<1.5; python_version == '2.6'
 py>=1.5.1; python_version > '2.6'


### PR DESCRIPTION
Rolls back PR #2377 into 0.17.5.