### PR TITLE
Reduced memory consumption of CIM objects by using lazy initialization

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -57,6 +57,9 @@ Released: not yet
   element without keybindings. This is motivated by the fact that DSP0004 does
   not allow instance paths without keys (section 8.2.5). (See issue #2514)
 
+* Reduced memory consumption of CIM objects and CIM types by defining their
+  attributes to use Python slots. (see issue #2509)
+
 **Cleanup:**
 
 * Test: Fixed all remaining ResourceWarnings during test. (issue #86)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -60,6 +60,11 @@ Released: not yet
 * Reduced memory consumption of CIM objects and CIM types by defining their
   attributes to use Python slots. (see issue #2509)
 
+* Reduced memory consumption of CIM objects by using lazy initialization of
+  dictionary-type attributes. This resulted in significant savings when the
+  attribute is typically unused, for example in ``CIMInstance.qualifiers``.
+  (see issue #2511)
+
 **Cleanup:**
 
 * Test: Fixed all remaining ResourceWarnings during test. (issue #86)

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -1270,14 +1270,16 @@ class CIMInstanceName(_CIMComparisonMixin, SlottedPickleMixin):
             v2 = instpath['k2']  # Access value of "k2"
             del instpath['k2']  # Delete "k2" from the instance path
         """
+        if self._keybindings is None:  # Lazy initialization
+            self._keybindings = NocaseDict()
+            self._keybindings.allow_unnamed_keys = True
         return self._keybindings
 
     @keybindings.setter
     def keybindings(self, keybindings):
         """Setter method; for a description see the getter method."""
         # pylint: disable=attribute-defined-outside-init
-        self._keybindings = NocaseDict()
-        self._keybindings.allow_unnamed_keys = True
+        self._keybindings = None  # Lazy initialization
         if keybindings:
             try:
                 # This is used for iterables:
@@ -2495,6 +2497,8 @@ class CIMInstance(_CIMComparisonMixin, SlottedPickleMixin):
             p2 = inst['p2']  # Access "p2"
             del inst['p2']  # Delete "p2" from the instance
         """
+        if self._properties is None:  # Lazy initialization
+            self._properties = NocaseDict()
         return self._properties
 
     @properties.setter
@@ -2503,7 +2507,7 @@ class CIMInstance(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMProperty objects:
         # pylint: disable=attribute-defined-outside-init
-        self._properties = NocaseDict()
+        self._properties = None  # Lazy initialization
         if properties:
             try:
                 # This is used for iterables:
@@ -2550,6 +2554,8 @@ class CIMInstance(_CIMComparisonMixin, SlottedPickleMixin):
         Note that :term:`DSP0200` has deprecated the presence of qualifier
         values on CIM instances.
         """
+        if self._qualifiers is None:  # Lazy initialization
+            self._qualifiers = NocaseDict()
         return self._qualifiers
 
     @qualifiers.setter
@@ -2558,7 +2564,7 @@ class CIMInstance(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict()
+        self._qualifiers = None  # Lazy initialization
         if qualifiers:
             try:
                 # This is used for iterables:
@@ -3993,6 +3999,8 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
             p1 = cls.properties['p1']  # Access "p1"
             del cls.properties['p1']  # Delete "p1" from the class
         """
+        if self._properties is None:  # Lazy initialization
+            self._properties = NocaseDict()
         return self._properties
 
     @properties.setter
@@ -4001,7 +4009,7 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMProperty objects:
         # pylint: disable=attribute-defined-outside-init
-        self._properties = NocaseDict()
+        self._properties = None  # Lazy initialization
         if properties:
             try:
                 # This is used for iterables:
@@ -4053,6 +4061,8 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
             m1 = cls.methods['m1']  # Access "m1"
             del cls.methods['m1']  # Delete "m1" from the class
         """
+        if self._methods is None:  # Lazy initialization
+            self._methods = NocaseDict()
         return self._methods
 
     @methods.setter
@@ -4061,7 +4071,7 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMMethod objects:
         # pylint: disable=attribute-defined-outside-init
-        self._methods = NocaseDict()
+        self._methods = None  # Lazy initialization
         if methods:
             try:
                 # This is used for iterables:
@@ -4114,6 +4124,8 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
             q1 = cls.qualifiers['q1']  # Access "q1"
             del cls.qualifiers['q1']  # Delete "q1" from the class
         """
+        if self._qualifiers is None:  # Lazy initialization
+            self._qualifiers = NocaseDict()
         return self._qualifiers
 
     @qualifiers.setter
@@ -4122,7 +4134,7 @@ class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict()
+        self._qualifiers = None  # Lazy initialization
         if qualifiers:
             try:
                 # This is used for iterables:
@@ -4897,6 +4909,8 @@ class CIMProperty(_CIMComparisonMixin, SlottedPickleMixin):
             q1 = prop.qualifiers['q1']  # Access "q1"
             del prop.qualifiers['q1']  # Delete "q1" from the class
         """
+        if self._qualifiers is None:  # Lazy initialization
+            self._qualifiers = NocaseDict()
         return self._qualifiers
 
     @qualifiers.setter
@@ -4905,7 +4919,7 @@ class CIMProperty(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict()
+        self._qualifiers = None  # Lazy initialization
         if qualifiers:
             try:
                 # This is used for iterables:
@@ -5494,13 +5508,15 @@ class CIMMethod(_CIMComparisonMixin, SlottedPickleMixin):
             p1 = meth.parameters['p1']  # Access "p1"
             del meth.parameters['p1']  # Delete "p1" from the class
         """
+        if self._parameters is None:  # Lazy initialization
+            self._parameters = NocaseDict()
         return self._parameters
 
     @parameters.setter
     def parameters(self, parameters):
         """Setter method; for a description see the getter method."""
         # pylint: disable=attribute-defined-outside-init
-        self._parameters = NocaseDict()
+        self._parameters = None  # Lazy initialization
         if parameters:
             try:
                 # This is used for iterables:
@@ -5553,6 +5569,8 @@ class CIMMethod(_CIMComparisonMixin, SlottedPickleMixin):
             q1 = meth.qualifiers['q1']  # Access "q1"
             del meth.qualifiers['q1']  # Delete "q1" from the class
         """
+        if self._qualifiers is None:  # Lazy initialization
+            self._qualifiers = NocaseDict()
         return self._qualifiers
 
     @qualifiers.setter
@@ -5561,7 +5579,7 @@ class CIMMethod(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict()
+        self._qualifiers = None  # Lazy initialization
         if qualifiers:
             try:
                 # This is used for iterables:
@@ -6083,6 +6101,8 @@ class CIMParameter(_CIMComparisonMixin, SlottedPickleMixin):
             q1 = parm.qualifiers['q1']  # Access "q1"
             del parm.qualifiers['q1']  # Delete "q1" from the class
         """
+        if self._qualifiers is None:  # Lazy initialization
+            self._qualifiers = NocaseDict()
         return self._qualifiers
 
     @qualifiers.setter
@@ -6091,7 +6111,7 @@ class CIMParameter(_CIMComparisonMixin, SlottedPickleMixin):
         # We make sure that the dictionary is a NocaseDict object, and that the
         # property values are CIMQualifier objects:
         # pylint: disable=attribute-defined-outside-init
-        self._qualifiers = NocaseDict()
+        self._qualifiers = None  # Lazy initialization
         if qualifiers:
             try:
                 # This is used for iterables:
@@ -7431,15 +7451,17 @@ class CIMQualifierDeclaration(_CIMComparisonMixin, SlottedPickleMixin):
         same-named init parameter of
         :class:`this class <pywbem.CIMQualifierDeclaration>`.
         """
+        if self._scopes is None:  # Lazy initialization
+            self._scopes = NocaseDict()
         return self._scopes
 
     @scopes.setter
     def scopes(self, scopes):
         """Setter method; for a description see the getter method."""
         # pylint: disable=attribute-defined-outside-init
-        self._scopes = NocaseDict()
+        self._scopes = None  # Lazy initialization
         if scopes:
-            self._scopes.update(scopes)
+            self.scopes.update(scopes)
 
     @property
     def tosubclass(self):

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -262,7 +262,7 @@ from .config import SEND_VALUE_NULL
 from . import config
 from ._cim_types import _CIMComparisonMixin, type_from_name, cimtype, \
     atomic_to_cim_xml, CIMType, CIMDateTime, number_types, CIMInt, \
-    CIMFloat, _Longint, Char16
+    CIMFloat, _Longint, Char16, SlottedPickleMixin
 from ._nocasedict import NocaseDict
 from ._utils import _ensure_unicode, _ensure_bool, \
     _hash_name, _hash_item, _hash_dict, _format, _integerValue_to_int, \
@@ -1099,7 +1099,7 @@ def _cim_qualifier(key, value):
     return qual
 
 
-class CIMInstanceName(_CIMComparisonMixin):
+class CIMInstanceName(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM instance path (aka *CIM instance name*).
 
@@ -1112,6 +1112,8 @@ class CIMInstanceName(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_classname', '_keybindings', '_host', '_namespace']
 
     def __init__(self, classname, keybindings=None, host=None, namespace=None):
         # pylint: disable=line-too-long
@@ -2347,7 +2349,7 @@ class CIMInstanceName(_CIMComparisonMixin):
                                host=host)
 
 
-class CIMInstance(_CIMComparisonMixin):
+class CIMInstance(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A representation of a CIM instance in a CIM namespace in a WBEM server,
     optionally including its instance path.
@@ -2358,6 +2360,8 @@ class CIMInstance(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_classname', '_properties', '_qualifiers', '_path']
 
     # pylint: disable=too-many-arguments
     def __init__(self, classname, properties=None, qualifiers=None,
@@ -3275,7 +3279,7 @@ class CIMInstance(_CIMComparisonMixin):
         return inst
 
 
-class CIMClassName(_CIMComparisonMixin):
+class CIMClassName(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM class path (aka *CIM class name*).
 
@@ -3288,6 +3292,8 @@ class CIMClassName(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_classname', '_host', '_namespace']
 
     def __init__(self, classname, host=None, namespace=None):
         """
@@ -3826,7 +3832,7 @@ class CIMClassName(_CIMComparisonMixin):
         return _ensure_unicode(''.join(ret))
 
 
-class CIMClass(_CIMComparisonMixin):
+class CIMClass(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A representation of a CIM class in a CIM namespace in a WBEM server,
     optionally including its class path.
@@ -3837,6 +3843,9 @@ class CIMClass(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_classname', '_properties', '_methods',
+                 '_superclass', '_qualifiers', '_path']
 
     # pylint: disable=too-many-arguments
     def __init__(self, classname, properties=None, methods=None,
@@ -4386,7 +4395,7 @@ class CIMClass(_CIMComparisonMixin):
 
 
 # pylint: disable=too-many-statements,too-many-instance-attributes
-class CIMProperty(_CIMComparisonMixin):
+class CIMProperty(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM property (value or declaration).
 
@@ -4421,11 +4430,14 @@ class CIMProperty(_CIMComparisonMixin):
     periods in which their public attributes remain unchanged.
     """
 
+    __slots__ = ['_name', '_value', '_type', '_class_origin',
+                 '_array_size', '_propagated', '_is_array',
+                 '_reference_class', '_qualifiers', '_embedded_object']
+
     # pylint: disable=too-many-statements
-    def __init__(self, name, value, type=None,
-                 class_origin=None, array_size=None, propagated=None,
-                 is_array=None, reference_class=None, qualifiers=None,
-                 embedded_object=None):
+    def __init__(self, name, value, type=None, class_origin=None,
+                 array_size=None, propagated=None, is_array=None,
+                 reference_class=None, qualifiers=None, embedded_object=None):
         # pylint: disable=redefined-builtin,too-many-arguments,too-many-branches
         # pylint: disable=too-many-statements,too-many-instance-attributes
         """
@@ -5257,7 +5269,7 @@ class CIMProperty(_CIMComparisonMixin):
         return hash(hashes)
 
 
-class CIMMethod(_CIMComparisonMixin):
+class CIMMethod(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A method (declaration) in a CIM class.
 
@@ -5267,6 +5279,9 @@ class CIMMethod(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_name', '_return_type', '_parameters',
+                 '_class_origin', '_propagated', '_qualifiers']
 
     # pylint: disable=too-many-arguments
     def __init__(self, name=None, return_type=None, parameters=None,
@@ -5771,7 +5786,7 @@ class CIMMethod(_CIMComparisonMixin):
         return u''.join(mof)
 
 
-class CIMParameter(_CIMComparisonMixin):
+class CIMParameter(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM parameter (value or declaration).
 
@@ -5799,6 +5814,10 @@ class CIMParameter(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_name', '_type', '_reference_class', '_is_array',
+                 '_array_size', '_qualifiers', '_value',
+                 '_embedded_object']
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, type, reference_class=None, is_array=None,
@@ -6469,7 +6488,7 @@ class CIMParameter(_CIMComparisonMixin):
 
 
 # pylint: disable=too-many-instance-attributes
-class CIMQualifier(_CIMComparisonMixin):
+class CIMQualifier(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM qualifier value.
 
@@ -6514,6 +6533,10 @@ class CIMQualifier(_CIMComparisonMixin):
     class can be used as members in a set (or as dictionary keys) only during
     periods in which their public attributes remain unchanged.
     """
+
+    __slots__ = ['_name', '_value', '_type', '_propagated',
+                 '_overridable', '_tosubclass', '_toinstance',
+                 '_translatable']
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, value, type=None, propagated=None,
@@ -7074,7 +7097,7 @@ class CIMQualifier(_CIMComparisonMixin):
 
 
 # pylint: disable=too-many-instance-attributes
-class CIMQualifierDeclaration(_CIMComparisonMixin):
+class CIMQualifierDeclaration(_CIMComparisonMixin, SlottedPickleMixin):
     """
     A CIM qualifier type is the declaration of a qualifier and defines the
     attributes of qualifier name, qualifier type, value, scopes, and flavors
@@ -7120,6 +7143,10 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
     periods in which their public attributes remain unchanged.
     """
 
+    __slots__ = ['_name', '_type', '_value', '_is_array',
+                 '_array_size', '_scopes', '_overridable',
+                 '_tosubclass', '_toinstance', '_translatable']
+
     # Order of scopes when externalizing the qualifier declaration
     _ordered_scopes = ["CLASS", "ASSOCIATION", "INDICATION",
                        "PROPERTY", "REFERENCE", "METHOD", "PARAMETER",
@@ -7127,9 +7154,8 @@ class CIMQualifierDeclaration(_CIMComparisonMixin):
 
     # pylint: disable=too-many-arguments
     def __init__(self, name, type, value=None, is_array=False,
-                 array_size=None, scopes=None,
-                 overridable=None, tosubclass=None, toinstance=None,
-                 translatable=None):
+                 array_size=None, scopes=None, overridable=None,
+                 tosubclass=None, toinstance=None, translatable=None):
         # pylint: disable=redefined-builtin
         """
         Parameters:

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -433,9 +433,10 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                             "non-association class {1!A}",
                             new_prop.name, new_class.classname))
 
-        objects = list(new_class.properties.values())
-        for meth in new_class.methods.values():
-            objects += list(meth.parameters.values())
+        # XXX: Remove this once tests succeed
+        # objects = list(new_class.properties.values())
+        # for meth in new_class.methods.values():
+        #     objects += list(meth.parameters.values())
 
         # Validate the attributes of all qualifiers in the new class and that
         # their value is True
@@ -465,9 +466,10 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
 
         # resolve class level qualifiers and attributes
         qualdict = superclass.qualifiers if superclass else {}
-        new_class.classorigin = superclass.classname if superclass \
-            else new_class.classname
-        new_class.propagated = bool(superclass)
+        # XXX: Remove this once tests succeed
+        # new_class.class_origin = superclass.classname if superclass \
+        #     else new_class.classname
+        # new_class.propagated = bool(superclass)
         self._resolve_qualifiers(new_class.qualifiers,
                                  qualdict,
                                  new_class,

--- a/pywbem_mock/_resolvermixin.py
+++ b/pywbem_mock/_resolvermixin.py
@@ -433,11 +433,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
                             "non-association class {1!A}",
                             new_prop.name, new_class.classname))
 
-        # XXX: Remove this once tests succeed
-        # objects = list(new_class.properties.values())
-        # for meth in new_class.methods.values():
-        #     objects += list(meth.parameters.values())
-
         # Validate the attributes of all qualifiers in the new class and that
         # their value is True
         if qualifier_store:
@@ -466,10 +461,6 @@ class ResolverMixin(object):  # pylint: disable=too-few-public-methods
 
         # resolve class level qualifiers and attributes
         qualdict = superclass.qualifiers if superclass else {}
-        # XXX: Remove this once tests succeed
-        # new_class.class_origin = superclass.classname if superclass \
-        #     else new_class.classname
-        # new_class.propagated = bool(superclass)
         self._resolve_qualifiers(new_class.qualifiers,
                                  qualdict,
                                  new_class,

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -1123,6 +1123,8 @@ def test_CIMInstanceName_init(testcase, init_args, init_kwargs, exp_attrs):
     # The code to be tested
     obj = CIMInstanceName(*init_args, **init_kwargs)
 
+    assert not hasattr(obj, '__dict__')
+
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
     assert testcase.exp_exc_types is None
@@ -6528,6 +6530,8 @@ def test_CIMInstance_init(testcase, init_args, init_kwargs, exp_attrs):
     # The code to be tested
     obj = CIMInstance(*init_args, **init_kwargs)
 
+    assert not hasattr(obj, '__dict__')
+
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
     assert testcase.exp_exc_types is None
@@ -11651,6 +11655,8 @@ def test_CIMProperty_init(testcase, init_args, init_kwargs, exp_attrs):
 
     # The code to be tested
     obj = CIMProperty(*init_args, **init_kwargs)
+
+    assert not hasattr(obj, '__dict__')
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
@@ -18693,6 +18699,8 @@ def test_CIMQualifier_init(testcase, init_args, init_kwargs, exp_attrs):
     # The code to be tested
     obj = CIMQualifier(*init_args, **init_kwargs)
 
+    assert not hasattr(obj, '__dict__')
+
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
     assert testcase.exp_exc_types is None
@@ -23340,6 +23348,8 @@ def test_CIMClassName_init(testcase, init_args, init_kwargs, exp_attrs):
     # The code to be tested
     obj = CIMClassName(*init_args, **init_kwargs)
 
+    assert not hasattr(obj, '__dict__')
+
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
     assert testcase.exp_exc_types is None
@@ -25506,6 +25516,8 @@ def test_CIMClass_init(testcase, init_args, init_kwargs, exp_attrs):
 
     # The code to be tested
     obj = CIMClass(*init_args, **init_kwargs)
+
+    assert not hasattr(obj, '__dict__')
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
@@ -27889,6 +27901,8 @@ def test_CIMMethod_init(testcase, init_args, init_kwargs, exp_attrs):
 
     # The code to be tested
     obj = CIMMethod(*init_args, **init_kwargs)
+
+    assert not hasattr(obj, '__dict__')
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
@@ -30509,6 +30523,8 @@ def test_CIMParameter_init(testcase, init_args, init_kwargs, exp_attrs):
 
     # The code to be tested
     obj = CIMParameter(*init_args, **init_kwargs)
+
+    assert not hasattr(obj, '__dict__')
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
@@ -37684,6 +37700,8 @@ def test_CIMQualifierDeclaration_init(
 
     # The code to be tested
     obj = CIMQualifierDeclaration(*init_args, **init_kwargs)
+
+    assert not hasattr(obj, '__dict__')
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions

--- a/tests/unittest/pywbem/test_cim_types.py
+++ b/tests/unittest/pywbem/test_cim_types.py
@@ -97,6 +97,7 @@ def test_char16_init(char16_init_tuple):
     except Exception as exc:  # pylint: disable=broad-except
         assert isinstance(exc, exp_exc_type)
     else:
+        assert not hasattr(obj, '__dict__')
         assert exp_exc_type is None
         assert obj == exp_str
         assert obj is not in_str
@@ -852,6 +853,7 @@ def test_datetime_init(datetime_init_tuple):
     except Exception as exc:  # pylint: disable=broad-except
         assert isinstance(exc, exp_kind)
     else:
+        assert not hasattr(obj, '__dict__')
         assert obj.is_interval == (exp_kind == 'interval')
         assert obj.datetime == exp_datetime
         if obj.datetime is not None:
@@ -977,6 +979,8 @@ def test_MinutesFromUTC_init(testcase, args, kwargs, exp_offset):
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions
     assert testcase.exp_exc_types is None
+
+    assert not hasattr(tz, '__dict__')
 
     # Verify the UTC offset of the tz object.
     exp_utcoffset = timedelta(minutes=exp_offset)
@@ -1506,6 +1510,11 @@ def test_cimtype(testcase, obj, exp_type_name):
     """
     Test function for cimtype().
     """
+
+    # There are no init testcases covering all CIM types, so the following
+    # check is placed here.
+    # TODO: Create init testcaes for CIM types and move this check to there.
+    assert not hasattr(obj, '__dict__')
 
     # The code to be tested
     type_name = cimtype(obj)


### PR DESCRIPTION
**Note: This PR is on top of PR #2501 - review only the delta.**

For seeing the resource savings by this change, compare the output of `make resourcetest` between this PR and PR #2501. Results have been posted to issue #2511.

For details, see commit message.