### PR TITLE
1.1: Increased min version of psutil to fix install error on Windows with py>=36

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -129,9 +129,10 @@ tabulate >= 0.8.3
 
 # Performance profiling tools
 pyinstrument >=3.0.1
-
-psutil>=5.0.0; sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'
-psutil>=5.0.0,<=5.6.3; sys_platform != 'cygwin' and platform_python_implementation == 'PyPy'
+# psutil on PyPy needs to be <=5.6.3 to avoid an installation error,
+#   see https://github.com/giampaolo/psutil/issues/1659.
+psutil>=5.6.0; sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'
+psutil>=5.6.0,<=5.6.3; sys_platform != 'cygwin' and platform_python_implementation == 'PyPy'
 
 pyzmq>=16.0.4; python_version <= '3.8'
 pyzmq>=19.0.0; python_version >= '3.9'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -221,7 +221,7 @@ tabulate==0.8.3
 # Performance profiling tools
 pyinstrument==3.0.1
 pyinstrument-cext==0.2.0  # from pyinstrument
-
+psutil==5.6.0; sys_platform != 'cygwin'
 
 pyzmq==16.0.4; python_version <= '3.8'
 pyzmq==19.0.0; python_version >= '3.9'


### PR DESCRIPTION
Rolls back PR #2526 into 1.1.3.