### PR TITLE
Fix issue with slow indications with Windows OS in tests

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -51,6 +51,13 @@ Released: not yet
     to make the create/modify decision.
   - Added the client host as a component of the Name property for owned
     filters and destinations. (issue #2701).
+  - Fix issue where windows indication throughput is very slow.  It is in
+    the range of 1 indication every 2 seconds.  The issue is not pywbem but
+    windows itself apparently because of hosts file and DNS configuration
+    such that using localhost builds in a delay. This can be fixed by using
+    an IP address 127.0.0.1 for the indication listener or modifying the hosts
+    table in windows. For this test we chose to just change the host name  See
+    issue #528)
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -640,7 +640,12 @@ def test_WBEMListener_send_indications(send_count):
     if LOGLEVEL > logging.NOTSET:
         logging.getLogger('').setLevel(LOGLEVEL)
 
-    host = 'localhost'
+    # Fixes issue #528 where on Windows, localhost adds multisecond delay
+    # probably due to hosts table or DNS misconfiguration.
+    if sys.platform == 'win32':
+        host = '127.0.0.1'
+    else:
+        host = 'localhost'
     http_port = 50000
 
     listener = WBEMListener(host, http_port)


### PR DESCRIPTION
For windows the host name was changed from localhost to 127.0.0.1 in test_indicationlistener.py to eliminate the delay

Also added note to examples/sendindications.py and fixed a number of flake8 issues in that code.