### PR TITLE
1.1: Enabled pypy3, py39; Various fixes for that and for pypy2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,14 +111,12 @@ matrix:
 #      env:
 #        - PACKAGE_LEVEL=latest
 
-# TODO: pypy3 disabled due to install error with typed-ast (from pylint)
 #    - os: linux
 #      language: python
 #      python: "pypy3"  # currently Python 3.6.1, PyPy 7.1.1-beta0
 #      env:
 #        - PACKAGE_LEVEL=minimum
 
-# TODO: pypy3 disabled due to install error with typed-ast (from pylint)
 #    - os: linux
 #      language: python
 #      python: "pypy3"  # currently Python 3.6.1, PyPy 7.1.1-beta0

--- a/.travis.yml
+++ b/.travis.yml
@@ -273,7 +273,7 @@ script:
   # TODO(nocasedict): Re-enable once nocasedict has been released
   # - make installtest
   - make test
-  - if [[ "$TRAVIS_PYTHON_VERSION" != "pypy" ]]; then make leaktest; fi
+  - if ! [[ $TRAVIS_PYTHON_VERSION =~ pypy.* ]]; then make leaktest; fi
 
 after_success:
 # Note: In case of error 422 (Couldn't find a repository matching this job),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -53,13 +53,9 @@ pylint>=2.4.4,<2.5.0; python_version >= '3.5'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
 astroid>=2.3.3,<2.4.0; python_version >= '3.5'
-# Pinning typed-ast to <1.4.0 for Python 3.4 because it started removing
-# Python 3.4 support.
-# Requiring typed-ast>=1.4.0 for Python 3.8 since it addresses compile errors
-# with missing pgenheaders.h and duplicate definition of a struct.
-typed-ast>=1.3.0,<1.4.0; python_version == '3.4'
-typed-ast>=1.3.0; python_version >= '3.5' and python_version < '3.8'
-typed-ast>=1.4.0; python_version >= '3.8'
+# typed-ast 1.4.0 removed support for Python 3.4.
+typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8>=3.7.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -133,5 +133,7 @@ pyinstrument >=3.0.1
 psutil>=5.0.0; sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'
 psutil>=5.0.0,<=5.6.3; sys_platform != 'cygwin' and platform_python_implementation == 'PyPy'
 
+pyzmq>=16.0.4; python_version <= '3.8'
+pyzmq>=19.0.0; python_version >= '3.9'
 
 # Indirect dependencies are not specified in this file unless constraints are needed.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -130,5 +130,8 @@ tabulate >= 0.8.3
 # Performance profiling tools
 pyinstrument >=3.0.1
 
+psutil>=5.0.0; sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'
+psutil>=5.0.0,<=5.6.3; sys_platform != 'cygwin' and platform_python_implementation == 'PyPy'
+
 
 # Indirect dependencies are not specified in this file unless constraints are needed.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,8 @@ Released: not yet
 * Test: Adjusted _format()/_ascii2() testcases to PyPy3 behavior with binary vs
   unicode results.
 
+* Test: Disabled leaktest in travis also on PyPy3 (in addition to PyPy2).
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -40,6 +40,9 @@ Released: not yet
 * Test: Circumvented unicode issue with lxml.etree.fromstring()/XML() on
   Python 3.9 by passing in binary strings.
 
+* Test: Adjusted _format()/_ascii2() testcases to PyPy3 behavior with binary vs
+  unicode results.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
 
 * Test: Pinned psutil to <=5.6.3 on PyPy2+3 to avoid an installation error.
 
+* Test: Increased the minimum version of 'pyzmq' on Python 3.9 to 19.0.0 to
+  avoid an installation error.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,9 @@ Released: not yet
 * Test: Increased the minimum version of 'pyzmq' on Python 3.9 to 19.0.0 to
   avoid an installation error.
 
+* Test: Circumvented unicode issue with lxml.etree.fromstring()/XML() on
+  Python 3.9 by passing in binary strings.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,8 @@ Released: not yet
 * Test: Changed dependency to 'typed-ast' to match the needs of 'astroid' and to
   install it only on CPython. This allows re-enabling PyPy3 on Travis.
 
+* Test: Pinned psutil to <=5.6.3 on PyPy2+3 to avoid an installation error.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,13 @@ Released: not yet
 
 **Bug fixes:**
 
