### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ on:
     - # cron (in UTC): minute hour day_of_month month day_of_week
       cron: '00 03 * * SUN'
   push:
-    branches: [ master, stable_1.1 ]
+    branches: [ master, stable_1.2 ]
   pull_request:
-    branches: [ master, stable_1.1 ]
+    branches: [ master, stable_1.2 ]
 
 env:
   # Local Docker image cache directory

--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,9 @@ py_test_files := \
 # - 39621: Pylint cannot be upgraded on py27+py34
 # - 39525: Jinja2 cannot be upgraded on py34
 # - 40072: lxml HTML cleaner in lxml 4.6.3 no longer includes the HTML5 'formaction'
+# - 38932: cryptography cannot be upgraded to 3.2 on py34
+# - 39252: cryptography cannot be upgraded to 3.3 on py34+py35
+# - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
 
 safety_ignore_opts := \
     -i 38100 \
@@ -294,6 +297,9 @@ safety_ignore_opts := \
 		-i 39621 \
 		-i 39525 \
 		-i 40072 \
+		-i 38932 \
+		-i 39252 \
+		-i 39606 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/README_PYPI.rst
+++ b/README_PYPI.rst
@@ -4,10 +4,10 @@
 .. # we have to specify the package version directly in the links.
 
 .. # begin of customization for the current version
-.. |pywbem-version-mn| replace:: 1.1
-.. _Readme file on GitHub: https://github.com/pywbem/pywbem/blob/stable_1.1/README.rst
-.. _Documentation on RTD: https://pywbem.readthedocs.io/en/stable_1.1/
-.. _Change log on RTD: https://pywbem.readthedocs.io/en/stable_1.1/changes.html
+.. |pywbem-version-mn| replace:: 1.2
+.. _Readme file on GitHub: https://github.com/pywbem/pywbem/blob/stable_1.2/README.rst
+.. _Documentation on RTD: https://pywbem.readthedocs.io/en/stable_1.2/
+.. _Change log on RTD: https://pywbem.readthedocs.io/en/stable_1.2/changes.html
 .. # end of customization for the current version
 
 Pywbem is a WBEM client and WBEM indication listener and provides related

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,8 +29,10 @@ safety>=1.8.7,<1.9.0; python_version <= '3.4'
 safety>=1.9.0; python_version >= '3.5'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
+# Pip 19.1.1 does not recognize that dparse 0.5.0 has dropped support for Python 3.4
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
-dparse>=0.4.1; python_version >= '3.4'
+dparse>=0.4.1,<0.5.0; python_version == '3.4'
+dparse>=0.5.1; python_version >= '3.5'
 
 # Tox
 tox>=2.5.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,12 +14,12 @@ Change log
       :revisions: 1
 
 
-pywbem 1.2.0.dev1
------------------
+pywbem 1.2.0
+------------
 
-This version contains all fixes up to pywbem 1.1.x.
+This version contains all fixes up to pywbem 1.1.3.
 
-Released: not yet
+Released: 2021-04-26
 
 **Incompatible changes:**
 
@@ -49,8 +49,6 @@ Released: not yet
   The logging support which uses the operation recorder remains publicly
   available. If you are using the operation recorder, please create an issue in
   the issue tracker describing how you use it.
-
-**Deprecations:**
 
 **Bug fixes:**
 
@@ -321,10 +319,6 @@ Released: not yet
   Python 3.4 support. As a consequence,
   `safety issue <https://github.com/pyupio/safety-db/blob/master/data/insecure_full.json>`_
   38834 cannot be addressed on Python 3.4.
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/pywbem/pywbem/issues
 
 
 pywbem 1.1.0

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -72,10 +72,11 @@
 # For the base packages, we use the versions from Ubuntu 18.04 as a general
 # minimum, and then increase it to the first version that introduced support
 # for a particular Python version:
+# The cryptography package requires pip>=21.0 on Windows on GitHub Actions.
 pip==9.0.1; python_version <= '3.5'
-pip==10.0.0; python_version == '3.6'
-pip==18.1; python_version == '3.7'
-pip==19.3.1; python_version >= '3.8'
+pip==21.0; python_version == '3.6'
+pip==21.0; python_version == '3.7'
+pip==21.0; python_version >= '3.8'
 setuptools==39.0.1; python_version <= '3.6'
 setuptools==40.6.0; python_version == '3.7'
 setuptools==41.5.0; python_version >= '3.8'
@@ -106,6 +107,13 @@ urllib3==1.25.9; python_version == '2.7'
 urllib3==1.24.2; python_version == '3.4'
 urllib3==1.25.9; python_version >= '3.5'
 # funcsigs; is covered in direct deps for develop, from mock
+
+# From easy-vault:
+cryptography==3.3; python_version == '2.7'
+cryptography==2.8; python_version == '3.4'
+cryptography==3.2.1; python_version == '3.5'
+cryptography==3.4.7; python_version >= '3.6'
+keyring==18.0.0
 
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
@@ -161,7 +169,8 @@ coveralls==2.1.2; python_version >= '3.5'
 # Safety CI by pyup.io
 safety==1.8.7; python_version <= '3.4'
 safety==1.9.0; python_version >= '3.5'
-dparse==0.4.1
+dparse==0.4.1; python_version <= '3.4'
+dparse==0.5.1; python_version >= '3.5'
 
 # Tox
 tox==2.5.0
@@ -192,10 +201,10 @@ lazy-object-proxy==1.4.3; python_version == '3.4'
 lazy-object-proxy==1.4.3; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-flake8==3.7.9
+flake8==3.8.0
 mccabe==0.6.0
-pycodestyle==2.5.0
-pyflakes==2.1.0
+pycodestyle==2.6.0
+pyflakes==2.2.0
 entrypoints==0.3.0
 functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 

--- a/pywbem/_version.py
+++ b/pywbem/_version.py
@@ -29,4 +29,4 @@ Version of the pywbem package.
 #:
 #: * "M.N.P.devD": Development level D of a not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.2.0.dev1'
+__version__ = '1.2.0'


### PR DESCRIPTION
Please approve the release of pywbem 1.2.0.

The one extra commit solves an issue that only shows up in the full set of tests, but nt in the normal set of tests. That's why it is part of the release PR.