### PR TITLE
Deprecated the iter..() methods of CIMInstanceName

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -64,6 +64,14 @@ Released: not yet
 
 **Deprecations:**
 
+* Deprecated the iterkeys(), itervalues() and iteritems() methods of
+  CIMInstanceName on Python 3, to be more consistent with the built-in dict
+  class that does not support these methods on Python 3. Use the keys(),
+  values() or items() methods instead. Because the iter..() methods of
+  CIMInstance have a different semantics (they return the property values
+  and not the CIMProperty objects), this has not been done for the iter..()
+  methods of CIMInstance. (See issue #2372)
+
 **Bug fixes:**
 
 * Test: Fixed issue with Swig when installing M2Crypto on native Windows in the

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -1539,7 +1539,17 @@ class CIMInstanceName(_CIMComparisonMixin):
 
         The keybinding names have their original lexical case, and the order
         of keybindings is preserved.
+
+        Deprecated: This method is deprecated on Python 3 and will be removed
+        in a future version of pywbem, consistent with the built-in dict class
+        on Python 3. Use the :meth:`keys` method instead.
         """
+        if six.PY3:
+            warnings.warn(
+                "The iterkeys() method of pywbem.CIMInstanceName has been "
+                "deprecated on Python 3 and will be removed in a future "
+                "version of pywbem",
+                DeprecationWarning, 2)
         return six.iterkeys(self.keybindings)
 
     def itervalues(self):
@@ -1548,7 +1558,17 @@ class CIMInstanceName(_CIMComparisonMixin):
         path.
 
         The order of keybindings is preserved.
+
+        Deprecated: This method is deprecated on Python 3 and will be removed
+        in a future version of pywbem, consistent with the built-in dict class
+        on Python 3. Use the :meth:`values` method instead.
         """
+        if six.PY3:
+            warnings.warn(
+                "The itervalues() method of pywbem.CIMInstanceName has been "
+                "deprecated on Python 3 and will be removed in a future "
+                "version of pywbem",
+                DeprecationWarning, 2)
         return six.itervalues(self.keybindings)
 
     def iteritems(self):
@@ -1558,7 +1578,17 @@ class CIMInstanceName(_CIMComparisonMixin):
 
         The keybinding names have their original lexical case, and the order
         of keybindings is preserved.
+
+        Deprecated: This method is deprecated on Python 3 and will be removed
+        in a future version of pywbem, consistent with the built-in dict class
+        on Python 3. Use the :meth:`items` method instead.
         """
+        if six.PY3:
+            warnings.warn(
+                "The iteritems() method of pywbem.CIMInstanceName has been "
+                "deprecated on Python 3 and will be removed in a future "
+                "version of pywbem",
+                DeprecationWarning, 2)
         return six.iteritems(self.keybindings)
 
     # pylint: disable=too-many-branches


### PR DESCRIPTION
See commit message.

**DISCUSSION**:

* It is quite unsatisfactory to have CIMInstance.values/items() return lists. This is inconsistent, prevents deprecation of its iter..() methods, and does not provide a good path forward.
* It is equally unsatisfactory that NocaseDict.keys/values/items() returns lists on py2, even though it has dict view classes it could return also on py2.

Both could be addressed by having these methods return dict view objects on all Python versions. For NocaseDict, the price would be incompatibility with the built-in dict on py2 e.g. in cases where a dict is modified while iterating over it.