### PR TITLE
1.1: Fixed safety issue 39253 with py

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -257,7 +257,7 @@ pickleshare==0.7.4
 pkginfo==1.4.1
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
-py==1.5.1
+py==1.10.0
 qtconsole==4.2.1
 sh==1.12.14
 simplegeneric==0.8.1


### PR DESCRIPTION
Rolls back PR #2555 into 1.1.3.