### PR TITLE
Fix issue #2645 & #2647, Safety failure in make check with lxml & decorator pkg version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ py_src_files := \
 # - 39611: PyYAML cannot be upgraded on py34+py35; We are not using the FullLoader.
 # - 39621: Pylint cannot be upgraded on py27+py34
 # - 39525: Jinja2 cannot be upgraded on py34
+# - 40072: lxml HTML cleaner in lxml 4.6.3 no longer includes the HTML5 'formaction'
 
 safety_ignore_opts := \
     -i 38100 \
@@ -279,6 +280,7 @@ safety_ignore_opts := \
 		-i 39611 \
 		-i 39621 \
 		-i 39525 \
+		-i 40072 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -123,6 +123,13 @@ Released: not yet
 * Fixed an incorrect calculation of the min/max values for the server response
   time in the statistics support of pywbem (issue #2599)
 
+* Security - Add safety issue 40072 (lxml version 4.6,3) to safety ignore
+  list. No change to pywbem since we apparently do not use the affected
+  component (see issue #2645)
+
+* Test: Pinned decorator package to python <=5.0.0 on Python 2+3.4 because
+  decorator 5.0.0 does not support python < 3.5 (see issue #2647)
+
 **Enhancements:**
 
 * Logging: Added a value 'off' for the log destination in the

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -38,7 +38,11 @@ pytz>=2016.10
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
 pluggy>=0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy>=0.13.0; python_version >= '3.7'
-decorator>=4.0.11
+
+# Decorator version 5.0 no longer supports python < 3.5
+decorator>=4.0.11,<5.0.0; python_version < '3.5'
+decorator>=4.0.11; python_version >= '3.5'
+
 backports.statistics>=0.1.0; python_version == '2.7'
 # FormEncode is used for xml comparisons in unit test
 FormEncode>=1.3.1
@@ -48,6 +52,7 @@ FormEncode>=1.3.1
 # lxml 4.4.3 added Python 3.8 support and exposed it correctly
 # lxml 4.6.1 addressed safety issue 38892
 # lxml 4.6.2 addressed safety issue 39194
+# lxml 4.6.3 addressed safety issue 40072
 lxml>=4.6.2; python_version == '2.7'
 lxml>=4.2.4,<4.4.0; python_version == '3.4'
 lxml>=4.6.2; python_version >= '3.5'


### PR DESCRIPTION
Added the safety id 40072 (lxml) to the Makefile safety ignore list
and comment in test_requirements.txt