### PR TITLE
Migrate to using unittest.mock (2)

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -86,7 +86,7 @@ wheel==0.33.5; python_version >= '3.8'
 
 # Direct dependencies for installation (must be consistent with requirements.txt)
 
-mock>=2.0.0; python_version < "3.3"
+mock==2.0.0; python_version == '2.7'
 ordereddict==1.1
 ply==3.10
 PyYAML==5.3.1; python_version == '2.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -86,7 +86,7 @@ wheel==0.33.5; python_version >= '3.8'
 
 # Direct dependencies for installation (must be consistent with requirements.txt)
 
-mock==2.0.0
+mock>=2.0.0; python_version < "3.3"
 ordereddict==1.1
 ply==3.10
 PyYAML==5.3.1; python_version == '2.7'

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -31,7 +31,10 @@ import os
 import time
 import re
 from xml.dom import minidom
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 import six
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-mock>=2.0.0,<4.0.0; python_version < '3.6'
-mock>=2.0.0; python_version >= '3.6'
+mock>=2.0.0; python_version < "3.3"
 ply>=3.10
 # PyYAML 5.3 removed support for Python 3.4
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-mock>=2.0.0; python_version < "3.3"
+mock>=2.0.0,<4.0.0; python_version == '2.7'
 ply>=3.10
 # PyYAML 5.3 removed support for Python 3.4
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -9,7 +9,10 @@ from __future__ import absolute_import, print_function
 import sys
 import re
 from datetime import timedelta, datetime
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 try:
     from collections import OrderedDict
 except ImportError:

--- a/tests/unittest/pywbem/test_itermethods.py
+++ b/tests/unittest/pywbem/test_itermethods.py
@@ -24,7 +24,10 @@ from __future__ import absolute_import, print_function
 import pytest
 import six
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed

--- a/tests/unittest/pywbem/test_valuemapping.py
+++ b/tests/unittest/pywbem/test_valuemapping.py
@@ -7,7 +7,11 @@ from __future__ import absolute_import
 
 import re
 import pytest
-from mock import Mock
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -41,7 +41,12 @@ try:
 except ImportError:
     from ordereddict import OrderedDict  # pylint: disable=import-error
 import six
-from mock import Mock
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 import pytest
 from nocaselist import NocaseList
 from testfixtures import OutputCapture


### PR DESCRIPTION
This includes the change from PR #2590 plus a fix in the minimum constraints file.