### PR TITLE
Fixes issue #2701, SubscriptionManager code issues 

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,21 @@ Released: not yet
   surrounded by verbose test (if p.parse.verbose:). See pywbemcli issue
   #395,
 
+* Fixes several issues in WBEMSubscriptionManager:
+  - add_filter() and add_destinations() methods  can no longer modify
+    existing instances on the WBEM server. They can only create new instances.
+  - Modified the algorithm to determine owned filters and
+    instances so they are are correctly recovered from the WBEM server when the
+    WBEMSubscriptionManager is restarted (before this they could be returned
+    as not-owned object).
+  - Change to use WBEM server systemname as the value of the SystemName
+    property.
+  - Removed code that built instance path for new filter and destination
+    instances since that was used only to try to determine if instance existed
+    to make the create/modify decision.
+  - Added the client host as a component of the Name property for owned
+    filters and destinations. (issue #2701).
+
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 
 * Jupyter Notebook: Ignored safety issues 40380..40386 in order to continue


### PR DESCRIPTION
1. Fixes an issue where the build of owned CIM Listener destination and CIM
indication filter objects and the regex to find the objects when
restoring these objects from a server did not have a common
understanding of the exact format of the Name property. The host_name
element was part of the regex but not of the string in the Name
property. This pr simply adds the host_name to the Name property.

Resolved: We send them

2. Fixes an issue where the add_subscription() comparison of the new instance path with paths from the list of owned instances is working with an incomplete path on the new instance (the keybindings have not been added).

Resolved: We don't do the modify so that code removed.


It also adds tests to confirm that when a SubscriptionManager is created, the owned subscriptions, filters, and destinations are
recovered from the server correctly and the subscription if added twice does not actually add the second time

**DISCUSSION:** 
There are a couple of issues for discussion:

1. Should we be sending the properties for SystemCreationClassName and SystemName properties to the server at all when we create filters and destinations.  OpenPegasus allows them but tests the values against what it expects and changes the values if necessary.  NOTE: This question covers a lot more than just these classes for the client since that pattern of properties in paths is common.

   Update by Andy: We decided to always send the key properties when creating instances in order to support older implementations.

2. Should we be caching the SystemCreationClassName as we are now with the ServerName to be used to build local paths to help determine if filters and destinations already exist in the server.

   Update by Andy: Don't think so, if we change the comparison as I suggested in the comments I don't think that is necessary.