### PR TITLE
Fixes #2458: Assert from mof_compiler in dependency compile

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -110,6 +110,10 @@ Released: not yet
 * Fixed issue where compiler would fail of a EmbeddedObject qualifier
   defined Null (None) as the embedded object class.
 
+* Fixed issue where mof compiler asserts if the creation of new class fails
+  because of reference or embedded object depency failures. Changed to
+  a MOFDependencyError exception (see issue # 2458)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -632,7 +632,18 @@ def p_mp_createClass(p):
                 if errcode in [CIM_ERR_INVALID_PARAMETER,
                                CIM_ERR_NOT_FOUND,
                                CIM_ERR_FAILED]:
-                    assert not fixedRefs  # Should not happen if we fixed it
+                    # Should not happend if we fixed the issues
+                    if fixedRefs:
+                        raise MOFDependencyError(
+                            msg=_format(
+                                "Cannot compile class {0!A} because "
+                                "errorcode={1} ({2!A}) was returned from "
+                                "CreateClass. The CreateClass exception was "
+                                "{3!A}",
+                                cc.classname, errcode, ce.status_code_name,
+                                ce),
+                            parser_token=p)
+
                     if not p.parser.qualcache[ns]:
                         for fname in ['qualifiers', 'qualifiers_optional']:
                             qualfile = p.parser.mofcomp.find_mof(fname)
@@ -673,7 +684,7 @@ def p_mp_createClass(p):
                         if cln in p.parser.classnames[ns]:
                             continue
                         try:
-                            # don't limit it with LocalOnly=True,
+                            # Don't limit it with LocalOnly=True,
                             # PropertyList, IncludeQualifiers=False, ...
                             # because of caching in case we're using the
                             # special WBEMConnection subclass used for

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -124,9 +124,11 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                 raise CIMError(
                     CIM_ERR_INVALID_PARAMETER,
                     _format("Qualifier {0!A} in new class {1!A} is used in "
-                            "invalid scope {2!A} (Qualifier declaration "
-                            "scopes: {3})",
-                            qname, new_class.classname, scope, q_decl.scopes))
+                            "invalid scope: {2!A}. (QualifierDeclaration "
+                            "scopes: ({3})",
+                            qname, new_class.classname, scope,
+                            ", ".join(
+                                [s for s, v in q_decl.scopes.items() if v])))
 
     @staticmethod
     def _init_qualifier(qualifier, qualifier_store):


### PR DESCRIPTION
The mof compiler failed with an assert if a class compile had
dependencies that were not in the repository or were invalid so the
dependency resolution failed.   While this might be logical for a local
compile, it is an issue when the compiler is part of another application.

Changed to use MOFDependencyError and also show the originating
exception since that may present more information about the failure.

Added tests for this issue to:
tests/unittest/pywbem_mock/test_wbemconnection.py

Note: We also modified one of the Exception messages in
pywbem_mock/_resolver to clarify it.