### PR TITLE
Add more tests to increase coverage for _cim_operations.py and refactor one piece of code

### DIFF
--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -2569,9 +2569,71 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                                                  namespace)
         return (rtn_objects, end_of_sequence, rtn_ctxt)
 
+    def _get_returned_objects(self, result, ObjectName):
+        """
+        Support for Associators, References operations
+        Get returned objects and validate that the types correspond to the types
+        for Associators and References
+        """
+        objects = [] if result is None else [x[2] for x in result[0][2]]
+
+        if isinstance(ObjectName, CIMInstanceName):
+            # instance-level invocation
+            for instance in objects:
+                if not isinstance(instance, CIMInstance):
+                    raise CIMXMLParseError(
+                        _format("Expecting CIMInstance object in result "
+                                "list, got {0} object",
+                                instance.__class__.__name__),
+                        conn_id=self.conn_id)
+        else:
+            # class-level invocation
+            for classpath, klass in objects:
+                if not isinstance(classpath, CIMClassName) or \
+                        not isinstance(klass, CIMClass):
+                    raise CIMXMLParseError(
+                        _format("Expecting tuple (CIMClassName, CIMClass) "
+                                "in result list, got tuple ({0}, {1})",
+                                classpath.__class__.__name__,
+                                klass.__class__.__name__),
+                        conn_id=self.conn_id)
+        return objects
+
+    def _get_returned_objectnames(self, result, ObjectName):
+        """
+        Support for AssociatorNames, ReferenceNames operations
+
+        Get returned objects from results and validate that the are either
+        CIMInstanceName if the request was CIMInstanceName or
+        CIMClassName if the request was CIMClassName
+        """
+        objects = [] if result is None else [x[2] for x in result[0][2]]
+
+        if isinstance(ObjectName, CIMInstanceName):
+            # instance-level invocation
+            for instancepath in objects:
+                if not isinstance(instancepath, CIMInstanceName):
+                    raise CIMXMLParseError(
+                        _format("Expecting CIMInstanceName object in "
+                                "result list, got {0} object",
+                                instancepath.__class__.__name__),
+                        conn_id=self.conn_id)
+        else:
+            # class-level invocation
+            for classpath in objects:
+                if not isinstance(classpath, CIMClassName):
+                    raise CIMXMLParseError(
+                        _format("Expecting CIMClassName object in result "
+                                "list, got {0} object",
+                                classpath.__class__.__name__),
+                        conn_id=self.conn_id)
+        return objects
+
+    ###############################################################
     #
-    # Operations
+    # Request Operation methods
     #
+    ###############################################################
 
     def EnumerateInstances(self, ClassName, namespace=None, LocalOnly=None,
                            DeepInheritance=None, IncludeQualifiers=None,
@@ -3635,35 +3697,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 IncludeClassOrigin=IncludeClassOrigin,
                 PropertyList=PropertyList)
 
-            # instance-level invocation: list of CIMInstance
-            # class-level invocation: list of CIMClass
-            if result is None:
-                objects = []
-            else:
-                objects = [x[2] for x in result[0][2]]
-
-            if isinstance(ObjectName, CIMInstanceName):
-                # instance-level invocation
-                for instance in objects:
-                    if not isinstance(instance, CIMInstance):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMInstance object in result "
-                                    "list, got {0} object",
-                                    instance.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # path and namespace are already set
-            else:
-                # class-level invocation
-                for classpath, klass in objects:
-                    if not isinstance(classpath, CIMClassName) or \
-                            not isinstance(klass, CIMClass):
-                        raise CIMXMLParseError(
-                            _format("Expecting tuple (CIMClassName, CIMClass) "
-                                    "in result list, got tuple ({0}, {1})",
-                                    classpath.__class__.__name__,
-                                    klass.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # path and namespace are already set
+            objects = self._get_returned_objects(result, ObjectName)
+            # namespace already set
 
             return objects
 
@@ -3818,31 +3853,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 Role=Role,
                 ResultRole=ResultRole)
 
-            if result is None:
-                objects = []
-            else:
-                objects = [x[2] for x in result[0][2]]
-
-            if isinstance(ObjectName, CIMInstanceName):
-                # instance-level invocation
-                for instancepath in objects:
-                    if not isinstance(instancepath, CIMInstanceName):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMInstanceName object in "
-                                    "result list, got {0} object",
-                                    instancepath.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # namespace is already set
-            else:
-                # class-level invocation
-                for classpath in objects:
-                    if not isinstance(classpath, CIMClassName):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMClassName object in result "
-                                    "list, got {0} object",
-                                    classpath.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # namespace is already set
+            objects = self._get_returned_objectnames(result, ObjectName)
+            # namespace already set
 
             return objects
 
@@ -4036,33 +4048,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 IncludeClassOrigin=IncludeClassOrigin,
                 PropertyList=PropertyList)
 
