### PR TITLE
Adds index section to generated documentation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -219,6 +219,8 @@ Released: not yet
 * Test: Cleaned up DeprecationWarning for the propagation of key property values
   introduced in pywbem 1.1.0. (see issue #2498)
 
+* Add index section to generated documentation.
+
 **Known issues:**
 
 * On Python 3.4, the urllib3 package is pinned to <1.25.8 because 1.25.9 removed

--- a/docs/genindex.rst
+++ b/docs/genindex.rst
@@ -1,0 +1,6 @@
+Document Index
+##############
+
+.. This is effectively an empty file that is required to generate
+.. the document index. It is overlayed in html with the generated
+.. index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,3 +40,5 @@ https://pywbem.github.io/.
    development.rst
    appendix.rst
    changes.rst
+   genindex.rst
+.. The genindex.rst above and corresponding file required to include index


### PR DESCRIPTION
This pr adds a new section to the end of the pywbem documentation, an
index.  Note that there are probably no hand created index entries but
the index gathers a number of entries from API information, etc.

This is parallel to what we did for pywbemcli and only adds a new rst
file (genindex.rst) and a reference to that file in index.rst.