### PR TITLE
1.1: Docs: Fixed incorrect attr 'provider_classnames' in method provider example

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -69,6 +69,9 @@ Released: 2021-01-01
 * Fixed issue on GitHub Actions with macos by no longer running "brew update"
   in pywbem_os_setup.sh. (issue #2544)
 
+* Docs: Fixed incorrect attribute name 'provider_classnames' in method provider
+  example. (issue #2564)
+
 **Enhancements:**
 
 * Migrated from Travis and Appveyor to GitHub Actions. This required several

--- a/pywbem_mock/_methodprovider.py
+++ b/pywbem_mock/_methodprovider.py
@@ -57,7 +57,7 @@ and returns it as its output parameter ``OutputParam2``:
 
     class MyMethodProvider(MethodProvider):
 
-        provider_classname = 'CIM_Foo_sub_sub'
+        provider_classnames = 'CIM_Foo_sub_sub'
 
         def InvokeMethod(self, methodname, localobject, params):
 


### PR DESCRIPTION
Rolls back PR #2565 into 1.1.4.