### PR TITLE
Demo: Show issue with virtualenv on cygwin py38

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@
 environment:
   matrix:
 
-    - TOX_ENV: win64_py27_32
-      UNIX_PATH: none
-      PYTHON_CMD: python
+#    - TOX_ENV: win64_py27_32
+#      UNIX_PATH: none
+#      PYTHON_CMD: python
 
 #    - TOX_ENV: win64_py27_64
 #      UNIX_PATH: none
@@ -57,11 +57,11 @@ environment:
 #   this system or executable".
 # - On Python 3.6 and upwards, Tox returns success but does not do anything.
 
-#    - TOX_ENV: cygwin64_py27
-#      UNIX_PATH: C:\cygwin64\bin
-#      PYTHON_CMD: python2.7
-#      PIP_CMD: pip
-#      CYGWIN_PYTHON_DEVEL: python27-devel
+    - TOX_ENV: cygwin64_py27
+      UNIX_PATH: C:\cygwin64\bin
+      PYTHON_CMD: python2.7
+      PIP_CMD: pip
+      CYGWIN_PYTHON_DEVEL: python27-devel
 
 #    - TOX_ENV: cygwin64_py36
 #      UNIX_PATH: C:\cygwin64\bin
@@ -191,6 +191,7 @@ install:
 build: false
 
 before_test:
+  - 'if "%UNIX_PATH%"=="C:\cygwin64\bin" ( bash --noprofile --norc -c "%PYTHON_CMD% -m virtualenv -vvv --with-traceback --no-download --python %PYTHON_CMD% test_py38" )'
 
 test_script:
   - 'if "%UNIX_PATH%"=="none" ( where tox & tox -vv -e %TOX_ENV% & echo appveyor.yml: tox rc=%errorlevel% )'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -183,6 +183,11 @@ install:
   - 'if "%UNIX_PATH%"=="C:\cygwin\bin" ( C:\cygwin\setup-x86.exe --no-shortcuts --quiet-mode )'
   - 'if "%UNIX_PATH%"=="C:\cygwin64\bin" ( C:\cygwin64\setup-x86_64.exe --no-shortcuts --quiet-mode )'
 
+  # List Python packages in host environment of tox
+  - 'if "%UNIX_PATH%"=="none" ( %PIP_CMD% --version & %PIP_CMD% list )'
+  - 'if "%UNIX_PATH%"=="C:\cygwin\bin" ( bash -c "%PIP_CMD% --version && %PIP_CMD% list" )'
+  - 'if "%UNIX_PATH%"=="C:\cygwin64\bin" ( bash -c "%PIP_CMD% --version && %PIP_CMD% list" )'
+
 build: false
 
 before_test:

--- a/makefile
+++ b/makefile
@@ -378,6 +378,7 @@ platform:
 	@$(PYTHON_CMD) tools/python_unicodesize.py
 	@echo "Pip command name: $(PIP_CMD)"
 	@echo "Pip command location: $(shell $(WHICH) $(PIP_CMD))"
+	@echo "Pip command version: $(shell $(PIP_CMD) --version)"
 	@echo "$(package_name) package version: $(package_version)"
 
 .PHONY: pip_list


### PR DESCRIPTION
This PR is used to demonstrate and investigate an error when tox creates a virtualenv on cygwin.

The original error showed up here: https://ci.appveyor.com/project/andy-maier/pywbem/builds/35526352/job/l3k6a2vb39bweqsw#L936:

```
if "%UNIX_PATH%"=="C:\cygwin64\bin" ( bash -c "which tox && tox -vv -e %TOX_ENV% && echo appveyor.yml: tox rc=$?" )
/usr/bin/tox
using tox.ini: /cygdrive/c/projects/pywbem/tox.ini (pid 1822)
using tox-3.20.0 from /usr/lib/python3.8/site-packages/tox/__init__.py (pid 1822)
skipping sdist step
cygwin64_py38 uses /usr/bin/python3.8.exe
cygwin64_py38 start: getenv /cygdrive/c/projects/pywbem/.tox/cygwin64_py38
cygwin64_py38 cannot reuse: no previous config /cygdrive/c/projects/pywbem/.tox/cygwin64_py38/.tox-config1
cygwin64_py38 create: /cygdrive/c/projects/pywbem/.tox/cygwin64_py38
setting PATH=/cygdrive/c/projects/pywbem/.tox/cygwin64_py38/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/ProgramData/chocolatey/bin
[1825] /cygdrive/c/projects/pywbem/.tox$ /usr/bin/python3.8.exe -m virtualenv --no-download --python /usr/bin/python3.8.exe cygwin64_py38
AttributeError: 'NoneType' object has no attribute 'group'
ERROR: invocation failed (exit code 1)
ERROR: InvocationError for command /usr/bin/python3.8.exe -m virtualenv --no-download --python /usr/bin/python3.8.exe cygwin64_py38 (exited with code 1)
cygwin64_py38 finish: getenv /cygdrive/c/projects/pywbem/.tox/cygwin64_py38 after 4.23 seconds
```

I have opened issue https://github.com/pypa/virtualenv/issues/1962 for virtualenv.