+* MOF compiler: Fixed bug where MOF compiler did not correctly install a CIM schema
+  in a non-default namespace because it tried to get the qualifiers from the
+  default namespace. (see issue #2502)
+
+* Test: Changed dependency to 'typed-ast' to match the needs of 'astroid' and to
+  install it only on CPython. This allows re-enabling PyPy3 on Travis.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -156,15 +156,15 @@ sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3
 sphinx-rtd-theme==0.5.0
 
-# PyLint (no imports, invoked via pylint script) - does not support py3:
+# PyLint (no imports, invoked via pylint script):
 pylint==1.6.4; python_version == '2.7'
 pylint==2.2.2; python_version == '3.4'
 pylint==2.4.4; python_version >= '3.5'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
 astroid==2.3.3; python_version >= '3.5'
-typed-ast==1.3.0; python_version >= '3.4' and python_version < '3.8'
-typed-ast==1.4.0; python_version >= '3.8'
+typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
+typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.7.9

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -223,6 +223,9 @@ pyinstrument==3.0.1
 pyinstrument-cext==0.2.0  # from pyinstrument
 
 
+pyzmq==16.0.4; python_version <= '3.8'
+pyzmq==19.0.0; python_version >= '3.9'
+
 # Indirect dependencies for develop (not in dev-requirements.txt)
 
 alabaster==0.7.9
@@ -250,7 +253,6 @@ pkginfo==1.4.1
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
 py==1.5.1
-pyzmq==16.0.4
 qtconsole==4.2.1
 sh==1.12.14
 simplegeneric==0.8.1

--- a/pywbem_os_setup.sh
+++ b/pywbem_os_setup.sh
@@ -144,7 +144,7 @@ if [[ "$OS" == "Windows_NT" ]]; then
 elif [[ "$(uname -s)" == "Linux" ]]; then
   distro_id=$(python -c "import distro; print(distro.id())" 2>/dev/null)
   if [[ $? != 0 ]]; then
-    pyenv=$(python -c "import sys; out='venv' if hasattr(sys, 'real_prefix') or getattr(sys, 'base_prefix', None) == sys.prefix else 'system'; print(out)")
+    pyenv=$(python -c "import sys; out='venv' if hasattr(sys, 'real_prefix') or getattr(sys, 'base_prefix', None) != sys.prefix else 'system'; print(out)")
     if [[ $pyenv == "venv" ]]; then
       echo "$myname: Installing the Python 'distro' package into the current virtual Python environment."
       pip install distro
@@ -154,7 +154,9 @@ elif [[ "$(uname -s)" == "Linux" ]]; then
       fi
       distro_id=$(python -c "import distro; print(distro.id())")
     else
-      echo "$myname: Error: The Python 'distro' package is not installed, and you do not currently have a virtual Python environment active." >&2
+      info=$(python -c "import sys; print('sys.real_prefix={}; sys.base_prefix={}; sys.prefix={}'.format(getattr(sys, 'real_prefix', 'not set'), getattr(sys, 'base_prefix', 'not set'), sys.prefix)")
+      echo "$myname: Info: $info"
+      echo "$myname: Error: The Python 'distro' package is not installed, and you do not currently have a virtual Python environment active so it is not being installed." >&2
       exit  1
     fi
   fi

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -152,7 +152,7 @@ import six
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ..utils import import_installed
 pywbem = import_installed('pywbem')
-from pywbem._utils import _ensure_unicode  # noqa: E402
+from pywbem._utils import _ensure_unicode, _ensure_bytes  # noqa: E402
 from pywbem._nocasedict import NocaseDict  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
@@ -674,8 +674,12 @@ def assertXMLEqual(s_act, s_exp, entity):
 
     parser = etree.XMLParser(remove_blank_text=True)
     try:
-        x_act = etree.XML(s_act, parser=parser)
-        x_exp = etree.XML(s_exp, parser=parser)
+        # Note: lxml.etree.XML() has issues with unicode strings as input,
+        # so we pass UTF-8 encoded byte strings. See lxml bug
+        # https://bugs.launchpad.net/lxml/+bug/1902364 for a similar issue
+        # with lxml.etree.fromstring().
+        x_act = etree.XML(_ensure_bytes(s_act), parser=parser)
+        x_exp = etree.XML(_ensure_bytes(s_exp), parser=parser)
     except etree.XMLSyntaxError as exc:
         raise AssertionError("XML cannot be validated for %s: %s" %
                              (entity, exc))

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -204,7 +204,7 @@ def patched_makefile(self, mode='r', bufsize=-1):
         else:
             timeout = self.timeout
         t.join(timeout)
-        if t.isAlive():
+        if t.is_alive():
             raise socket.timeout
 
     return self.fd

--- a/tests/unittest/pywbem/test_utils.py
+++ b/tests/unittest/pywbem/test_utils.py
@@ -5,6 +5,7 @@ Tests for _utils module
 
 from __future__ import absolute_import
 
+import platform
 try:
     from collections import OrderedDict
 except ImportError:
@@ -24,6 +25,9 @@ from pywbem._utils import _ascii2, _format, _integerValue_to_int  # noqa: E402
 from pywbem._cim_obj import NocaseDict  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Indicates whether binary strings are supported for the format string of
+# _ascii2()
+BYTE_FORMAT_SUPPORTED = six.PY2 or platform.python_implementation() == 'PyPy'
 
 TESTCASES_ASCII2 = [
 
@@ -268,9 +272,9 @@ TESTCASES_FORMAT_FIXED = [
             format_str=b"",
             format_args=[],
             format_kwargs=dict(),
-            exp_result=b"" if six.PY2 else None,
+            exp_result="",
         ),
-        None if six.PY2 else TypeError, None, True
+        None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
     ),
     (
         "Format string, empty",
@@ -298,9 +302,9 @@ TESTCASES_FORMAT_FIXED = [
             format_str=b"{0}",
             format_args=[u"abc"],
             format_kwargs=dict(),
-            exp_result=u"abc" if six.PY2 else None,
+            exp_result=u"abc",
         ),
-        None if six.PY2 else TypeError, None, True
+        None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
     ),
     (
         "Format string without conversion and unicode string ASCII",
@@ -318,7 +322,7 @@ TESTCASES_FORMAT_FIXED = [
             format_str=u"{0}",
             format_args=[b"abc"],
             format_kwargs=dict(),
-            exp_result=b"abc" if six.PY2 else u"b'abc'",
+            exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None, None, True
     ),
@@ -328,9 +332,9 @@ TESTCASES_FORMAT_FIXED = [
             format_str=b"{0}",
             format_args=[b"abc"],
             format_kwargs=dict(),
-            exp_result=b"abc" if six.PY2 else None,
+            exp_result="abc" if six.PY2 else "b'abc'",
         ),
-        None if six.PY2 else TypeError, None, True
+        None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
     ),
     (
         "Format string without conversion and byte string ASCII",
@@ -338,7 +342,7 @@ TESTCASES_FORMAT_FIXED = [
             format_str="{0}",
             format_args=[b"abc"],
             format_kwargs=dict(),
-            exp_result=b"abc" if six.PY2 else u"b'abc'",
+            exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None, None, True
     ),

--- a/tests/unittest/utils/validate.py
+++ b/tests/unittest/utils/validate.py
@@ -147,15 +147,19 @@ def _xml_semantic_compare(left_xml_str, right_xml_str):
     """
     Compare two XML strings semantically to ensure the content is the same.
     """
-    # Reasons for using lxml.etree instead of Python's xml.etree.ElementTree:
+    # Reasons for using lxml.etree instead of Python's xml.etree.ElementTree
+    # (ET):
     # - The XML strings do not contain an XML directive specifying the
-    #   encoding, and the encoding parameter of ElementTree.XMLParser() does
-    #   not seem to work.
+    #   encoding, and the encoding parameter of ET.XMLParser() does not seem
+    #   to work.
     # - ET.fromstring() and ET.XML() do not handle byte strings in Python 2.x
     #   (see bugs.python.org/issue11033), so a manual conversion to unicode
     #   would be needed.
-    left_xml = etree.fromstring(left_xml_str)
-    right_xml = etree.fromstring(right_xml_str)
+    # Note: lxml.etree.fromstring() has issues with unicode strings as input,
+    # so we pass UTF-8 encoded byte strings. See lxml bug
+    # https://bugs.launchpad.net/lxml/+bug/1902364.
+    left_xml = etree.fromstring(_ensure_bytes(left_xml_str))
+    right_xml = etree.fromstring(_ensure_bytes(right_xml_str))
     return doctest_xml_compare.xml_compare(left_xml, right_xml)
 
 


### PR DESCRIPTION
This PR rolls back PR #2520 (except for resourcetest changes which does not exist yet) into 1.1.3.