### PR TITLE
Add tests to increase test coverage for WBEMConnection class

### DIFF
--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -208,17 +208,6 @@ def _to_pretty_xml(xml_item):
     return re.sub(r'>( *[\r\n]+)+( *)<', r'>\n\2<', pretty_result)
 
 
-def _check_classname(val):
-    """
-    Validate a classname.
-
-    At this point, only the type is validated to be a string.
-    """
-    if not isinstance(val, six.string_types):
-        raise ValueError(
-            _format("string expected for classname, not {0!A}", val))
-
-
 def _iparam_propertylist(property_list):
     """
     Validate property_list input parameter and return it as a tuple/list,

--- a/tests/unittest/pywbem/test_logging.py
+++ b/tests/unittest/pywbem/test_logging.py
@@ -134,11 +134,14 @@ class TestLoggingConfigure(object):
             ['stderr', 10, TEST_OUTPUT_LOG, None],
             ['file', 'summary', TEST_OUTPUT_LOG, None],
             ['stderr', 'summary', TEST_OUTPUT_LOG, None],
+            ['stderr', None, TEST_OUTPUT_LOG, None],
             # Error tests
             ['blah', 'all', TEST_OUTPUT_LOG, ValueError],
             ['blah', 'all', TEST_OUTPUT_LOG, ValueError],
             ['file', 'blah', TEST_OUTPUT_LOG, ValueError],
+            ['file', 'all', None, ValueError],
             ['file', -9, TEST_OUTPUT_LOG, ValueError],
+            ['file', [-9], TEST_OUTPUT_LOG, ValueError],
         ]
     )
     def test_configure_logger(self, log_name, log_dest, detail_level,


### PR DESCRIPTION
Adds tests to:

1. test cim operation request failures. This should now test
about all of the request validation failures we can test.

2. extend some of the other tests in test_cim_operations.py

3. Removes an orphan function from _cim_operations.py