### PR TITLE
partly fix #2490, increase code coverage

### DIFF
--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -1040,7 +1040,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         when the connection has no operation recorders.
         """
         for recorder in self._operation_recorders:
-            if recorder.enabled():
+            if recorder.enabled:
                 return True
         return False
 
@@ -2473,22 +2473,29 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         return string_param
 
     @staticmethod
-    def _iparam_integer(integer_param, arg_name):
+    def _iparam_positive_integer(integer_param, arg_name):
         # pylint: disable=invalid-name,
         """
-        Validate a integer typed operation parameter that may be None.
+        Validate a integer typed operation parameter that may be None, zero,
+        or a positive integer.
 
         Returns:
            The input integer, or None.
 
         Raises:
           TypeError - integer_param has an invalid type
+          ValueError - integer param is LT 0
         """
         if not isinstance(integer_param, (six.integer_types, type(None))):
             raise TypeError(
                 _format("The {0!A} parameter of the WBEMConnection operation "
                         "has invalid type {1} (must be None, or an integer)",
                         arg_name, type(integer_param)))
+
+        if integer_param is not None and integer_param < 0:
+            raise ValueError(
+                _format("The {0!A} parameter must be >= 0 but is {0}",
+                        arg_name, integer_param))
         return integer_param
 
     @staticmethod
@@ -6771,7 +6778,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -7006,7 +7013,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -7283,7 +7290,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -7538,7 +7545,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -7801,7 +7808,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -8019,10 +8026,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 ContinueOnError=ContinueOnError,
                 MaxObjectCount=MaxObjectCount)
 
-        if MaxObjectCount is not None and MaxObjectCount < 0:
-            raise ValueError(
-                _format("MaxObjectCount must be >= 0 but is {0}",
-                        MaxObjectCount))
         try:
 
             stats = self.statistics.start_timer(method_name)
@@ -8035,7 +8038,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQueryLanguage = self._iparam_string(
                 FilterQueryLanguage, 'FilterQueryLanguage')
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')
@@ -8267,7 +8270,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             FilterQuery = self._iparam_string(FilterQuery, 'FilterQuery')
             ReturnQueryResultClass = self._iparam_bool(
                 ReturnQueryResultClass, 'ReturnQueryResultClass')
-            OperationTimeout = self._iparam_integer(
+            OperationTimeout = self._iparam_positive_integer(
                 OperationTimeout, 'OperationTimeout')
             ContinueOnError = self._iparam_bool(
                 ContinueOnError, 'ContinueOnError')

--- a/tests/functiontest/associatornames_classes.yaml
+++ b/tests/functiontest/associatornames_classes.yaml
@@ -817,6 +817,88 @@
               </MESSAGE>
             </CIM>
 
+- name: AssociatorNames_ClassesF2
+  description: Associator Names Fails CIMXMLParseError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: AssociatorNames
+      ResultClass: CIM_Collection
+      Role: member
+      AssocClass: PyWBEM_MemberOfPersonCollection
+      ObjectName: PyWBEM_Person
+      ResultRole: Collection
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: AssociatorNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="AssociatorNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ResultClass">
+      <CLASSNAME NAME="CIM_Collection"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Role">
+      <VALUE>member</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ResultRole">
+      <VALUE>Collection</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="AssocClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGEXXX ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="AssociatorNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <CLASSNAME NAME="CIM_Collection"/>
+      </CLASSPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGEXXX>
+      </CIM>'
+
 - name: AssociatorNames_ClassesNS1
   description: AssociatorNames on class, providing class name and default namespace with leading/trailing slashes
   pywbem_request:

--- a/tests/functiontest/associatornames_instances.yaml
+++ b/tests/functiontest/associatornames_instances.yaml
@@ -185,7 +185,7 @@
       </CIM>'
 
 - name: AssociatorNames_Instances2
-  description: AssociatorNames Inst of PyWBEM_Person with
+  description: AssociatorNames Inst of PyWBEM_Person
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -289,7 +289,7 @@
       </MESSAGE>
       </CIM>'
 
--   name: AssociatorNamesE1
+-   name: AssociatorNamesError1
     description: AssociatorNames fails with CIM_ERR_ACCESS_DENIED
     pywbem_request:
         url: http://acme.com:80
@@ -371,6 +371,183 @@
                 </SIMPLERSP>
               </MESSAGE>
             </CIM>
+
+- name: AssociatorNames_InstancesError2
+  description: AssociatorNames returns CIMClass and CIMXMLParserError.
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: AssociatorNames
+      ResultClass: null
+      Role: null
+      AssocClass: null
+      ObjectName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+      ResultRole: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: AssociatorNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="AssociatorNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ObjectName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="AssociatorNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <CLASSNAME CLASSNAME="PyWBEM_PersonCollection">
+      </CLASSNAME>
+      </INSTANCEPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
+- name: AssociatorNames_Instances1
+  description: AssociatorNames on inst of PyWBEM_Person with no other parameters. Returns 1 Instance
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: AssociatorNames
+      ResultClass: null
+      Role: null
+      AssocClass: null
+      ObjectName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+      ResultRole: null
+  pywbem_response:
+    result:
+    - pywbem_object: CIMInstanceName
+      classname: PyWBEM_PersonCollection
+      namespace: root/cimv2
+      host: sheldon
+      keybindings:
+        instanceid: PersonCollection
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: AssociatorNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="AssociatorNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ObjectName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="AssociatorNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
 
 - name: AssociatorNames_InstancesNS1
   description: AssociatorNames on instance, with leading/trailing slashes in default namespace

--- a/tests/functiontest/associators_classes.yaml
+++ b/tests/functiontest/associators_classes.yaml
@@ -147,6 +147,178 @@
       </MESSAGE>
       </CIM>'
 
+- name: Associators_ClassesError1
+  description: Associators fails, CIMXMLParseError (XML bad entity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: Associators
+      IncludeQualifiers: null
+      ObjectName: PyWBEM_Person
+      ResultClass: null
+      PropertyList: null
+      ResultRole: null
+      IncludeClassOrigin: null
+      Role: null
+      AssocClass: PyWBEM_MemberOfPersonCollection
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: Associators
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="Associators">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="AssocClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="Associators">
+      <IRETURNVALUE>
+      <VALUE.OBJECTWITHPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <CLASSNAME CLASSNAME="CIM_Collection"/>
+      </CLASSPATH>
+      <INSTANCE CLASSNAME="CIM_Collection">
+      <PROPERTY NAME="InstanceID"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      </INSTANCE>
+      </VALUE.OBJECTWITHPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
+- name: Associators_Classes_Error2
+  description: Associators fails, CIMXMLParseError, entity CIMXXXX
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: Associators
+      IncludeQualifiers: null
+      ObjectName: PyWBEM_Person
+      ResultClass: null
+      PropertyList: null
+      ResultRole: null
+      IncludeClassOrigin: null
+      Role: null
+      AssocClass: PyWBEM_MemberOfPersonCollection
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: Associators
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="Associators">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="AssocClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMXXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="Associators">
+      <IRETURNVALUE>
+      <VALUE.OBJECTWITHPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <CLASSNAME NAME="CIM_Collection"/>
+      </CLASSPATH>
+      <CLASS NAME="CIM_Collection"  SUPERCLASS="CIM_ManagedElement" >
+      <PROPERTY NAME="InstanceID"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      </CLASS>
+      </VALUE.OBJECTWITHPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMXXXX>'
+
 - name: Associators_ClassesNS1
   description: Associators on class, providing class name and default namespace with leading/trailing slashes
   pywbem_request:

--- a/tests/functiontest/associators_instances.yaml
+++ b/tests/functiontest/associators_instances.yaml
@@ -719,7 +719,7 @@
       </MESSAGE>
       </CIMXXX>'
 
-- name: Associators_InstancesF6
+- name: Associators_InstancesF3
   description: Return Fails, returns CLASS Element
   pywbem_request:
     url: http://acme.com:80
@@ -794,7 +794,7 @@
       <IMETHODRESPONSE NAME="Associators">
       <IRETURNVALUE>
       <VALUE.OBJECTWITHPATH>
-      <INSTANCEPATH>
+      <CLASSPATH>
       <NAMESPACEPATH>
       <HOST>sheldon</HOST>
       <LOCALNAMESPACEPATH>
@@ -802,21 +802,16 @@
       <NAMESPACE NAME="cimv2"/>
       </LOCALNAMESPACEPATH>
       </NAMESPACEPATH>
-      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
-      <KEYBINDING NAME="InstanceID">
-      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
-      </KEYBINDING>
-      </INSTANCENAME>
-      </INSTANCEPATH>
-      <CLASS NAME="PyWBEM_PersonCollection" >
+      <CLASSNAME NAME="CIM_Collection"/>
+      </CLASSPATH>
+      <CLASS NAME="CIM_Collection"  SUPERCLASS="CIM_ManagedElement" >
+      <PROPERTY NAME="InstanceID"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
       <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
       </PROPERTY>
       <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
       </PROPERTY>
       <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
-      </PROPERTY>
-      <PROPERTY NAME="InstanceID"  TYPE="string">
-      <VALUE>PersonCollection</VALUE>
       </PROPERTY>
       </CLASS>
       </VALUE.OBJECTWITHPATH>

--- a/tests/functiontest/associators_instances.yaml
+++ b/tests/functiontest/associators_instances.yaml
@@ -648,6 +648,184 @@
             </MESSAGE>
           </CIM>
 
+- name: Associators_InstancesF2
+  description: Simple associator instances Fails, CIMXMLParseError (CIMXXX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: Associators
+      IncludeQualifiers: null
+      ObjectName:
+        pywbem_object: CIMInstanceName
+        classname: TST_Blah
+        namespace: root/cimv2
+        keybindings:
+          Name: Blah
+      ResultClass: null
+      PropertyList: null
+      ResultRole: null
+      IncludeClassOrigin: null
+      Role: null
+      AssocClass: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: Associators
+      CIMObject: root/cimv2
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <IMETHODCALL NAME="Associators">
+              <LOCALNAMESPACEPATH>
+                <NAMESPACE NAME="root"/>
+                <NAMESPACE NAME="cimv2"/>
+              </LOCALNAMESPACEPATH>
+              <IPARAMVALUE NAME="ObjectName">
+                <INSTANCENAME CLASSNAME="TST_Blah">
+                  <KEYBINDING NAME="Name">
+                    <KEYVALUE VALUETYPE="string" TYPE="string">Blah</KEYVALUE>
+                  </KEYBINDING>
+                </INSTANCENAME>
+              </IPARAMVALUE>
+            </IMETHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="Associators">
+      <IRETURNVALUE>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMXXX>'
+
+- name: Associators_InstancesF6
+  description: Return Fails, returns CLASS Element
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: Associators
+      IncludeQualifiers: null
+      ObjectName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+      ResultClass: null
+      PropertyList: null
+      ResultRole: null
+      IncludeClassOrigin: null
+      Role: member
+      AssocClass: PyWBEM_MemberOfPersonCollection
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: Associators
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="Associators">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ObjectName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Role">
+      <VALUE>member</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="AssocClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="Associators">
+      <IRETURNVALUE>
+      <VALUE.OBJECTWITHPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      <CLASS NAME="PyWBEM_PersonCollection" >
+      <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="InstanceID"  TYPE="string">
+      <VALUE>PersonCollection</VALUE>
+      </PROPERTY>
+      </CLASS>
+      </VALUE.OBJECTWITHPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
 - name: Associators_InstancesNS1
   description: Associator instances, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/closeenumeration.yaml
+++ b/tests/functiontest/closeenumeration.yaml
@@ -50,6 +50,7 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
+
 - name: CloseEnumerationF1
   description: CloseEnumeration on nonexistent(closed) enumeration sequence. Returns status CIM_ERR_INVALID_ENUMERATION_CONTEXT
   pywbem_request:
@@ -105,3 +106,59 @@
             </SIMPLERSP>
           </MESSAGE>
         </CIM>
+
+- name: CloseEnumerationF2
+  description: CloseEnumeration fails CIMXMLParseError (Returns CIMXXXX rather than CIM)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: CloseEnumeration
+      context:
+      - '500063'
+      - root/cimv2
+  pywbem_response:
+     exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: CloseEnumeration
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CloseEnumeration">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500063</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIMXXXX CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="CloseEnumeration">
+                <ERROR CODE="21" DESCRIPTION="CIM_ERR_INVALID_ENUMERATION_CONTEXT:"/>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIMXXXX>

--- a/tests/functiontest/createclass.yaml
+++ b/tests/functiontest/createclass.yaml
@@ -599,6 +599,116 @@
       </MESSAGE>
       </CIM>'
 
+- name: CreateClassF2
+  description: CreateClass request fails CIMXMLParseError (invalid XML CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: CreateClass
+      NewClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations0
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: CreateClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="CreateClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="NewClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations0">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="CreateClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: CreateClassNS1
   description: CreateClass, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/deleteclass.yaml
+++ b/tests/functiontest/deleteclass.yaml
@@ -104,6 +104,59 @@
       </MESSAGE>
       </CIM>'
 
+- name: DeleteClassF2
+  description: Delete class fails, CIMXMLParseError (Invalid XML entity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: DeleteClass
+      ClassName: PyWbem_Run_CIM_Operations1
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="PyWbem_Run_CIM_Operations1"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: DeleteClassNS1
   description: DeleteClass, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/deleteinstance.yaml
+++ b/tests/functiontest/deleteinstance.yaml
@@ -62,7 +62,7 @@
       </MESSAGE>
       </CIM>'
 
-- name: DeleteInstanceF1
+- name: DeleteInstanceError1
   description: Delete Instance of PyWBEM_Person fails. Instance does not exist
   pywbem_request:
     url: http://acme.com:80
@@ -123,6 +123,138 @@
       <SIMPLERSP>
       <IMETHODRESPONSE NAME="DeleteInstance">
       <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: PyWBEM_Person.CreationClassName=&quot;PyWBEM_Person&quot;,Name=&quot;run_cimoperations_test&quot;"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: DeleteInstanceError2
+  description: Delete instance fail, Invalid response (CIM entity)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: DeleteInstance
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: null
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: run_cimoperations_test
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteInstance
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteInstance">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">run_cimoperations_test</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteInstance">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
+- name: DeleteInstanceError3
+  description:  Delete instance fail, return includes IRETURNVALUE wo has_return_value set.
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: DeleteInstance
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: null
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: run_cimoperations_test
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteInstance
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteInstance">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">run_cimoperations_test</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteInstance">
+      <IRETURNVALUE>
+      </IRETURNVALUE>
       </IMETHODRESPONSE>
       </SIMPLERSP>
       </MESSAGE>

--- a/tests/functiontest/enumerateclasses.yaml
+++ b/tests/functiontest/enumerateclasses.yaml
@@ -228,6 +228,31 @@
       </MESSAGE>
       </CIM>'
   http_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateClasses
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateClasses">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="CIM_Blah"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
     status: 200
     headers:
       cimoperation: MethodResponse
@@ -241,6 +266,64 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
+
+- name: EnumerateClassesF2
+  description: EnumerateClasses fails, CIMXMLParseError (returns CIMXXX rather than CIM)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: EnumerateClasses
+      IncludeClassOrigin: null
+      IncludeQualifiers: null
+      namespace: null
+      LocalOnly: null
+      ClassName: CIM_Blah
+      DeepInheritance: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateClasses
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateClasses">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="CIM_Blah"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMXXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="EnumerateClasses">
+      <ERROR CODE="5" DESCRIPTION="CIM_ERR_INVALID_CLASS: CIM_Blah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMXXXX>'
 
 - name: EnumerateClassesNS1
   description: EnumerateClasses, with leading/trailing slashes in default namespace

--- a/tests/functiontest/enumerateclassnames.yaml
+++ b/tests/functiontest/enumerateclassnames.yaml
@@ -364,6 +364,114 @@
       </MESSAGE>
       </CIM>'
 
+- name: EnumerateClassNamesF2
+  description: EnumerateClassNames failwith CIMXMLParseError, returning instancename
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: EnumerateClassNames
+      ClassName: null
+      namespace: null
+      DeepInheritance: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateClassNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateClassNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="EnumerateClassNames">
+      <IRETURNVALUE>
+      <INSTANCENAME CLASSNAME="CIM_CollectionInSystem"/>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: EnumerateClassNamesF3
+  description: EnumerateClassNames fails catches CIMXMLParseError (CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: EnumerateClassNames
+      ClassName: null
+      namespace: null
+      DeepInheritance: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateClassNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateClassNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="EnumerateClassNames">
+      <IRETURNVALUE>
+      <CLASSNAME NAME="CIM_CollectionInSystem"/>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: EnumerateClassNamesNS1
   description: EnumerateClassNames, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/enumerateinstancenames.yaml
+++ b/tests/functiontest/enumerateinstancenames.yaml
@@ -941,6 +941,181 @@
               </MESSAGE>
             </CIM>
 
+-   name: EnumerateInstanceNamesF7
+    description: EnumerateInstanceNames, Fails CIMXMLParseError CIMX XML entity
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstanceNames
+            ClassName: PyWBEM_Bad
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstanceNames
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="EnumerateInstanceNames">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="ClassName">
+                        <CLASSNAME NAME="PyWBEM_Bad"/>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="EnumerateInstanceNames">
+                    <ERROR CODE="5" DESCRIPTION="CIM_ERR_INVALID_CLASS: The specified class does not exist."/>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIMX>
+
+-   name: EnumerateInstanceNamesF8
+    description: EnumerateInstanceNames fails CIMXMLPARSEERROR returns classname
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstanceNames
+            ClassName: PyWBEM_Person
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstanceNames
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstanceNames">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstanceNames">
+                            <IRETURNVALUE>
+                                <CLASSNAME NAME="PyWBEM_Person">
+                                </CLASSNAME>
+                            </IRETURNVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+
+-   name: EnumerateInstanceNamesF9
+    description: EnumerateInstanceNames fails CIMXMLPARSEERROR caught in return (CIMX XML entity)
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstanceNames
+            ClassName: PyWBEM_Person
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstanceNames
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstanceNames">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstanceNames">
+                           <LOCALNAMESPACEPATH>
+                              <NAMESPACE NAME="root"/>
+                              <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIMX>
+
 -   name: EnumerateInstanceNamesNS1
     description: EnumerateInstanceNames, with leading/trailing slashes in default namespace
     pywbem_request:

--- a/tests/functiontest/enumerateinstances.yaml
+++ b/tests/functiontest/enumerateinstances.yaml
@@ -1870,6 +1870,82 @@
               </MESSAGE>
             </CIM>
 
+-   name: EnumerateInstancesError8
+    description: EnumerateInstances Fail CIMXMLParseError, classes returned.
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Person
+            LocalOnly: false
+            # These input parameters do not need to be varied, because they
+            # are just passed through and the test is that the specified
+            # parameters occur correctly in the request message, and any others
+            # don't.
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Person"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                            <IRETURNVALUE>
+                                <VALUE.NAMEDINSTANCE>
+                                    <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                        <KEYBINDING NAME="CreationClassName">
+                                            <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                        </KEYBINDING>
+                                        <KEYBINDING NAME="Name">
+                                            <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                                        </KEYBINDING>
+                                    </INSTANCENAME>
+                                    <CLASS CLASSNAME="PyWBEM_Person">
+                                    </CLASS>
+                                </VALUE.NAMEDINSTANCE>
+                            </IRETURNVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
 -   name: EnumerateInstancesNS1
     description: EnumerateInstances, with leading/trailing slashes in default namespace
     pywbem_request:

--- a/tests/functiontest/enumeratequalifiers.yaml
+++ b/tests/functiontest/enumeratequalifiers.yaml
@@ -1395,6 +1395,63 @@
       </MESSAGE>
       </CIM>'
 
+- name: EnumerateQualifiersF2
+  description: EnumerateQualifiers fails CIMXMLParseError (Invalid XML CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: null
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: EnumerateQualifiers
+      namespace: //root/mycim//
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: EnumerateQualifiers
+      CIMObject: root/mycim
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="EnumerateQualifiers">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="mycim"/>
+      </LOCALNAMESPACEPATH>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="EnumerateQualifiers">
+      <IRETURNVALUE>
+      <QUALIFIER.DECLARATION NAME="Exception" TYPE="boolean"
+       TOSUBCLASS="FALSE" TOINSTANCE="TRUE" OVERRIDABLE="FALSE"
+       TRANSLATABLE="TRUE">
+      <SCOPE INDICATION="true" CLASS="true"/>
+      <VALUE>FALSE</VALUE>
+      </QUALIFIER.DECLARATION>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: EnumerateQualifiersNS1
   description: EnumerateQualifiers, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/execquery.yaml
+++ b/tests/functiontest/execquery.yaml
@@ -263,6 +263,65 @@
       </MESSAGE>
       </CIM>'
 
+- name: ExecQuery2
+  description: ExecQuery request returns no instances. Successful
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: WQL
+      Query: Select * from CIM_ComputerSystem
+      namespace: null
+  pywbem_response:
+    result: []
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <IRETURNVALUE>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
 - name: ExecQueryF1
   description: ExecQuery request fails, invalid query
   pywbem_request:
@@ -436,6 +495,65 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>'
+
+
+- name: ExecQueryF4
+  description: ExecQueryRequest fails, XML entity bad (CIM -> CIMX) causes CIMXMLParserror
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ExecQuery
+      QueryLanguage: WQL
+      Query: Select * from CIM_ComputerSystem
+      namespace: root/blah
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/blah
+      CIMMethod: ExecQuery
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ExecQuery">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="blah"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Query">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ExecQuery">
+      <ERROR CODE="3" DESCRIPTION="CIM_ERR_INVALID_NAMESPACE: root/blah"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
 
 - name: ExecQueryNS1
   description: ExecQuery, with leading/trailing slashes in default namespace

--- a/tests/functiontest/getclass.yaml
+++ b/tests/functiontest/getclass.yaml
@@ -851,6 +851,76 @@
 
 # TODO getclass needs more success tests with different input parameters.
 
+- name: GetClassError
+  description: GetClass fails, CIMXMLParseError (Bad element CIM)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: GetClass
+      IncludeClassOrigin: null
+      IncludeQualifiers: null
+      PropertyList:
+      - PowerManagementCapabilities
+      namespace: null
+      LocalOnly: false
+      ClassName: CIM_ComputerSystem
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: GetClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="GetClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ClassName">
+      <CLASSNAME NAME="CIM_ComputerSystem"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="PropertyList">
+      <VALUE.ARRAY>
+      <VALUE>PowerManagementCapabilities</VALUE>
+      </VALUE.ARRAY>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="LocalOnly">
+      <VALUE>FALSE</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="GetClass">
+      <IRETURNVALUE>
+      <CLASS NAME="CIM_ComputerSystem"  SUPERCLASS="CIM_System" >
+      </CLASS>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: GetClassNS1
   description: GetClass, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/getinstance.yaml
+++ b/tests/functiontest/getinstance.yaml
@@ -624,7 +624,6 @@
             LocalOnly: false
     pywbem_response:
         exception: CIMXMLParseError
-
     http_request:
         verb: POST
         url: http://acme.com:80/cimom
@@ -761,7 +760,6 @@
             LocalOnly: false
     pywbem_response:
         exception: CIMXMLParseError
-
     http_request:
         verb: POST
         url: http://acme.com:80/cimom
@@ -805,6 +803,83 @@
                   <IMETHODRESPONSE NAME="GetInstance">
                     <IRETURNVALUE>
                       <CLASS CLASSNAME="PyWBEM_Person">
+                      </CLASS>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+
+-   name: GetInstanceError11
+    description: GetInstance fails, returns class
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        stats-enabled: false
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="GetInstance">
+                    <IRETURNVALUE>
+                      <CLASS NAME="PyWBEM_Person">
+                        <PROPERTY NAME="Name" TYPE="string">
+                          <VALUE>Fritz</VALUE>
+                        </PROPERTY>
+                        <PROPERTY NAME="Address" TYPE="string">
+                          <VALUE>Fritz Town</VALUE>
+                        </PROPERTY>
                       </CLASS>
                     </IRETURNVALUE>
                   </IMETHODRESPONSE>

--- a/tests/functiontest/getinstance.yaml
+++ b/tests/functiontest/getinstance.yaml
@@ -604,6 +604,214 @@
               </MESSAGE>
             </CIM>
 
+-   name: GetInstanceE8
+    description: GetInstance No element below IMETHODRESPONSE
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="GetInstance">
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+
+-   name: GetInstanceE9
+    description: GetInstance No element below IRETURNVALUE
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="GetInstance">
+                    <IRETURNVALUE>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+
+
+-   name: GetInstanceE10
+    description: GetInstance Returns CLASS, not INSTANCE
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: GetInstance
+            InstanceName:
+                pywbem_object: CIMInstanceName
+                classname: PyWBEM_Person
+                keybindings:
+                    Name: Fritz
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: GetInstance
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLEREQ>
+                  <IMETHODCALL NAME="GetInstance">
+                    <LOCALNAMESPACEPATH>
+                      <NAMESPACE NAME="root"/>
+                      <NAMESPACE NAME="cimv2"/>
+                    </LOCALNAMESPACEPATH>
+                    <IPARAMVALUE NAME="InstanceName">
+                      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                        <KEYBINDING NAME="Name">
+                          <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                        </KEYBINDING>
+                      </INSTANCENAME>
+                    </IPARAMVALUE>
+                    <IPARAMVALUE NAME="LocalOnly">
+                      <VALUE>FALSE</VALUE>
+                    </IPARAMVALUE>
+                  </IMETHODCALL>
+                </SIMPLEREQ>
+              </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+              <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                <SIMPLERSP>
+                  <IMETHODRESPONSE NAME="GetInstance">
+                    <IRETURNVALUE>
+                      <CLASS CLASSNAME="PyWBEM_Person">
+                      </CLASS>
+                    </IRETURNVALUE>
+                  </IMETHODRESPONSE>
+                </SIMPLERSP>
+              </MESSAGE>
+            </CIM>
+
 -   name: GetInstanceNS1
     description: GetInstance, with leading/trailing slashes in default namespace
     pywbem_request:

--- a/tests/functiontest/getqualifier.yaml
+++ b/tests/functiontest/getqualifier.yaml
@@ -125,6 +125,177 @@
       </MESSAGE>
       </CIM>'
 
+- name: GetQualifierF2
+  description: GetQualifier fails, CIMXMLParseError, (Invalid XML CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: GetQualifier
+      QualifierName: Abstract
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: GetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="GetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>Abstract</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="GetQualifier">
+      <IRETURNVALUE>
+      <QUALIFIER.DECLARATION NAME="Abstract" TYPE="boolean" TOSUBCLASS="false">
+      <SCOPE CLASS="true" ASSOCIATION="true" INDICATION="true"/>
+      <VALUE>FALSE</VALUE>
+      </QUALIFIER.DECLARATION>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
+- name: GetQualifierF3
+  description: GetQualifier Fails, invalid object type (CIMCLASS)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: GetQualifier
+      QualifierName: Abstract
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: GetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="GetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>Abstract</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="GetQualifier">
+      <IRETURNVALUE>
+      <CLASS CLASSNAME="Abstract">
+      </CLASS>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
+- name: GetQualifierF4
+  description: GetQualifier Fails, no object in response but no error
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: GetQualifier
+      QualifierName: Abstract
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: GetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="GetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>Abstract</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="GetQualifier">
+      <IRETURNVALUE>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
 - name: GetQualifierNS1
   description: GetQualifier, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/headers.yaml
+++ b/tests/functiontest/headers.yaml
@@ -292,3 +292,359 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
+
+-   name: ResponseContentTypeError1
+    description: Response with bad CIM entity (CIMX)'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIMX>
+
+-   name: ResponseContentTypeError1
+    description: Response with bad CIM entity (CIMX)'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGEX ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGEX>
+            </CIM>
+
+-   name: ResponseContentTypeError2
+    description: Response with bad MESSAGE entity (MESSAGEX)'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGEX ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGEX>
+            </CIM>
+
+-   name: ResponseContentTypeError3
+    description: Response with bad SIMPLERSP entity'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSPX>
+                        <IMETHODRESPONSE NAME="EnumerateInstances">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSPX>
+                </MESSAGE>
+            </CIM>
+
+
+-   name: ResponseContentTypeError4
+    description: Response with bad IMETHODRESPONSE entity'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSEX NAME="EnumerateInstances">
+                        </IMETHODRESPONSEX>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>
+
+
+-   name: ResponseContentTypeError4
+    description: Response with bad IMETHODRESPONSE entity'
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: EnumerateInstances
+            ClassName: PyWBEM_Nothing
+            LocalOnly: false
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: EnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                    <SIMPLEREQ>
+                        <IMETHODCALL NAME="EnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                <NAMESPACE NAME="root"/>
+                                <NAMESPACE NAME="cimv2"/>
+                            </LOCALNAMESPACEPATH>
+                            <IPARAMVALUE NAME="ClassName">
+                                <CLASSNAME NAME="PyWBEM_Nothing"/>
+                            </IPARAMVALUE>
+                            <IPARAMVALUE NAME="LocalOnly">
+                                <VALUE>FALSE</VALUE>
+                            </IPARAMVALUE>
+                        </IMETHODCALL>
+                    </SIMPLEREQ>
+                </MESSAGE>
+            </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+            Content-type: application/xml
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="EnumerateInstancesXXX">
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIM>

--- a/tests/functiontest/invokemethod.yaml
+++ b/tests/functiontest/invokemethod.yaml
@@ -377,4 +377,343 @@
       </MESSAGE>
       </CIM>
 
+- name: InvokeMethodError1
+  description: Invalid CIM Entity header on response
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>
+
+- name: InvokeMethodError2
+  description: Invalid MESSAGE Entity header on response
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGEX ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGEX>
+      </CIM>
+
+- name: InvokeMethodError3
+  description: Invalid SIMPLERSP Entity header on response
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSPX>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSPX>
+      </MESSAGE>
+      </CIM>
+
+
+- name: InvokeMethodError
+  description: Invalid NAME Entity header on response invalid
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSEX NAME="SendTestIndicationsCountXXXX">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSEX>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethodError5
+  description: ERROR response
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+        cim_status: 6
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: PyWBEM_Person.CreationClassName=&quot;PyWBEM_Person&quot;,Name=&quot;run_cimoperations_test&quot;"/>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
 # TODO 01/18 AM: Add testcases for namespaces with leading/trailing slashes

--- a/tests/functiontest/invokemethod.yaml
+++ b/tests/functiontest/invokemethod.yaml
@@ -377,6 +377,284 @@
       </MESSAGE>
       </CIM>
 
+- name: InvokeMethod5
+  description: InvokeMethod, return one parameter inferred type string
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: InferredTypesTest
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_InferredTypes
+        host: null
+        namespace: test/TestProvider
+  pywbem_response:
+    result:
+    - 0
+    - {'InferStringParam': 'Blah'}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: InferredTypesTest
+      CIMObject: test/TestProvider:Test_InferredTypes
+    data: >
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <METHODCALL NAME="InferredTypesTest">
+              <LOCALCLASSPATH>
+                <LOCALNAMESPACEPATH>
+                  <NAMESPACE NAME="test"></NAMESPACE>
+                  <NAMESPACE NAME="TestProvider"></NAMESPACE>
+                </LOCALNAMESPACEPATH>
+                <CLASSNAME NAME="Test_InferredTypes"></CLASSNAME>
+              </LOCALCLASSPATH>
+            </METHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="InferredTypesTest">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      <PARAMVALUE NAME="InferStringParam">
+      <VALUE>Blah</VALUE>
+      </PARAMVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethod6
+  description: InvokeMethod, return one parameter inferred type boolean
+  ignore_test: true
+  # Ignoring this test because infer type with boolean does not work.
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: InferredType
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_InferredTypes
+        host: null
+        namespace: test/TestProvider
+  pywbem_response:
+    result:
+    - 0
+    - {'InferBoolParam': 'True'}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: InferredType
+      CIMObject: test/TestProvider:Test_InferredTypes
+    data: >
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <METHODCALL NAME="InferredType">
+              <LOCALCLASSPATH>
+                <LOCALNAMESPACEPATH>
+                  <NAMESPACE NAME="test"></NAMESPACE>
+                  <NAMESPACE NAME="TestProvider"></NAMESPACE>
+                </LOCALNAMESPACEPATH>
+                <CLASSNAME NAME="Test_InferredTypes"></CLASSNAME>
+              </LOCALCLASSPATH>
+            </METHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="InferredType">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      <PARAMVALUE NAME="InferBoolParam">
+        <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+
+- name: InvokeMethod7
+  description: InvokeMethod, return one parameter inferred type list of string
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: InferredType
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_InferredTypes
+        host: null
+        namespace: test/TestProvider
+  pywbem_response:
+    result:
+    - 0
+    - {'InferStringParam': ["StrParam1", "StrParam2"]}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: InferredType
+      CIMObject: test/TestProvider:Test_InferredTypes
+    data: >
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <METHODCALL NAME="InferredType">
+              <LOCALCLASSPATH>
+                <LOCALNAMESPACEPATH>
+                  <NAMESPACE NAME="test"></NAMESPACE>
+                  <NAMESPACE NAME="TestProvider"></NAMESPACE>
+                </LOCALNAMESPACEPATH>
+                <CLASSNAME NAME="Test_InferredTypes"></CLASSNAME>
+              </LOCALCLASSPATH>
+            </METHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="InferredType">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      <PARAMVALUE NAME="InferStringParam">
+        <VALUE.ARRAY>
+          <VALUE>StrParam1</VALUE>
+          <VALUE>StrParam2</VALUE>
+        </VALUE.ARRAY>
+      </PARAMVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethod8
+  description: InvokeMethod, return one parameter inferred type CIMClass
+  ignore_test: true
+  # Ignoring this test because I do not know how to define CIMClass in a
+  # list in YAML
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: ClassType
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_ClassTypes
+        host: null
+        namespace: test/TestProvider
+  pywbem_response:
+    result:
+    - 0
+    - {"ClassParam": CIMClass("CIM_Blah")}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ClassType
+      CIMObject: test/TestProvider:Test_ClassTypes
+    data: >
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+          <SIMPLEREQ>
+            <METHODCALL NAME="ClassType">
+              <LOCALCLASSPATH>
+                <LOCALNAMESPACEPATH>
+                  <NAMESPACE NAME="test"></NAMESPACE>
+                  <NAMESPACE NAME="TestProvider"></NAMESPACE>
+                </LOCALNAMESPACEPATH>
+                <CLASSNAME NAME="Test_ClassTypes"></CLASSNAME>
+              </LOCALCLASSPATH>
+            </METHODCALL>
+          </SIMPLEREQ>
+        </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="ClassType">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      <PARAMVALUE NAME="ClassParam">
+        <CLASS NAME="CIM_BLAH"></CLASS>
+      </PARAMVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
 - name: InvokeMethodError1
   description: Invalid CIM Entity header on response (CIMX)
   pywbem_request:

--- a/tests/functiontest/invokemethod.yaml
+++ b/tests/functiontest/invokemethod.yaml
@@ -378,7 +378,7 @@
       </CIM>
 
 - name: InvokeMethodError1
-  description: Invalid CIM Entity header on response
+  description: Invalid CIM Entity header on response (CIMX)
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -446,7 +446,7 @@
       </CIMX>
 
 - name: InvokeMethodError2
-  description: Invalid MESSAGE Entity header on response
+  description: Invalid MESSAGE Entity header on response (MESSAGEX)
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -581,8 +581,7 @@
       </MESSAGE>
       </CIM>
 
-
-- name: InvokeMethodError
+- name: InvokeMethodError4
   description: Invalid NAME Entity header on response invalid
   pywbem_request:
     url: http://acme.com:80
@@ -651,7 +650,146 @@
       </CIM>
 
 - name: InvokeMethodError5
-  description: ERROR response
+  description: Invalid return value, no value component
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCountXXXX">
+      <RETURNVALUE PARAMTYPE="sint32">
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+
+- name: InvokeMethodError6
+  description: Invalid out param. PARAMVALUE with no value
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      indicationSendCount:
+        pywbem_object: Uint32
+        x: 0
+  pywbem_response:
+    exception:  CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCountXXXX">
+      <PARAMVALUE NAME="UserPassword" PARAMTYPE="string">
+      <VALUE>foo</VALUE>
+      </PARAMVALUE>
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethodError7
+  description: ERROR response to InvokeMethod
   pywbem_request:
     url: http://acme.com:80
     creds:

--- a/tests/functiontest/modifyclass.yaml
+++ b/tests/functiontest/modifyclass.yaml
@@ -637,6 +637,129 @@
       </MESSAGE>
       </CIM>'
 
+- name: ModifyClassF3
+  description: ModifyClass response fails, CIMXMLParseError (Invalid XML CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ModifyClass
+      namespace: null
+      ModifiedClass:
+        pywbem_object: CIMClass
+        classname: PyWbem_Run_CIM_Operations0
+        superclass: null
+        properties:
+          instanceid:
+            pywbem_object: CIMProperty
+            name: InstanceID
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          myuint8:
+            pywbem_object: CIMProperty
+            name: MyUint8
+            value: 99
+            type: uint8
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          str2:
+            pywbem_object: CIMProperty
+            name: Str2
+            value: null
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        methods:
+          delete:
+            pywbem_object: CIMMethod
+            name: Delete
+            return_type: uint32
+            class_origin: null
+            propagated: false
+            parameters: {}
+            qualifiers: {}
+        qualifiers:
+          description:
+            pywbem_object: CIMQualifier
+            name: Description
+            value: This is a class description
+            type: string
+            propagated: null
+            tosubclass: null
+            toinstance: null
+            overridable: null
+            translatable: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyClass
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyClass">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedClass">
+      <CLASS NAME="PyWbem_Run_CIM_Operations0">
+      <QUALIFIER NAME="Description" TYPE="string">
+      <VALUE>This is a class description</VALUE>
+      </QUALIFIER>
+      <PROPERTY NAME="InstanceID" TYPE="string"/>
+      <PROPERTY NAME="MyUint8" TYPE="uint8">
+      <VALUE>99</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Str2" TYPE="string"/>
+      <METHOD NAME="Delete" PROPAGATED="false" TYPE="uint32"/>
+      </CLASS>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyClass">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: ModifyClassNS1
   description: ModifyClass, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/modifyinstance.yaml
+++ b/tests/functiontest/modifyinstance.yaml
@@ -239,6 +239,126 @@
               </MESSAGE>
             </CIM>
 
+- name: ModifyInstanceE2
+  description: ModifyInstance fail, CIMXMLParseError
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ModifyInstance
+      IncludeQualifiers: null
+      PropertyList: null
+      ModifiedInstance:
+        pywbem_object: CIMInstance
+        classname: PyWBEM_Person
+        properties:
+          CreationClassName:
+            pywbem_object: CIMProperty
+            name: CreationClassName
+            value: PyWBEM_Person
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          Name:
+            pywbem_object: CIMProperty
+            name: Name
+            value: Test
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+          Title:
+            pywbem_object: CIMProperty
+            name: Title
+            value: Sir
+            type: string
+            reference_class: null
+            embedded_object: null
+            is_array: false
+            array_size: null
+            class_origin: null
+            propagated: null
+            qualifiers: {}
+        path:
+          pywbem_object: CIMInstanceName
+          classname: PyWBEM_Person
+          namespace: root/cimv2
+          keybindings:
+            CreationClassName: PyWBEM_Person
+            Name: Test
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ModifyInstance
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ModifyInstance">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ModifiedInstance">
+      <VALUE.NAMEDINSTANCE>
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Test</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      <INSTANCE CLASSNAME="PyWBEM_Person">
+      <PROPERTY NAME="CreationClassName" TYPE="string">
+      <VALUE>PyWBEM_Person</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name" TYPE="string">
+      <VALUE>Test</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Title" TYPE="string">
+      <VALUE>Sir</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </VALUE.NAMEDINSTANCE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGEXX ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ModifyInstance">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGEXX>
+      </CIM>'
+
 - name: ModifyInstanceNS1
   description: ModifyInstance, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/openassociatorinstances.yaml
+++ b/tests/functiontest/openassociatorinstances.yaml
@@ -141,6 +141,111 @@
       </MESSAGE>
       </CIM>'
 
+- name: OpenAssociatorInstancesError1
+  description: OpenAssociatorInstances fails with CIMXMLParseError (Bad XML Entity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: OpenAssociatorInstances
+      MaxObjectCount: 100
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: OpenAssociatorInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenAssociatorInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="OpenAssociatorInstances">
+      <IRETURNVALUE>
+      <VALUE.INSTANCEWITHPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      <INSTANCE CLASSNAME="PyWBEM_PersonCollection" >
+      <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
+      </PROPERTY>
+      <PROPERTY NAME="InstanceID"  TYPE="string">
+      <VALUE>PersonCollection</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </VALUE.INSTANCEWITHPATH>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>FALSE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>500028</VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
+
 - name: OpenAssociatorInstancesNS1
   description: OpenAssociatorInstances, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/openasssociatorinstancepaths.yaml
+++ b/tests/functiontest/openasssociatorinstancepaths.yaml
@@ -189,6 +189,105 @@
               </MESSAGE>
             </CIM>
 
+- name: OpenAssociatorInstancePathsE2
+  description: OpenAssociators of instance fails CIMXMLParseError (bad entity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: OpenAssociatorInstancePaths
+      FilterQuery: null
+      FilterQueryLanguage: null
+      OperationTimeout: null
+      ResultClass: null
+      ResultRole: null
+      ContinueOnError: null
+      Role: null
+      MaxObjectCount: 100
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+      AssocClass: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: OpenAssociatorInstancePaths
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenAssociatorInstancePaths">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="OpenAssociatorInstancePaths">
+      <IRETURNVALUE>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>FALSE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>500034</VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: OpenAssociatorInstancePathsNS1
   description: OpenAssociatorInstancePaths, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/openenumerateinstancepaths.yaml
+++ b/tests/functiontest/openenumerateinstancepaths.yaml
@@ -705,6 +705,119 @@
               </MESSAGE>
             </CIM>
 
+-   name: OpenEnumerateInstancePaths1
+    description: OpenEnumerateInstancePaths fails, CIMXMLParseError from bad XML CIMX
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: OpenEnumerateInstancePaths
+            ClassName: PyWBEM_Person
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: OpenEnumerateInstancePaths
+            CIMObject: root/cimv2
+        data: >
+             <?xml version="1.0" encoding="utf-8" ?>
+             <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                 <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                     <SIMPLEREQ>
+                         <IMETHODCALL NAME="OpenEnumerateInstancePaths">
+                            <LOCALNAMESPACEPATH>
+                                 <NAMESPACE NAME="root"/>
+                                 <NAMESPACE NAME="cimv2"/>
+                             </LOCALNAMESPACEPATH>
+                             <IPARAMVALUE NAME="ClassName">
+                                 <CLASSNAME NAME="PyWBEM_Person"/>
+                             </IPARAMVALUE>
+                         </IMETHODCALL>
+                     </SIMPLEREQ>
+                 </MESSAGE>
+             </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="OpenEnumerateInstancePaths">
+                            <IRETURNVALUE>
+                                <INSTANCEPATH>
+                                  <NAMESPACEPATH>
+                                    <HOST>sheldon</HOST>
+                                      <LOCALNAMESPACEPATH>
+                                        <NAMESPACE NAME="root"/>
+                                        <NAMESPACE NAME="cimv2"/>
+                                     </LOCALNAMESPACEPATH>
+                                  </NAMESPACEPATH>
+                                  <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                    <KEYBINDING NAME="CreationClassName">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                    </KEYBINDING>
+                                    <KEYBINDING NAME="Name">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                                    </KEYBINDING>
+                                  </INSTANCENAME>
+                                </INSTANCEPATH>
+                                <INSTANCEPATH>
+                                  <NAMESPACEPATH>
+                                    <HOST>sheldon</HOST>
+                                      <LOCALNAMESPACEPATH>
+                                        <NAMESPACE NAME="root"/>
+                                        <NAMESPACE NAME="cimv2"/>
+                                     </LOCALNAMESPACEPATH>
+                                  </NAMESPACEPATH>
+                                  <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                    <KEYBINDING NAME="CreationClassName">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                    </KEYBINDING>
+                                    <KEYBINDING NAME="Name">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+                                    </KEYBINDING>
+                                  </INSTANCENAME>
+                                </INSTANCEPATH>
+                                <INSTANCEPATH>
+                                  <NAMESPACEPATH>
+                                    <HOST>sheldon</HOST>
+                                      <LOCALNAMESPACEPATH>
+                                        <NAMESPACE NAME="root"/>
+                                        <NAMESPACE NAME="cimv2"/>
+                                     </LOCALNAMESPACEPATH>
+                                  </NAMESPACEPATH>
+                                  <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                    <KEYBINDING NAME="CreationClassName">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                    </KEYBINDING>
+                                    <KEYBINDING NAME="Name">
+                                        <KEYVALUE VALUETYPE="string" TYPE="string">Charlie</KEYVALUE>
+                                    </KEYBINDING>
+                                  </INSTANCENAME>
+                                </INSTANCEPATH>
+                            </IRETURNVALUE>
+                                <PARAMVALUE NAME="EndOfSequence">
+                                    <VALUE>TRUE</VALUE>
+                                </PARAMVALUE>
+                                <PARAMVALUE NAME="EnumerationContext">
+                                    <VALUE></VALUE>
+                                </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIMX>
+
 -   name: OpenEnumerateInstancePathsNS1
     description: OpenEnumerateInstancePaths, with leading/trailing slashes in default namespace
     pywbem_request:

--- a/tests/functiontest/openenumerateinstances.yaml
+++ b/tests/functiontest/openenumerateinstances.yaml
@@ -1230,6 +1230,128 @@
               </MESSAGE>
             </CIM>
 
+-   name: OpenEnumerateInstancesF7
+    description: OpenEnumerateInstances; fails generates CIMXMLParseError
+    pywbem_request:
+        url: http://acme.com:80
+        creds:
+            - username
+            - password
+        namespace: root/cimv2
+        timeout: 10
+        debug: true
+        operation:
+            pywbem_method: OpenEnumerateInstances
+            ClassName: PyWBEM_Person
+    pywbem_response:
+        exception: CIMXMLParseError
+    http_request:
+        verb: POST
+        url: http://acme.com:80/cimom
+        headers:
+            CIMOperation: MethodCall
+            CIMMethod: OpenEnumerateInstances
+            CIMObject: root/cimv2
+        data: >
+             <?xml version="1.0" encoding="utf-8" ?>
+             <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+                 <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+                     <SIMPLEREQ>
+                         <IMETHODCALL NAME="OpenEnumerateInstances">
+                            <LOCALNAMESPACEPATH>
+                                 <NAMESPACE NAME="root"/>
+                                 <NAMESPACE NAME="cimv2"/>
+                             </LOCALNAMESPACEPATH>
+                             <IPARAMVALUE NAME="ClassName">
+                                 <CLASSNAME NAME="PyWBEM_Person"/>
+                             </IPARAMVALUE>
+                         </IMETHODCALL>
+                     </SIMPLEREQ>
+                 </MESSAGE>
+             </CIM>
+    http_response:
+        status: 200
+        headers:
+            CIMOperation: MethodResponse
+        data: >
+            <?xml version="1.0" encoding="utf-8" ?>
+            <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+                <MESSAGE ID="1000" PROTOCOLVERSION="1.0">
+                    <SIMPLERSP>
+                        <IMETHODRESPONSE NAME="OpenEnumerateInstances">
+                            <IRETURNVALUE>
+                                <VALUE.INSTANCEWITHPATH>
+                                    <INSTANCEPATH>
+                                        <NAMESPACEPATH>
+                                            <HOST>fred</HOST>
+                                            <LOCALNAMESPACEPATH>
+                                                <NAMESPACE NAME="root"/>
+                                                <NAMESPACE NAME="cimv2"/>
+                                            </LOCALNAMESPACEPATH>
+                                        </NAMESPACEPATH>
+                                        <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                            <KEYBINDING NAME="CreationClassName">
+                                                <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                            </KEYBINDING>
+                                            <KEYBINDING NAME="Name">
+                                                <KEYVALUE VALUETYPE="string" TYPE="string">Fritz</KEYVALUE>
+                                            </KEYBINDING>
+                                        </INSTANCENAME>
+                                    </INSTANCEPATH>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Fritz</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Fritz Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.INSTANCEWITHPATH>
+                                <VALUE.INSTANCEWITHPATH>
+                                    <INSTANCEPATH>
+                                        <NAMESPACEPATH>
+                                            <HOST>Fred</HOST>
+                                            <LOCALNAMESPACEPATH>
+                                                <NAMESPACE NAME="root"/>
+                                                <NAMESPACE NAME="cimv2"/>
+                                            </LOCALNAMESPACEPATH>
+                                        </NAMESPACEPATH>
+                                        <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                                            <KEYBINDING NAME="CreationClassName">
+                                                <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                                            </KEYBINDING>
+                                            <KEYBINDING NAME="Name">
+                                                <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+                                            </KEYBINDING>
+                                        </INSTANCENAME>
+                                    </INSTANCEPATH>
+                                    <INSTANCE CLASSNAME="PyWBEM_Person">
+                                        <PROPERTY NAME="CreationClassName" TYPE="string">
+                                            <VALUE>PyWBEM_Person</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Name" TYPE="string">
+                                            <VALUE>Alice</VALUE>
+                                        </PROPERTY>
+                                        <PROPERTY NAME="Address" TYPE="string">
+                                            <VALUE>Alice Town</VALUE>
+                                        </PROPERTY>
+                                    </INSTANCE>
+                                </VALUE.INSTANCEWITHPATH>
+                            </IRETURNVALUE>
+                            <PARAMVALUE NAME="EndOfSequence">
+                                <VALUE>TRUE</VALUE>
+                            </PARAMVALUE>
+                            <PARAMVALUE NAME="EnumerationContext">
+                                <VALUE></VALUE>
+                            </PARAMVALUE>
+                        </IMETHODRESPONSE>
+                    </SIMPLERSP>
+                </MESSAGE>
+            </CIMX>
+
 -   name: OpenEnumerateInstancesNS1
     description: OpenEnumerateInstances with leading/trailing slashes in default namespace
     pywbem_request:

--- a/tests/functiontest/openqueryinstances.yaml
+++ b/tests/functiontest/openqueryinstances.yaml
@@ -254,6 +254,119 @@
       </MESSAGE>
       </CIM>'
 
+- name: OpenQueryInstancesError1
+  description: OpenQueryInstances request fails CIMXMLParseError (XML CIM entity)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: OpenQueryInstances
+      MaxObjectCount: 100
+      FilterQuery: Select * from CIM_ComputerSystem
+      FilterQueryLanguage: WQL
+      ContinueOnError: null
+      OperationTimeout: null
+      namespace: null
+      ReturnQueryResultClass: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMObject: root/cimv2
+      CIMMethod: OpenQueryInstances
+      CIMOperation: MethodCall
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenQueryInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="FilterQuery">
+      <VALUE>Select * from CIM_ComputerSystem</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="FilterQueryLanguage">
+      <VALUE>WQL</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="OpenQueryInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Description"  TYPE="string">
+      <VALUE>Linux version 3.13.0-105-generic (buildd@lgw01-59) (gcc version 4.8.4
+      (Ubuntu 4.8.4-2ubuntu1~14.04.3) ) #152-Ubuntu SMP Fri Dec 2 15:37:11 UTC 2016</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>
+      </VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: OpenQueryInstancesNS1
   description: OpenQueryInstances, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/openreferenceinstancepaths.yaml
+++ b/tests/functiontest/openreferenceinstancepaths.yaml
@@ -479,6 +479,122 @@
               </MESSAGE>
             </CIM>
 
+- name: OpenReferenceInstancePathsE2
+  description: OpenReferencePaths fails CIMXMLParseError (invalid XML entity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: OpenReferenceInstancePaths
+      FilterQuery: null
+      FilterQueryLanguage: null
+      OperationTimeout: null
+      ResultClass: null
+      ContinueOnError: null
+      Role: null
+      MaxObjectCount: 100
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: OpenReferenceInstancePaths
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenReferenceInstancePaths">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: >
+        <?xml version="1.0" encoding="utf-8" ?>
+        <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+          <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+            <SIMPLERSP>
+              <IMETHODRESPONSE NAME="OpenReferenceInstancePaths">
+                <IRETURNVALUE>
+                  <INSTANCEPATH>
+                    <NAMESPACEPATH>
+                      <HOST>sheldon</HOST>
+                      <LOCALNAMESPACEPATH>
+                        <NAMESPACE NAME="root"/>
+                        <NAMESPACE NAME="cimv2"/>
+                      </LOCALNAMESPACEPATH>
+                    </NAMESPACEPATH>
+                    <INSTANCENAME CLASSNAME="PyWBEM_MemberOfPersonCollection">
+                      <KEYBINDING NAME="Collection">
+                        <VALUE.REFERENCE>
+                          <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+                            <KEYBINDING NAME="InstanceID">
+                              <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+                            </KEYBINDING>
+                          </INSTANCENAME>
+                        </VALUE.REFERENCE>
+                      </KEYBINDING>
+                      <KEYBINDING NAME="Member">
+                        <VALUE.REFERENCE>
+                          <INSTANCENAME CLASSNAME="PyWBEM_Person">
+                            <KEYBINDING NAME="CreationClassName">
+                              <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+                            </KEYBINDING>
+                            <KEYBINDING NAME="Name">
+                              <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+                            </KEYBINDING>
+                          </INSTANCENAME>
+                        </VALUE.REFERENCE>
+                      </KEYBINDING>
+                    </INSTANCENAME>
+                  </INSTANCEPATH>
+                </IRETURNVALUE>
+                <PARAMVALUE NAME="EndOfSequence">
+                  <VALUE>FALSE</VALUE>
+                </PARAMVALUE>
+                <PARAMVALUE NAME="EnumerationContext">
+                  <VALUE>500060</VALUE>
+                </PARAMVALUE>
+              </IMETHODRESPONSE>
+            </SIMPLERSP>
+          </MESSAGE>
+        </CIMX>
+
 - name: OpenReferenceInstancePathsNS1
   description: OpenReferenceInstancePaths, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/openreferenceinstances.yaml
+++ b/tests/functiontest/openreferenceinstances.yaml
@@ -203,7 +203,149 @@
       </MESSAGE>
       </CIM>'
 
-# TODO: add error test.
+# TODO: add error tests.
+
+- name: OpenReferenceInstancesError1
+  description: OpenReferenceInstances fails with CIMXMLParserError (CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: OpenReferenceInstances
+      FilterQuery: null
+      FilterQueryLanguage: null
+      OperationTimeout: null
+      ResultClass: null
+      PropertyList: null
+      IncludeClassOrigin: null
+      ContinueOnError: null
+      Role: null
+      MaxObjectCount: 100
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: root/cimv2
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: Alice
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: OpenReferenceInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="OpenReferenceInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="OpenReferenceInstances">
+      <IRETURNVALUE>
+      <VALUE.INSTANCEWITHPATH>
+      <INSTANCEPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_MemberOfPersonCollection">
+      <KEYBINDING NAME="Collection">
+      <VALUE.REFERENCE>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </VALUE.REFERENCE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Member">
+      <VALUE.REFERENCE>
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </VALUE.REFERENCE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </INSTANCEPATH>
+      <INSTANCE CLASSNAME="PyWBEM_MemberOfPersonCollection" >
+      <PROPERTY.REFERENCE NAME="Collection"  REFERENCECLASS="CIM_Collection">
+      <VALUE.REFERENCE>
+      <INSTANCENAME CLASSNAME="PyWBEM_PersonCollection">
+      <KEYBINDING NAME="InstanceID">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PersonCollection</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </VALUE.REFERENCE>
+      </PROPERTY.REFERENCE>
+      <PROPERTY.REFERENCE NAME="Member"  REFERENCECLASS="CIM_ManagedElement">
+      <VALUE.REFERENCE>
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </VALUE.REFERENCE>
+      </PROPERTY.REFERENCE>
+      </INSTANCE>
+      </VALUE.INSTANCEWITHPATH>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>FALSE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>500054</VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
 
 - name: OpenReferenceInstancesNS1
   description: OpenReferenceInstances, with leading/trailing slashes in default namespace

--- a/tests/functiontest/pullinstances.yaml
+++ b/tests/functiontest/pullinstances.yaml
@@ -790,3 +790,106 @@
                     </SIMPLERSP>
                 </MESSAGE>
             </CIM>
+
+- name: PullInstancesF8
+  description: PullInstances fails, Invalid EndOfSequence
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: PullInstances
+      MaxObjectCount: 100
+      context:
+      - '500182'
+      - root/cimv2
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: PullInstances
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="PullInstances">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="EnumerationContext">
+      <VALUE>500182</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="MaxObjectCount">
+      <VALUE>100</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="PullInstances">
+      <IRETURNVALUE>
+      <INSTANCE CLASSNAME="PG_ComputerSystem" >
+      <PROPERTY NAME="Caption"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Status"  TYPE="string">
+      <VALUE>OK</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="OperationalStatus"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>2</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="ElementName"  TYPE="string">
+      <VALUE>Computer System</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="CreationClassName"  TYPE="string">
+      <VALUE>PG_ComputerSystem</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="Name"  TYPE="string">
+      <VALUE>sheldon</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="NameFormat"  TYPE="string">
+      <VALUE>Other</VALUE>
+      </PROPERTY>
+      <PROPERTY.ARRAY NAME="PowerManagementCapabilities"  TYPE="uint16">
+      <VALUE.ARRAY>
+      <VALUE>1</VALUE>
+      </VALUE.ARRAY>
+      </PROPERTY.ARRAY>
+      <PROPERTY NAME="PowerManagementSupported"  TYPE="boolean">
+      <VALUE>FALSE</VALUE>
+      </PROPERTY>
+      <PROPERTY NAME="PowerState"  TYPE="uint16">
+      <VALUE>1</VALUE>
+      </PROPERTY>
+      </INSTANCE>
+      </IRETURNVALUE>
+      <PARAMVALUE NAME="EndOfSequence">
+      <VALUE>NOTVALIDVALUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+      <VALUE>
+      </VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'

--- a/tests/functiontest/referencenames_classes.yaml
+++ b/tests/functiontest/referencenames_classes.yaml
@@ -137,3 +137,152 @@
                 </SIMPLERSP>
               </MESSAGE>
             </CIM>
+
+- name: ReferenceNames_ClassesF2
+  description: ReferenceNames Fails, invalid XML CIMXXX in response
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ReferenceNames
+      Role: member
+      ResultClass: PyWBEM_MemberOfPersonCollection
+      ObjectName: PyWBEM_Person
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ReferenceNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ReferenceNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ResultClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Role">
+      <VALUE>member</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ReferenceNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </CLASSPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMXXX>'
+
+
+- name: ReferenceNames_ClassesF3
+  description: ReferenceNames Fails, returns instancenames
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: ReferenceNames
+      Role: member
+      ResultClass: PyWBEM_MemberOfPersonCollection
+      ObjectName: PyWBEM_Person
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: ReferenceNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="ReferenceNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ResultClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Role">
+      <VALUE>member</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="ReferenceNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_MemberOfPersonCollection"/>
+      </CLASSPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMXXX>'

--- a/tests/functiontest/setqualifier.yaml
+++ b/tests/functiontest/setqualifier.yaml
@@ -143,6 +143,75 @@
       </MESSAGE>
       </CIM>'
 
+- name: SetQualifierF2
+  description: SetQualifier request fails, CIMXMLParseErrot (XML CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: SetQualifier
+      namespace: null
+      QualifierDeclaration:
+        pywbem_object: CIMQualifierDeclaration
+        name: FooQualDecl
+        type: string
+        value: Some string
+        is_array: false
+        array_size: null
+        scopes:
+          CLASS: true
+        tosubclass: false
+        toinstance: null
+        overridable: false
+        translatable: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SetQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="SetQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierDeclaration">
+      <QUALIFIER.DECLARATION ISARRAY="false" NAME="FooQualDecl" OVERRIDABLE="false"
+      TOSUBCLASS="false" TYPE="string">
+      <SCOPE CLASS="true"/>
+      <VALUE>Some string</VALUE>
+      </QUALIFIER.DECLARATION>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="SetQualifier">
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: SetQualifierNS1
   description: SetQualifier, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -405,6 +405,29 @@ class TestCreateConnection(object):
         with pytest.raises(ValueError):
             conn.add_operation_recorder(LogOperationRecorder('fake_conn_id'))
 
+    def test_stats_enabled(self):  # pylint: disable=no-self-use
+        """
+        Test the property stats_enabled setter
+        """
+        conn = WBEMConnection('http://localhost')
+        assert conn.stats_enabled is False
+        conn.stats_enabled = True
+        assert conn.stats_enabled is True
+        conn.stats_enabled = False
+        assert conn.stats_enabled is False
+
+    def test_operation_recorder_enabled(self):  # pylint: disable=no-self-use
+        """
+        Test the property operation_recorder enabled setter
+        """
+        conn = WBEMConnection('http://localhost')
+        conn.add_operation_recorder(LogOperationRecorder('fake_conn_id'))
+        assert conn.operation_recorder_enabled is True
+        conn.operation_recorder_enabled = False
+        assert conn.operation_recorder_enabled is False
+        conn.operation_recorder_enabled = True
+        assert conn.operation_recorder_enabled is True
+
     def test_close(self):  # pylint: disable=no-self-use
         """
         Test closing a connection once.
