### PR TITLE
Support for building cythonized distribution archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,12 @@ jobs:
       matrix: ${{ fromJson(needs.set_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Select whether to run steps for cythonized archive
+      id: run_cythonized
+      # TODO: Remove 'andy/cythonize' branch once tests succeed
+      if: "! startsWith(matrix.os, 'windows-') && (github.event_name == 'schedule' || startsWith(github.head_ref, 'release_') || github.head_ref == 'andy/cythonize')"
+      run: |
+        echo "Running steps for cythonized archive"
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
@@ -206,6 +212,29 @@ jobs:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
       run: |
         make resourcetest
+    - name: Build cythonized archive
+      if: steps.run_cythonized.outcome == 'success'
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+      run: |
+        make buildc
+    - name: Install cythonized archive
+      # Excluded py27 because the abitag in the dist file name is hard to predict
+      # Excluded py27 and py34 because they do not have a __file__ member in a module
+      if: steps.run_cythonized.outcome == 'success' && matrix.python-version != '2.7' && matrix.python-version != '3.4'
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+      run: |
+        make installc
+    - name: Test cythonized archive
+      # Excluded py27 and py34 because they do not have a __file__ member in a module
+      if: steps.run_cythonized.outcome == 'success' && matrix.python-version != '2.7' && matrix.python-version != '3.4'
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+        # TODO: Remove -x option once tests succeed
+        TESTOPTS: "-x"
+      run: |
+        make testc
 
   test_finish:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ pylint_done
 cprofilerstats*.profile
 /build/
 /build_doc/
+/build_build_ext/
+/build_cythonize/
 mofparsetab.py
 _mofparsetab.py
 moflextab.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,9 @@
 
 # Direct dependencies:
 
+# Cythonize
+Cython>=0.29.22
+
 # Coverage reporting (no imports, invoked via coveralls script):
 # We exclude Python 3.4 from coverage testing and reporting.
 # coverage 5.0 has removed support for py34

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -238,6 +238,42 @@ can be installed.
 .. _PyPI: https://pypi.python.org/pypi
 
 
+.. _`Building a compiled archive with Cython`:
+
+Building a compiled archive with Cython
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The 'Cython' package allows building a wheel distribution archive containing
+compiled code for Python packages such as pywbem. These distribution archives
+are nicknamed "cythonized" wheel distribution archives. They have the wheel
+format, but are specific to a Python version and to the target operating system.
+
+Since the code in a cythonized wheel archive is native machine code for the
+target system, this speeds up execution in compute-intensive areas of pywbem
+such as when parsing the CIM-XML responses of a WBEM server. The downside is
+that a cythonized wheel archive is significantly larger than a universal wheel
+archive, and the memory consumption is also larger.
+
+The pywbem project does not provide cythonized wheel distribution archives, but
+allows users to build them on their own. The build process for them is part of
+the regular tests to ensure they can be built.
+
+To build the cythonized wheel distribution archive of pywbem, execute:
+
+.. code-block:: bash
+
+    $ make buildc
+
+The resulting distribution archive can be installed with Pip, for example:
+
+.. code-block:: bash
+
+    $ pip install dist/pywbem-1.2.0.dev1-cp38-cp38-macosx_10_15_x86_64.whl
+
+Pip will verify that the target system and Python version matches what the wheel
+archive was built for.
+
+
 .. _`Verifying the installation`:
 
 Verifying the installation

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -110,6 +110,9 @@ urllib3==1.25.9; python_version >= '3.5'
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
 
+# Cythonize
+Cython==0.29.22
+
 # Unit test (imports into testcases):
 packaging==17.0
 funcsigs==1.0.2; python_version < '3.3'

--- a/pywbem/_cim_types.py
+++ b/pywbem/_cim_types.py
@@ -215,12 +215,9 @@ class SlottedPickleMixin(object):
 
     def __setstate__(self, dct):
 
-        try:
-            class_type = CIMClass
-        except NameError:
-            # Defer import due to circular import dependencies:
-            # pylint: disable=import-outside-toplevel
-            from pywbem._cim_obj import CIMClass as class_type
+        # Defer import due to circular import dependencies:
+        # pylint: disable=import-outside-toplevel
+        from pywbem._cim_obj import CIMClass as class_type
 
         for attr in dct:
 
@@ -1174,30 +1171,24 @@ def cimtype(obj):
     if isinstance(obj, (datetime, timedelta)):
         return 'datetime'
 
-    try:
-        instancename_type = CIMInstanceName
-    except NameError:
-        # Defer import due to circular import dependencies:
-        # pylint: disable=import-outside-toplevel
-        from pywbem._cim_obj import CIMInstanceName as instancename_type
+    # Defer import due to circular import dependencies:
+    # pylint: disable=import-outside-toplevel
+    from pywbem._cim_obj import CIMInstanceName as instancename_type
+
     if isinstance(obj, instancename_type):
         return 'reference'
 
-    try:
-        instance_type = CIMInstance
-    except NameError:
-        # Defer import due to circular import dependencies:
-        # pylint: disable=import-outside-toplevel
-        from pywbem._cim_obj import CIMInstance as instance_type
+    # Defer import due to circular import dependencies:
+    # pylint: disable=import-outside-toplevel
+    from pywbem._cim_obj import CIMInstance as instance_type
+
     if isinstance(obj, instance_type):  # embedded instance
         return 'string'
 
-    try:
-        class_type = CIMClass
-    except NameError:
-        # Defer import due to circular import dependencies:
-        # pylint: disable=import-outside-toplevel
-        from pywbem._cim_obj import CIMClass as class_type
+    # Defer import due to circular import dependencies:
+    # pylint: disable=import-outside-toplevel
+    from pywbem._cim_obj import CIMClass as class_type
+
     if isinstance(obj, class_type):  # embedded class
         return 'string'
 

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -76,6 +76,7 @@ from __future__ import print_function, absolute_import
 
 import sys
 import os
+import io
 import re
 import tempfile
 
@@ -115,6 +116,7 @@ __all__ = ['MOFCompileError', 'MOFParseError', 'MOFDependencyError',
 _optimize = 1
 _tabmodule = '_mofparsetab'
 _lextab = '_moflextab'
+_module = sys.modules.get('pywbem._mof_compiler', None)
 
 # Directory for _tabmodule and _lextab
 _tabdir = os.path.dirname(os.path.abspath(__file__))
@@ -544,6 +546,15 @@ class MOFRepositoryError(MOFCompileError):
         ret_str = super(MOFRepositoryError, self).get_err_msg()
         ret_str += "\n{0}".format(self.cim_error)
         return ret_str
+
+
+class MOFCompilerSetupError(Exception):
+    """
+    Exception indicating that the MOF compiler cannot be set up.
+
+    Derived from :exc:`Exception`.
+    """
+    pass
 
 
 def p_error(p):
@@ -3093,6 +3104,9 @@ def _yacc(verbose=False, out_dir=None):
     Returns:
 
       yacc.Parser: YACC parser object for the MOF compiler.
+
+    Raises:
+      MOFCompilerSetupError: Error creating the YACC parser.
     """
 
     # The write_tables argument controls whether the YACC parser writes
@@ -3105,14 +3119,23 @@ def _yacc(verbose=False, out_dir=None):
     # we enable debug but set the debuglog to the NullLogger.
     # To enable debug logging, set debuglog to some other logger
     # (ex. PlyLogger(sys.stdout) to generate log output.
-    return yacc.yacc(optimize=_optimize,
-                     tabmodule=_tabmodule,
-                     outputdir=out_dir,
-                     write_tables=write_tables,
-                     debug=verbose,
-                     debuglog=yacc.NullLogger(),
-                     errorlog=yacc.PlyLogger(sys.stdout) if verbose
-                     else yacc.NullLogger())
+    # The 'module' argument needed to be passed to support Cython. Without it,
+    # the default way of determining it skipps the cythonized call levels,
+    # resulting in an incorrect module and subsequently to an error
+    # message "ERROR: No token list is defined" and
+    # an exception YaccError("Unable to build parser").
+
+    log_stream = io.BytesIO() if six.PY2 else io.StringIO()
+    try:
+        parser = yacc.yacc(
+            optimize=_optimize, tabmodule=_tabmodule, module=_module,
+            outputdir=out_dir, write_tables=write_tables, debug=verbose,
+            debuglog=yacc.NullLogger(), errorlog=yacc.PlyLogger(log_stream))
+    except yacc.YaccError as exc:
+        raise MOFCompilerSetupError("{}: {}".format(exc, log_stream.getvalue()))
+    if verbose:
+        print(log_stream.getvalue())
+    return parser
 
 
 def _lex(verbose=False, out_dir=None):
@@ -3130,6 +3153,9 @@ def _lex(verbose=False, out_dir=None):
     Returns:
 
       lex.Lexer: LEX analyzer object for the MOF compiler.
+
+    Raises:
+      MOFCompilerSetupError: Error creating the LEX scanner.
     """
 
     # Unfortunately, lex() does not support a write_tables argument. It
@@ -3141,10 +3167,16 @@ def _lex(verbose=False, out_dir=None):
 
     # To debug lex you may set debug=True and enable the debuglog statement.
     # or other logger definition.
-    return lex.lex(optimize=_optimize,
-                   lextab=_lextab,
-                   outputdir=out_dir,
-                   debug=False,
-                   # debuglog = lex.PlyLogger(sys.stdout),
-                   errorlog=yacc.PlyLogger(sys.stdout) if verbose
-                   else yacc.NullLogger())
+
+    log_stream = io.BytesIO() if six.PY2 else io.StringIO()
+    try:
+        lexer = lex.lex(
+            optimize=_optimize, lextab=_lextab, module=_module,
+            outputdir=out_dir, debug=False,
+            # debuglog=lex.PlyLogger(sys.stdout),
+            errorlog=yacc.PlyLogger(log_stream))
+    except SyntaxError as exc:
+        raise MOFCompilerSetupError("{}: {}".format(exc, log_stream.getvalue()))
+    if verbose:
+        print(log_stream.getvalue())
+    return lexer

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -210,7 +210,11 @@ def is_inherited_from(member_name, derived_class, base_class):
     derived_member = getattr(derived_class, member_name)
     base_member = getattr(base_class, member_name)
 
-    if isinstance(derived_member, types.MethodType) and \
+    if derived_member.__class__.__name__ == 'cython_function_or_method' and \
+            base_member.__class__.__name__ == 'cython_function_or_method':
+        derived_code = derived_member.func_code
+        base_code = base_member.func_code
+    elif isinstance(derived_member, types.MethodType) and \
             isinstance(base_member, types.MethodType):
         # instance method
         derived_code = derived_member.__func__.__code__


### PR DESCRIPTION
This adds support so that users can build a cythonized version of the wheel distribution archive for pywbem, by using **either one** of these commands:
`$ make buildc`
or
`$ ./setup.py bdist_wheel --cythonized`

Note that `./setup.py bdist_wheel --help` displays help text that covers the `--cythonized` option.

The cythonized version can be successfully built on macOs and Ubuntu on Python 3.5 and higher, but not on Windows.
The failing tests should only be the occasional ConnectionError failures when sending indications.

See the commit message for details.