### PR TITLE
0.17: Fixed test install issue on CygWin due to missing libffi-devel

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,10 @@ Released: not yet
   items() methods of CIMInstanceName to state that they return lists on
   Python 2, but dictionary views on Python 3. (See issue #2373)
 
+* Test: Added libffi-devel as an OS-level package on CygWin, it is needed by
+  the Python cffi package which recently started to be needed.
+  (See issue #2394)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbem_os_setup.sh
+++ b/pywbem_os_setup.sh
@@ -295,6 +295,7 @@ elif [[ "$distro_family" == "cygwin" ]]; then
     install_cygwin libcrypt-devel
     # For pyzmq (used by Jupyter):
     install_cygwin libzmq-devel
+    install_cygwin libffi-devel
     if [[ "$py_m" == "3" ]]; then
       # For pyzmq, lxml:
       install_cygwin python3-devel


### PR DESCRIPTION
Rolls back PR #2395 into 0.17.5.