-            if result is None:
-                objects = []
-            else:
-                objects = [x[2] for x in result[0][2]]
-
-            if isinstance(ObjectName, CIMInstanceName):
-                # instance-level invocation
-                for instance in objects:
-                    if not isinstance(instance, CIMInstance):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMInstance object in result "
-                                    "list, got {0} object",
-                                    instance.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # path and namespace are already set
-            else:
-                # class-level invocation
-                for classpath, klass in objects:
-                    if not isinstance(classpath, CIMClassName) or \
-                            not isinstance(klass, CIMClass):
-                        raise CIMXMLParseError(
-                            _format("Expecting tuple (CIMClassName, CIMClass) "
-                                    "in result list, got tuple ({0}, {1})",
-                                    classpath.__class__.__name__,
-                                    klass.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # path and namespace are already set
+            objects = self._get_returned_objects(result, ObjectName)
+            # path and namespace are already set
 
             return objects
 
@@ -4195,31 +4182,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                 ResultClass=ResultClass,
                 Role=Role)
 
-            if result is None:
-                objects = []
-            else:
-                objects = [x[2] for x in result[0][2]]
-
-            if isinstance(ObjectName, CIMInstanceName):
-                # instance-level invocation
-                for instancepath in objects:
-                    if not isinstance(instancepath, CIMInstanceName):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMInstanceName object in "
-                                    "result list, got {0} object",
-                                    instancepath.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # namespace is already set
-            else:
-                # class-level invocation
-                for classpath in objects:
-                    if not isinstance(classpath, CIMClassName):
-                        raise CIMXMLParseError(
-                            _format("Expecting CIMClassName object in result "
-                                    "list, got {0} object",
-                                    classpath.__class__.__name__),
-                            conn_id=self.conn_id)
-                    # namespace is already set
+            objects = self._get_returned_objectnames(result, ObjectName)
+            # namespace is already set
 
             return objects
 

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -1983,7 +1983,6 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
 
         self._verify_open()
-
         if isinstance(objectname, (CIMInstanceName, CIMClassName)):
             localobject = objectname.copy()
             if localobject.namespace is None:

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -2603,7 +2603,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         """
         Support for AssociatorNames, ReferenceNames operations
 
-        Get returned objects from results and validate that the are either
+        Get returned objects from results and validate that they are either
         CIMInstanceName if the request was CIMInstanceName or
         CIMClassName if the request was CIMClassName
         """

--- a/tests/functiontest/associatornames_classes.yaml
+++ b/tests/functiontest/associatornames_classes.yaml
@@ -818,7 +818,7 @@
             </CIM>
 
 - name: AssociatorNames_ClassesF2
-  description: Associator Names Fails CIMXMLParseError
+  description: Associator Names Fails CIMXMLParseError (Bad XML entity MESSAGEXXX)
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -898,6 +898,93 @@
       </SIMPLERSP>
       </MESSAGEXXX>
       </CIM>'
+
+- name: AssociatorNames_ClassesF3
+  description: Associator Names fails, Returns instance names
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: AssociatorNames
+      ResultClass: CIM_Collection
+      Role: member
+      AssocClass: PyWBEM_MemberOfPersonCollection
+      ObjectName: PyWBEM_Person
+      ResultRole: Collection
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: AssociatorNames
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="AssociatorNames">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="ResultClass">
+      <CLASSNAME NAME="CIM_Collection"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="Role">
+      <VALUE>member</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ResultRole">
+      <VALUE>Collection</VALUE>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="ObjectName">
+      <CLASSNAME NAME="PyWBEM_Person"/>
+      </IPARAMVALUE>
+      <IPARAMVALUE NAME="AssocClass">
+      <CLASSNAME NAME="PyWBEM_MemberOfPersonCollection"/>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="AssociatorNames">
+      <IRETURNVALUE>
+      <OBJECTPATH>
+      <CLASSPATH>
+      <NAMESPACEPATH>
+      <HOST>sheldon</HOST>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      </NAMESPACEPATH>
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">Alice</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </CLASSPATH>
+      </OBJECTPATH>
+      </IRETURNVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
 
 - name: AssociatorNames_ClassesNS1
   description: AssociatorNames on class, providing class name and default namespace with leading/trailing slashes

--- a/tests/functiontest/associatornames_instances.yaml
+++ b/tests/functiontest/associatornames_instances.yaml
@@ -373,7 +373,7 @@
             </CIM>
 
 - name: AssociatorNames_InstancesError2
-  description: AssociatorNames returns CIMClass and CIMXMLParserError.
+  description: AssociatorNames returns CIMClass, generates CIMXMLParserError.
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -446,7 +446,7 @@
       <NAMESPACE NAME="cimv2"/>
       </LOCALNAMESPACEPATH>
       </NAMESPACEPATH>
-      <CLASSNAME CLASSNAME="PyWBEM_PersonCollection">
+      <CLASSNAME NAME="PyWBEM_PersonCollection">
       </CLASSNAME>
       </INSTANCEPATH>
       </OBJECTPATH>

--- a/tests/functiontest/associators_classes.yaml
+++ b/tests/functiontest/associators_classes.yaml
@@ -233,8 +233,8 @@
       </MESSAGE>
       </CIMX>'
 
-- name: Associators_Classes_Error2
-  description: Associators fails, CIMXMLParseError, entity CIMXXXX
+- name: Associators_ClassesError2
+  description: Associators fails, CIMXMLParseError, Returns instances on class request
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -286,7 +286,7 @@
     headers:
       cimoperation: MethodResponse
     data: '<?xml version="1.0" encoding="utf-8" ?>
-      <CIMXXXX CIMVERSION="2.0" DTDVERSION="2.0">
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
       <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
       <SIMPLERSP>
       <IMETHODRESPONSE NAME="Associators">
@@ -302,22 +302,14 @@
       </NAMESPACEPATH>
       <CLASSNAME NAME="CIM_Collection"/>
       </CLASSPATH>
-      <CLASS NAME="CIM_Collection"  SUPERCLASS="CIM_ManagedElement" >
-      <PROPERTY NAME="InstanceID"  PROPAGATED="true" TYPE="string">
-      </PROPERTY>
-      <PROPERTY NAME="Caption"  PROPAGATED="true" TYPE="string">
-      </PROPERTY>
-      <PROPERTY NAME="Description"  PROPAGATED="true" TYPE="string">
-      </PROPERTY>
-      <PROPERTY NAME="ElementName"  PROPAGATED="true" TYPE="string">
-      </PROPERTY>
-      </CLASS>
+      <INSTANCE CLASSNAME="CIM_Collection" >
+      </INSTANCE>
       </VALUE.OBJECTWITHPATH>
       </IRETURNVALUE>
       </IMETHODRESPONSE>
       </SIMPLERSP>
       </MESSAGE>
-      </CIMXXXX>'
+      </CIM>'
 
 - name: Associators_ClassesNS1
   description: Associators on class, providing class name and default namespace with leading/trailing slashes

--- a/tests/functiontest/deleteinstance.yaml
+++ b/tests/functiontest/deleteinstance.yaml
@@ -62,6 +62,77 @@
       </MESSAGE>
       </CIM>'
 
+- name: DeleteInstance2
+  description: Delete instance of PyWBEM_Person fails CIMXMLParseError because returns param
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: DeleteInstance
+      InstanceName:
+        pywbem_object: CIMInstanceName
+        classname: PyWBEM_Person
+        namespace: null
+        keybindings:
+          CreationClassName: PyWBEM_Person
+          Name: run_cimoperations_test
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteInstance
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteInstance">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="InstanceName">
+      <INSTANCENAME CLASSNAME="PyWBEM_Person">
+      <KEYBINDING NAME="CreationClassName">
+      <KEYVALUE VALUETYPE="string" TYPE="string">PyWBEM_Person</KEYVALUE>
+      </KEYBINDING>
+      <KEYBINDING NAME="Name">
+      <KEYVALUE VALUETYPE="string" TYPE="string">run_cimoperations_test</KEYVALUE>
+      </KEYBINDING>
+      </INSTANCENAME>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteInstance">
+      <PARAMVALUE NAME="EndOfSequence">
+        <VALUE>TRUE</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="EnumerationContext">
+        <VALUE></VALUE>
+      </PARAMVALUE>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>'
+
 - name: DeleteInstanceError1
   description: Delete Instance of PyWBEM_Person fails. Instance does not exist
   pywbem_request:

--- a/tests/functiontest/deletequalifier.yaml
+++ b/tests/functiontest/deletequalifier.yaml
@@ -106,6 +106,60 @@
       </MESSAGE>
       </CIM>'
 
+- name: DeleteQualifierF2
+  description: DeleteQualifier request fails CIMXMLParserError (bad endity CIMX)
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: DeleteQualifier
+      QualifierName: FooQualDecl
+      namespace: null
+  pywbem_response:
+    exception: CIMXMLParseError
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: DeleteQualifier
+      CIMObject: root/cimv2
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <IMETHODCALL NAME="DeleteQualifier">
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <IPARAMVALUE NAME="QualifierName">
+      <VALUE>FooQualDecl</VALUE>
+      </IPARAMVALUE>
+      </IMETHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>'
+  http_response:
+    status: 200
+    headers:
+      cimoperation: MethodResponse
+    data: '<?xml version="1.0" encoding="utf-8" ?>
+      <CIMX CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <IMETHODRESPONSE NAME="DeleteQualifier">
+      <ERROR CODE="6" DESCRIPTION="CIM_ERR_NOT_FOUND: FooQualDecl"/>
+      </IMETHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIMX>'
+
 - name: DeleteQualifierNS1
   description: DeleteQualifier, with leading/trailing slashes in default namespace
   pywbem_request:

--- a/tests/functiontest/invokemethod.yaml
+++ b/tests/functiontest/invokemethod.yaml
@@ -308,8 +308,9 @@
       </MESSAGE>
       </CIM>
 
-- name: InvokeMethod_SFCB_UEP
-  description: Verify that UpdateExpiredPassword causes the corresponding Pragma header to be added
+- name: InvokeMethod5
+  description: Pass one boolean input parameter via **params as value to test infered value, no output parameters
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
   pywbem_request:
     url: http://acme.com:80
     creds:
@@ -320,13 +321,13 @@
     debug: true
     operation:
       pywbem_method: InvokeMethod
-      MethodName: UpdateExpiredPassword
+      MethodName: SendTestIndicationsCount
       ObjectName:
         pywbem_object: CIMClassName
-        classname: SFCB_Account
+        classname: Test_IndicationProviderClass
         host: null
-        namespace: root/interop
-      UserPassword: foo
+        namespace: test/TestProvider
+      indicationSendCount: true
   pywbem_response:
     result:
     - 0
@@ -336,24 +337,23 @@
     url: http://acme.com:80/cimom
     headers:
       CIMOperation: MethodCall
-      CIMMethod: UpdateExpiredPassword
-      CIMObject: root/interop:SFCB_Account
-      Pragma: UpdateExpiredPassword
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
     data: >
       <?xml version="1.0" encoding="utf-8" ?>
       <CIM CIMVERSION="2.0" DTDVERSION="2.0">
       <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
       <SIMPLEREQ>
-      <METHODCALL NAME="UpdateExpiredPassword">
+      <METHODCALL NAME="SendTestIndicationsCount">
       <LOCALCLASSPATH>
       <LOCALNAMESPACEPATH>
-      <NAMESPACE NAME="root"/>
-      <NAMESPACE NAME="interop"/>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
       </LOCALNAMESPACEPATH>
-      <CLASSNAME NAME="SFCB_Account"/>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
       </LOCALCLASSPATH>
-      <PARAMVALUE NAME="UserPassword" PARAMTYPE="string">
-      <VALUE>foo</VALUE>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="boolean">
+      <VALUE>TRUE</VALUE>
       </PARAMVALUE>
       </METHODCALL>
       </SIMPLEREQ>
@@ -368,7 +368,7 @@
       <CIM CIMVERSION="2.0" DTDVERSION="2.0">
       <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
       <SIMPLERSP>
-      <METHODRESPONSE NAME="UpdateExpiredPassword">
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
       <RETURNVALUE PARAMTYPE="sint32">
       <VALUE>0</VALUE>
       </RETURNVALUE>
@@ -377,8 +377,8 @@
       </MESSAGE>
       </CIM>
 
-- name: InvokeMethod5
-  description: InvokeMethod, return one parameter inferred type string
+- name: InvokeMethod6
+  description: Pass one boolean list input parameter via **params as list of value(boolean), no output parameters
   # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
   pywbem_request:
     url: http://acme.com:80
@@ -390,40 +390,49 @@
     debug: true
     operation:
       pywbem_method: InvokeMethod
-      MethodName: InferredTypesTest
+      MethodName: SendTestIndicationsCount
       ObjectName:
         pywbem_object: CIMClassName
-        classname: Test_InferredTypes
+        classname: Test_IndicationProviderClass
         host: null
         namespace: test/TestProvider
+      indicationSendCount:
+        - true
+        - false
   pywbem_response:
     result:
     - 0
-    - {'InferStringParam': 'Blah'}
+    - {}
   http_request:
     verb: POST
     url: http://acme.com:80/cimom
     headers:
       CIMOperation: MethodCall
-      CIMMethod: InferredTypesTest
-      CIMObject: test/TestProvider:Test_InferredTypes
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
     data: >
+      <?xml version="1.0" encoding="utf-8" ?>
       <CIM CIMVERSION="2.0" DTDVERSION="2.0">
-        <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
-          <SIMPLEREQ>
-            <METHODCALL NAME="InferredTypesTest">
-              <LOCALCLASSPATH>
-                <LOCALNAMESPACEPATH>
-                  <NAMESPACE NAME="test"></NAMESPACE>
-                  <NAMESPACE NAME="TestProvider"></NAMESPACE>
-                </LOCALNAMESPACEPATH>
-                <CLASSNAME NAME="Test_InferredTypes"></CLASSNAME>
-              </LOCALCLASSPATH>
-            </METHODCALL>
-          </SIMPLEREQ>
-        </MESSAGE>
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="boolean">
+      <VALUE.ARRAY>
+      <VALUE>TRUE</VALUE>
+      <VALUE>FALSE</VALUE>
+      </VALUE.ARRAY>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
       </CIM>
-
   http_response:
     status: 200
     headers:
@@ -433,20 +442,17 @@
       <CIM CIMVERSION="2.0" DTDVERSION="2.0">
       <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
       <SIMPLERSP>
-      <METHODRESPONSE NAME="InferredTypesTest">
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
       <RETURNVALUE PARAMTYPE="sint32">
       <VALUE>0</VALUE>
       </RETURNVALUE>
-      <PARAMVALUE NAME="InferStringParam">
-      <VALUE>Blah</VALUE>
-      </PARAMVALUE>
       </METHODRESPONSE>
       </SIMPLERSP>
       </MESSAGE>
       </CIM>
 
-- name: InvokeMethod6
-  description: InvokeMethod, return one parameter inferred type boolean
+- name: InvokeMethod7
+  description: InvokeMethod, return one parameter type boolean
   ignore_test: true
   # Ignoring this test because infer type with boolean does not work.
   # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
@@ -514,9 +520,8 @@
       </MESSAGE>
       </CIM>
 
-
-- name: InvokeMethod7
-  description: InvokeMethod, return one parameter inferred type list of string
+- name: InvokeMethod8
+  description: InvokeMethod, return one parameter returned type list of string
   # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
   pywbem_request:
     url: http://acme.com:80
@@ -585,8 +590,8 @@
       </MESSAGE>
       </CIM>
 
-- name: InvokeMethod8
-  description: InvokeMethod, return one parameter inferred type CIMClass
+- name: InvokeMethod9
+  description: InvokeMethod, return one parameter returned type CIMClass
   ignore_test: true
   # Ignoring this test because I do not know how to define CIMClass in a
   # list in YAML
@@ -650,6 +655,155 @@
       <PARAMVALUE NAME="ClassParam">
         <CLASS NAME="CIM_BLAH"></CLASS>
       </PARAMVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethod10
+  description: Pass two input parameters but no namespace on request object
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: null
+      Params:
+        - - indicationSendCount
+          - pywbem_object: Uint32
+            x: 0
+        - - indicationDropCount
+          - pywbem_object: Uint32
+            x: 42
+        - - optionalP1
+          - null
+  pywbem_response:
+    result:
+    - 0
+    - {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: root/cimv2:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="cimv2"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="uint32">
+      <VALUE>0</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="indicationDropCount" PARAMTYPE="uint32">
+      <VALUE>42</VALUE>
+      </PARAMVALUE>
+      <PARAMVALUE NAME="optionalP1"/>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethod_SFCB_UEP
+  description: Verify that UpdateExpiredPassword causes the corresponding Pragma header to be added
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: UpdateExpiredPassword
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: SFCB_Account
+        host: null
+        namespace: root/interop
+      UserPassword: foo
+  pywbem_response:
+    result:
+    - 0
+    - {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: UpdateExpiredPassword
+      CIMObject: root/interop:SFCB_Account
+      Pragma: UpdateExpiredPassword
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="UpdateExpiredPassword">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="root"/>
+      <NAMESPACE NAME="interop"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="SFCB_Account"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="UserPassword" PARAMTYPE="string">
+      <VALUE>foo</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="UpdateExpiredPassword">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
       </METHODRESPONSE>
       </SIMPLERSP>
       </MESSAGE>
@@ -1131,5 +1285,162 @@
       </SIMPLERSP>
       </MESSAGE>
       </CIM>
+
+- name: InvokeMethod11
+  # Test fails because the list defined for classnameList parameter creates object has type <class 'collections.OrderedDict'>
+  # while _methodcall isinstance only handles list type
+  ignore_test: true
+  description: Pass list of CIMClassName parameter, no output parameters
+  # Note: We can pass only one parameter because the **kwargs mechanism does not preserve the order
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      classnameList:
+        - ObjectName:
+              pywbem_object: CIMClassName
+              classname: Test_classnameinparam1
+              host: null
+              namespace: test/TestProvider
+        - ObjectName:
+              pywbem_object: CIMClassName
+              classname: Test_classnameinparam2
+              host: null
+              namespace: test/TestProvider
+  pywbem_response:
+    result:
+    - 0
+    - {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="indicationSendCount" PARAMTYPE="boolean">
+      <VALUE.ARRAY>
+      <VALUE>TRUE</VALUE>
+      <VALUE>FALSE</VALUE>
+      </VALUE.ARRAY>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
+- name: InvokeMethod12
+  description: Pass input parameter as CIMDateTime, no output parameters
+  pywbem_request:
+    url: http://acme.com:80
+    creds:
+    - username
+    - password
+    namespace: root/cimv2
+    timeout: 10
+    debug: true
+    operation:
+      pywbem_method: InvokeMethod
+      MethodName: SendTestIndicationsCount
+      ObjectName:
+        pywbem_object: CIMClassName
+        classname: Test_IndicationProviderClass
+        host: null
+        namespace: test/TestProvider
+      Params:
+        - - datetimeparam
+          - pywbem_object: CIMDateTime
+            dtarg: "00001234567890.123456:000"
+  pywbem_response:
+    result:
+    - 0
+    - {}
+  http_request:
+    verb: POST
+    url: http://acme.com:80/cimom
+    headers:
+      CIMOperation: MethodCall
+      CIMMethod: SendTestIndicationsCount
+      CIMObject: test/TestProvider:Test_IndicationProviderClass
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLEREQ>
+      <METHODCALL NAME="SendTestIndicationsCount">
+      <LOCALCLASSPATH>
+      <LOCALNAMESPACEPATH>
+      <NAMESPACE NAME="test"/>
+      <NAMESPACE NAME="TestProvider"/>
+      </LOCALNAMESPACEPATH>
+      <CLASSNAME NAME="Test_IndicationProviderClass"/>
+      </LOCALCLASSPATH>
+      <PARAMVALUE NAME="datetimeparam" PARAMTYPE="datetime">
+            <VALUE>00001236091930.123456:000</VALUE>
+      </PARAMVALUE>
+      </METHODCALL>
+      </SIMPLEREQ>
+      </MESSAGE>
+      </CIM>
+  http_response:
+    status: 200
+    headers:
+      CIMOperation: MethodResponse
+    data: >
+      <?xml version="1.0" encoding="utf-8" ?>
+      <CIM CIMVERSION="2.0" DTDVERSION="2.0">
+      <MESSAGE ID="1001" PROTOCOLVERSION="1.0">
+      <SIMPLERSP>
+      <METHODRESPONSE NAME="SendTestIndicationsCount">
+      <RETURNVALUE PARAMTYPE="sint32">
+      <VALUE>0</VALUE>
+      </RETURNVALUE>
+      </METHODRESPONSE>
+      </SIMPLERSP>
+      </MESSAGE>
+      </CIM>
+
 
 # TODO 01/18 AM: Add testcases for namespaces with leading/trailing slashes

--- a/tests/functiontest/openenumerateinstancepaths.yaml
+++ b/tests/functiontest/openenumerateinstancepaths.yaml
@@ -595,7 +595,7 @@
               </MESSAGE>
             </CIM>
 
--   name: OpenEnumerateInstancePathsF5
+-   name: OpenEnumerateInstancePathsF4
     description: OpenEnumerateInstancePaths, server fails with CIM_ERR_INVALID_CLASS
     pywbem_request:
         url: http://acme.com:80
@@ -650,7 +650,7 @@
               </MESSAGE>
             </CIM>
 
--   name: OpenEnumerateInstancePathsF6
+-   name: OpenEnumerateInstancePathsF5
     description: OpenEnumerateInstancePaths, server fails with CIM_ERR_FAILED
     pywbem_request:
         url: http://acme.com:80
@@ -705,7 +705,7 @@
               </MESSAGE>
             </CIM>
 
--   name: OpenEnumerateInstancePaths1
+-   name: OpenEnumerateInstancePathsF6
     description: OpenEnumerateInstancePaths fails, CIMXMLParseError from bad XML CIMX
     pywbem_request:
         url: http://acme.com:80

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -31,7 +31,7 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
-OK = True     # mark tests OK when they execute correctly
+OK = False     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 SKIP = False
@@ -791,7 +791,7 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
         dict(
             init_kwargs={},
             method='openenumerateinstances',
-            args=[CIMInstance("CIMBlah")],
+            args=[CIMClass("CIMBlah")],
             kwargs={"OperationTimeout": "shouldbeinteger"},
         ),
         TypeError, None, OK
@@ -802,7 +802,7 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
         dict(
             init_kwargs={},
             method='openenumerateinstances',
-            args=[CIMInstance("CIMBlah")],
+            args=[CIMClass("CIMBlah")],
             kwargs={"OperationTimeout": -30},
         ),
         TypeError, None, OK
@@ -813,7 +813,7 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
         dict(
             init_kwargs={},
             method='openenumerateinstancepaths',
-            args=[CIMInstance("CIMBlah")],
+            args=[CIMClass("CIMBlah")],
             kwargs={"OperationTimeout": "shouldbeinteger"},
         ),
         TypeError, None, OK
@@ -824,7 +824,7 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
         dict(
             init_kwargs={},
             method='openenumerateinstancepaths',
-            args=[CIMInstance("CIMBlah")],
+            args=[CIMClass("CIMBlah")],
             kwargs={"OperationTimeout": -30},
         ),
         TypeError, None, OK

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -31,7 +31,7 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
-OK = False     # mark tests OK when they execute correctly
+OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 SKIP = False
@@ -734,12 +734,12 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
         TypeError, None, OK
     ),
     (
-        "Test invalid invokemethod objectname None",
+        "Test invalid invokemethod inferred object integer None",
         dict(
             init_kwargs={},
             method='invokemethod',
             args=[None, "ObjectName"],
-            kwargs={},
+            kwargs={"param1": 1},
         ),
         TypeError, None, False  # Fails with connection failure.
     ),


### PR DESCRIPTION
1. Refactor the code for the open... methods that duplicate some of the test code (test for object types returned) to create common functions.
2. Add tests for this code and other pieces of _cimoperations.py that are not covered.  This reduces the uncovered code in _cim_operaitons.py to about 130 lines of which about 100 are the recorder calls and several are code that apparently duplicates tests in the xml parser and so may never be called.