### PR TITLE
Fixed DeprecationWarning issued by urllib3

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,9 @@ Released: not yet
   declarations to raise `pywbem.CIMXMLParseError` from `WBEMConnection`
   operations.
 
+* Fixed a `DeprecationWarning` issued by urllib3 about using the
+  `whitelist_methods` parameter of `Retry`.
+
 **Enhancements:**
 
 * Logging: Added a value 'off' for the log destination in the


### PR DESCRIPTION
See commit message.
Since we are now enforcing expected warnings in tests, the unexpected DeprecationWarning causes tests to fail. This PR fixes that.