### PR TITLE
New MissingKeybindingsWarning warning for instance paths without keys

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,19 @@ Released: not yet
   change because users were already potentially getting pywbem.CIMXMLParseError
   exceptions in other cases. (see issue #2512)
 
+* Test: Added CIM-XML testcases in the area of instance paths. (see issue #2514)
+
+* Docs: Clarified that `pywbem.type_from_name()` returns `CIMInstanceName` for
+  type name "reference", even though for use in CIM method parameters,
+  `CIMClassName` is also valid.
+
+* Issued a new `pywbem.MissingKeybindingsWarning` warning if a `CIMInstanceName`
+  object that does not have any keybindings gets converted to CIM-XML by calling
+  its `tocimxml()` method, or gets converted to a WBEM URI by calling its
+  `to_wbem_uri()` method, or gets parsed from CIM-XML via an INSTANCENAME
+  element without keybindings. This is motivated by the fact that DSP0004 does
+  not allow instance paths without keys (section 8.2.5). (See issue #2514)
+
 **Cleanup:**
 
 * Test: Fixed all remaining ResourceWarnings during test. (issue #86)

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -268,6 +268,7 @@ from ._utils import _ensure_unicode, _ensure_bool, \
     _hash_name, _hash_item, _hash_dict, _format, _integerValue_to_int, \
     _realValue_to_float, _to_unicode, _eq_name, _eq_item, _eq_dict, \
     _stacklevel_above_module
+from ._warnings import MissingKeybindingsWarning
 
 
 __all__ = ['CIMClassName', 'CIMProperty', 'CIMInstanceName', 'CIMInstance',
@@ -1670,6 +1671,10 @@ class CIMInstanceName(_CIMComparisonMixin):
         The order of keybindings in the returned CIM-XML representation is
         preserved from the :class:`~pywbem.CIMInstanceName` object.
 
+        :class:`~pywbem.CIMInstanceName` objects without keybindings cause
+        a UserWarning to be issued, because this is invalid according to
+        :term:`DSP0004` (section 7.7.5).
+
         Parameters:
 
           ignore_host (:class:`py:bool`): Ignore the host of the
@@ -1746,6 +1751,14 @@ class CIMInstanceName(_CIMComparisonMixin):
 
             kbs.append(_cim_xml.KEYBINDING(
                 key, _cim_xml.KEYVALUE(value, value_type, cim_type)))
+
+        if not kbs:
+            warnings.warn(
+                _format(
+                    "Instance path without keybindings encountered for "
+                    "classname {0!A} when converting to CIM-XML - this not "
+                    "permitted according to DSP0004", self.classname),
+                MissingKeybindingsWarning, _stacklevel_above_module('pywbem'))
 
         instancename_xml = _cim_xml.INSTANCENAME(self.classname, kbs)
 
@@ -2169,6 +2182,14 @@ class CIMInstanceName(_CIMComparisonMixin):
         if format not in ('standard', 'canonical', 'cimobject', 'historical'):
             raise ValueError(
                 _format("Invalid format argument: {0}", format))
+
+        if not self.keybindings:
+            warnings.warn(
+                _format(
+                    "Instance path without keybindings encountered for "
+                    "classname {0!A} when converting to WBEM URI - this not "
+                    "permitted according to DSP0004", self.classname),
+                MissingKeybindingsWarning, _stacklevel_above_module('pywbem'))
 
         if self.host is not None and format != 'cimobject':
             # The CIMObject format assumes there is no host component

--- a/pywbem/_cim_types.py
+++ b/pywbem/_cim_types.py
@@ -1143,6 +1143,10 @@ def type_from_name(type_name):
       Use `decode()` and `encode()` for strings instead of type conversion
       syntax (in both Python 2 and 3, for consistency).
 
+    * For CIM type "reference", type object :class:`~pywbem.CIMInstanceName`
+      is returned, even though for use in CIM method parameters,
+      :class:`~pywbem.CIMClassName` is also valid.
+
     Parameters:
 
       type_name (:term:`string`):

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -24,7 +24,8 @@ from ._exceptions import Error
 
 # This module is meant to be safe for 'import *'.
 
-__all__ = ['Warning', 'ToleratedServerIssueWarning']
+__all__ = ['Warning', 'ToleratedServerIssueWarning',
+           'MissingKeybindingsWarning']
 
 
 class Warning(Error, six.moves.builtins.Warning):
@@ -39,5 +40,17 @@ class ToleratedServerIssueWarning(Warning):
     """
     This warning indicates an issue with the WBEM server that has been
     tolerated by pywbem.
+    """
+    pass
+
+
+class MissingKeybindingsWarning(Warning):
+    """
+    This warning indicates that an instance path without keybindings has been
+    encountered, either when sending a CIM-XML request to a WBEM server or
+    when receiving a CIM-XML response from a WBEM server.
+
+    A local creation of :class:`~pywbem.CIMinstanceName` objects without
+    keybindings does not issue this warning.
     """
     pass

--- a/tests/unittest/pywbem/test_cim_http.py
+++ b/tests/unittest/pywbem/test_cim_http.py
@@ -14,7 +14,7 @@ from ..utils.pytest_extensions import simplified_test_function
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
-from pywbem import _cim_http  # noqa: E402
+from pywbem import _cim_http, MissingKeybindingsWarning  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
 
@@ -895,7 +895,7 @@ TESTCASES_GET_CIMOBJECT_HEADER = [
             obj=pywbem.CIMInstanceName('C1'),
             exp_result=':C1',
         ),
-        None, None, True
+        None, MissingKeybindingsWarning, True
     ),
     (
         "Input object is CIMInstanceName with namespace and no keys",
@@ -903,7 +903,7 @@ TESTCASES_GET_CIMOBJECT_HEADER = [
             obj=pywbem.CIMInstanceName('C1', namespace='ns'),
             exp_result='ns:C1',
         ),
-        None, None, True
+        None, MissingKeybindingsWarning, True
     ),
     (
         "Input object is CIMInstanceName with namespace and one key",


### PR DESCRIPTION
See commit message.
Ready for review.

**Note: Other than discussed in the meeting, I did not raise ValueError when creating a WBEM URI, but issued the new warning as well. This was because WBEM URIs are often created to report issues with instances, for example instances without keys, and so we should be as tolerant as before.**