### PR TITLE
Fix issue in add_subscriptions()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,8 @@ Released: not yet
   - Fixes issue with SubscriptionManager class where add_destinations loses
     the input parameter owned if there are multiple urls in the listener_urls
     parameter (see issue #2715)
+  - Fixes issue where add_subscription returned wrong instance if the
+    instance already exists. (See issue #2719)
 
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)


### PR DESCRIPTION
Fixes issue defined in issue #2719 with instance returned from
add_subacriptions()

This pr does not add a test for this change.  That is accomplished in
other PRs.

NOTE: I did not mark this one for rollback because it is in the new code. The old code tried to modify the instances.