### PR TITLE
Increased minimum versions of several packages; enforcing safety reports no issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,9 +30,13 @@ tox>=2.5.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Keep in sync with rtd-requirements.txt
-Sphinx>=1.7.6
+# Sphinx 2.0.0 removed support for Python 2.7 and 3.4
+Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
+Sphinx>=3.0.4; python_version >= '3.5'
 sphinx-git>=10.1.1
-GitPython>=2.1.1
+# GitPython 3.0.0 removed support for Python 2.7
+GitPython>=2.1.1,<3.0.0; python_version == '2.7'
+GitPython>=2.1.1; python_version >= '3.4'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 # Pygments 2.4.0 has removed support for Python 3.4
@@ -46,15 +50,14 @@ sphinx-rtd-theme>=0.5.0
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
-# TODO: Pinned pylint to <2.5.0 due to issues in 2.5.0 - remove in a while
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.4.4,<2.5.0; python_version >= '3.5'
+pylint>=2.5.2; python_version >= '3.5'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.3.3,<2.4.0; python_version >= '3.5'
+astroid>=2.4.0; python_version >= '3.5'
 # typed-ast 1.4.0 removed support for Python 3.4.
-typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
+typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
@@ -66,7 +69,10 @@ entrypoints>=0.3.0
 functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-twine>=1.8.1
+# twine 2.0.0 removed support for Python < 3.6
+twine>=1.8.1,<2.0.0; python_version <= '3.5'
+twine>=3.0.0; python_version >= '3.6'
+
 # readme-renderer 25.0 has removed support for Python 3.4
 # readme-renderer 23.0 has made cmarkgfm part of extras (it fails on Cygwin)
 readme-renderer>=23.0; python_version == '2.7'
@@ -138,3 +144,13 @@ pyzmq>=16.0.4; python_version <= '3.8'
 pyzmq>=19.0.0; python_version >= '3.9'
 
 # Indirect dependencies are not specified in this file unless constraints are needed.
+
+# bleach is used by nbconvert and readme-renderer
+# bleach 3.1.3 removed support for Python 3.4
+# bleach 3.1.1 addressed safety issue 38546
+# bleach 3.1.1 addressed safety issue 37910
+# bleach 3.1.2 addressed safety issue 38076
+# bleach 3.1.4 addressed safety issue 38107
+bleach>=3.1.4; python_version == '2.7'
+bleach>=3.1.2,<3.1.3; python_version == '3.4'
+bleach>=3.1.4; python_version >= '3.5'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -73,6 +73,22 @@ Released: not yet
 * Fixed a `DeprecationWarning` issued by urllib3 about using the
   `whitelist_methods` parameter of `Retry`.
 
+* Security: Increased minimum version of 'PyYAML' to 5.2 on Python 3.4 and to
+  5.3.1 on Python 2.7 and >=3.5 to address security issues reported by safety.
+  The relevant functions of 'PyYAML' are not used by pywbem, though.
+
+* Security: Increased minimum version of 'urllib3' to 1.24.2 on Python 3.4 and
+  to 1.25.9 on Python 2.7 and >=3.5 to address security issues reported by
+  safety. To support these versions of 'urllib3', increased minimum version of
+  'requests' to 2.20.1 on Python 3.4 and to 2.22.0 on Python 2.7 and >=3.5.
+
+* Security: Increased minimum versions of several packages that are needed only
+  for test or development of pywbem to address security issues reported by
+  safety: requests-toolbelt to 0.8.0; lxml to 4.6.1 (except for Python 3.4);
+  pylint to 2.5.2 and astroid to 2.4.0 on Python >=3.5; typed-ast to 1.3.2 on
+  Python 3.4; twine to 3.0.0 on Python >=3.6; pkginfo to 1.4.2; bleach to 3.1.2
+  on Python 3.4 and to 3.1.4 on Python 2.7 and Python >=3.5.
+
 **Enhancements:**
 
 * Logging: Added a value 'off' for the log destination in the
@@ -124,6 +140,16 @@ Released: not yet
   `pywbem.CIMXMLParseError`, and unsupported DTD or protocol versions were
   ignored by pywbem.
 
