### PR TITLE
Add tests to pywbem_mock; remove orphan code

### DIFF
--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -344,7 +344,7 @@ class MainProvider(ResolverMixin, BaseProvider):
 
              If `False` or `None` all properties are returned. This method
              maintains the code to implement local only consistent with
-             version 1.4 of DSP0004. However evert call to _get_instances
+             version 1.4 of DSP0004. However every call to _get_instances
              now sets the default `False` since that was the only way to
              get around issues between different versions of DSP0200 that
              defined incompatible behaviors to this request parameter.
@@ -355,7 +355,8 @@ class MainProvider(ResolverMixin, BaseProvider):
               returned object
 
               The value of this argument may be overridden by the
-              IGNORE_INSTANCE_ICO_PARAM config variable.
+              IGNORE_INSTANCE_ICO_PARAM config variable.  The default config
+              value is True(ignore this parameter and use False)
 
           include_qualifiers (:class:`pybool`):
               If `True`, any qualifiers in the stored instance the instance and
@@ -365,7 +366,8 @@ class MainProvider(ResolverMixin, BaseProvider):
               are returned.
 
               The value of this argument may be overridden by the
-              IGNORE_INSTANCE_IQ_PARAM config variable.
+              IGNORE_INSTANCE_IQ_PARAM config variable. The default config
+              value is True(ignore this parameter and use False)
 
         Returns:
 
@@ -1208,6 +1210,9 @@ class MainProvider(ResolverMixin, BaseProvider):
 
             This parameter has been deprecated in :term:`DSP0200`. Clients
             cannot rely on qualifiers to be returned in this operation.
+            The value of this argument may be overridden by the
+            IGNORE_INSTANCE_IQ_PARAM config variable. The default config
+            value is True(ignore this parameter and use False)
 
           IncludeClassOrigin (:class:`py:bool`):
             Indicates that class origin information is to be included on each
@@ -1216,6 +1221,10 @@ class MainProvider(ResolverMixin, BaseProvider):
             * If `False`, class origin information is not included.
             * If `True`, class origin information is included.
             * If `None`, uses :term:`DSP0200` server default `False`.
+
+            The value of this argument may be overridden by the
+            IGNORE_INSTANCE_ICO_PARAM config variable. The default config
+            value is True(ignore this parameter and use False)
 
           PropertyList (:term:`string` or :term:`py:iterable` of :term:`string`):
             An iterable specifying the names of the properties (or a string
@@ -1258,9 +1267,6 @@ class MainProvider(ResolverMixin, BaseProvider):
         self.validate_namespace(namespace)
         iname = InstanceName
 
-        # Set LocalOnly to False as fixed value.
-        LocalOnly = INSTANCE_RETRIEVE_LOCAL_ONLY
-
         instance_store = self.cimrepository.get_instance_store(namespace)
 
         if not self.class_exists(namespace, iname.classname):
@@ -1268,7 +1274,8 @@ class MainProvider(ResolverMixin, BaseProvider):
                 CIM_ERR_INVALID_CLASS,
                 _format("Class {0!A} for GetInstance of instance {1!A} "
                         "does not exist.", iname.classname, iname))
-
+        # Set LocalOnly to False as fixed value.
+        LocalOnly = INSTANCE_RETRIEVE_LOCAL_ONLY
         return self._get_instance(iname, instance_store,
                                   LocalOnly,
                                   IncludeClassOrigin,
@@ -1382,8 +1389,6 @@ class MainProvider(ResolverMixin, BaseProvider):
         instance_store = self.cimrepository.get_instance_store(namespace)
         class_store = self.cimrepository.get_class_store(namespace)
 
-        LocalOnly = INSTANCE_RETRIEVE_LOCAL_ONLY
-
         # If DeepInheritance False use only properties from the original
         # class. Modify property list to limit properties to those from this
         # class.  This only works if class exists. If class not in
@@ -1424,6 +1429,7 @@ class MainProvider(ResolverMixin, BaseProvider):
                                                       class_store)
 
         # get and process instances from the instance_store
