### PR TITLE
Fixes issue #2451- Mock CreateClass incomplete test for qualifiers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -98,6 +98,9 @@ Released: not yet
 * Test: Changed collection of .yaml files in function tests to address
   DeprecationWarning issued by pytest (see issue #2430).
 
+* Fix issue where pywbem_mock would accept a CreateClass where the qualifier
+  scopes did not match the corresponding QualifierDeclarations (See issue #2451)
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
The test in the class resolver was extended to correctly catch errors
where the qualifier on a class creating has a scope that does not match
the qualifier declaration.

Also added tests for some other cases where the coverage showed we were
not executing code.