### PR TITLE
0.17: Roll back fixes: pyrsistent install; pytest collection of .yaml files

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -144,6 +144,9 @@ jupyter_core>=4.2.1; python_version >= '2.7' and (python_version != '3.4' or sys
 nbconvert>=5.0.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 nbformat>=4.2.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 notebook>=4.3.1; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
+pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
+pyrsistent>=0.14.0,<0.15.0; python_version == '3.4' and sys_platform != 'win32'
+pyrsistent>=0.14.0; python_version >= '3.5'
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 226 needs to be excluded, see issue #1946.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,9 @@ Released: not yet
 
 * Windows install: Upgraded WinOpenSSL to 1.1.1h.
 
+* Test: Fixed dependency issues with 'pyrsistent' package on Python 2.7 and
+  Python 3.4.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,9 @@ Released: not yet
 * Test: Fixed dependency issues with 'pyrsistent' package on Python 2.7 and
   Python 3.4.
 
+* Test: Changed collection of .yaml files in function tests to address
+  DeprecationWarning issued by pytest (see issue #2430).
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -205,6 +205,7 @@ jupyter_core==4.2.1; python_version >= '2.7' and (python_version != '3.4' or sys
 nbconvert==5.0.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 nbformat==4.2.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 notebook==4.3.1; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
+pyrsistent==0.14.0; python_version >= '2.7' and (python_version != '3.4' or sys_platform != 'win32')
 
 # Pywin32 is used (at least?) by jupyter.
 # Pywin32 version 226 needs to be excluded, see issue #1946.

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -226,7 +226,13 @@ def pytest_collect_file(parent, path):
     https://docs.pytest.org/en/latest/example/nonpython.html
     """
     if path.ext == ".yaml":
-        return YamlFile(path, parent)
+        if hasattr(YamlFile, 'from_parent'):
+            # pylint: disable=no-member
+            return YamlFile.from_parent(fspath=path, parent=parent)
+        # Direct creation has been deprecated in pytest, but
+        # from_parent() was introduced only in pytest 6.0.0 and we
+        # have to pin to lower pytest versions on py27/py34/py35.
+        return YamlFile(fspath=path, parent=parent)
     return None  # to avoid pylint inconsistent-return-statements
 
 
@@ -249,7 +255,18 @@ class YamlFile(pytest.File):
                 except KeyError:
                     raise ClientTestError("Test case #%s does not have a "
                                           "'name' attribute" % i + 1)
-                yield YamlItem(tc_name, self, testcase, filepath)
+                if hasattr(YamlItem, 'from_parent'):
+                    # pylint: disable=no-member
+                    yield YamlItem.from_parent(
+                        name=tc_name, parent=self,
+                        testcase=testcase, filepath=filepath)
+                else:
+                    # Direct creation has been deprecated in pytest, but
+                    # from_parent() was introduced only in pytest 6.0.0 and we
+                    # have to pin to lower pytest versions on py27/py34/py35.
+                    yield YamlItem(
+                        name=tc_name, parent=self,
+                        testcase=testcase, filepath=filepath)
 
 
 class YamlItem(pytest.Item):


### PR DESCRIPTION
This PR rolls back into 0.17.6:
* PR #2441: Fixed dependency issues with 'pyrsistent' package on py27 and py34
* PR #2444: Test: Changed collection of .yaml files to address pytest DeprecationWarning