### PR TITLE
1.1: Fixed issue with github version of coveralls in constraints file

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -140,7 +140,8 @@ lxml==4.6.1; python_version >= '3.5'
 # We exclude Python 3.4 from coverage testing and reporting.
 coverage==5.0; python_version == '2.7' or python_version >= '3.5'
 pytest-cov==2.7.0; python_version == '2.7' or python_version >= '3.5'
-git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
+# Links are not allowed in constraint files - minimum ensured by dev-requirements.txt:
+# git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
 coveralls==2.1.2; python_version >= '3.5'
 
 # Safety CI by pyup.io


### PR DESCRIPTION
Rolls back commit 3a9babc (no PR) into 1.1.3.