### PR TITLE
Ks/more todo cleanup

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -141,8 +141,7 @@ pyrsistent>=0.14.0; python_version >= '3.5'
 pywin32>=222,!=226; sys_platform == 'win32' and python_version == '2.7'
 pywin32>=222,!=226; sys_platform == 'win32' and python_version >= '3.5' and python_version <= '3.6'
 pywin32>=223,!=226; sys_platform == 'win32' and python_version == '3.7'
-# TODO: Re-enable once pywin32 fixes its Python version advertising on Pypi
-#       (see issue #1975).
+# ISSUE #1975: Re-enable once pywin32 fixes its Python version advertising on Pypi
 # pywin32>=225,!=226; sys_platform == 'win32' and python_version >= '3.8'
 
 # The tornado package is used by ipykernel which is used by jupyter.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -21,7 +21,7 @@ operations.
 The CIM/WBEM architecture
 -------------------------
 
-TODO: Write this section on  CIM/WBEM architecture
+ISSUE #2669: Write this section on  CIM/WBEM architecture
 
 .. _`The CIM model and CIM objects`:
 
@@ -29,7 +29,7 @@ TODO: Write this section on  CIM/WBEM architecture
 The CIM model and CIM objects
 -----------------------------
 
-TODO: Write this section on the model and CIM objects
+ISSUE #2669: Write this section on the model and CIM objects
 
 
 .. _`WBEM operations: Communicating with the WBEM Server`:
@@ -37,21 +37,21 @@ TODO: Write this section on the model and CIM objects
 WBEM Operations: Communicating with the WBEM Server
 ---------------------------------------------------
 
-TODO: Write this section  on WBEM Operations
+ISSUE #2669: Write this section  on WBEM Operations
 
 .. _`WBEM operations overview`:
 
 WBEM operations overview
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO Write this section on WBEM operations overview
+ISSUE #2669 Write this section on WBEM operations overview
 
 .. _`Traditional operations`:
 
 Traditional operations
 ^^^^^^^^^^^^^^^^^^^^^^
 
-TODO - Write this section on traditional operations
+ISSUE #2669 - Write this section on traditional operations
 
 .. _`Pull operations`:
 
@@ -489,12 +489,12 @@ already complete, this call will also be ignored.
 WBEM indications and subscriptions
 ----------------------------------
 
-TODO: write this Section on indications and subscriptions
+ISSUE #2669: write this Section on indications and subscriptions
 
 .. _`WBEM Management Profiles`:
 
 WBEM Management Profiles
 ------------------------
 
-TODO: Create this section describing profiles, why there exist and
+ISSUE #2669: Create this section describing profiles, why there exist and
 very generally how to use them

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -1614,8 +1614,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     # for recording the WBEM connection information.
                     connection.add_operation_recorder(recorder)
 
-                # TODO execute stage of wbem connection if not already executed.
-                # How do we know it is already executed???
+                # ISSUE #2667 execute stage of wbem connection if not already
+                # executed. How do we know it is already executed since there
+                # multiple paths through the _activate_logger method
 
     def _verify_open(self):
         """
@@ -6436,7 +6437,7 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     qrc = pull_result.query_result_class if \
                         ReturnQueryResultClass else None
 
-                    # FUTURE TODO: Change to yield each Open/Pull instead of
+                    # ISSUE #2668: Change to yield each Open/Pull instead of
                     # first calculating the total result and then yielding it.
                     # NOTE that this is only a performance issue. All instances
                     # are delivered but not until the operation is complete

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -985,7 +985,6 @@ class WBEMListener(object):
 
         # Stopping the server will cause its `serve_forever()` method
         # to return, which will cause the server thread to terminate.
-        # TODO: Describe how the processing threads terminate.
 
         if self._http_server:
             self.logger.info("Stopping threaded HTTP server")

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -574,15 +574,6 @@ class LogOperationRecorder(BaseOperationRecorder):
         if self.enabled and self.api_detail_level is not None and \
                 self.apilogger.isEnabledFor(logging.DEBUG):
 
-            # TODO: future bypassed code to only ouput name and method if the
-            # detail is summary.  We are not doing this because this is
-            # effectively the same information in the response so the only
-            # additional infomation is the time stamp.
-
-            # if self.api_detail_level == summary:
-            #    self.apilogger.debug('Request:%s %s', self._conn_id, method)
-            #    return
-
             # Order kwargs.  Note that this is done automatically starting
             # with python 3.6
             kwstr = ', '.join([('{0}={1!r}'.format(key, kwargs[key]))

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -940,7 +940,7 @@ class FakedWBEMConnection(WBEMConnection):
         'Methods').
         """
 
-        # Issue #2062: TODO/ks FUTURE Consider sorting to preserve order of
+        # Issue #2062: Consider sorting to preserve order of
         # compile/add. Make this part of refactor to separate repository and
         # datastore because it may be data store dependent
         _uprint(dest,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -210,7 +210,11 @@ def is_inherited_from(member_name, derived_class, base_class):
     derived_member = getattr(derived_class, member_name)
     base_member = getattr(base_class, member_name)
 
-    if isinstance(derived_member, types.MethodType) and \
+    if derived_member.__class__.__name__ == 'cython_function_or_method' and \
+            base_member.__class__.__name__ == 'cython_function_or_method':
+        derived_code = derived_member.func_code
+        base_code = base_member.func_code
+    elif isinstance(derived_member, types.MethodType) and \
             isinstance(base_member, types.MethodType):
         # instance method
         derived_code = derived_member.__func__.__code__


### PR DESCRIPTION
One more round of minor TODO cleanup
  
1. Modify one TODO to ISSUE statement in dev-requirements.  Leaves 2
TODOs in dev-requirements.txt

2. Change the TODOS in docs/concepts.rst to ISSUE # 2669. That leaves 2
TODOS in notebooks and one in docs/conf.py

3. Change 2 TODOS in _cim_operations.py to ISSUEs

4. Remove TODO about completion doc in _listener.py

5. Remove TODO in _recorder.py

6. Remove TODO from comment in _wbemconnection.py

with these changes, the TODOS outside of tests are:

1. try - 6 TODOS
2. dev-requirements - 3 (actually 2) TODOS
3. 3. docs - docs.conf.py 1 TODO, notebooks - 2 TODOS
3. pylintrc - 6 TODOS

**tests: 145**

