### PR TITLE
Fixes #2327-incomplete mock tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,4 +1,5 @@
 
+
 .. _`Change log`:
 
 Change log
@@ -87,6 +88,9 @@ Released: not yet
 * Mock: Cleaned up the output of repr(BaseProvider) to no longer show the
   CIM repository, and to include the other attributes that were not shown so
   far. (See issue #2432)
+
+* Complete pywbem_mock tests that were documented as missing in issue.
+  (see issue # 2327)
 
 * Removed dependency on package custom-inherit and removed package from
   pywbem.  (see issue # 2436)

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -201,14 +201,6 @@ class MainProvider(ResolverMixin, BaseProvider):
     #####################################################################
 
     @staticmethod
-    def _make_tuple(rtn_value):
-        """
-        Change the return value from the value consistent with the definition
-        in cim_operations.py into a tuple in accord with _imethodcall
-        """
-        return [("IRETURNVALUE", {}, rtn_value)]
-
-    @staticmethod
     def _get_superclass_names(classname, class_store):
         """
         Get list of superclasses names from the class datastore for the

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -184,7 +184,8 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                                      False, type_str)
                 continue
 
-            # If obj_name in superclass_objects
+            # Error if obj_name in superclass_objects and not override,
+            # except parameters which have no override concept.
             if 'Override' not in new_objects[obj_name].qualifiers:
                 if not isinstance(new_objects[obj_name], CIMParameter):
                     raise CIMError(
@@ -193,8 +194,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                                 "{3!A} without override.",
                                 type_str, obj_name, new_class.classname,
                                 superclass.classname))
-
-                # TODO need to finish this.  For now let parameter slide
                 continue
 
             # process object override


### PR DESCRIPTION
Added and extended tests for pywbem_mock documented in issue #2327 and
where the coverage report showed untested code.

Remove unused method _make_tuple in _mainprovider.py

NOTE: This leaves 3 of the items from issue # 2327 in the code open and two other tests (the original namespace tests) marked skipped for the moment.  Otherwise all tests extended per iseu # 2327 and the comments removed .


