### PR TITLE
Fixes issue ##2447. Extends pywbem_mock ModifyClass and tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -230,6 +230,10 @@ Released: not yet
   prevent incorrect interpretations of the counters when only a subset of the
   operations returned server response time. (issue #2603)
 
+* Added validation tests to pywbem_mock ModifyClass to limit classes
+  that can be modified (no subclasses, and no instances exist, and
+  correct superclass) (see issue #2447)
+
 **Cleanup:**
 
 * Test: Fixed all remaining ResourceWarnings during test. (issue #86)
@@ -242,6 +246,9 @@ Released: not yet
 * Fixed new issues reported by pylint 2.7.0. At the same time, needed to
   temporarily pin pylint to <2.7.0 and astroid to <2.5.0 due to massive
   elongation of the run time of pylint in the pywbem project.
+
+* Added tests for pywbem_mock ModifyClass request operation to test the
+  validation exceptions and correctness of modified class. (see issue #2210)
 
 **Known issues:**
 

--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -456,13 +456,17 @@ Class operations only work if the CIM repository is in full operation mode.
   :meth:`~pywbem.WBEMConnection.CreateClass`. Requires that the superclass of
   the new class (if it specifies one) is in the CIM repository.
 
-- **DeleteClass:** Behaves like
-  :meth:`~pywbem.WBEMConnection.DeleteClass`, with the following difference:
-  This operation additionally deletes all direct and indirect subclasses of the
-  class to be deleted, and all instances of the classes that are being deleted.
-  Requires that the class to be deleted is in the CIM repository.
+- **DeleteClass:** Behaves like :meth:`~pywbem.WBEMConnection.DeleteClass`,
+  with the following difference: This operation additionally deletes all direct
+  and indirect subclasses of the class to be deleted, and all instances of the
+  classes that are being deleted. Requires that the class to be deleted is in
+  the CIM repository.
 
-- **ModifyClass:** Not currently implemented.
+- **ModifyClass:** Behaves like :meth:`~pywbem.WBEMConnection.ModifyClass`.
+  The pywbem_mock implementation rejects modifications where the class to
+  modifiy has either subclasses or instances and resolves the various
+  qualifiers, class origin values and propagated values as the the CreateClass
+  operation.
 
 
 .. _`Faked qualifier declaration operations`:


### PR DESCRIPTION
Extends pywbem_mock ModifyClass to test for a number of possible errors including:

1. Instances exist
2. Subclasses exist
3. Invalid superclass
4. Invalid prerequisite classes

Adds a test_modifyclass test to pywbem_mock/test_wbemconnection.py for
most of these errors and for correct handling of simple modifications.  The test covers 10% of the ModifyClass method

NOTE: ModifiedClass is still probably missing tests for some particular conditions when a superclass exists (i.e validation of the sutibility of all inherited elements) but does all the tests that CreateClass does. 