### PR TITLE
Improved the running of indication listeners when using HTTPS

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,12 @@ Released: not yet
 
 **Incompatible changes:**
 
+* The `WBEMListener.start()` method may raise new exceptions
+  `pywbem.ListenerPortError`, `pywbem.ListenerPromptError` and
+  `pywbem.ListenerCertificateError`. The `OSError` and `IOError` exceptions
+  raised in earlier versions may still be raised for other, less common cases.
+  For details, see the corresponding item in the Enhancements section, below.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -34,6 +40,26 @@ Released: not yet
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 
 **Enhancements:**
+
+* Improved the running of indication listeners via `WBEMListener.start()`:
+
+  - The method will now raise a new exception `pywbem.ListenerPortError` when
+    the port is in use, instead of the previous `socket.error` on Python 2 and
+    `OSError` on Python 3 that had confusing or unspecific error messages.
+
+  - The method will now raise a new exception `pywbem.ListenerCertificateError`
+    when using HTTPS and there is an issue with the server certificate file,
+    private key file, or invalid password for the private key file, instead of
+    the previous `ssl.SSLError` or `OSError` that had confusing or unspecific
+    error messages.
+
+  - The method will now raise a new exception `pywbem.ListenerPromptError`
+    when using HTTPS and the prompt for the password of the private key file
+    was interrupted or ended, instead of the previous `IOError` or `OSError`
+    that had unspecific error messages.
+
+  - If the private key file is protected with a password, the password prompt
+    now states the path name of the private key file in the prompt message.
 
 **Cleanup:**
 

--- a/docs/indication.rst
+++ b/docs/indication.rst
@@ -30,3 +30,29 @@ WBEMListener
     :autosummary-inherited-members:
 
 .. autofunction:: pywbem.callback_interface
+
+
+.. _`Listener exceptions`:
+
+Listener exceptions
+^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: pywbem.ListenerCertificateError
+    :members:
+    :autosummary:
+    :autosummary-inherited-members:
+
+.. autoclass:: pywbem.ListenerPortError
+    :members:
+    :autosummary:
+    :autosummary-inherited-members:
+
+.. autoclass:: pywbem.ListenerPromptError
+    :members:
+    :autosummary:
+    :autosummary-inherited-members:
+
+.. autoclass:: pywbem.ListenerError
+    :members:
+    :autosummary:
+    :autosummary-inherited-members:

--- a/examples/listen.py
+++ b/examples/listen.py
@@ -60,7 +60,7 @@ def status(reset=None):
     global RECEIVED_INDICATION_DICT
     for host, count in six.iteritems(RECEIVED_INDICATION_DICT):
         print('Host %s Received %s indications' % (host, count))
-        
+
     if reset:
         for host in RECEIVED_INDICATION_DICT:
             RECEIVED_INDICATION_DICT[host] = 0
@@ -96,8 +96,11 @@ def _main():
                                    keyfile=keyfile)
 
     listener.add_callback(_process_indication)
-    listener.start()
-
+    try:
+        listener.start()
+    except pywbem.ListenerError as exc:
+        print("Error: {}".format(exc))
+        return 1
 
     banner = """
 WBEM listener started on host %s (HTTP port: %s, HTTPS port: %s).

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -27,7 +27,9 @@ from ._cim_constants import _statuscode2name, _statuscode2string
 __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
            'VersionError', 'ParseError', 'CIMVersionError', 'DTDVersionError',
            'ProtocolVersionError', 'CIMXMLParseError', 'XMLParseError',
-           'HeaderParseError', 'CIMError', 'ModelError']
+           'HeaderParseError', 'CIMError', 'ModelError',
+           'ListenerError', 'ListenerCertificateError',
+           'ListenerPortError', 'ListenerPromptError']
 
 
 class _RequestExceptionMixin(object):
@@ -132,7 +134,7 @@ class _ResponseExceptionMixin(object):
 
 class Error(Exception):
     """
