### PR TITLE
Allow initalization defined url for FakedWBEMConnection class

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -64,6 +64,11 @@ Released: not yet
   - If the private key file is protected with a password, the password prompt
     now states the path name of the private key file in the prompt message.
 
+  - Add optional initialization parameter `url` to pywbem_mock
+    FakedWBEMConnection class. This allows a different URL than the default
+    http://FakedWBEMConnection:5988. With this, tests can be executed with
+    multiple simultaneous mock environments pywbem. (See issue #2711)
+
 * Test: Added support for validating the structure of user-defined properties in
   the easy-server server and vault files. As part of that, increased the minimum
   version of the 'pytest-easy-server' package to 0.8.0. (issue #2660)

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -144,7 +144,7 @@ class FakedWBEMConnection(WBEMConnection):
     def __init__(self, default_namespace=DEFAULT_NAMESPACE,
                  use_pull_operations=False, stats_enabled=False,
                  timeout=None, response_delay=None,
-                 disable_pull_operations=None):
+                 disable_pull_operations=None, url=None):
         """
         Parameters:
 
@@ -187,6 +187,12 @@ class FakedWBEMConnection(WBEMConnection):
             The :attr:`~pywbem_mock.FakedWBEMConnection.disable_pull_operations`
             property can be used to set this variable.
 
+        url (:term:`string`):
+            Defines a url to replace the default http://FakedURL.5988 url which
+            is passed to the superclass. The url must be an acceptable syntax
+            for WBEMConnection initialization.  This is useful when multiple
+            mocks are required for testing.
+
         Raises:
           ValueError for invalid arguments
         """
@@ -201,7 +207,7 @@ class FakedWBEMConnection(WBEMConnection):
         self._disable_pull_operations = disable_pull_operations
 
         super(FakedWBEMConnection, self).__init__(
-            'http://FakedUrl:5988',
+            url or 'http://FakedUrl:5988',
             default_namespace=default_namespace,
             use_pull_operations=use_pull_operations,
             stats_enabled=stats_enabled, timeout=timeout)

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -1110,6 +1110,42 @@ class TestFakedWBEMConnection(object):
         assert conn.default_namespace == DEFAULT_NAMESPACE
         assert conn.operation_recorder_enabled is False
 
+    def test_userdefined_url(self):
+        # pylint: disable=no-self-use
+        """
+        Test FadedWBEMConnection url __init__ parameter.
+        """
+        # pylint: disable=protected-access
+        FakedWBEMConnection._reset_logging_config()
+        conn = FakedWBEMConnection(url="http://FakedUrl1:5988")
+        assert conn.scheme == 'http'
+        assert conn.host == 'FakedUrl1:5988'
+        assert conn.url == 'http://FakedUrl1:5988'
+        assert conn.use_pull_operations is False
+        assert conn.stats_enabled is False
+        assert conn.default_namespace == DEFAULT_NAMESPACE
+        assert conn.operation_recorder_enabled is False
+
+    def test_multiple_urls(self):
+        # pylint: disable=no-self-use
+        """
+        Test FadedWBEMConnection url __init__ parameter.
+        """
+        # pylint: disable=protected-access
+        FakedWBEMConnection._reset_logging_config()
+        conn1 = FakedWBEMConnection(url="http://FakedUrl1:5988")
+        conn2 = FakedWBEMConnection(url="http://FakedUrl2:5988")
+        assert conn1.scheme == 'http'
+        assert conn1.host == 'FakedUrl1:5988'
+        assert conn1.url == 'http://FakedUrl1:5988'
+        assert conn1.use_pull_operations is False
+        assert conn1.stats_enabled is False
+        assert conn1.default_namespace == DEFAULT_NAMESPACE
+        assert conn1.operation_recorder_enabled is False
+        assert conn2.scheme == 'http'
+        assert conn2.host == 'FakedUrl2:5988'
+        assert conn2.url == 'http://FakedUrl2:5988'
+
 
 class TestRepoMethods(object):
     """


### PR DESCRIPTION
Adds one more parameter to the __init__ method of FakedWBEMConnection
(url) to allow the user to define a different url that will be passed to
the superclass in place of http://FakedURL:5988.

This will be useful in testing, particularly subscription testing where
we want to establish multiple server_ids in the tests.