### PR TITLE
Fixes issue #2643 mock delete instance

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -130,6 +130,9 @@ Released: not yet
 * Test: Pinned decorator package to python <=5.0.0 on Python 2+3.4 because
   decorator 5.0.0 does not support python < 3.5 (see issue #2647)
 
+* Fix pywem_mock issue with Delete class not calling providers to handle
+  the DeleteInstance (see issu #2643)
+
 **Enhancements:**
 
 * Logging: Added a value 'off' for the log destination in the

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -218,18 +218,19 @@ class FakedWBEMConnection(WBEMConnection):
         self._provider_dependent_registry = ProviderDependentRegistry()
 
         # Define the datastore to be used with an initial namespace, the client
-        # connection default namespace. This is passed to the mainprovider
-        # and not used further in this class.
+        # connection default namespace. This is passed to the providerdispatcher
+        # and mainprovider and not used further in this class.
+        # Initiate instance of the ProviderDispatcher with required
+        # parameters including the CIM repository. This call initializes
+        # self.cimrepository.
+        self._providerdispatcher = ProviderDispatcher(
+            self.cimrepository, self._provider_registry)
 
         # Initiate the MainProvider with parameters required to execute
         self._mainprovider = MainProvider(self.host,
                                           self.disable_pull_operations,
-                                          self.cimrepository)
-
-        # Initiate instance of the ProviderDispatcher with required
-        # parameters including the CIM repository
-        self._providerdispatcher = ProviderDispatcher(
-            self._cimrepository, self._provider_registry)
+                                          self.cimrepository,
+                                          self._providerdispatcher)
 
         # Flag to allow or disallow the use of the Open... and Pull...
         # operations. Uses the setter method


### PR DESCRIPTION
Based on PR #2644

Waiting on PR #2646 - Andy: meanwhile merged.

Fixes issue where DeleteClass was calling the cim reopository directly to delete instances rather than calling the 
providerdispatcher to allow any instance providers that delete instances to  correctly handle the delete.

