### PR TITLE
Fixes issue #2502 pywbem compiler issue building in second namespace

### DIFF
--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -816,7 +816,8 @@ def p_mp_setQualifier(p):
     ns = p.parser.target_namespace
     if p.parser.verbose:
         p.parser.log(
-            _format("Setting qualifier {0!A}", qualdecl.name))
+            _format("Setting qualifier {0!A} namespace {0!A}",
+                    qualdecl.name, ns))
     try:
         p.parser.handle.SetQualifier(qualdecl, namespace=ns)
     except CIMError as ce:
@@ -1015,7 +1016,7 @@ def p_qualifier(p):
         qualdecl = p.parser.qualcache[ns][qname]
     except KeyError:
         try:
-            quals = p.parser.handle.EnumerateQualifiers()
+            quals = p.parser.handle.EnumerateQualifiers(namespace=ns)
         except CIMError as ce:
             if ce.status_code != CIM_ERR_INVALID_NAMESPACE:
                 raise MOFRepositoryError(


### PR DESCRIPTION
The MOF compiler cannot install a DMTF schema in a second namespace
because it tries to get the qualifiers from an incorrect remote
namespace.  This is a one line fix to the   compiler.

Adds test for pywbem_mock compiling into multiple namespaces.

Marked as priority because while this is a mof compiler issue it directly affects the last pywbem 0.8.0. This is blocking pywbemtools 0.8.0 release.

NOTE: I did not add comment to change log because it still reflects 1.1.0-dev.
