### PR TITLE
Fixes issue #2436, Remove package custom-inherit from pywbem

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -75,6 +75,9 @@ Released: not yet
   CIM repository, and to include the other attributes that were not shown so
   far. (See issue #2432)
 
+* Removed dependency on package custom-inherit and removed package from
+  pywbem.  (see issue # 2436)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -235,7 +235,6 @@ Babel==2.3.4
 bleach==2.1.4
 chardet==3.0.2
 clint==0.5.1
-custom-inherit==2.2.2
 docutils==0.13.1
 filelock==3.0.0
 gitdb2==2.0.0

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -46,8 +46,7 @@ Example :
 """
 
 from abc import abstractmethod, abstractproperty
-from six import add_metaclass, PY2
-from custom_inherit import DocInheritMeta
+from six import PY2
 
 
 def compatibleabstractproperty(func):
@@ -66,7 +65,6 @@ def compatibleabstractproperty(func):
         return property(abstractmethod(func))
 
 
-@add_metaclass(DocInheritMeta(style="google", abstract_base_class=True))
 class BaseObjectStore(object):
     """
     An abstract class that defines the APIs for the methods of an object store
@@ -253,7 +251,6 @@ class BaseObjectStore(object):
         pass
 
 
-@add_metaclass(DocInheritMeta(style="google", abstract_base_class=True))
 class BaseRepository(object):
     """
     An abstract base class defining the required  APIs to provide access to a

--- a/pywbem_mock/_inmemoryrepository.py
+++ b/pywbem_mock/_inmemoryrepository.py
@@ -155,15 +155,25 @@ class InMemoryObjectStore(BaseObjectStore):
 
 class InMemoryRepository(BaseRepository):
     """
-    A CIM repository that maintains its data in memory.
+    A CIM repository that maintains the data in memory using the
+    methods defined in its superclass (~pywbem_mock:`BaseObjectStore`).
+    This implementation creates the repository as multi-level dictionary
+    elements to define the namespaces and within each
+    namespace the CIM classes, CIM instances, and CIM qualifiers in the
+    repository.
     """
-    # Documentation for the methods and properties inherited from
-    # ~pywbem_mock:`BaseObjectStore` is also inherited in the pywbem
-    # documentation. Therefore the methods in this class have no documentation
-    # string.
+    # Documentation for the methods and properties  isinherited from
+    # ~pywbem_mock:`BaseObjectStore` by sphinx when building documentaton.
+    # Therefore the methods in this class have no documentation
+    # string unless they add or modify documentation in the parent class or
+    # are not defined in the parent class. Any method that needs to modifyu
+    # the base method documentation must copy the base class documentation.
 
     def __init__(self, initial_namespace=None):
         """
+        Initialize an empty in-memory CIM repository and optionally add a
+        namespace in the repository..
+
         Parameters:
 
           initial_namespace:(:term:`string` or None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,6 @@ PyYAML>=5.1; python_version > '3.4'
 # tox 3.17 (used in dev-requirements.txt) requires six>=1.14.0
 six>=1.14.0
 requests>=2.20.0
-# Pinned because this is the current version and the developer
-# is planing to remove python 2.7 support in next version.
-custom-inherit==2.2.2
 yamlloader>=0.5.5
 
 # nocaselist>=1.0.2


### PR DESCRIPTION
Removes the use of and install of thePython custom-inherit package in pywbem since it is causing problems for at least one of the OS developer/packaging organizations that use pywbem and  and which must build their own versions of packages into their releases for all dependencies used by apps such as pywbem that they package into OS  releases.