### PR TITLE
Fix mof_compiler unwanted output of trace log information.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixes bug in compiler where log of ModifyClass request failure was not
+  surrounded by verbose test (if p.parse.verbose:). See pywbemcli issue
+  #395,
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -759,16 +759,21 @@ def p_mp_createClass(p):
             p.parser.log(
                 _format("Class already exists - modifying class {0}",
                         cc_path))
+
+        # Attempt to modify class since it exists.
         try:
             p.parser.handle.ModifyClass(cc, ns)
+
+        # Handle exceptions from ModifyClass.
         except CIMError as ce:
-            p.parser.log(
-                _format("Error modifying class {0}: {1}, {2}",
-                        cc_path, ce.status_code, ce.status_description))
+            if p.parser.verbose:
+                p.parser.log(
+                    _format("Error modifying class {0}: {1}, {2}",
+                            cc_path, ce.status_code, ce.status_description))
             raise MOFRepositoryError(
                 msg=_format(
                     "Cannot compile class {0} because the class already "
-                    "existed and the CIM repository returned an error for "
+                    "exists and the CIM repository returned an error for "
                     "ModifyClass",
                     cc_path),
                 parser_token=p,


### PR DESCRIPTION
Add test for p.parser.lverbose test around p.parser.log output if ModifyClass within createclass production fails.  This was causing a log output whether the verbose flag was set or not.

This resolves part of the issue defined by pywbemtools issue https://github.com/pywbem/pywbemtools/issues/935  (ModifyClass exception produces multiple output).

NOTE: There is still an issue documented in the original pywbemtools issue in that the exception is displayed twice and I have not yet concluded whether that is a pywbem or pywbemtools issue.