@@ -526,7 +549,7 @@ class TestGetRsltParams(object):
 
 def build_repo():
     """Fixture to initialize the mock environment and install classes.
-       Definde as a function without the pytest.fixture decorator becasue
+       Defined as a function without the pytest.fixture decorator because
        there is no way to include a fixture in the signature of a test
        function that uses simplified_test_function. Simplified_test_function
        reports a parameter count difference because of the extram parameter
@@ -764,6 +787,50 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
     ),
 
     (
+        "Test OpenEnumerateInstances, Invalid type for operationtimeout",
+        dict(
+            init_kwargs={},
+            method='openenumerateinstances',
+            args=[CIMInstance("CIMBlah")],
+            kwargs={"OperationTimeout": "shouldbeinteger"},
+        ),
+        TypeError, None, OK
+    ),
+
+    (
+        "Test OpenEnumerateInstances, Invalid value for operationtimeout",
+        dict(
+            init_kwargs={},
+            method='openenumerateinstances',
+            args=[CIMInstance("CIMBlah")],
+            kwargs={"OperationTimeout": -30},
+        ),
+        TypeError, None, OK
+    ),
+
+    (
+        "Test OpenEnumerateInstancepaths, Invalid type for operationtimeout",
+        dict(
+            init_kwargs={},
+            method='openenumerateinstancepaths',
+            args=[CIMInstance("CIMBlah")],
+            kwargs={"OperationTimeout": "shouldbeinteger"},
+        ),
+        TypeError, None, OK
+    ),
+
+    (
+        "Test OpenEnumerateInstancePaths, Invalid value for operationtimeout",
+        dict(
+            init_kwargs={},
+            method='openenumerateinstancepaths',
+            args=[CIMInstance("CIMBlah")],
+            kwargs={"OperationTimeout": -30},
+        ),
+        TypeError, None, OK
+    ),
+
+    (
         "Test pullinstancewithpath, Invalid context type",
         dict(
             init_kwargs={},
@@ -924,6 +991,9 @@ def test_request_invalid_params(testcase, init_kwargs, method, args, kwargs):
 
     elif method == 'openenumerateinstances':
         _ = conn.OpenEnumerateInstances(*args, **kwargs)
+
+    elif method == 'openenumerateinstancepaths':
+        _ = conn.OpenEnumerateInstancePaths(*args, **kwargs)
 
     elif method == 'pullinstanceswithpath':
         _ = conn.PullInstancesWithPath(*args, **kwargs)

--- a/tests/unittest/pywbem/test_logging.py
+++ b/tests/unittest/pywbem/test_logging.py
@@ -164,6 +164,15 @@ class TestLoggingConfigure(object):
             # Disable logger to get log file closed.
             configure_logger(log_name, log_dest='off')
 
+    def test_configure_logger_nameerror(self):
+        """
+        Test that invalid logger name parameter generates exception. The
+        previous test handles valid names
+        """
+        with pytest.raises(ValueError):
+            configure_logger("BadLogName", log_dest='stderr',
+                             detail_level="all")
+
 
 TESTCASES_TEST_LOGGERS_FROM_STRING = [
     # Each list item is a testcase tuple with these items:

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -61,7 +61,7 @@ class BaseMethodsForTests(object):
     def setup_method(self):
         """
         Create the Fake connection and setup the connection. This
