### PR TITLE
Fixed WinOpenSSL version on Windows with py27; added py27 to normal tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,17 @@ jobs:
             \"include\": [ \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"2.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.9\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"2.7\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/pywbem_os_setup.bat
+++ b/pywbem_os_setup.bat
@@ -161,8 +161,8 @@ echo %myname%: Installing Win32OpenSSL ...
 :: Note that the Win32OpenSSL project at https://slproweb.com/ removes
 :: the previously available version when a new version is released. Whenever
 :: that happens, this version here must be updated.
-set _WIN32OPENSSL_VERSION_UNDERSCORED=1_1_1h
-set _WIN32OPENSSL_VERSION_DASHED=1-1-1h
+set _WIN32OPENSSL_VERSION_UNDERSCORED=1_1_1i
+set _WIN32OPENSSL_VERSION_DASHED=1-1-1i
 
 :: The bit size of Win32OpenSSL must match the bit size of the Python env.
 set _WIN32OPENSSL_BITSIZE=%PYTHON_ARCH%


### PR DESCRIPTION
See commit message.
No review needed.