### PR TITLE
1.1: Fixed, improved, clarified support for Interop namespace in mock+WBEMServer

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,11 +21,19 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The `pywbem.WBEMServer.get_selected_profiles()` method now raises
+  `pywbem.ModelError` instead of `KeyError` when required properties were found
+  to be missing. This is an incompatible change for users that catch this
+  exception. (related to issue #2580).
+
 **Deprecations:**
 
 **Bug fixes:**
 
 **Enhancements:**
+
+* In `CIMNamespaceProvider.post_register_setup()`, fixed an `AttributeError`
+  when accessing the 'Name' property of a CIM instance (related to issue #2580).
 
 **Cleanup:**
 

--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -46,6 +46,13 @@ has a default CIM namespace that is created in the CIM repository upon
 Additional namespaces in the CIM repository can be created with
 :meth:`~pywbem_mock.FakedWBEMConnection.add_namespace()` .
 
+An Interop namespace can be created by adding it via
+:meth:`~pywbem_mock.FakedWBEMConnection.add_namespace`. The Interop
+namespace will be initially empty, and the necessary instance(s) of a CIM
+namespace class will be automatically created when registering the namespace
+provider :class:`~pywbem_mock.CIMNamespaceProvider`. See
+:ref:`Mocking multiple CIM namespaces` for details.
+
 The CIM repository must contain the CIM classes, CIM instances and CIM qualifier
 declaration types that are needed for the operations that are invoked. This
 results in a behavior of the mock WBEM server that is close to the behavior of
@@ -913,17 +920,18 @@ However, a working WBEM environment normally includes at least two namespaces:
 
 Pywbem_mock includes a user-defined provider for the CIM_Namespace class that
 can be enabled by adding code similar to the following to the setup of a
-mock environment.
+mock environment:
 
-.. code-block:: text
+.. code-block:: python
 
-    # Register the provider for the CIM_Namespace class, assuming that
-    # dependent classes and qualifier types have already been created in
-    # the interop namespace.
+    conn = pywbem_mock.FakedWBEMConnection(...)
+
+    . . .
+
+    interop_ns = "interop"   # or "root/interop"
+    conn.add_namespace(interop_ns)
     ns_provider = pywbem_mock.CIMNamespaceProvider(conn.cimrepository)
-    interop_namespace = "interop"   # or "root/interop"
-    conn.add_namespace(interop_namespace)
-    conn.register_provider(ns_provider, namespaces=interop_namespace)
+    conn.register_provider(ns_provider, namespaces=interop_ns)
 
 
 .. index:: pair: User defined providers; user providers

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -382,6 +382,11 @@ class WBEMServer(object):
         update this WBEMServer object to reflect the new namespace
         there.
 
+        This method cannot create an Interop namespace because creating the
+        first Interop namespace with client operations depends on the prior
+        existence of an Interop namespace, and creating additional Interop
+        namespaces is usually prevented by servers.
+
         This method attempts the following approaches for creating the
         namespace, in order, until an approach succeeds:
 
@@ -423,7 +428,10 @@ class WBEMServer(object):
 
         std_namespace = _ensure_unicode(namespace.strip('/'))
 
-        ws_profiles = self.get_selected_profiles('DMTF', 'WBEM Server')
+        try:
+            ws_profiles = self.get_selected_profiles('DMTF', 'WBEM Server')
+        except (CIMError, ModelError):
+            ws_profiles = None
         if ws_profiles:
 
             # Use approach 1: Method defined in WBEM Server profile
@@ -519,6 +527,9 @@ class WBEMServer(object):
 
         The specified namespace must be empty (i.e. must not contain any
         classes, instances, or qualifier types.
+
+        This method cannot delete the Interop namespace because servers will
+        usually prevent their deletion.
 
         This method attempts the following approaches for deleting the
         namespace, in order, until an approach succeeds:
@@ -647,7 +658,7 @@ class WBEMServer(object):
             Exceptions raised by :class:`~pywbem.WBEMConnection`.
             CIMError: CIM_ERR_NOT_FOUND, Interop namespace could not be
               determined.
-            KeyError: If an instance in the list of profiles is incomplete
+            ModelError: If an instance in the list of profiles is incomplete
               and does not include the required properties.
         """
 
@@ -666,7 +677,7 @@ class WBEMServer(object):
             try:
                 inst_org_value = inst['RegisteredOrganization']
             except KeyError:
-                raise KeyError(
+                raise ModelError(
                     _format("CIM_RegisteredProfile instance in namespace "
                             "{0!A} does not have a property "
                             "'RegisteredOrganization'",
@@ -675,7 +686,7 @@ class WBEMServer(object):
             try:
                 inst_name = inst['RegisteredName']
             except KeyError:
-                raise KeyError(
+                raise ModelError(
                     _format("CIM_RegisteredProfile instance in namespace "
                             "{0!A} does not have a property "
                             "'RegisteredName'",
@@ -683,7 +694,7 @@ class WBEMServer(object):
             try:
                 inst_version = inst['RegisteredVersion']
             except KeyError:
-                raise KeyError(
+                raise ModelError(
                     _format("CIM_RegisteredProfile instance in namespace "
                             "{0!A} does not have a property "
                             "'RegisteredVersion'",

--- a/pywbem_mock/_namespaceprovider.py
+++ b/pywbem_mock/_namespaceprovider.py
@@ -176,8 +176,10 @@ class CIMNamespaceProvider(InstanceWriteProvider):
                     ccn_pname, new_instance[ccn_pname]))
 
         # Create the new namespace in the CIM repository, if needed.
+        # The add_namespace() method will prevent the creation of a second
+        # Interop namespace, raising CIMError(CIM_ERR_ALREADY_EXISTS).
         if new_namespace not in self.cimrepository.namespaces:
-            self.cimrepository.add_namespace(new_namespace)
+            self.add_namespace(new_namespace)
 
         # Create the CIM instance for the new namespace in the CIM repository,
         # by delegating to the default provider method.
@@ -278,7 +280,8 @@ class CIMNamespaceProvider(InstanceWriteProvider):
                                         DeepInheritance=False)
 
         # List of namespaces for which there are CIM instances
-        inst_ns_list = NocaseList([inst.name for inst in insts])
+        inst_ns_list = NocaseList(
+            [inst['Name'] for inst in insts if 'Name' in inst])
 
         klass = conn.GetClass(provider_classname, interop_namespace,
                               LocalOnly=False,

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -183,6 +183,9 @@ class FakedWBEMConnection(WBEMConnection):
 
             The :attr:`~pywbem_mock.FakedWBEMConnection.disable_pull_operations`
             property can be used to set this variable.
+
+        Raises:
+          ValueError for invalid arguments
         """
 
         # Response delay in seconds. Any operation is delayed by this time.

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -195,9 +195,17 @@ TESTCASES_CREATE_NAMESPACE = [
         None, None, True
     ),
     (
-        "Existing top level namespace",
+        "Existing Interop namespace",
         dict(
             new_namespace='interop',
+            exp_namespace=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "Non-existing second Interop namespace",
+        dict(
+            new_namespace='root/interop',
             exp_namespace=None,
         ),
         CIMError, None, True
@@ -305,6 +313,24 @@ TESTCASES_DELETE_NAMESPACE = [
             namespace_content={'abc': [
                 CIMQualifierDeclaration('Foo', 'string')
             ]},
+            exp_namespace=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "Existing Interop namespace",
+        dict(
+            namespace='interop',
+            namespace_content={},
+            exp_namespace=None,
+        ),
+        CIMError, None, True
+    ),
+    (
+        "Second non-existing Interop namespace",
+        dict(
+            namespace='root/interop',
+            namespace_content={},
             exp_namespace=None,
         ),
         CIMError, None, True


### PR DESCRIPTION
Rolls back PR #2581 into 1.1.4.
No review needed.