### PR TITLE
Release 0.17.5 as the last 0.17.x release

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,14 +13,10 @@ Change log
       :revisions: 1
 
 
-pywbem 0.17.5.dev1
-------------------
+pywbem 0.17.5
+-------------
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2020-08-09
 
 **Bug fixes:**
 
@@ -35,14 +31,6 @@ Released: not yet
 **Enhancements:**
 
 * Improved logging in WBEM listener and its test module.
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/pywbem/pywbem/issues
 
 
 pywbem 0.17.4

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -29,4 +29,4 @@ Version of the pywbem package.
 #:
 #: * "M.N.P.devD": Development level D of a not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '0.17.5.dev1'
+__version__ = '0.17.5'


### PR DESCRIPTION
Please approve the release of pywbem 0.17.5, and that this is the last 0.17 version, which means that I suggest not fixing issue #2383 on 0.17 anymore.
