### PR TITLE
Added Python's OpenSSL version to 'make platform'

### DIFF
--- a/makefile
+++ b/makefile
@@ -164,6 +164,9 @@ python_mn_version := $(shell $(PYTHON_CMD) tools/python_version.py 2)
 python_m_version := $(shell $(PYTHON_CMD) tools/python_version.py 1)
 pymn := py$(python_mn_version)
 
+# OpenSSL version used by Python's ssl
+openssl_version := $(shell $(PYTHON_CMD) -c "import ssl; print(ssl.OPENSSL_VERSION)")
+
 # Directory for the generated distribution files
 dist_dir := dist
 
@@ -376,6 +379,7 @@ platform:
 	@echo "Python version: $(python_version)"
 	@$(PYTHON_CMD) tools/python_bitsize.py
 	@$(PYTHON_CMD) tools/python_unicodesize.py
+	@echo "OpenSSL version used by Python ssl: $(openssl_version)"
 	@echo "Pip command name: $(PIP_CMD)"
 	@echo "Pip command location: $(shell $(WHICH) $(PIP_CMD))"
 	@echo "Pip command version: $(shell $(PIP_CMD) --version)"


### PR DESCRIPTION
You can now see the OpenSSL version that is used by Python's ssl module in each test.

Result as shown by the tests of this PR:

| CI | OS       | Python | OpenSSL | 
|:--- |:------ |:------ |:------ |
| Appveyor | Windows | 2.7.17 |1.0.2t |
| Appveyor | CygWin | 3.8.3 | 1.1.1f |
| Travis | Ubuntu 16.04.6 | 2.7.15 | 1.0.2g |
| Travis | Ubuntu 16.04.6 | 3.4.8 | 1.0.2g |
| Travis | Ubuntu 16.04.6 | 3.8.0 | 1.0.2g |

