### PR TITLE
Added RollbackWBEMConnection

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,11 @@ Released: not yet
 
 **Deprecations:**
 
+* Deprecated class `pywbem.MOFWBEMConnection` due to its limitations. Use the
+  new class `pywbem.RollbackWBEMConnection` if you need rollback functionality,
+  or class `pywbem_mock.FakedWBEMConnection` if you need an in-memory CIM
+  repository. (issue #2500)
+
 **Bug fixes:**
 
 * MOF compiler: Fixed bug where MOF compiler did not correctly install a CIM schema
@@ -155,6 +160,12 @@ Released: not yet
 
 * Migrated from Travis and Appveyor to GitHub Actions. This required several
   changes in package dependencies for development.
+
+* Added a new class `pywbem.RollbackWBEMConnection` that is able to commit
+  and roll back WBEM operations. (issue #2500)
+
+* Changed the MOF compiler to use the new class `pywbem.RollbackWBEMConnection`
+  instead of class `pywbem.MOFWBEMConnection`. (issue #2500)
 
 **Cleanup:**
 

--- a/docs/client/exceptions.rst
+++ b/docs/client/exceptions.rst
@@ -213,3 +213,35 @@ Exceptions
       :attributes:
 
    .. rubric:: Details
+
+.. autoclass:: pywbem.RollbackError
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.RollbackError
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.RollbackError
+      :attributes:
+
+   .. rubric:: Details
+
+.. autoclass:: pywbem.RollbackPreparationError
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.RollbackPreparationError
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.RollbackPreparationError
+      :attributes:
+
+   .. rubric:: Details

--- a/docs/client/operations.rst
+++ b/docs/client/operations.rst
@@ -6,6 +6,8 @@ WBEM operations
 
 .. automodule:: pywbem._cim_operations
 
+.. automodule:: pywbem._rollback_conn
+
 WBEMConnection
 ^^^^^^^^^^^^^^
 
@@ -21,6 +23,26 @@ WBEMConnection
    .. rubric:: Attributes
 
    .. autoautosummary:: pywbem.WBEMConnection
+      :attributes:
+
+   .. rubric:: Details
+
+
+RollbackWBEMConnection
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: pywbem.RollbackWBEMConnection
+   :members:
+
+   .. rubric:: Methods
+
+   .. autoautosummary:: pywbem.RollbackWBEMConnection
+      :methods:
+      :nosignatures:
+
+   .. rubric:: Attributes
+
+   .. autoautosummary:: pywbem.RollbackWBEMConnection
       :attributes:
 
    .. rubric:: Details

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -7,9 +7,7 @@ Positional arguments:
                         Can be specified multiple times.
 
 Server related options:
-  Specify the WBEM server and namespace the MOF compiler works against, for
-  looking up existing elements, and for applying the MOF compilation results
-  to.
+  Specify the WBEM server and namespace the MOF compiler works against.
 
   -s url, --server url  Host name or URL of the WBEM server (required),
                         in this format:
@@ -33,20 +31,19 @@ Server related options:
                         Default: root/cimv2
 
 Connection security related options:
-  Specify user name and password or certificates and keys
+  Specify user name and password or certificates and keys.
 
   -u user, --user user  User name for authenticating with the WBEM server.
                         Default: No user name.
   -p password, --password password
                         Password for authenticating with the WBEM server.
-                        Default: Will be prompted for, if user name
-                        specified.
+                        Default: Will be prompted for, if user name specified.
   -nvc, --no-verify-cert
-                        Client will not verify certificate returned by the
-                        WBEM server (see cacerts). This bypasses the client-
-                        side verification of the server identity, but allows
-                        encrypted communication with a server for which the
-                        client does not have certificates.
+                        Client will not verify certificate returned by the WBEM
+                        server (see cacerts). This bypasses the client-side
+                        verification of the server identity, but allows encrypted
+                        communication with a server for which the client does not have
+                        certificates.
   --cacerts cacerts     CA certificates to be used for verifying the server
                         certificate presented by the WBEM server during TLS/SSL
                         handshake:
@@ -61,18 +58,17 @@ Connection security related options:
                         WBEM server. Not required if private key is part of the
                         certfile option. Not allowed if no certfile option.
                         Default: No client key file. Client private key should
-                        then be part  of the certfile
+                        then be part of the certfile.
 
 Action related options:
-  Specify actions against the WBEM server's namespace. Default:
-  Create/update elements.
+  Specify actions against the WBEM server's namespace.
 
-  -r, --remove          Removal mode: Remove elements (found in the MOF files)
-                        from the WBEM server's namespace, instead of creating
-                        or updating them
+  -r, --remove          Removal mode: Remove elements (found in the MOF files) from
+                        the WBEM server's namespace, instead of creating or updating
+                        them.
   -d, --dry-run         Dry-run mode: Don't actually modify the WBEM server's
-                        namespace, just check MOF syntax. Connection to WBEM
-                        server is still required to check qualifiers.
+                        namespace, just check MOF syntax. Connection to WBEM server is
+                        still required to check qualifiers.
 
 General options:
   -I dir, --include dir
@@ -87,7 +83,7 @@ General options:
                          COMP=[DEST[:DETAIL]] where:
                            COMP:   Logger component name:[api|http|all].
                                    (Default=all)
-                           DEST:   Destination for component:[file|stderr].
+                           DEST:   Destination for component:[file|stderr|off].
                                    (Default=file)
                            DETAIL: Detail Level to log: [all|paths|summary] or
                                    an integer that defines the maximum length of

--- a/pywbem/__init__.py
+++ b/pywbem/__init__.py
@@ -47,6 +47,7 @@ from ._warnings import *  # noqa: F403,F401 pylint: disable=redefined-builtin
 from ._cim_types import *  # noqa: F403,F401
 from ._cim_constants import *  # noqa: F403,F401
 from ._cim_operations import *  # noqa: F403,F401
+from ._rollback_conn import *  # noqa: F403,F401
 from ._nocasedict import *  # noqa: F403,F401
 from ._cim_obj import *  # noqa: F403,F401
 from ._tupleparse import *  # noqa: F403,F401

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -27,7 +27,8 @@ from ._cim_constants import _statuscode2name, _statuscode2string
 __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
            'VersionError', 'ParseError', 'CIMVersionError', 'DTDVersionError',
            'ProtocolVersionError', 'CIMXMLParseError', 'XMLParseError',
-           'HeaderParseError', 'CIMError', 'ModelError',
+           'HeaderParseError', 'CIMError', 'ModelError', 'RollbackError',
+           'RollbackPreparationError',
            '_RequestExceptionMixin', '_ResponseExceptionMixin']
 
 
@@ -700,3 +701,77 @@ class ModelError(Error):
         assert message is None or isinstance(message, six.string_types), \
             str(type(message))
         super(ModelError, self).__init__(message, conn_id=conn_id)
+
+
+class RollbackError(Error):
+    """
+    This exception indicates an error during rollback of a
+    :class:`~pywbem.RollbackWBEMConnection` object.
+
+    The attributes indicate the original operation that is being undone,
+    the undo operation, and the keyword arguments for the undo operation.
+
+    *New in pywbem 1.2.*
+    """
+
+    def __init__(self, message, orig_name=None, undo_name=None,
+                 undo_kwargs=None, conn_id=None):
+        """
+        Parameters:
+
+          message (:term:`string`): Exception message.
+
+          orig_name (:term:`string`): Name of the original WBEM operation
+            that was attempted to be undone.
+
+          undo_name (:term:`string`): Name of the WBEM operation that was
+            invoked to undo the original WBEM operation and that failed.
+
+          undo_kwargs (dict): Keyword arguments for the undo WBEM operation.
+
+          conn_id (:term:`connection id`):
+            Connection ID of the target connection in whose context the error
+            happened.
+            Omitted or `None` if the error did not happen in context of any
+            connection, or if the connection context was not known.
+
+        :ivar args: A tuple (message, orig_name, undo_name, undo_kwargs) set
+            from the corresponding init arguments.
+        """
+        assert message is None or isinstance(message, six.string_types), \
+            str(type(message))
+        super(RollbackError, self).__init__(
+            message, orig_name, undo_name, undo_kwargs, conn_id=conn_id)
+
+    @property
+    def orig_name(self):
+        """
+        :term:`string`: Name of the original WBEM operation that was attempted
+            to be undone.
+        """
+        return self.args[1]  # pylint: disable=unsubscriptable-object
+
+    @property
+    def undo_name(self):
+        """
+        :term:`string`: Name of the WBEM operation that was invoked to undo
+            the original WBEM operation and that failed.
+        """
+        return self.args[2]  # pylint: disable=unsubscriptable-object
+
+    @property
+    def undo_kwargs(self):
+        """
+        dict: Keyword arguments for the undo WBEM operation.
+        """
+        return self.args[3]  # pylint: disable=unsubscriptable-object
+
+
+class RollbackPreparationError(Error):
+    """
+    This exception indicates an error during preparation for a future rollback
+    in a :class:`~pywbem.RollbackWBEMConnection` object.
+
+    *New in pywbem 1.2.*
+    """
+    pass

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -73,7 +73,7 @@ import sys
 import os
 import re
 import tempfile
-
+import warnings
 from abc import ABCMeta, abstractmethod
 try:
     from collections import OrderedDict
@@ -96,7 +96,7 @@ from ._cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
     CIM_ERR_NOT_SUPPORTED
 from ._exceptions import Error, CIMError
-from ._utils import _format
+from ._utils import _format, _stacklevel_above_module
 
 __all__ = ['MOFCompileError', 'MOFParseError', 'MOFDependencyError',
            'MOFRepositoryError', 'MOFCompiler', 'BaseRepositoryConnection']
@@ -2163,6 +2163,11 @@ class MOFWBEMConnection(BaseRepositoryConnection):
     A CIM repository connection to an in-memory repository on top of an
     optional underlying WBEM connection.
 
+    Deprecated: This class is deprecated and will be removed in a future version
+    of pywbem. Use :class:`~pywbem.RollbackWBEMConnection` if you need rollback
+    functionality or :class:`~pywbem_mock.FakedWBEMConnection` if you need an
+    in-memory CIM repository.
+
     If a WBEM connection is provided with the conn parameter, that connection
     is the target for any operations that acquire CIM objects and the in-memory
     store acts as a cache for CIM qualifiers declarations, CIM Classes, and CIM
@@ -2212,6 +2217,11 @@ class MOFWBEMConnection(BaseRepositoryConnection):
             # of 'default_namespace' behave as it should, in the case
             # of conn=None.
             self.__default_namespace = 'root/cimv2'
+
+        warnings.warn(
+            "The pywbem.MOFWBEMConnection class is deprecated and will be "
+            "removed in a future version of pywbem.",
+            DeprecationWarning, _stacklevel_above_module(__name__))
 
     def _getns(self):
         """

--- a/pywbem/_rollback_conn.py
+++ b/pywbem/_rollback_conn.py
@@ -1,0 +1,632 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+"""
+:class:`~pywbem.RollbackWBEMConnection` is a WBEM connection that can commit
+and roll back the operations.
+"""
+
+from __future__ import print_function, absolute_import
+
+from ._cim_operations import WBEMConnection
+from ._cim_constants import CIM_ERR_NOT_FOUND
+from ._exceptions import Error, CIMError, RollbackError, \
+    RollbackPreparationError
+
+__all__ = ['RollbackWBEMConnection']
+
+
+class RollbackWBEMConnection(object):
+    """
+    A WBEM connection that can commit and roll back the operations.
+
+    *New in pywbem 1.2.*
+
+    The :class:`RollbackWBEMConnection` object is initialized with a target
+    WBEM connection and any WBEM operations are passed on to the target WBEM
+    connection, maintaining an undo list of the inverse operations.
+
+    The target WBEM connection can be a :class:`~pywbem.WBEMConnection` object
+    or a :class:`~pywbem_mock.FakedWBEMConnection` object.
+
+    When the :meth:`commit` method is called, the operations are committed by
+    emptying the undo list.
+
+    When the :meth:`rollback` method is called, the current undo list is used
+    to perform the inverse operations in the undo list, so that a roll back is
+    performed back to the last commit point. For each successful undo operation,
+    the corresponding item is removed from the undo list. If all undo
+    operations succeed, the undo list will be empty.
+
+    The WBEM operation methods listed below are those that have associated
+    undo operations. All other WBEM operations are passed through to the
+    target connection.
+
+    Limitations:
+
+    * CIM method invocations (i.e. the
+      :meth:`~pywbem.WBEMConnection.InvokeMethod` operation) cannot be rolled
+      back for conceptual reasons. The :meth:`rollback` method will raise
+      :exc:`~pywbem.RollbackError` once it encounters the undo item for that
+      operation. Users that want to simply ignore CIM method invocations during
+      rollback can catch that exception, detect the operation from its
+      :attr:`~pywbem.RollbackError.orig_name` attribute and ignore it.
+
+    * An enumeration session that was closed either implicitly by exhausting
+      the enumeration, or explicitly via
+      :meth:`~pywbem.WBEMConnection.CloseEnumeration` will not be reopened
+      during a roll back. No exception is raised, though.
+    """
+
+    def __init__(self, conn):
+        """
+        Parameters:
+
+          conn (:class:`~pywbem.WBEMConnection`): The target WBEM connection.
+            Can also be a :class:`~pywbem_mock.FakedWBEMConnection` object.
+            Must not be `None`.
+        """
+        if not isinstance(conn, WBEMConnection):
+            raise TypeError(
+                "conn argument must be a pywbem.WBEMConnection object, "
+                "but is {}".format(type(conn)))
+
+        # Target connection
+        self._conn = conn
+
+        # Undo list with items: tuple(orig_name, undo_name, undo_kwargs)
+        # The items are in the original (=forward) order.
+        self._undo_list = []
+
+    @property
+    def conn(self):
+        """
+        :class:`~pywbem.WBEMConnection`: The target WBEM connection.
+        """
+        return self._conn
+
+    @property
+    def undo_list(self):
+        """
+        list: The current undo list.
+
+        The undo list is in the original (=forward) order, where each item is
+        a tuple(orig_name, undo_name, undo_kwargs), with:
+
+        * orig_name(string): Name of the original operation that will be undone.
+        * undo_name(string): Name of the undo operation.
+        * undo_kwargs(dict): Keyword arguments for the undo operation.
+        """
+        return self._undo_list
+
+    def commit(self):
+        """
+        Commit the operations, establishing a new commit point.
+
+        This empties the undo list.
+        """
+        del self.undo_list[:]  # list.clear() requires Python >=3.3
+
+    def rollback(self):
+        """
+        Roll back the operations until the current commit point.
+
+        This performs the undo operations in the current undo list in reverse
+        order. For each successful undo operation, it removes the
+        corresponding item from the undo list. If all undo operations succeed,
+        the undo list will be empty; otherwise it will contain the remaining
+        undo items.
+
+        Raises:
+          RollbackError: An undo operation had a problem.
+        """
+        for undo_tuple in reversed(self.undo_list):
+            orig_name, undo_name, undo_kwargs = undo_tuple
+            if undo_name == 'RollbackError':
+                raise RollbackError(
+                    orig_name=orig_name,
+                    message=undo_kwargs['message'])
+            undo_meth = getattr(self.conn, undo_name)
+            try:
+                undo_meth(**undo_kwargs)
+                del self.undo_list[-1]  # Last item
+            except Error as exc:
+                new_exc = RollbackError(
+                    orig_name=orig_name,
+                    undo_name=undo_name,
+                    undo_kwargs=undo_kwargs,
+                    message="Cannot roll back {oop}: {uop} failed: {msg}".
+                    format(oop=orig_name, uop=undo_name, msg=exc))
+                new_exc.__cause__ = None
+                raise new_exc
+        assert not self.undo_list
+
+    def ModifyInstance(
+            self, ModifiedInstance, IncludeQualifiers=None, PropertyList=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.ModifyInstance` and prepare the
+        inverse ModifyInstance operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_inst = self.conn.GetInstance(
+                InstanceName=ModifiedInstance.path,
+                LocalOnly=False,
+                IncludeQualifiers=IncludeQualifiers,
+                IncludeClassOrigin=False)
+            exc = None
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.ModifyInstance(
+            ModifiedInstance=ModifiedInstance,
+            IncludeQualifiers=IncludeQualifiers,
+            PropertyList=PropertyList)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for ModifyInstance: "
+                "GetInstance failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        self.undo_list.append(
+            ('ModifyInstance',
+             'ModifyInstance',
+             dict(
+                 ModifiedInstance=original_inst,
+                 IncludeQualifiers=IncludeQualifiers,
+                 PropertyList=PropertyList)))
+
+    def CreateInstance(self, NewInstance, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.CreateInstance` and prepare the
+        inverse DeleteInstance operation in the undo list.
+        """
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        inst_path = self.conn.CreateInstance(
+            NewInstance=NewInstance,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        self.undo_list.append(
+            ('CreateInstance',
+             'DeleteInstance',
+             dict(
+                 InstanceName=inst_path)))
+
+        return inst_path
+
+    def DeleteInstance(self, InstanceName):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.DeleteInstance` and prepare the
+        inverse CreateInstance operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_inst = self.conn.GetInstance(
+                InstanceName=InstanceName,
+                LocalOnly=False,
+                IncludeQualifiers=False,
+                IncludeClassOrigin=False)
+            exc = None
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.DeleteInstance(InstanceName=InstanceName)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for DeleteInstance: "
+                "GetInstance failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        self.undo_list.append(
+            ('DeleteInstance',
+             'CreateInstance',
+             dict(
+                 NewInstance=original_inst,
+                 namespace=InstanceName.namespace)))
+
+    def InvokeMethod(self, MethodName, ObjectName, Params=None, **params):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.InvokeMethod` and prepare a
+        rollback error in the undo list (CIM method invocations cannot be
+        rolled back).
+        """
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        result = self.conn.InvokeMethod(
+            MethodName=MethodName,
+            ObjectName=ObjectName,
+            Params=Params,
+            **params)
+
+        # The operation succeeded.
+        # Append a rollback error to the undo list.
+        self.undo_list.append(
+            ('InvokeMethod',
+             'RollbackError',
+             dict(
+                 message="Cannot roll back InvokeMethod: MethodName={mn}, "
+                 "ObjectName={on}".format(mn=MethodName, on=ObjectName))))
+
+        return result
+
+    def ModifyClass(self, ModifiedClass, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.ModifyClass` and prepare the
+        inverse ModifyClass operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_class = self.conn.GetClass(
+                ClassName=ModifiedClass.classname,
+                namespace=namespace,
+                LocalOnly=True,
+                IncludeQualifiers=True,
+                IncludeClassOrigin=True)
+            exc = None
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.ModifyClass(
+            ModifiedClass=ModifiedClass,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for ModifyClass: "
+                "GetClass failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        self.undo_list.append(
+            ('ModifyClass',
+             'ModifyClass',
+             dict(
+                 ModifiedClass=original_class,
+                 namespace=namespace)))
+
+    def CreateClass(self, NewClass, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.CreateClass` and prepare the
+        inverse DeleteClass operation in the undo list.
+        """
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.CreateClass(
+            NewClass=NewClass,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        self.undo_list.append(
+            ('CreateClass',
+             'DeleteClass',
+             dict(
+                 ClassName=NewClass.classname,
+                 namespace=namespace)))
+
+    def DeleteClass(self, ClassName, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.DeleteClass` and prepare the
+        inverse CreateClass operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_class = self.conn.GetClass(
+                ClassName=ClassName,
+                namespace=namespace,
+                LocalOnly=True,
+                IncludeQualifiers=True,
+                IncludeClassOrigin=True)
+            exc = None
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.DeleteClass(
+            ClassName=ClassName,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for DeleteClass: "
+                "GetClass failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        self.undo_list.append(
+            ('DeleteClass',
+             'CreateClass',
+             dict(
+                 NewClass=original_class,
+                 namespace=namespace)))
+
+    def SetQualifier(self, QualifierDeclaration, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.SetQualifier` and prepare the
+        inverse SetQualifier or DeleteQualifier operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_qualifier = self.conn.GetQualifier(
+                QualifierName=QualifierDeclaration.name,
+                namespace=namespace)
+            exc = None
+        except CIMError as ex:
+            if ex.status_code == CIM_ERR_NOT_FOUND:
+                original_qualifier = None
+                exc = None
+            else:
+                exc = ex
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.SetQualifier(
+            QualifierDeclaration=QualifierDeclaration,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for SetQualifier: "
+                "GetQualifier failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        if original_qualifier:
+            # The qualifier declaration existed before, so this was a modify:
+            self.undo_list.append(
+                ('SetQualifier',
+                 'SetQualifier',
+                 dict(
+                     QualifierDeclaration=original_qualifier,
+                     namespace=namespace)))
+        else:
+            # The qualifier declaration did not exist before, so this was a
+            # create:
+            self.undo_list.append(
+                ('SetQualifier',
+                 'DeleteQualifier',
+                 dict(
+                     QualifierName=QualifierDeclaration.name,
+                     namespace=namespace)))
+
+    def DeleteQualifier(self, QualifierName, namespace=None):
+        # pylint: disable=invalid-name
+        """
+        Call :meth:`~pywbem.WBEMConnection.DeleteQualifier` and prepare the
+        inverse SetQualifier operation in the undo list.
+        """
+
+        # Get data needed for inverse operation
+        try:
+            original_qualifier = self.conn.GetQualifier(
+                QualifierName=QualifierName,
+                namespace=namespace)
+            exc = None
+        except Error as ex:
+            exc = ex
+
+        # Call the operation on the target connection.
+        # Exceptions will perculate up and the undo list remains unchanged.
+        self.conn.DeleteQualifier(
+            QualifierName=QualifierName,
+            namespace=namespace)
+
+        # The operation succeeded.
+        # Append the inverse operation to the undo list.
+        if exc:
+            new_exc = RollbackPreparationError(
+                "Cannot create undo operation for DeleteQualifier: "
+                "GetQualifier failed: {}".format(exc))
+            new_exc.__cause__ = None
+            raise new_exc
+        self.undo_list.append(
+            ('DeleteQualifier',
+             'SetQualifier',
+             dict(
+                 QualifierDeclaration=original_qualifier,
+                 namespace=namespace)))
+
+    def EnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.EnumerateInstances`"
+        return self.conn.EnumerateInstances(*args, **kwargs)
+
+    def EnumerateInstanceNames(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.EnumerateInstanceNames`"
+        return self.conn.EnumerateInstanceNames(*args, **kwargs)
+
+    def GetInstance(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.GetInstance`"
+        return self.conn.GetInstance(*args, **kwargs)
+
+    def Associators(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.Associators`"
+        return self.conn.Associators(*args, **kwargs)
+
+    def AssociatorNames(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.AssociatorNames`"
+        return self.conn.AssociatorNames(*args, **kwargs)
+
+    def References(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.References`"
+        return self.conn.References(*args, **kwargs)
+
+    def ReferenceNames(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.ReferenceNames`"
+        return self.conn.ReferenceNames(*args, **kwargs)
+
+    def ExecQuery(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.ExecQuery`"
+        return self.conn.ExecQuery(*args, **kwargs)
+
+    def IterEnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterEnumerateInstances`"
+        return self.conn.IterEnumerateInstances(*args, **kwargs)
+
+    def IterEnumerateInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterEnumerateInstancePaths`"
+        return self.conn.IterEnumerateInstancePaths(*args, **kwargs)
+
+    def IterAssociatorInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterAssociatorInstances`"
+        return self.conn.IterAssociatorInstances(*args, **kwargs)
+
+    def IterAssociatorInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterAssociatorInstancePaths`"
+        return self.conn.IterAssociatorInstancePaths(*args, **kwargs)
+
+    def IterReferenceInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterReferenceInstances`"
+        return self.conn.IterReferenceInstances(*args, **kwargs)
+
+    def IterReferenceInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterReferenceInstancePaths`"
+        return self.conn.IterReferenceInstancePaths(*args, **kwargs)
+
+    def IterQueryInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.IterQueryInstances`"
+        return self.conn.IterQueryInstances(*args, **kwargs)
+
+    def OpenEnumerateInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenEnumerateInstances`"
+        return self.conn.OpenEnumerateInstances(*args, **kwargs)
+
+    def OpenEnumerateInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenEnumerateInstancePaths`"
+        return self.conn.OpenEnumerateInstancePaths(*args, **kwargs)
+
+    def OpenAssociatorInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenAssociatorInstances`"
+        return self.conn.OpenAssociatorInstances(*args, **kwargs)
+
+    def OpenAssociatorInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenAssociatorInstancePaths`"
+        return self.conn.OpenAssociatorInstancePaths(*args, **kwargs)
+
+    def OpenReferenceInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenReferenceInstances`"
+        return self.conn.OpenReferenceInstances(*args, **kwargs)
+
+    def OpenReferenceInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenReferenceInstancePaths`"
+        return self.conn.OpenReferenceInstancePaths(*args, **kwargs)
+
+    def OpenQueryInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.OpenQueryInstances`"
+        return self.conn.OpenQueryInstances(*args, **kwargs)
+
+    def PullInstancesWithPath(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.PullInstancesWithPath`"
+        return self.conn.PullInstancesWithPath(*args, **kwargs)
+
+    def PullInstancePaths(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.PullInstancePaths`"
+        return self.conn.PullInstancePaths(*args, **kwargs)
+
+    def PullInstances(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.PullInstances`"
+        return self.conn.PullInstances(*args, **kwargs)
+
+    def CloseEnumeration(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.CloseEnumeration`"
+        return self.conn.CloseEnumeration(*args, **kwargs)
+
+    def EnumerateClasses(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.EnumerateClasses`"
+        return self.conn.EnumerateClasses(*args, **kwargs)
+
+    def EnumerateClassNames(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.EnumerateClassNames`"
+        return self.conn.EnumerateClassNames(*args, **kwargs)
+
+    def GetClass(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.GetClass`"
+        return self.conn.GetClass(*args, **kwargs)
+
+    def EnumerateQualifiers(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.EnumerateQualifiers`"
+        return self.conn.EnumerateQualifiers(*args, **kwargs)
+
+    def GetQualifier(self, *args, **kwargs):
+        # pylint: disable=invalid-name
+        "Call :meth:`~pywbem.WBEMConnection.GetQualifier`"
+        return self.conn.GetQualifier(*args, **kwargs)

--- a/tests/unittest/pywbem/test_rollback_conn.py
+++ b/tests/unittest/pywbem/test_rollback_conn.py
@@ -1,0 +1,1238 @@
+"""
+Unittest functions in _rollback_conn.
+"""
+
+from __future__ import print_function, absolute_import
+
+import re
+from copy import deepcopy
+import pytest
+from mock import patch
+
+from ..utils.pytest_extensions import simplified_test_function
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from ...utils import import_installed
+pywbem = import_installed('pywbem')
+from pywbem import RollbackWBEMConnection, RollbackError, \
+    RollbackPreparationError, WBEMConnection, CIMInstanceName, \
+    CIMInstance, CIMClass, CIMProperty, CIMMethod, CIMQualifier, \
+    CIMQualifierDeclaration, CIMError, HTTPError, Uint32, \
+    CIM_ERR_FAILED, CIM_ERR_NOT_FOUND, CIM_ERR_ALREADY_EXISTS, \
+    CIM_ERR_METHOD_NOT_AVAILABLE  # noqa: E402
+pywbem_mock = import_installed('pywbem_mock')
+from pywbem_mock import FakedWBEMConnection, MethodProvider  # noqa: E402
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+
+def remove_path_origin(cim_obj):
+    """
+    Return a copy of a CIMInstance or CIMClass object with removed path and
+    class origin of its properties and methods.
+    """
+    assert isinstance(cim_obj, (CIMInstance, CIMClass))
+    cim_obj = deepcopy(cim_obj)
+    cim_obj.path = None
+    for prop in cim_obj.properties.values():
+        prop.class_origin = None
+    if isinstance(cim_obj, CIMClass):
+        for meth in cim_obj.methods.values():
+            meth.class_origin = None
+    return cim_obj
+
+
+def assert_equal_ignoring_path_origin(act_obj, exp_obj, msg):
+    """
+    Assert that two objects are equal, except that if they are CIMInstance or
+    CIMClass objects or lists/tuples thereof, then their path and the class
+    origin of their properties and methods is ignored in the equality test.
+
+    Background for this function is that some WBEM operations return instances
+    or classes with the path and class origin set, and ignoring that keeps the
+    testcase definitions simpler.
+    """
+
+    if isinstance(exp_obj, (list, tuple)):
+        assert len(act_obj) == len(exp_obj), msg
+        for i, exp_obj_item in enumerate(exp_obj):
+            act_obj_item = act_obj[i]
+            assert_equal_ignoring_path_origin(act_obj_item, exp_obj_item, msg)
+        return
+
+    if isinstance(exp_obj, (CIMInstance, CIMClass)):
+        act_obj = remove_path_origin(act_obj)
+        exp_obj = remove_path_origin(exp_obj)
+
+    assert act_obj == exp_obj, msg
+
+
+# A simple mock repository for testing:
+
+REPO_OBJS_QUAL_KEY = CIMQualifierDeclaration(
+    'Key', type='boolean', value=False,
+    scopes=dict(PROPERTY=True))
+REPO_OBJS_QUAL_KEY_NEW = CIMQualifierDeclaration(
+    'Key', type='boolean', value=False,
+    scopes=dict(PROPERTY=True, REFERENCE=True))
+
+REPO_OBJS_QUAL_KOO = CIMQualifierDeclaration(
+    'Koo', type='boolean', value=False,
+    scopes=dict(PROPERTY=True))
+
+REPO_OBJS_PROP_FOO_K1 = CIMProperty(
+    'K1', type='string', value=None,
+    qualifiers=[CIMQualifier('Key', value=True)])
+
+REPO_OBJS_PROP_FOO_P1 = CIMProperty(
+    'P1', type='string', value=None)
+
+REPO_OBJS_METH_FOO_M1 = CIMMethod(
+    'M1', return_type='uint32')
+
+REPO_OBJS_CLASS_FOO = CIMClass(
+    'Foo',
+    properties=[
+        REPO_OBJS_PROP_FOO_K1,
+        REPO_OBJS_PROP_FOO_P1,
+    ],
+    methods=[
+        REPO_OBJS_METH_FOO_M1,
+    ]
+)
+REPO_OBJS_CLASS_FOO_MOD = CIMClass(
+    'Foo',
+    properties=[
+        REPO_OBJS_PROP_FOO_K1,
+        REPO_OBJS_PROP_FOO_P1,
+    ],
+    methods=[
+        # Deleted the method M1
+    ]
+)
+
+REPO_OBJS_INSTNAME_FOO_K1 = CIMInstanceName(
+    'Foo',
+    keybindings=dict(K1='k1'),
+    namespace='root/cimv2',
+)
+REPO_OBJS_INST_FOO_K1 = CIMInstance(
+    'Foo',
+    properties=[
+        CIMProperty('K1', value='k1'),
+        CIMProperty('P1', value='p1'),
+    ],
+    path=REPO_OBJS_INSTNAME_FOO_K1,
+)
+REPO_OBJS_INST_FOO_K1_MOD = CIMInstance(
+    'Foo',
+    properties=[
+        CIMProperty('K1', value='k1'),
+        CIMProperty('P1', value='p1changed'),
+    ],
+    path=REPO_OBJS_INSTNAME_FOO_K1,
+)
+
+REPO_OBJS_INSTNAME_FOO_K2 = CIMInstanceName(
+    'Foo',
+    keybindings=dict(K1='k2'),
+    namespace='root/cimv2',
+)
+REPO_OBJS_INST_FOO_K2_NEW = CIMInstance(
+    'Foo',
+    properties=[
+        CIMProperty('K1', value='k2'),
+        CIMProperty('P1', value='p2'),
+    ],
+    path=REPO_OBJS_INSTNAME_FOO_K2,
+)
+
+REPO_OBJS_CLASS_BOO_NEW = CIMClass('Boo')
+
+REPO_OBJECTS = [
+    REPO_OBJS_QUAL_KEY,
+    REPO_OBJS_CLASS_FOO,
+    REPO_OBJS_INST_FOO_K1,
+]
+
+
+# Providers for the simple mock repository:
+
+class FooM1MethodProvider(MethodProvider):
+    """
+    A method provider for Foo.M1() in the simple repo.
+    """
+    provider_classnames = 'Foo'
+
+    def InvokeMethod(self, methodname, localobject, params):
+        """
+        All method invocations for Foo.
+        """
+        if methodname.lower() == 'm1':
+            return (Uint32(42), {})
+        raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
+
+
+REPO_PROVIDERS = [
+    FooM1MethodProvider(),
+]
+
+
+# Dummy WBEM connections for testing:
+FAKED_CONN = FakedWBEMConnection()
+REAL_CONN = WBEMConnection(url="localhost")
+
+
+TESTCASES_RBCONN_INIT = [
+
+    # Testcases for initialization of a RollbackWBEMConnection object.
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * init_kwargs: dict of init arguments for RollbackWBEMConnection
+    #   * exp_attrs: dict of expected RollbackWBEMConnection attrs after init
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    (
+        "Missing required conn init parameter",
+        dict(
+            init_kwargs=dict(),
+            exp_attrs=dict(),
+        ),
+        TypeError, None, True
+    ),
+    (
+        "Invalid type for conn init parameter",
+        dict(
+            init_kwargs=dict(conn='bla'),
+            exp_attrs=dict(),
+        ),
+        TypeError, None, True
+    ),
+    (
+        "Pass FakedWBEMConnection() object for conn init parameter",
+        dict(
+            init_kwargs=dict(conn=FAKED_CONN),
+            exp_attrs=dict(conn=FAKED_CONN, undo_list=[]),
+        ),
+        None, None, True
+    ),
+    (
+        "Pass WBEMConnection() object for conn init parameter",
+        dict(
+            init_kwargs=dict(conn=REAL_CONN),
+            exp_attrs=dict(conn=REAL_CONN, undo_list=[]),
+        ),
+        None, None, True
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_RBCONN_INIT)
+@simplified_test_function
+def test_rbconn_init(testcase, init_kwargs, exp_attrs):
+    """
+    Test function for initialization of a RollbackWBEMConnection object.
+    """
+
+    # The code to be tested
+    conn = RollbackWBEMConnection(**init_kwargs)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    for name in exp_attrs:
+        exp_value = exp_attrs[name]
+        act_value = getattr(conn, name)
+        assert act_value == exp_value
+
+
+TESTCASES_RBCONN_OPERATION = [
+
+    # Testcases for RollbackWBEMConnection operation method calls.
+
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * method: Name of operation method to call.
+    #   * kwargs: Keyword arguments for the operation being called.
+    #   * inject_exc: Dictionary defining an exception to inject into an
+    #     operation, or None:
+    #     * method: Name of the operation method that should raise the
+    #       exception.
+    #     * exc_obj: Exception object to be raised.
+    #   * exp_result: Expected return value from operation being called.
+    #   * exp_undo_method: Expected name of operation undo method, or None to
+    #     indicate that no undo item is expected.
+    #   * exp_undo_kwargs: Expected keyword arguments for the undo method, or
+    #     None.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    # Methods that have undo work (we test all of them):
+    (
+        "ModifyInstance on existing instance Foo.K1=k1",
+        dict(
+            method='ModifyInstance',
+            kwargs=dict(
+                ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='ModifyInstance',
+            exp_undo_kwargs=dict(
+                ModifiedInstance=REPO_OBJS_INST_FOO_K1,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance on existing instance Foo.K1=k1, with failing "
+        "undo preparation method GetInstance",
+        dict(
+            method='ModifyInstance',
+            kwargs=dict(
+                ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+            ),
+            inject_exc=dict(
+                method='GetInstance',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "ModifyInstance on non-existing instance Foo.K1=k2",
+        dict(
+            method='ModifyInstance',
+            kwargs=dict(
+                ModifiedInstance=REPO_OBJS_INST_FOO_K2_NEW,
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_NOT_FOUND),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "CreateInstance on non-existing instance Foo.K1=k2",
+        dict(
+            method='CreateInstance',
+            kwargs=dict(
+                NewInstance=REPO_OBJS_INST_FOO_K2_NEW,
+            ),
+            inject_exc=None,
+            exp_result=REPO_OBJS_INSTNAME_FOO_K2,
+            exp_undo_method='DeleteInstance',
+            exp_undo_kwargs=dict(
+                InstanceName=REPO_OBJS_INSTNAME_FOO_K2,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "CreateInstance on existing instance Foo.K1=k1",
+        dict(
+            method='CreateInstance',
+            kwargs=dict(
+                NewInstance=REPO_OBJS_INST_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_ALREADY_EXISTS),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "DeleteInstance on existing instance Foo.K1=k1",
+        dict(
+            method='DeleteInstance',
+            kwargs=dict(
+                InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='CreateInstance',
+            exp_undo_kwargs=dict(
+                NewInstance=REPO_OBJS_INST_FOO_K1,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "DeleteInstance on existing instance Foo.K1=k1, with failing "
+        "undo preparation method GetInstance",
+        dict(
+            method='DeleteInstance',
+            kwargs=dict(
+                InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=dict(
+                method='GetInstance',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "DeleteInstance on non-existing instance Foo.K1=k2",
+        dict(
+            method='DeleteInstance',
+            kwargs=dict(
+                InstanceName=REPO_OBJS_INSTNAME_FOO_K2,
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_NOT_FOUND),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "InvokeMethod on existing instance Foo.K1=k1",
+        dict(
+            method='InvokeMethod',
+            kwargs=dict(
+                MethodName='M1',
+                ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=(Uint32(42), {}),
+            exp_undo_method='RollbackError',
+            exp_undo_kwargs=dict(
+                message="Cannot roll back InvokeMethod",
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyClass on existing class Foo",
+        dict(
+            method='ModifyClass',
+            kwargs=dict(
+                ModifiedClass=REPO_OBJS_CLASS_FOO_MOD,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='ModifyClass',
+            exp_undo_kwargs=dict(
+                ModifiedClass=REPO_OBJS_CLASS_FOO,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyClass on existing class Foo, with failing "
+        "undo preparation method GetClass",
+        dict(
+            method='ModifyClass',
+            kwargs=dict(
+                ModifiedClass=REPO_OBJS_CLASS_FOO_MOD,
+            ),
+            inject_exc=dict(
+                method='GetClass',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "ModifyClass on non-existing class Boo",
+        dict(
+            method='ModifyClass',
+            kwargs=dict(
+                ModifiedClass=REPO_OBJS_CLASS_BOO_NEW,
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_NOT_FOUND),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "CreateClass on non-existing class Boo",
+        dict(
+            method='CreateClass',
+            kwargs=dict(
+                NewClass=REPO_OBJS_CLASS_BOO_NEW,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='DeleteClass',
+            exp_undo_kwargs=dict(
+                ClassName='Boo',
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "CreateClass on existing class Foo",
+        dict(
+            method='CreateClass',
+            kwargs=dict(
+                NewClass=REPO_OBJS_CLASS_FOO,
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_ALREADY_EXISTS),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "DeleteClass on existing class Foo",
+        dict(
+            method='DeleteClass',
+            kwargs=dict(
+                ClassName='Foo',
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='CreateClass',
+            exp_undo_kwargs=dict(
+                NewClass=REPO_OBJS_CLASS_FOO,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "DeleteClass on existing class Foo, with failing "
+        "undo preparation method GetClass",
+        dict(
+            method='DeleteClass',
+            kwargs=dict(
+                ClassName='Foo',
+            ),
+            inject_exc=dict(
+                method='GetClass',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "DeleteClass on non-existing class Boo",
+        dict(
+            method='DeleteClass',
+            kwargs=dict(
+                ClassName='Boo',
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_NOT_FOUND),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "SetQualifier on existing qualifier declaration Key",
+        dict(
+            method='SetQualifier',
+            kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KEY_NEW,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='SetQualifier',
+            exp_undo_kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KEY,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "SetQualifier on existing qualifier declaration Key, with failing "
+        "undo preparation method GetQualifier raising CIMError",
+        dict(
+            method='SetQualifier',
+            kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KEY_NEW,
+            ),
+            inject_exc=dict(
+                method='GetQualifier',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "SetQualifier on existing qualifier declaration Key, with failing "
+        "undo preparation method GetQualifier raising HTTPError",
+        dict(
+            method='SetQualifier',
+            kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KEY_NEW,
+            ),
+            inject_exc=dict(
+                method='GetQualifier',
+                exc_obj=HTTPError(500, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "SetQualifier on non-existing qualifier declaration Koo",
+        dict(
+            method='SetQualifier',
+            kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KOO,
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='DeleteQualifier',
+            exp_undo_kwargs=dict(
+                QualifierName='Koo',
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "SetQualifier on non-existing qualifier declaration Koo, with failing "
+        "undo preparation method GetQualifier",
+        dict(
+            method='SetQualifier',
+            kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KOO,
+            ),
+            inject_exc=dict(
+                method='GetQualifier',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "DeleteQualifier on existing qualifier declaration Key",
+        dict(
+            method='DeleteQualifier',
+            kwargs=dict(
+                QualifierName='Key',
+            ),
+            inject_exc=None,
+            exp_result=None,
+            exp_undo_method='SetQualifier',
+            exp_undo_kwargs=dict(
+                QualifierDeclaration=REPO_OBJS_QUAL_KEY,
+            ),
+        ),
+        None, None, True
+    ),
+    (
+        "DeleteQualifier on existing qualifier declaration Key, with failing "
+        "undo preparation method GetQualifier",
+        dict(
+            method='DeleteQualifier',
+            kwargs=dict(
+                QualifierName='Key',
+            ),
+            inject_exc=dict(
+                method='GetQualifier',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_result=None,
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        RollbackPreparationError, None, True
+    ),
+    (
+        "DeleteQualifier on non-existing qualifier declaration Koo",
+        dict(
+            method='DeleteQualifier',
+            kwargs=dict(
+                QualifierName='Koo',
+            ),
+            inject_exc=None,
+            exp_result=CIMError(CIM_ERR_NOT_FOUND),
+            exp_undo_method=None,
+            exp_undo_kwargs=None,
+        ),
+        CIMError, None, True
+    ),
+
+    # Passthru methods without undo work:
+    (
+        "EnumerateInstances on existing class Foo",
+        dict(
+            method='EnumerateInstances',
+            kwargs=dict(
+                ClassName='Foo',
+            ),
+            inject_exc=None,
+            exp_result=[REPO_OBJS_INST_FOO_K1],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "EnumerateInstanceNames on existing class Foo",
+        dict(
+            method='EnumerateInstanceNames',
+            kwargs=dict(
+                ClassName='Foo',
+            ),
+            inject_exc=None,
+            exp_result=[REPO_OBJS_INSTNAME_FOO_K1],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "GetInstance on existing instance Foo.K1=k1",
+        dict(
+            method='GetInstance',
+            kwargs=dict(
+                InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=REPO_OBJS_INST_FOO_K1,
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "Associators on existing instance Foo.K1=k1",
+        dict(
+            method='Associators',
+            kwargs=dict(
+                ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=[],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "AssociatorNames on existing instance Foo.K1=k1",
+        dict(
+            method='AssociatorNames',
+            kwargs=dict(
+                ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=[],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "References on existing instance Foo.K1=k1",
+        dict(
+            method='References',
+            kwargs=dict(
+                ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=[],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "ReferenceNames on existing instance Foo.K1=k1",
+        dict(
+            method='ReferenceNames',
+            kwargs=dict(
+                ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+            ),
+            inject_exc=None,
+            exp_result=[],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "EnumerateClasses",
+        dict(
+            method='EnumerateClasses',
+            kwargs=dict(),
+            inject_exc=None,
+            exp_result=[REPO_OBJS_CLASS_FOO],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "EnumerateClassNames",
+        dict(
+            method='EnumerateClassNames',
+            kwargs=dict(),
+            inject_exc=None,
+            exp_result=['Foo'],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "GetClass on existing class Foo",
+        dict(
+            method='GetClass',
+            kwargs=dict(
+                ClassName='Foo',
+            ),
+            inject_exc=None,
+            exp_result=REPO_OBJS_CLASS_FOO,
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "EnumerateQualifiers",
+        dict(
+            method='EnumerateQualifiers',
+            kwargs=dict(),
+            inject_exc=None,
+            exp_result=[REPO_OBJS_QUAL_KEY],
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+    (
+        "GetQualifier on existing qualifier Key",
+        dict(
+            method='GetQualifier',
+            kwargs=dict(
+                QualifierName='Key',
+            ),
+            inject_exc=None,
+            exp_result=REPO_OBJS_QUAL_KEY,
+            exp_undo_method=None,  # Indicates passthru method
+            exp_undo_kwargs=None,
+        ),
+        None, None, True
+    ),
+
+    # The following pass-through operations do not have testcases, because
+    # that would make the testcase definition more complex:
+    # * ExecQuery
+    # * IterEnumerateInstances
+    # * IterEnumerateInstancePaths
+    # * IterAssociatorInstances
+    # * IterAssociatorInstancePaths
+    # * IterReferenceInstances
+    # * IterReferenceInstancePaths
+    # * IterQueryInstances
+    # * OpenEnumerateInstances
+    # * OpenEnumerateInstancePaths
+    # * OpenAssociatorInstances
+    # * OpenAssociatorInstancePaths
+    # * OpenReferenceInstances
+    # * OpenReferenceInstancePaths
+    # * OpenQueryInstances
+    # * PullInstancesWithPath
+    # * PullInstancePaths
+    # * PullInstances
+    # * CloseEnumeration
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_RBCONN_OPERATION)
+@simplified_test_function
+def test_rbconn_operation(
+        testcase, method, kwargs, inject_exc, exp_result, exp_undo_method,
+        exp_undo_kwargs):
+    """
+    Test function for RollbackWBEMConnection operation method calls.
+
+    Execute the defined operation method, verify it was called with the
+    expected arguments, and verify the resulting undo list. This is an in-depth
+    verification of each single operation method and its effects on the undo
+    list.
+
+    A pywbem mock environment with a simple repository REPO_OBJECTS and
+    providers defined in REPO_PROVIDERS is used as the target connection of the
+    rollback connection.
+
+    The operation being tested is (Python-)mocked at the level of the
+    FakedWBEMConnection class by wrapping it so that it is still called but the
+    call can be verified using a Python mock object.
+    """
+
+    conn = FakedWBEMConnection()
+    conn.add_cimobjects(REPO_OBJECTS)
+    for prov in REPO_PROVIDERS:
+        conn.register_provider(prov)
+
+    rbconn = RollbackWBEMConnection(conn)
+    meth = getattr(rbconn, method)
+
+    with patch.object(conn, method, wraps=getattr(conn, method)) as method_mock:
+
+        try:
+            if inject_exc:
+                inject_patcher = patch.object(conn, inject_exc['method'])
+                inject_mock = inject_patcher.start()
+                inject_mock.side_effect = inject_exc['exc_obj']
+
+            # The code to be tested
+            result = meth(**kwargs)
+
+            # Ensure that exceptions raised in the remainder of this function
+            # are not mistaken as expected exceptions
+            assert testcase.exp_exc_types is None
+
+            # Check return value
+            assert_equal_ignoring_path_origin(
+                result, exp_result, 'Unexpected result')
+
+            # Check that the target connection operation was called correctly
+            method_mock.assert_called_once()
+            for arg_name in kwargs:
+                exp_arg_value = kwargs[arg_name]
+                act_kwargs = method_mock.call_args[1]
+                act_arg_value = act_kwargs[arg_name]
+                assert act_arg_value == exp_arg_value, arg_name
+
+            # Check the undo list
+            if exp_undo_method is None:
+                assert len(rbconn.undo_list) == 0
+            else:
+                assert len(rbconn.undo_list) == 1
+                orig_name, undo_name, undo_kwargs = rbconn.undo_list[0]
+                assert orig_name == method
+                assert undo_name == exp_undo_method
+                if undo_name == 'RollbackError':
+                    # Check just the message (as a regexp)
+                    exp_msg_pattern = exp_undo_kwargs['message']
+                    act_msg = undo_kwargs['message']
+                    assert re.search(exp_msg_pattern, act_msg)
+                else:
+                    # Check each expected undo argument.
+                    for arg_name in exp_undo_kwargs:
+                        exp_arg_value = exp_undo_kwargs[arg_name]
+                        act_arg_value = undo_kwargs[arg_name]
+                        assert_equal_ignoring_path_origin(
+                            exp_arg_value, act_arg_value,
+                            "Unexpected undo argument {}".format(arg_name))
+        finally:
+            if inject_exc:
+                inject_patcher.stop()
+
+
+TESTCASES_RBCONN_COMMIT_ROLLBACK = [
+
+    # Testcases for RollbackWBEMConnection.commit/rollback().
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * actions: List of actions to perform, where each list item specifies
+    #     one method to be invoked as a dict with items:
+    #     * method: Name of method to call.
+    #     * kwargs: Keyword arguments for the method being called.
+    #   * inject_exc: Dictionary defining an exception to inject into an
+    #     operation, or None:
+    #     * method: Name of the operation method that should raise the
+    #       exception.
+    #     * exc_obj: Exception object to be raised.
+    #   * exp_orig_names: Expected original method names in the undo list
+    #     after the actions have been performed.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    (
+        "rollback without any ops performed",
+        dict(
+            actions=[
+                dict(method='rollback'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "commit without any ops performed",
+        dict(
+            actions=[
+                dict(method='commit'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+            ],
+            inject_exc=None,
+            exp_orig_names=['ModifyInstance'],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance + rollback",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(method='rollback'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance + DeleteInstance + rollback",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(
+                    method='DeleteInstance',
+                    kwargs=dict(
+                        InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+                dict(method='rollback'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "DeleteInstance + rollback, with failing "
+        "undo method CreateInstance",
+        dict(
+            actions=[
+                dict(
+                    method='DeleteInstance',
+                    kwargs=dict(
+                        InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+                dict(method='rollback'),
+            ],
+            inject_exc=dict(
+                method='CreateInstance',
+                exc_obj=CIMError(CIM_ERR_FAILED, "Injected error"),
+            ),
+            exp_orig_names=[],
+        ),
+        RollbackError, None, True
+    ),
+    (
+        "ModifyInstance + rollback + DeleteInstance",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(method='rollback'),
+                dict(
+                    method='DeleteInstance',
+                    kwargs=dict(
+                        InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+            ],
+            inject_exc=None,
+            exp_orig_names=['DeleteInstance'],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance + commit",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(method='commit'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance + DeleteInstance + commit",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(
+                    method='DeleteInstance',
+                    kwargs=dict(
+                        InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+                dict(method='commit'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+    (
+        "ModifyInstance + commit + DeleteInstance",
+        dict(
+            actions=[
+                dict(
+                    method='ModifyInstance',
+                    kwargs=dict(
+                        ModifiedInstance=REPO_OBJS_INST_FOO_K1_MOD,
+                    )),
+                dict(method='commit'),
+                dict(
+                    method='DeleteInstance',
+                    kwargs=dict(
+                        InstanceName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+            ],
+            inject_exc=None,
+            exp_orig_names=['DeleteInstance'],
+        ),
+        None, None, True
+    ),
+    (
+        "InvokeMethod + rollback (raises RollbackError)",
+        dict(
+            actions=[
+                dict(
+                    method='InvokeMethod',
+                    kwargs=dict(
+                        MethodName='M1',
+                        ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+                dict(method='rollback'),  # raises RollbackError
+            ],
+            inject_exc=None,
+            exp_orig_names=['InvokeMethod'],
+        ),
+        RollbackError, None, True
+    ),
+    (
+        "InvokeMethod + commit + rollback",
+        dict(
+            actions=[
+                dict(
+                    method='InvokeMethod',
+                    kwargs=dict(
+                        MethodName='M1',
+                        ObjectName=REPO_OBJS_INSTNAME_FOO_K1,
+                    )),
+                dict(method='commit'),
+                dict(method='rollback'),
+            ],
+            inject_exc=None,
+            exp_orig_names=[],
+        ),
+        None, None, True
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_RBCONN_COMMIT_ROLLBACK)
+@simplified_test_function
+def test_rbconn_commit_rollback(testcase, actions, inject_exc, exp_orig_names):
+    """
+    Test function for RollbackWBEMConnection.commit/rollback().
+
+    Execute the defined actions (WBEM operations and commit/rollback) and
+    verify that the undo list is as expected.
+
+    A pywbem mock environment with a simple repository REPO_OBJECTS and
+    providers defined in REPO_PROVIDERS is used as the target connection of the
+    rollback connection.
+    """
+
+    conn = FakedWBEMConnection()
+    conn.add_cimobjects(REPO_OBJECTS)
+    for prov in REPO_PROVIDERS:
+        conn.register_provider(prov)
+
+    rbconn = RollbackWBEMConnection(conn)
+
+    try:
+        if inject_exc:
+            inject_patcher = patch.object(conn, inject_exc['method'])
+            inject_mock = inject_patcher.start()
+            inject_mock.side_effect = inject_exc['exc_obj']
+
+        # Perform the defined actions
+        for action in actions:
+            meth = getattr(rbconn, action['method'])
+            kwargs = action.get('kwargs', {})
+
+            # The code to be tested
+            meth(**kwargs)
+
+        # Ensure that exceptions raised in the remainder of this function
+        # are not mistaken as expected exceptions
+        assert testcase.exp_exc_types is None
+
+        # Check the original names in the undo list
+        act_orig_names = [item[0] for item in rbconn.undo_list]
+        assert act_orig_names == exp_orig_names
+
+    finally:
+        if inject_exc:
+            inject_patcher.stop()


### PR DESCRIPTION
See commit message.

While there are still some things to do, the interface to the new class RollbackWBEMConnection is already worthwhile reviewing. Build the documentation with 'make builddoc' and search for the new class "RollbackWBEMConnection".

**DISCUSSION:** 
* Fact: The mof_compiler script implements its `--remove` and `--dry-run` functionalities using `MOFWBEMConnection`:
  - Neither specified: MOF compiled against a real `WBEMConnection`
  - `--dry-run` specified: MOF compiled against a `MOFWBEMConnection` on top of a real `WBEMConnection` (which does not update the real `WBEMConnection`)
  - `--remove` specified: MOF compiled against a `MOFWBEMConnection` on top of a real `WBEMConnection` (which does not update the real `WBEMConnection`), then `rollback()` is called (which does update the real `WBEMConnection`)
* Should we continue to support the dry-run and removal functionalities?
* How to implement dry-run and removal with `RollbackWBEMConnection`?

TODO:
* Use the new RollbackWBEMConnection class in the MOFCompiler class
* Double check how the mof_compiler script creates the MOFCompiler object
* Double check the docstrings of the _mof_compiler.py module and the MOFCompiler class