+        LocalOnly = INSTANCE_RETRIEVE_LOCAL_ONLY
         insts = [self._get_instance(inst.path, instance_store,
                                     LocalOnly,
                                     IncludeClassOrigin,

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -101,11 +101,6 @@ class ProviderDispatcher(BaseProvider):
                 self.cimrepository)
         return self._default_method_provider
 
-    @staticmethod
-    def _array_ness(is_array):
-        """Return text for array-ness"""
-        return "an array" if is_array else "a scalar"
-
     def _validate_property(
             self, prop_name, instance, creation_class, namespace, class_store):
         """
@@ -337,6 +332,7 @@ class ProviderDispatcher(BaseProvider):
         # creation class and have the correct type-related attributes.
         # Strictly, we would only need to verify the properties to be modified
         # as reduced by the PropertyList.
+
         for pn in ModifiedInstance.properties:
 
             self._validate_property(
@@ -344,7 +340,9 @@ class ProviderDispatcher(BaseProvider):
 
             prop_inst = ModifiedInstance.properties[pn]
             prop_cls = creation_class.properties[pn]
-
+            # See issue #2449. This test never executed since if the key
+            # properties changed, the original instance get would have already
+            # failed.
             if prop_cls.qualifiers.get('key', False) and \
                     prop_inst.value != instance[pn]:
                 raise CIMError(

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -74,19 +74,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
        attributes such as class_origin, and propagated properties.
 
     """
-    @staticmethod
-    def _test_qualifier_decl(qualifier, qualifier_store, namespace):
-        """
-        Test that qualifier is in repo and valid.
-        """
-        if qualifier_store is None:
-            return
-        if not qualifier_store.object_exists(qualifier.name):
-            raise CIMError(
-                CIM_ERR_INVALID_PARAMETER,
-                _format("Qualifier declaration {0!A} required by CreateClass "
-                        "not found in namespace {1!A}.",
-                        qualifier.name, namespace))
 
     @staticmethod
     def _validate_qualifiers(qualifier_list, qualifier_store, new_class, scope):
@@ -144,20 +131,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                 qualifier.overridable = qual_dict_entry.overridable
         if qualifier.translatable is None:
             qualifier.translatable = qual_dict_entry.translatable
-
-    @staticmethod
-    def _init_qualifier_decl(qualifier_decl, qualifier_store):
-        """
-        Initialize the flavors of a qualifier declaration if they are not
-        already set.
-        """
-        assert qualifier_store.object_exists(qualifier_decl.name)
-        if qualifier_decl.tosubclass is None:
-            qualifier_decl.tosubclass = True
-        if qualifier_decl.overridable is None:
-            qualifier_decl.overridable = True
-        if qualifier_decl.translatable is None:
-            qualifier_decl.translatable = False
 
     def _resolve_objects(self, new_objects, superclass_objects, new_class,
                          superclass, classrepo, qualifier_store, type_str,

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -908,18 +908,11 @@ class FakedWBEMConnection(WBEMConnection):
         # Issue #2062: TODO/ks FUTURE Consider sorting to preserve order of
         # compile/add. Make this part of refactor to separate repository and
         # datastore because it may be data store dependent
-        if obj_type == 'Methods':
-            _uprint(dest,
-                    _format(u"{0}Namespace {1!A}: contains {2} {3}:{4}\n",
-                            cmt_begin, namespace,
-                            len(object_repo),
-                            obj_type, cmt_end))
-        else:
-            _uprint(dest,
-                    _format(u"{0}Namespace {1!A}: contains {2} {3} {4}\n",
-                            cmt_begin, namespace,
-                            object_repo.len(),
-                            obj_type, cmt_end))
+        _uprint(dest,
+                _format(u"{0}Namespace {1!A}: contains {2} {3} {4}\n",
+                        cmt_begin, namespace,
+                        object_repo.len(),
+                        obj_type, cmt_end))
         if summary:
             return
 
@@ -942,21 +935,6 @@ class FakedWBEMConnection(WBEMConnection):
                             _format(u"{0} Path={1} {2}\n{3}",
                                     cmt_begin, inst.path.to_wbem_uri(),
                                     cmt_end, inst.tomof()))
-
-        elif obj_type == 'Methods':
-            try:
-                methods = object_repo
-            except KeyError:
-                return
-
-            for cln in methods:
-                for method in methods[cln]:
-                    _uprint(dest,
-                            _format(u"{0}Class: {1}, method: {2}, "
-                                    u"callback: {3} {4}",
-                                    cmt_begin, cln, method,
-                                    methods[cln][method].__name__,
-                                    cmt_end))
 
         else:
             # Display classes and qualifier declarations sorted


### PR DESCRIPTION
Adds a number of tests to test_wbemconnection.py, removes some orphan methods, and fixes one issue in a test in _resolvermixin where a test for error in qualifier decl scope incorrect on CreateClass was not accomplishing anything.

See commit message for details.

Sadly this is still at 90% coverage.

This is partial response to issue #2353 but by itself should not close that issue