### PR TITLE
Circumvented an install failure of lazy-object-proxy on py35/minimum

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -55,19 +55,27 @@ sphinx-rtd-theme>=0.5.0
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
 # TODO: Temporary pinning to pylint<2.7.0 / astroid<2.5.0 due to performance issues
+# Workaround: lazy-object-proxy fails installing on macos/py35/minimum, because it uses
+#   setuptools-scm for its setup and (up to 1.5.2) does not correctly pin setuptools-scm.
+#   Not clear why this does not happen on ubuntu/windows with py35 or on py34.
+#   See issue https://github.com/ionelmc/python-lazy-object-proxy/issues/51.
+#   Working around this by not installing pylint/astroid on py35.
+#   TODO: If lazy-object-proxy releases a correctly pinned 1.4.x version, this workaround
+#         can be removed again.
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.5.2,<2.7.0; python_version >= '3.5'
+pylint>=2.5.2,<2.7.0; python_version >= '3.6'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.4.0,<2.5.0; python_version >= '3.5'
+astroid>=2.4.0,<2.5.0; python_version >= '3.6'
 # typed-ast 1.4.0 removed support for Python 3.4.
 typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
-# lazy-object-proxy 1.5.0 dropped support for py34 but declared it as supported
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# Workaround: lazy-object-proxy is used by astroid, and lazy-object-proxy 1.5.0
+# dropped support for py34 but declared it as supported
 lazy-object-proxy>=1.4.3; python_version == '2.7'
 lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
-lazy-object-proxy>=1.4.3; python_version >= '3.5'
+lazy-object-proxy>=1.4.3; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal

--- a/makefile
+++ b/makefile
@@ -705,12 +705,16 @@ else
 ifeq ($(python_mn_version),3.4)
 	@echo "makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
 else
+ifeq ($(python_mn_version),3.5)
+	@echo "makefile: Warning: Skipping Pylint on Python $(python_version)" >&2
+else
 	@echo "makefile: Running Pylint"
 	-$(call RM_FUNC,$@)
 	pylint --version
 	pylint $(pylint_opts) --rcfile=$(pylint_rc_file) $(py_src_files)
 	echo "done" >$@
 	@echo "makefile: Done running Pylint"
+endif
 endif
 endif
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -171,13 +171,16 @@ sphinx-rtd-theme==0.5.0
 # PyLint (no imports, invoked via pylint script):
 pylint==1.6.4; python_version == '2.7'
 pylint==2.2.2; python_version == '3.4'
-pylint==2.5.2; python_version >= '3.5'
+pylint==2.5.2; python_version >= '3.6'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
-astroid==2.4.0; python_version >= '3.5'
+astroid==2.4.0; python_version >= '3.6'
 typed-ast==1.3.2; python_version == '3.4' and implementation_name=='cpython'
-typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
-lazy-object-proxy==1.4.3
+typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# Workaround: lazy-object-proxy is used by astroid
+lazy-object-proxy==1.4.3; python_version == '2.7'
+lazy-object-proxy==1.4.3; python_version == '3.4'
+lazy-object-proxy==1.4.3; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.7.9


### PR DESCRIPTION
See commit message for details.
No review needed.