### PR TITLE
Circumvented safety issues 40380..40386 with the notebook package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ py_test_files := \
 # - 39252: cryptography cannot be upgraded to 3.3 on py34+py35
 # - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
 # - 40291: pip cannot be upgraded to 21.1 py<3.6
+# - 40380..40386: notebook issues fixed in 6.1.5 which would prevent using notebook on py2
 
 safety_ignore_opts := \
     -i 38100 \
@@ -302,6 +303,13 @@ safety_ignore_opts := \
 		-i 39252 \
 		-i 39606 \
 		-i 40291 \
+		-i 40380 \
+		-i 40381 \
+		-i 40382 \
+		-i 40383 \
+		-i 40384 \
+		-i 40385 \
+		-i 40386 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,9 @@ Released: not yet
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 
+* Jupyter Notebook: Ignored safety issues 40380..40386 in order to continue
+  supporting it with Python 2.7. (issue #2703)
+
 **Enhancements:**
 
 * Improved the running of indication listeners via `WBEMListener.start()`:


### PR DESCRIPTION
See commit message.

This PR circumvents the issue by ignoring the safety issues, which allows using notebook on py27. Fixing the safety issues would require using notebook 6.1.5 as a minimum version which would require us to drop support for using Jupyter Notebook on Python 2.7. There is an according discussion point in issue #2703.