### PR TITLE
Fixes and tests for use of compiler namespace pragma

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -98,6 +98,10 @@ Released: not yet
 * Mitigated the coveralls HTTP status 422 by pinning coveralls-python to
   <3.0.0.
 
+* Test: Add tests to test_mof_compiler to test for errors where the namespace
+  name component of the namespace pragma is missing.
+
+
 **Enhancements:**
 
 * Logging: Added a value 'off' for the log destination in the
@@ -164,6 +168,16 @@ Released: not yet
 
 * Docs: Added examples to the `pywbem.siunit()` and `pywbem.siunit_obj()`
   functions.
+
+* Extend the MOF compiler so that the pywbem_mock can compile MOF containing
+  the namespace pragma that defines a namespace other than the one defined in
+  the compile_mof_string() or compile_mof_file() methods namespace parameter if
+  the namespace exists. Extend documentation on use of the namespace parameter
+  to reflect the behavior if the MOF contains a namespace pragma. Since the
+  code gives precedence to tha pragma over the namespace specified
+  in in the namespace parameter, the documentation reflects this. (see issue
+  #2256 partial fix).
+
 
 **Cleanup:**
 

--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -7,9 +7,7 @@ Positional arguments:
                         Can be specified multiple times.
 
 Server related options:
-  Specify the WBEM server and namespace the MOF compiler works against, for
-  looking up existing elements, and for applying the MOF compilation results
-  to.
+  Specify the WBEM server and namespace the MOF compiler works against.
 
   -s url, --server url  Host name or URL of the WBEM server (required),
                         in this format:
@@ -33,20 +31,19 @@ Server related options:
                         Default: root/cimv2
 
 Connection security related options:
-  Specify user name and password or certificates and keys
+  Specify user name and password or certificates and keys.
 
   -u user, --user user  User name for authenticating with the WBEM server.
                         Default: No user name.
   -p password, --password password
                         Password for authenticating with the WBEM server.
-                        Default: Will be prompted for, if user name
-                        specified.
+                        Default: Will be prompted for, if user name specified.
   -nvc, --no-verify-cert
-                        Client will not verify certificate returned by the
-                        WBEM server (see cacerts). This bypasses the client-
-                        side verification of the server identity, but allows
-                        encrypted communication with a server for which the
-                        client does not have certificates.
+                        Client will not verify certificate returned by the WBEM
+                        server (see cacerts). This bypasses the client-side
+                        verification of the server identity, but allows encrypted
+                        communication with a server for which the client does not have
+                        certificates.
   --cacerts cacerts     CA certificates to be used for verifying the server
                         certificate presented by the WBEM server during TLS/SSL
                         handshake:
@@ -61,18 +58,17 @@ Connection security related options:
                         WBEM server. Not required if private key is part of the
                         certfile option. Not allowed if no certfile option.
                         Default: No client key file. Client private key should
-                        then be part  of the certfile
+                        then be part of the certfile.
 
 Action related options:
-  Specify actions against the WBEM server's namespace. Default:
-  Create/update elements.
+  Specify actions against the WBEM server's namespace.
 
-  -r, --remove          Removal mode: Remove elements (found in the MOF files)
-                        from the WBEM server's namespace, instead of creating
-                        or updating them
+  -r, --remove          Removal mode: Remove elements (found in the MOF files) from
+                        the WBEM server's namespace, instead of creating or updating
+                        them.
   -d, --dry-run         Dry-run mode: Don't actually modify the WBEM server's
-                        namespace, just check MOF syntax. Connection to WBEM
-                        server is still required to check qualifiers.
+                        namespace, just check MOF syntax. Connection to WBEM server is
+                        still required to check qualifiers.
 
 General options:
   -I dir, --include dir
@@ -87,7 +83,7 @@ General options:
                          COMP=[DEST[:DETAIL]] where:
                            COMP:   Logger component name:[api|http|all].
                                    (Default=all)
-                           DEST:   Destination for component:[file|stderr].
+                           DEST:   Destination for component:[file|stderr|off].
                                    (Default=file)
                            DETAIL: Detail Level to log: [all|paths|summary] or
                                    an integer that defines the maximum length of

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -520,10 +520,14 @@ class FakedWBEMConnection(WBEMConnection):
             Path name of the file containing the MOF definitions to be compiled.
 
           namespace (:term:`string`):
-            The name of the target CIM namespace in the CIM repository. This
-            namespace is also used for lookup of any existing or dependent
-            CIM objects. If `None`, the default namespace of the connection is
-            used.
+            The name of the CIM namespace in the associated CIM repository that
+            is the target of the compilation, and is also used for lookup of any
+            dependent CIM elements. If `None`, the default namespace of the
+            connection is used. A namespace defined in a namespace pragma of
+            the MOF superceeds this namespace from the point in the
+            compilation unit(string/file) where it is declared.  The namespace
+            specified in this parameter or the MOF inamespace pragma must
+            exist.
 
           search_paths (:term:`py:iterable` of :term:`string`):
             An iterable of directory path names where MOF dependent files will
@@ -585,10 +589,14 @@ class FakedWBEMConnection(WBEMConnection):
             A string with the MOF definitions to be compiled.
 
           namespace (:term:`string`):
-            The name of the target CIM namespace in the CIM repository. This
-            namespace is also used for lookup of any existing or dependent
-            CIM objects. If `None`, the default namespace of the connection is
-            used.
+            The name of the CIM namespace in the associated CIM repository that
+            is the target of the compilation, and is also used for lookup of any
+            dependent CIM elements. If `None`, the default namespace of the
+            connection is used. A namespace defined in a namespace pragma of
+            the MOF superceeds this namespace from the point in the
+            compilation unit(string/file) where it is declared.  The namespace
+            specified in this parameter or the MOF inamespace pragma must
+            exist.
 
           search_paths (:term:`py:iterable` of :term:`string`):
             An iterable of directory path names where MOF dependent files will
@@ -664,8 +672,14 @@ class FakedWBEMConnection(WBEMConnection):
             :attr:`pywbem_mock.DMTFCIMSchema.schema_pragma_file`.
 
           namespace (:term:`string`):
-            Namespace into which the classes and qualifier declarations will
-            be installed.
+            The name of the CIM namespace in the associated CIM repository that
+            is the target of the compilation, and is also used for lookup of any
+            dependent CIM elements. If `None`, the default namespace of the
+            connection is used. A namespace defined in a namespace pragma of
+            the MOF superceeds this namespace from the point in the
+            compilation unit(string/file) where it is declared.  The namespace
+            specified in this parameter or the MOF inamespace pragma must
+            exist.
 
           verbose (:class:`py:bool`):
             If `True`, progress messages are output to stdout as the schema is


### PR DESCRIPTION
This pr fixes issue #2256 as follows:

1. Adds tests to mof compiler for no  name on the namespace pragma
just to be sure we have that covered

2. Adds tests in pywbem_mock for use of the namespace pragma.

3. Adds fix to the mof compiler for case where pybwbem_mock
compile_mof_string and compile_mof_file fail if the MOF contains a
namespace pragma that has a different namespace name than the namespace
parameter on the methods.  Note that it is just that one of the
MOFWBEMConnection lists does not get created for the namespace defined
in the pragma.

4. Extends documentation on the namespace parameter for the
compile_mof_string and compile_mof_file() methods to clarify the
behavior with the namespace pragma in the MOF.

5. Add note on limitation of name in namespace pragma to just the name and not the path. This
becomes part of the documentation on the compiler limitations.

This pr does NOT fix the issue with the pragma including host name and
there is a new issue dealing with the errors that come back if the
namespace defined in the pragma does not exist.

	addtestmof.py