### PR TITLE
Ks/#2712 add subscription properties

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,10 @@ Released: not yet
     parameter (see issue #2715)
   - Fixes issue where add_subscription returned wrong instance if the
     instance already exists. (See issue #2719)
+  - Fix issues in SubscriptionManager.add_destination to add optional parameter
+    which populates the destination PersistenceType property and modified the
+    class for the destination to CIM_ListenerDestination since the
+    CIM_ListenerDestinationXML class is deprecated. (See issue #2712)
 
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)

--- a/pywbem_mock/_subscriptionproviders.py
+++ b/pywbem_mock/_subscriptionproviders.py
@@ -292,6 +292,7 @@ class CIMIndicationFilterProvider(CommonMethodsMixin, InstanceWriteProvider):
             namespace, new_instance)
 
     def ModifyInstance(self, modified_instance, IncludeQualifiers=None):
+        # pylint: disable=invalid-name
         """
         Modification of CIM_IndicationFilter instance not allowed
         """
@@ -399,6 +400,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
             s=self)
 
     def CreateInstance(self, namespace, new_instance):
+        # pylint: disable=invalid-name
         """
         Create an instance of the CIM_ListenerDestination class in an
         Interop namespace of the CIM repository, and if not yet existing create
@@ -466,6 +468,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
             namespace, new_instance)
 
     def ModifyInstance(self, modified_instance, IncludeQualifiers=None):
+        # pylint: disable=invalid-name
         """
         Modification of CIM_ListenerDestination instance not allowed
         """
@@ -554,8 +557,8 @@ class CIMIndicationSubscriptionProvider(CommonMethodsMixin,
         if not self.find_interop_namespace():
             raise CIMError(
                 CIM_ERR_INVALID_PARAMETER,
-                _format("Cannot create indication filter provider (for class "
-                        "{0}): "
+                _format("Cannot create indication subscription provider for "
+                        "class: {0}. "
                         "No Interop namespace exists in the CIM repository. "
                         "Valid Interop namespaces are: {1}",
                         FILTER_CLASSNAME,
@@ -572,6 +575,7 @@ class CIMIndicationSubscriptionProvider(CommonMethodsMixin,
             s=self)
 
     def CreateInstance(self, namespace, new_instance):
+        # pylint: disable=invalid-name
         """
         Create an instance of the CIM_IndicationFilter class in an Interop
         namespace of the CIM repository, and if not yet existing create the new
@@ -623,6 +627,7 @@ class CIMIndicationSubscriptionProvider(CommonMethodsMixin,
             namespace, new_instance)
 
     def ModifyInstance(self, modified_instance, IncludeQualifiers=None):
+        # pylint: disable=invalid-name
         """
         Modification of CIM_IndicationSubscription instance not allowed
         """


### PR DESCRIPTION
See commit message for details

This pr depends on pr #2704, (the subscription providers)

NOTE: This does not change the SourceNamespace to SourceNamespaces because that change crosses so many other pieces in process.  Will do that as separate pr. A new issue  (issue # 2726) was created to handle that change and issue #2712 changed to reflect that alteration.

Adds PersistenceType property conditinally and changes name of ListenerDestinationClass to CIMListenerDestination.

Adds tests.for the PersistenceTpe change.

rebased this into pr #2704, user providers.  Note that we still allow CIMListenerDestinationXML as a class in the user provider