### PR TITLE
Fixed safety issue by increasing lxml to 4.6.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -84,7 +84,7 @@ Released: not yet
 
 * Security: Increased minimum versions of several packages that are needed only
   for test or development of pywbem to address security issues reported by
-  safety: requests-toolbelt to 0.8.0; lxml to 4.6.1 (except for Python 3.4);
+  safety: requests-toolbelt to 0.8.0; lxml to 4.6.2 (except for Python 3.4);
   pylint to 2.5.2 and astroid to 2.4.0 on Python >=3.5; typed-ast to 1.3.2 on
   Python 3.4; twine to 3.0.0 on Python >=3.6; pkginfo to 1.4.2; bleach to 3.1.2
   on Python 3.4 and to 3.1.4 on Python 2.7 and Python >=3.5.

--- a/makefile
+++ b/makefile
@@ -256,6 +256,8 @@ py_src_files := \
 # - 37765: psutil cannot be upgraded on PyPy
 # - 38107: bleach cannot be upgraded on py34
 # - 38330: Sphinx cannot be upgraded on py27+py34
+# - 39194: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
+# - 39195: lxml cannot be upgraded on py34; no issue since output file paths do not come from untrusted sources
 safety_ignore_opts := \
     -i 38100 \
 		-i 38834 \
@@ -266,6 +268,8 @@ safety_ignore_opts := \
     -i 37765 \
 		-i 38107 \
 		-i 38330 \
+		-i 39194 \
+		-i 39195 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -138,9 +138,9 @@ yamlloader==0.5.5
 FormEncode==1.3.1
 
 # Lxml
-lxml==4.6.1; python_version == '2.7'
+lxml==4.6.2; python_version == '2.7'
 lxml==4.2.4; python_version == '3.4'
-lxml==4.6.1; python_version >= '3.5'
+lxml==4.6.2; python_version >= '3.5'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 # We exclude Python 3.4 from coverage testing and reporting.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -47,9 +47,10 @@ FormEncode>=1.3.1
 # lxml 4.4.0 removed Python 3.4 support
 # lxml 4.4.3 added Python 3.8 support and exposed it correctly
 # lxml 4.6.1 addressed safety issue 38892
-lxml>=4.6.1; python_version == '2.7'
+# lxml 4.6.2 addressed safety issue 39194
+lxml>=4.6.2; python_version == '2.7'
 lxml>=4.2.4,<4.4.0; python_version == '3.4'
-lxml>=4.6.1; python_version >= '3.5'
+lxml>=4.6.2; python_version >= '3.5'
 
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.


### PR DESCRIPTION
No review needed.
No rollback into pywbem 1.1 needed, because safety checks were enforced only starting with pywbem 1.2.