-        method first initialized the WbemServerMock and then suplements
+        method first initializes the WbemServerMock and then supplements
         it with the classes required for the subscription manager.
         """
         skip_if_moftab_regenerated()
@@ -242,7 +242,7 @@ class BaseMethodsForTests(object):
         return sum(self.count_outstanding(sub_mgr, server_id))
 
     def empty_expected(self, sub_mgr, server_id):
-        """ TODO """
+        """ Get outstanding objects from server. Return True if 0 objects """
         # pylint: disable=no-self-use
 
         counts = self.count_outstanding(sub_mgr, server_id)
@@ -292,8 +292,6 @@ class TestSubMgrClass(BaseMethodsForTests):
                                                       filter_path,
                                                       owned=True)
             subscription_paths = [inst.path for inst in subscriptions]
-
-            # self.conn.display_repository()
 
             self.confirm_created(sub_mgr, server_id, filter_path,
                                  subscription_paths, owned=True)


### PR DESCRIPTION
1. Increased test coverage by adding tests mostly in tests for
_cim_operations.py. The tests were added in
tests/unittest/pywbem/test_cimoperationspy and in the function tests.

2. Fixed one issue in WBEMConnections.enable_stats where the setter
was defined with a method rather than a property.

3. Fixed a second issue in the association operations where the OperationTimeout value was being checked for integer but not for positive integer.  (Note that associatornames did add specific code for the check for positive integer and I removed that specific check.

Increases the overall coverage to  92% and the coverage of _cim_operations.py to 92%
