### PR TITLE
1.2: Windows: Removed dependency on bash command in pip upgrade in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,12 @@ endif
 
 pip_upgrade_$(pymn).done: Makefile
 	-$(call RM_FUNC,$@)
+ifeq ($(PLATFORM),Windows_native)
+	@echo "Makefile: On Windows, there is no automatic upgrade of Pip to a minimum version of 9.x. Current Pip version:"
+	$(PIP_CMD) --version
+else
 	bash -c 'pv=$$($(PIP_CMD) --version); if [[ $$pv =~ (^pip [1-8]\..*) ]]; then $(PIP_INSTALL_CMD) pip==9.0.1; fi'
+endif
 	$(PIP_INSTALL_CMD) $(pip_level_opts) pip
 	echo "done" >$@
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
 * Jupyter Notebook: Ignored safety issues 40380..40386 in order to continue
   supporting it with Python 2.7. (issue #2703)
 
+* Windows: Removed dependency on bash command in pip upgrade in Makefile.
+  (issue #2713)
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #2717 into 1.2.1.