### PR TITLE
Fixed new pylint issues raised by pylint 2.7.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -54,12 +54,13 @@ sphinx-rtd-theme>=0.5.0
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
+# TODO: Temporary pinning to pylint<2.7.0 / astroid<2.5.0 due to performance issues
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.5.2; python_version >= '3.5'
+pylint>=2.5.2,<2.7.0; python_version >= '3.5'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.4.0; python_version >= '3.5'
+astroid>=2.4.0,<2.5.0; python_version >= '3.5'
 # typed-ast 1.4.0 removed support for Python 3.4.
 typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -231,6 +231,10 @@ Released: not yet
 
 * Add index section to generated documentation.
 
+* Fixed new issues reported by pylint 2.7.0. At the same time, needed to
+  temporarily pin pylint to <2.7.0 and astroid to <2.5.0 due to massive
+  elongation of the run time of pylint in the pywbem project.
+
 **Known issues:**
 
 * On Python 3.4, the urllib3 package is pinned to <1.25.8 because 1.25.9 removed

--- a/pylintrc
+++ b/pylintrc
@@ -73,7 +73,11 @@ disable=I0011, bad-option-value,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        signature-differs, raise-missing-from, super-with-arguments
+        signature-differs, raise-missing-from, super-with-arguments,
+        R0801
+
+# TODO: Remove R0801 from disabled list again once pylint issue
+#       https://github.com/PyCQA/pylint/issues/4118 is addressed.
 
 # Note: "useless-object-inheritance" is python 3 only. In Python 2,
 #        "new-style" objects must inherit from object, or else
@@ -364,7 +368,7 @@ logging-modules=logging
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
-min-similarity-lines=8
+min-similarity-lines=40
 
 # Ignore comments when computing similarities.
 ignore-comments=yes
@@ -373,7 +377,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 
 [FORMAT]

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -957,6 +957,7 @@ class WBEMListener(object):
                         server_side=True)
                 except AttributeError:
                     # Fall back to deprecated ssl.wrap_socket() before Py 2.7.9
+                    # pylint: disable=deprecated-method
                     server.socket = ssl.wrap_socket(
                         server.socket,
                         certfile=self._certfile,

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -1840,7 +1840,7 @@ def p_instanceDeclaration(p):
             # If embedded instance/object property, compile the value component
             # and put into the property value.
             if 'EmbeddedInstance' in cprop.qualifiers:
-                allowed_types = (CIMInstance)
+                allowed_types = (CIMInstance,)
                 embedded_object_type = "instance"
                 # Issue: 2340: Extend to test with is_subclass from
                 # base repository when that is committed
@@ -1849,7 +1849,7 @@ def p_instanceDeclaration(p):
                 #   if not is_subclass(cprop, qclass):
                 #       raise MOFDependencyError ...
             elif 'EmbeddedObject' in cprop.qualifiers:
-                allowed_types = (CIMInstance)
+                allowed_types = (CIMInstance,)
                 embedded_object_type = "object"
 
             if embedded_object_type:

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -265,18 +265,18 @@ class WBEMConnectionAsserted(WBEMConnection):
             try:
                 return func(*args, **kwargs)
             except Error as exc:
-                self.raise_as_assertion_error(exc, funcname, *args, **kwargs)
+                raise self._assertion_error(exc, funcname, *args, **kwargs)
         else:
             return func(*args, **kwargs)
 
-    def raise_as_assertion_error(self, exc, funcname, *args, **kwargs):
+    def _assertion_error(self, exc, funcname, *args, **kwargs):
         """
-        Raise an AssertionError about the specified exception.
+        Return an AssertionError about the specified exception.
         """
         parm_list = ["{0!r}".format(a) for a in args]
         parm_list.extend(["{0}={1!r}".format(k, kwargs[k]) for k in kwargs])
         parm_str = ", ".join(parm_list)
-        raise AssertionError(
+        return AssertionError(
             "Server {0} at {1}: WBEMConnection.{2}() failed and raised "
             "{3} - {4}. "
             "Parameters: ({5})".


### PR DESCRIPTION
See commit message.

**DISCUSSION:**  The unpinning causes pylint 2.7.0 to be used, which increases its run time significantly (from 2 min to 22 min). See for example the test run for py39 with latest package levels. Should we exclude pylint 2.7.0?