-    Abstract base class for pywbem specific exceptions.
+    Abstract base class for pywbem client specific exceptions.
     """
 
     def __init__(self, *args, **kwargs):
@@ -184,6 +186,7 @@ class ConnectionError(Error):
     """
     This exception indicates a problem with the connection to the WBEM
     server. A retry may or may not succeed.
+
     Derived from :exc:`~pywbem.Error`.
     """
 
@@ -210,6 +213,7 @@ class AuthError(Error):
     """
     This exception indicates an authentication error with the WBEM server,
     either during TLS/SSL handshake, or during HTTP-level authentication.
+
     Derived from :exc:`~pywbem.Error`.
     """
 
@@ -235,7 +239,9 @@ class AuthError(Error):
 class HTTPError(_RequestExceptionMixin, _ResponseExceptionMixin, Error):
     """
     This exception indicates that the WBEM server returned an HTTP response
-    with a bad HTTP status code. Derived from :exc:`~pywbem.Error`.
+    with a bad HTTP status code.
+
+    Derived from :exc:`~pywbem.Error`.
 
     The `args` instance variable is a `tuple (status, reason, cimerror,
     cimdetails)`.
@@ -350,7 +356,9 @@ class TimeoutError(Error):
     # pylint: disable=redefined-builtin
     """
     This exception indicates that the client timed out waiting for the WBEM
-    server. Derived from :exc:`~pywbem.Error`.
+    server.
+
+    Derived from :exc:`~pywbem.Error`.
     """
 
     def __init__(self, message, conn_id=None):
@@ -542,7 +550,9 @@ class ProtocolVersionError(VersionError):
 class CIMError(_RequestExceptionMixin, Error):
     """
     This exception indicates that the WBEM server returned an error response
-    with a CIM status code. Derived from :exc:`~pywbem.Error`.
+    with a CIM status code.
+
+    Derived from :exc:`~pywbem.Error`.
 
     Accessing the CIM status code of a :class:`CIMError` object:
 
@@ -674,12 +684,12 @@ class ModelError(Error):
     This exception indicates an error with the model implemented by the WBEM
     server, that was detected by the pywbem client.
 
+    Derived from :exc:`~pywbem.Error`.
+
     Examples are mismatches in data types of CIM elements (properties, methods,
     parameters) between classes and instances, CIM elements that appear in
     instances without being declared in classes, or violations of requirements
     defined in advertised management profiles.
-
-    Derived from :exc:`~pywbem.Error`.
     """
 
     def __init__(self, message, conn_id=None):
@@ -699,3 +709,66 @@ class ModelError(Error):
         assert message is None or isinstance(message, six.string_types), \
             str(type(message))
         super(ModelError, self).__init__(message, conn_id=conn_id)
+
+
+class ListenerError(Exception):
+    """
+    Abstract base class for exceptions raised by the pywbem listener (i.e.
+    class :class:`~pywbem.WBEMListener`).
+
+    *New in pywbem 1.3.*
+
+    Derived from :exc:`Exception`.
+    """
+
+    def __init__(self, message):
+        """
+        Parameters:
+
+          message (:term:`string`): Error message (will be put into `args[0]`).
+
+        :ivar args: A tuple (message, ) set from the corresponding init
+            argument.
+        """
+        assert message is None or isinstance(message, six.string_types), \
+            str(type(message))
+        super(ListenerError, self).__init__(message)
+
+
+class ListenerCertificateError(ListenerError):
+    """
+    This exception indicates an error with the certificate file or its
+    private key file when using HTTPS.
+
+    *New in pywbem 1.3.*
+
+    Derived from :exc:`~pywbem.ListenerError`.
+
+    This includes bad format of the files, file not found, permission errors
+    when accessing the files, or an invalid password for the private key file.
+    """
+    pass
+
+
+class ListenerPortError(ListenerError):
+    """
+    This exception indicates that the port for the pywbem listener is already
+    in use.
+
+    *New in pywbem 1.3.*
+
+    Derived from :exc:`~pywbem.ListenerError`.
+    """
+    pass
+
+
+class ListenerPromptError(ListenerError):
+    """
+    This exception indicates that the prompt for the password of the private
+    key file of the pywbem listener was interrupted or ended.
+
+    *New in pywbem 1.3.*
+
+    Derived from :exc:`~pywbem.ListenerError`.
+    """
+    pass

