### PR TITLE
Added time statistics support to pywbem_mock

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,10 @@ Released: not yet
   This provides consistency with the way the input parameters of the method
   provider are represented. (See issue #2415)
 
+* Added time statistics support to pywbem_mock, that allows measuring which
+  parts of the setup and execution of a mock environment takes how much time.
+  (Part of issue #2365)
+
 **Cleanup:**
 
 **Known issues:**

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -503,14 +503,14 @@ class OperationStatistic(object):
         Return a two-line header.
         """
         ret_lines = [
-            'Count Excep         ClientTime      ',
-            '        Cnt     Avg     Min     Max ',
+            'Count ExcCnt          Time [s]      ',
+            '                Avg     Min     Max ',
         ]
         if include_server_time:
-            ret_lines[0] += '        ServerTime      '
+            ret_lines[0] += '       ServerTime [s]   '
             ret_lines[1] += '    Avg     Min     Max '
         if include_lengths:
-            ret_lines[0] += '       RequestLen                ReplyLen       '
+            ret_lines[0] += '       RequestLen [B]            ReplyLen [B]   '
             ret_lines[1] += '   Avg    Min    Max      Avg      Min      Max '
         ret_lines[0] += 'Operation\n'
         ret_lines[1] += '\n'
@@ -736,20 +736,20 @@ class Statistics(object):
 
         Example if statistics are enabled::
 
-            Statistics (times in seconds, lengths in Bytes):
-            Count Excep         ClientTime              ServerTime             RequestLen                ReplyLen       Operation
-                    Cnt     Avg     Min     Max     Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
+            Statistics:
+            Count ExcCnt         Time [s]             ServerTime [s]        RequestLen [B]            ReplyLen [B]      Operation
+                            Avg     Min     Max     Avg     Min     Max    Avg    Min    Max      Avg      Min      Max
                 3     0   0.234   0.100   0.401   0.204   0.080   0.361   1233   1000   1500    26667    20000    35000 EnumerateInstances
                 1     0   0.100   0.100   0.100   0.080   0.080   0.080   1200   1200   1200    22000    22000    22000 EnumerateInstanceNames
                 . . .
 
         Example if statistics are disabled::
 
-            Statistics (times in seconds, lengths in Bytes):
+            Statistics:
             Disabled
         """  # noqa: E501
         # pylint: enable=line-too-long
-        ret = "Statistics (times in seconds, lengths in Bytes):\n"
+        ret = "Statistics:\n"
         if self.enabled:
             snapshot = sorted(self.snapshot(),
                               key=lambda item: item[1].avg_time,

--- a/tests/unittest/pywbem/test_statistics.py
+++ b/tests/unittest/pywbem/test_statistics.py
@@ -600,11 +600,12 @@ def test_Statistics_print_statistics():
     report = statistics.formatted()
 
     assert re.match(
-        r'Statistics \(times in seconds, lengths in Bytes\)',
+        r'Statistics',
         report)
 
     assert re.search(
-        r"Count Excep *ClientTime *RequestLen *ReplyLen *Operation",
+        r"Count ExcCnt +Time \[s\] +RequestLen \[B\] +ReplyLen \[B\] "
+        r"+Operation",
         report)
 
     assert re.search(
@@ -694,12 +695,12 @@ def test_Statistics_print_stats_svrtime():
     report = statistics.formatted()
 
     assert re.search(
-        r'Count Excep +ClientTime +ServerTime +RequestLen +ReplyLen +'
-        r'Operation',
+        r'Count ExcCnt +Time \[s\] +ServerTime \[s\] +RequestLen \[B\] '
+        r'+ReplyLen \[B\] +Operation',
         report)
 
     assert re.search(
-        r'Cnt +Avg +Min +Max +Avg +Min +Max +Avg +Min +Max',
+        r' +Avg +Min +Max +Avg +Min +Max +Avg +Min +Max',
         report)
 
     assert re.search(

--- a/tests/unittest/pywbem/test_statistics.py
+++ b/tests/unittest/pywbem/test_statistics.py
@@ -262,6 +262,71 @@ def test_Statistics_measure_enabled():
     assert stats.max_time == 0
 
 
+def test_Statistics_measure_disabled_cm():
+    """
+    Test measuring time with disabled statistics, via context manager.
+    """
+
+    statistics = Statistics()
+
+    duration = 0.1
+
+    with statistics('EnumerateInstances'):
+        time.sleep(duration)
+
+    stats_list = statistics.snapshot()
+    assert len(stats_list) == 0
+
+
+def test_Statistics_measure_enabled_cm():
+    """
+    Test measuring time with enabled statistics, via context manager.
+    """
+
+    statistics = Statistics()
+    statistics.enable()
+
+    duration = 0.1
+
+    with statistics('EnumerateInstances'):
+        time.sleep(duration)
+
+    stats_dict = dict(statistics.snapshot())
+    assert len(stats_dict) == 1
+
+    assert 'EnumerateInstances' in stats_dict
+    stats = stats_dict['EnumerateInstances']
+    assert stats.count == 1
+
+
+def test_Statistics_measure_enabled_nested_cm():
+    """
+    Test measuring time with enabled statistics, via nested context managers.
+    """
+
+    statistics = Statistics()
+    statistics.enable()
+
+    duration = 0.1
+    inner_count = 3
+
+    with statistics('compile_schema_classes'):
+        for _ in range(0, inner_count):
+            with statistics('compile_mof_string'):
+                time.sleep(duration)
+
+    stats_dict = dict(statistics.snapshot())
+    assert len(stats_dict) == 2
+
+    assert 'compile_schema_classes' in stats_dict
+    stats = stats_dict['compile_schema_classes']
+    assert stats.count == 1
+
+    assert 'compile_mof_string' in stats_dict
+    stats = stats_dict['compile_mof_string']
+    assert stats.count == inner_count
+
+
 def test_Statistics_measure_enabled_with_servertime():
     # pylint: disable=invalid-name
     """


### PR DESCRIPTION
This is a first step to address the "make mock faster" issue #2365. It provides time statistics for the mock support, in order to find out where the time is spent.

There are no testcases for it yet, but it is ready to be tried out.

Usage:
```
conn.statistics.enabled = True  # or stats_enabled=True in ctor

# Do stuff with the faked connection, that collects time statistics:
conn.compile_schema_classes(...)
conn.compile_mof_string(...)
conn.compile_mof_file(...)
conn.add_cimobjects(...)
conn.EnumerateInstances(...) # and all other operations

print(conn.statistics.formatted())  # print formatted time statistics

stats = conn.statistics.snapshot()  # get a snapshot of the time statistics as a list of tuple(name, stats)
```

For details, see commit message.