+* Removed the pinning of Pylint to 2.5.2 on Python >=3.5. Disabled the following
+  warnings that were newly reported by the latest version (2.6.0) of Pylint:
+  'signature-differs' because it does not recognize compatible signature changes;
+  'raise-missing-from' and 'super-with-arguments' because these issues cannot
+  reasonably be addressed as long as Python 2.7 is supported.
+
+* In the makefile, added an ignore list for issues reported by safety along
+  with the reasons why each issue is ignored. This allowed enforcing that the
+  safety command reports no issues.
+
 **Cleanup:**
 
 * Test: Fixed all remaining ResourceWarnings during test. (issue #86)
@@ -132,6 +158,11 @@ Released: not yet
   introduced in pywbem 1.1.0. (see issue #2498)
 
 **Known issues:**
+
+* On Python 3.4, the urllib3 package is pinned to <1.25.8 because 1.25.9 removed
+  Python 3.4 support. As a consequence,
+  `safety issue <https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json>`_
+  38834 cannot be addressed on Python 3.4.
 
 * See `list of open issues`_.
 

--- a/makefile
+++ b/makefile
@@ -236,6 +236,37 @@ py_src_files := \
     mof_compiler \
     $(wildcard $(mock_package_name)/*.py) \
 
+# Issues reported by safety command that are ignored.
+# Package upgrade strategy due to reported safety issues:
+# - For packages that are direct or indirect runtime requirements, upgrade
+#   the package version only if possible w.r.t. the supported environments and
+#   if the issue affects pywbem, and add to the ignore list otherwise.
+# - For packages that are direct or indirect development or test requirements,
+#   upgrade the package version only if possible w.r.t. the supported
+#   environments and add to the ignore list otherwise.
+# Current safety ignore list, with reasons:
+# Runtime dependencies:
+# - 38100: PyYAML on py34 cannot be upgraded; no issue since PyYAML FullLoader is not used
+# - 38834: urllib3 on py34 cannot be upgraded -> remains an issue on py34
+# Development and test dependencies:
+# - 38765: We want to test install with minimum pip versions.
+# - 38892: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
+# - 38224: pylint cannot be upgraded on py27+py34
+# - 37504: twine cannot be upgraded on py34
+# - 37765: psutil cannot be upgraded on PyPy
+# - 38107: bleach cannot be upgraded on py34
+# - 38330: Sphinx cannot be upgraded on py27+py34
+safety_ignore_opts := \
+    -i 38100 \
+		-i 38834 \
+		-i 38765 \
+		-i 38892 \
+		-i 38224 \
+    -i 37504 \
+    -i 37765 \
+		-i 38107 \
+		-i 38330 \
+
 # Python source files for test (unit test and function test)
 test_src_files := \
     $(wildcard $(test_dir)/unittest/*.py) \
@@ -678,7 +709,7 @@ endif
 safety_$(pymn).done: develop_$(pymn).done makefile minimum-constraints.txt
 	@echo "makefile: Running pyup.io safety check"
 	-$(call RM_FUNC,$@)
-	-safety check -r minimum-constraints.txt --full-report
+	safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
 	echo "done" >$@
 	@echo "makefile: Done running pyup.io safety check"
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -89,16 +89,22 @@ wheel==0.33.5; python_version >= '3.8'
 mock==2.0.0
 ordereddict==1.1
 ply==3.10
-PyYAML==5.3; python_version == '2.7'  # PyYAML 5.3 fixes narrow build error
-PyYAML==5.1; python_version >= '3.4'
+PyYAML==5.3.1; python_version == '2.7'
+PyYAML==5.2; python_version == '3.4'
+PyYAML==5.3.1; python_version >= '3.5'
 six==1.14.0
-requests==2.20.1
+requests==2.22.0; python_version == '2.7'
+requests==2.20.1; python_version == '3.4'
+requests==2.22.0; python_version >= '3.5'
 nocaselist==1.0.3
 nocasedict==1.0.1
 
 
 # Indirect dependencies for installation (not in requirements.txt)
 
+urllib3==1.25.9; python_version == '2.7'
+urllib3==1.24.2; python_version == '3.4'
+urllib3==1.25.9; python_version >= '3.5'
 # funcsigs; is covered in direct deps for develop, from mock
 
 
@@ -115,7 +121,7 @@ colorama==0.4.0; python_version >= '3.5'
 importlib-metadata==0.12; python_version <= '3.7'
 pytz==2016.10
 requests-mock==1.6.0
-requests-toolbelt==0.7.0
+requests-toolbelt==0.8.0
 yagot==0.5.0
 
 # Virtualenv
@@ -132,8 +138,9 @@ yamlloader==0.5.5
 FormEncode==1.3.1
 
 # Lxml
-lxml==4.2.4; python_version <= '3.7'
-lxml==4.4.3; python_version >= '3.8'
+lxml==4.6.1; python_version == '2.7'
+lxml==4.2.4; python_version == '3.4'
+lxml==4.6.1; python_version >= '3.5'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==4.5.2
@@ -148,7 +155,8 @@ dparse==0.4.1
 tox==2.5.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx==1.7.6
+Sphinx==1.7.6; python_version <= '3.4'
+Sphinx==3.0.4; python_version >= '3.5'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0
@@ -159,11 +167,11 @@ sphinx-rtd-theme==0.5.0
 # PyLint (no imports, invoked via pylint script):
 pylint==1.6.4; python_version == '2.7'
 pylint==2.2.2; python_version == '3.4'
-pylint==2.4.4; python_version >= '3.5'
+pylint==2.5.2; python_version >= '3.5'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
-astroid==2.3.3; python_version >= '3.5'
-typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
+astroid==2.4.0; python_version >= '3.5'
+typed-ast==1.3.2; python_version == '3.4' and implementation_name=='cpython'
 typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
@@ -175,8 +183,10 @@ entrypoints==0.3.0
 functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
 # Twine (no imports, invoked via twine script):
-twine==1.8.1
+twine==1.8.1; python_version <= '3.5'
+twine==3.0.0; python_version >= '3.6'
 readme-renderer==23.0
+pkginfo==1.4.2
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 # The jupyter package is not installed on Python 3.4 on Windows, because its
@@ -226,13 +236,18 @@ psutil==5.6.0; sys_platform != 'cygwin'
 pyzmq==16.0.4; python_version <= '3.8'
 pyzmq==19.0.0; python_version >= '3.9'
 
+# Indirect dependencies for develop that need constraints
+
+bleach==3.1.4; python_version == '2.7'
+bleach==3.1.2; python_version == '3.4'
+bleach==3.1.4; python_version >= '3.5'
+
 # Indirect dependencies for develop (not in dev-requirements.txt)
 
 alabaster==0.7.9
 appnope==0.1.0
 args==0.1.0
 Babel==2.3.4
-bleach==2.1.4
 chardet==3.0.2
 clint==0.5.1
 docutils==0.13.1
@@ -249,7 +264,6 @@ mistune==0.8.1
 pandocfilters==1.4.1
 pexpect==4.2.1
 pickleshare==0.7.4
-pkginfo==1.4.1
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
 py==1.5.1
@@ -264,6 +278,5 @@ toml==0.10.0
 tornado==4.4.2
 traceback2==1.4.0
 traitlets==4.3.1
-urllib3==1.23
 wcwidth==0.1.7
 widgetsnbextension==1.2.6

--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,8 @@ disable=I0011, bad-option-value,
         too-many-nested-blocks, too-many-return-statements, too-many-arguments,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
-        consider-using-set-comprehension, unnecessary-pass, useless-return
+        consider-using-set-comprehension, unnecessary-pass, useless-return,
+        signature-differs, raise-missing-from, super-with-arguments
 
 # Note: "useless-object-inheritance" is python 3 only. In Python 2,
 #        "new-style" objects must inherit from object, or else

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,17 +12,34 @@
 mock>=2.0.0,<4.0.0; python_version < '3.6'
 mock>=2.0.0; python_version >= '3.6'
 ply>=3.10
-# PyYAML 5.3 has removed support for Python 3.4; fixes narrow build error
-PyYAML>=5.3; python_version == '2.7'
-PyYAML>=5.1,<5.3; python_version == '3.4'
-PyYAML>=5.1; python_version > '3.4'
+# PyYAML 5.3 removed support for Python 3.4
+# PyYAML 5.3 fixed narrow build error on Python 2.7
+# PyYAML 5.3.1 addressed issue 38100 reported by safety
+# PyYAML 5.2 addressed issue 38639 reported by safety
+PyYAML>=5.3.1; python_version == '2.7'
+PyYAML>=5.2,<5.3; python_version == '3.4'
+PyYAML>=5.3.1; python_version > '3.4'
 # virtualenv 20.0.0 (required on py3.8+) requires six>=0.12.0
 # tox 3.17 (used in dev-requirements.txt) requires six>=1.14.0
 six>=1.14.0
-requests>=2.20.0
+# requests 2.22.0 removed support for Python 3.4
+# requests 2.22.0 removed the pinning of urllib3 to <1.25.0, and urllib 1.25.9
+#   is required to address safety issues
+requests>=2.22.0; python_version == '2.7'
+requests>=2.20.1,<2.22.0; python_version == '3.4'
+requests>=2.22.0; python_version >= '3.5'
 yamlloader>=0.5.5
 nocaselist>=1.0.3
 nocasedict>=1.0.1
 
-# Indirect dependencies are no longer specified here, but for testing with a
-# minimum version, they are listed in the minimum-constraints.txt file.
+# Indirect dependencies only specified here if needed. Keep in sync with the
+# minimum-constraints.txt file.
+
+# urllib3 1.24.1 addressed issue 37055 reported by safety
+# urllib3 1.24.2 addressed issue 37071 reported by safety
+# urllib3 1.25.9 addressed issue 38834 reported by safety
+# urllib3 1.25.8 removed support for Python 3.4
+# urllib3 needs to be pinned to <1.25 for requests <2.22.0
+urllib3>=1.25.9; python_version == '2.7'
+urllib3>=1.24.2,<1.25.0; python_version == '3.4'
+urllib3>=1.25.9; python_version >= '3.5'

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,9 @@ def get_requirements(requirements_file):
         lines = fp.readlines()
     reqs = []
     for line in lines:
-        line = line.strip('\n')
-        if not line.startswith('#') and line != '':
+        line = line.strip(' \n')
+        if not line.startswith('#') and not line.startswith('-r ') and \
+                line != '':
             reqs.append(line)
     return reqs
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,8 @@
 # the minimum versions specified in minimum-constraints.txt.
 
 
+-r requirements.txt
+
 # Direct dependencies (just for "setup.py test")
 
 
@@ -26,9 +28,8 @@ testfixtures>=6.9.0
 colorama>=0.3.9,<0.4.0; python_version <= '3.4'
 colorama>=0.4.0; python_version >= '3.5'
 
-requests>=2.20.1
 requests-mock>=1.6.0
-requests-toolbelt>=0.7.0
+requests-toolbelt>=0.8.0
 yagot>=0.5.0
 importlib-metadata<1,>=0.12; python_version <= '3.7'
 pytz>=2016.10
@@ -41,24 +42,14 @@ decorator>=4.0.11
 backports.statistics>=0.1.0; python_version == '2.7'
 # FormEncode is used for xml comparisons in unit test
 FormEncode>=1.3.1
-# PyYAML 5.3 has removed support for Python 3.4; fixes narrow build error
-PyYAML>=5.3; python_version == '2.7'
-PyYAML>=5.1,<5.3; python_version == '3.4'
-PyYAML>=5.1; python_version > '3.4'
-yamlloader>=0.5.5
 
 # Lxml
-# lxml 4.4.0 removed Python 3.4 support.
-# lxml 4.4.1 added Python 3.8 support. However, while providing binary wheel
-#   files, it did not register Python 3.8 as a supported version in the
-#   package metadata on Pypi. A fix for that is expected for the next lxml
-#   version after 4.4.2 (See https://bugs.launchpad.net/lxml/+bug/1854465
-#   and https://github.com/lxml/lxml/pull/291). Before that, pip 19.3.1
-#   is required to properly deal with this inconsistency (see issue #1980).
-lxml>=4.2.4; python_version == '2.7'
+# lxml 4.4.0 removed Python 3.4 support
+# lxml 4.4.3 added Python 3.8 support and exposed it correctly
+# lxml 4.6.1 addressed safety issue 38892
+lxml>=4.6.1; python_version == '2.7'
 lxml>=4.2.4,<4.4.0; python_version == '3.4'
-lxml>=4.2.4; python_version >= '3.5' and python_version <= '3.7'
-lxml>=4.4.3; python_version >= '3.8'
+lxml>=4.6.1; python_version >= '3.5'
 
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.


### PR DESCRIPTION
See commit message.
Rollback not intended because it would restrict the applicability of these pywbem versions.