--- a/tests/unittest/pywbem/test_exceptions.py
+++ b/tests/unittest/pywbem/test_exceptions.py
@@ -15,7 +15,9 @@ from ...utils import import_installed
 pywbem = import_installed('pywbem')
 from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError, \
     ParseError, CIMXMLParseError, XMLParseError, HeaderParseError, \
-    VersionError, CIMError, ModelError, CIMInstance  # noqa: E402
+    VersionError, CIMError, ModelError, ListenerError, \
+    ListenerCertificateError, ListenerPortError, ListenerPromptError, \
+    CIMInstance  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
@@ -71,19 +73,19 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     # along with a tuple of names of keyword arguments the class supports.
     (
         Error,
-        ('conn_id'),
+        ('conn_id',),
     ),
     (
         ConnectionError,
-        ('conn_id'),
+        ('conn_id',),
     ),
     (
         AuthError,
-        ('conn_id'),
+        ('conn_id',),
     ),
     (
         TimeoutError,
-        ('conn_id'),
+        ('conn_id',),
     ),
     (
         ParseError,
@@ -103,11 +105,27 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     ),
     (
         VersionError,
-        ('conn_id'),
+        ('conn_id',),
     ),
     (
         ModelError,
-        ('conn_id'),
+        ('conn_id',),
+    ),
+    (
+        ListenerError,
+        tuple(),
+    ),
+    (
+        ListenerCertificateError,
+        tuple(),
+    ),
+    (
+        ListenerPortError,
+        tuple(),
+    ),
+    (
+        ListenerPromptError,
+        tuple(),
     ),
 ], scope='module')
 def message_exception_info(request):
@@ -227,7 +245,8 @@ def test_message_init(
     if 'response_data' in kwargs_names:
         assert exc.response_data == exp_response_data
 
-    _assert_connection(exc, conn_id_kwarg, exp_conn_str)
+    if 'conn_id' in kwargs_names:
+        _assert_connection(exc, conn_id_kwarg, exp_conn_str)
     _assert_subscription(exc)
 
 

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -7,7 +7,6 @@ Test _listener.py module.
 from __future__ import absolute_import
 
 import sys
-import errno
 import re
 import logging
 from time import time, sleep
@@ -20,7 +19,7 @@ from ...utils import import_installed, post_bsl
 from ...elapsed_timer import ElapsedTimer
 from ..utils.pytest_extensions import simplified_test_function
 pywbem = import_installed('pywbem')
-from pywbem import WBEMListener  # noqa: E402
+from pywbem import WBEMListener, ListenerPortError  # noqa: E402
 from pywbem._utils import _format  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
@@ -457,7 +456,7 @@ def test_WBEMListener_port_in_use():
     # as far as port reuse is concerned.
     http_port = '59999'
 
-    exp_exc_type = OSError
+    exp_exc_type = ListenerPortError
 
     listener1 = WBEMListener(host, http_port)
     listener1.start()
@@ -473,7 +472,6 @@ def test_WBEMListener_port_in_use():
     except Exception as exc:  # pylint: disable=broad-except
         # e.g. on Linux
         assert isinstance(exc, exp_exc_type)
-        assert getattr(exc, 'errno', None) == errno.EADDRINUSE
         assert listener2.http_started is False
     else:
         # e.g. on Windows


### PR DESCRIPTION
See commit message.
This came up when implementing listener support in pywbemtools. It started out as only an improvement with no required functionality for the listener support in pywbemtools, but it ended up with new exception classes pywbemtools now has a dependency on.