### PR TITLE
Ks/#2731 restoreclass cim listener destination cimxml

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,9 +82,7 @@ Released: not yet
   - Fixes issue where add_subscription returned wrong instance if the
     instance already exists. (See issue #2719)
   - Fix issues in SubscriptionManager.add_destination to add optional parameter
-    which populates the destination PersistenceType property and modified the
-    class for the destination to CIM_ListenerDestination since the
-    CIM_ListenerDestinationXML class is deprecated. (See issue #2712)
+    which populates the destination PersistenceType property. (See issue #2712)
   - Add capability to mock subscription providers to execute ModifyInstance
     (See issue #2722)
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,24 @@ Released: not yet
   raised in earlier versions may still be raised for other, less common cases.
   For details, see the corresponding item in the Enhancements section, below.
 
+* Changed 'SubscriptionManager.add_filter()' method to use the
+  'SourceNamespaces' property (allows multiple namespaces) of the
+  'CIM_IndicationFilter' class instead of the deprecated 'SourceNamespace'
+  property (allows only single namespace).  This changed the name of the
+  positional 'source_namespace' parameter to 'source_namespaces`. The new
+  parameter allows both string and list of strings as values.
+
+  This change brings the subscription manager in line with the incorporation of
+  the 'SourceNamespaces' property made to this CIM class definition
+  by DMTF CIM schema release 2.22.0.
+
+  An optional 'source_namespace' keyword parameter has been added to the
+  'add_filter()'method to account for any case where a WBEM Server cannot
+  handle the SourceNamespaces property. The primary incompatibility will be
+  that the instance created for CIM_Indication filter now has a property named
+  'SourceNamespaces' instead of 'SourceNamespace'. See further comments below
+  and issue #2725.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -115,6 +133,10 @@ Released: not yet
 
 * Finalized the support for SI units that was experimental so far, i.e. the
   'pywbem.siunit()' and 'pywbem.siunit_obj()' functions. (issue #2653)
+
+* Modify 'SubscriptionManager.add_filter()' to use the CIM_IndicationFilter
+  property 'SourceNamespaces' in place of the deprecated 'SourceNamespace'. (see
+  issue #2725 and the **Incompatible changes:** section above)
 
 **Cleanup:**
 

--- a/pywbem/_subscription_manager.py
+++ b/pywbem/_subscription_manager.py
@@ -23,7 +23,10 @@ indication filters and listener destinations) for multiple WBEM servers and
 multiple WBEM listeners and for getting information about existing indication
 subscriptions.
 
-The WBEM listener is identified through its URL, so it may be the pywbem
+The SubscriptionManager only manages CIM/XML listener destinations and does not
+view, add, or remove other destinations such as files, etc.
+
+The CIM/XML WBEM listener is identified through its URL, so it may be the pywbem
 listener (that is, a :class:`~pywbem.WBEMListener` object) or any other WBEM
 listener.
 
@@ -161,7 +164,7 @@ from ._utils import _format
 
 # CIM model classnames for subscription components
 SUBSCRIPTION_CLASSNAME = 'CIM_IndicationSubscription'
-DESTINATION_CLASSNAME = 'CIM_ListenerDestination'
+DESTINATION_CLASSNAME = 'CIM_ListenerDestinationCIMXML'
 FILTER_CLASSNAME = 'CIM_IndicationFilter'
 SYSTEM_CREATION_CLASSNAME = 'CIM_ComputerSystem'
 

--- a/pywbem_mock/_subscriptionproviders.py
+++ b/pywbem_mock/_subscriptionproviders.py
@@ -20,7 +20,7 @@
 
 """
 This module implements user providerw for the classews required to create and
-manage CIM indications subscriptions including: CIM_ListenerDestination,
+manage CIM indications subscriptions including: CIM_ListenerDestinationCIMXML,
 CIM_IndicationFilter, and CIM_IndicationSubscription.  These providers are
 packaged as single file because they are all required together.
 
@@ -44,8 +44,6 @@ is included in a subscription.
 """
 import six
 
-from nocaselist import NocaseList
-
 from pywbem import CIMError, CIM_ERR_NOT_SUPPORTED, \
     CIM_ERR_INVALID_PARAMETER, CIM_ERR_FAILED, Uint16, CIMDateTime
 from pywbem._utils import _format
@@ -56,8 +54,7 @@ from .config import SYSTEMNAME, SYSTEMCREATIONCLASSNAME
 # CIM class name of the classes implemented in these providers
 SUBSCRIPTION_CLASSNAME = 'CIM_IndicationSubscription'
 FILTER_CLASSNAME = 'CIM_IndicationFilter'
-LISTENERDESTINATIONS_CLASSNAMES = NocaseList(['CIM_ListenerDestination',
-                                              'CIM_ListenerDestinationCIMXML'])
+LISTENERDESTINATION_CLASSNAME = 'CIM_ListenerDestinationCIMXML'
 
 
 class CommonMethodsMixin(object):
@@ -459,10 +456,10 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
     # pylint: disable=line-too-long
     """
     Implements the user defined provider for the class
-    CIM_ListenerDestination.
+    CIM_ListenerDestinationCIMXML.
 
     This provider provides the create, modify, and delete methods for adding an
-    instance of the class CIM_ListenerDestination when a namespace is
+    instance of the class CIM_ListenerDestinationCIMXML when a namespace is
     created or deleted in a pywbem mock environment.
 
     This class and the instances of this class only exist in the WBEM server
@@ -472,7 +469,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
     this class and by methods of its superclasses (i.e.  InstanceWriteProvider).
 
     The provider defines the class level attribute `provider_classnames`
-    (CIM_ListenerDestination)
+    (CIM_ListenerDestinationCIMXML)
 
     This provider presumes that an Interop namespace has been created before
     the provider object is constructed and fails the constructor if
@@ -484,7 +481,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
     # for which this provider is responsible.
     #: provider_classnames (:term:`string`):
     #:        The classnames for this provider
-    provider_classnames = LISTENERDESTINATIONS_CLASSNAMES
+    provider_classnames = LISTENERDESTINATION_CLASSNAME
 
     def __init__(self, cimrepository):
         """
@@ -502,7 +499,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
                         "classes: ({0}). "
                         "No Interop namespace exists in the CIM repository. "
                         "Valid Interop namespaces are: {1}",
-                        ", ".join(LISTENERDESTINATIONS_CLASSNAMES),
+                        ", ".join(LISTENERDESTINATION_CLASSNAME),
                         ", ".join(self.interop_namespace_names)))
 
         self.installed = False  # test if provider previously installed.
@@ -518,7 +515,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
     def CreateInstance(self, namespace, new_instance):
         # pylint: disable=invalid-name
         """
-        Create an instance of the CIM_ListenerDestination class in an
+        Create an instance of the CIM_ListenerDestinationCIMXML class in an
         Interop namespace of the CIM repository, and if not yet existing create
         the new namespace in the CIM repository.
 
@@ -588,7 +585,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
     def ModifyInstance(self, modified_instance, IncludeQualifiers=None):
         # pylint: disable=invalid-name
         """
-        Modification of CIM_ListenerDestination instance allowed only for
+        Modification of CIM_ListenerDestinationXIMXML instance allowed only for
         selected properties. See the documentation in
         CommonMethodsMixin.validate_modify_instance for parameter documentation.
         """
@@ -604,7 +601,7 @@ class CIMListenerDestinationProvider(CommonMethodsMixin, InstanceWriteProvider):
 
     def DeleteInstance(self, InstanceName):  # pylint: disable=invalid-name
         """
-        Delete an instance of the CIM_ListenerDestination class in an
+        Delete an instance of the CIM_ListenerDestinationCIMXML class in an
         Interop namespace of the CIM repository unless it has an outstanding
         association through a subscription.
 

--- a/pywbem_mock/_subscriptionproviders.py
+++ b/pywbem_mock/_subscriptionproviders.py
@@ -386,6 +386,9 @@ class CIMIndicationFilterProvider(CommonMethodsMixin, InstanceWriteProvider):
         # Validates and possibly modifies the key properties except Name
         self.fix_key_properties(new_instance)
 
+        # Note: No test for SourceNamespace valid namespaces because profile
+        # allows creating filters for not-yet-created namespaces
+
         # Add missing properties that the might come from CIM_IndicationService
         # Issue # 2719, Should the following be set by the server or client
         new_instance['IndividualSubscriptionSupported'] = True

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -605,6 +605,10 @@ TESTCASES_SUBMGR = [
     #       * listener_count - Count of expected destinations
     #       * filter_count - Count of expected filters.
     #       * TODO: Add validation for filter, dest attributes
+    #       * dest_props - Test for specific properties in specific instances.
+    #         TODO: define syntax
+    #       * filter_props - Test for specific properties in specific instances.
+    #         TODO: define syntax
     #       * subscription_count - Count of expected subscriptions.
     #
     # * exp_exc_types: Expected exception type(s), or None.
@@ -715,7 +719,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -736,7 +740,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -757,7 +761,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="UnknownServerId",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -778,7 +782,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -799,7 +803,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=[dict(url=None), dict(url=None)],
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -820,7 +824,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -841,7 +845,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -862,7 +866,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -874,7 +878,61 @@ TESTCASES_SUBMGR = [
             remove_subscriptions=None,
             remove_server_attrs=None,
             exp_result=dict(server_id="http://FakedUrl:5988",
-                            filter_count=1)
+                            filter_count=1,
+                            filter_props=[0, [('SourceNamespaces',
+                                               ['root/interop'])]]),
+        ),
+        None, None, OK
+    ),
+    (
+        "Add_filter with valid filter that has multiple source namespaces",
+        dict(
+            submgr_id="ValidID",
+            connection_attrs=dict(url=None),
+            filter_attrs=dict(server_id="http://FakedUrl:5988",
+                              source_namespaces=['root/interop', 'root/cimv2'],
+                              query="SELECT * from blah",
+                              query_language='WQL',
+                              owned=True,
+                              filter_id="Filter1", name=None),
+            dest_attrs=None,
+            subscription_attrs=None,
+            remove_destinations=None,
+            remove_filters=None,
+            remove_subscriptions=None,
+            remove_server_attrs=None,
+            exp_result=dict(server_id="http://FakedUrl:5988",
+                            filter_count=1,
+                            filter_props=[0, [('SourceNamespaces',
+                                               ['root/interop',
+                                                'root/cimv2'])]]),
+        ),
+        None, None, OK
+    ),
+    (
+        "Add valid filter with multiple source namespaces, sourcenamespace",
+        dict(
+            submgr_id="ValidID",
+            connection_attrs=dict(url=None),
+            filter_attrs=dict(server_id="http://FakedUrl:5988",
+                              source_namespaces=['root/interop', 'root/cimv2'],
+                              query="SELECT * from blah",
+                              query_language='WQL',
+                              owned=True,
+                              filter_id="Filter1", name=None,
+                              source_namespace="root/cimv3"),
+            dest_attrs=None,
+            subscription_attrs=None,
+            remove_destinations=None,
+            remove_filters=None,
+            remove_subscriptions=None,
+            remove_server_attrs=None,
+            exp_result=dict(
+                server_id="http://FakedUrl:5988",
+                filter_count=1,
+                filter_props=[0, [('SourceNamespaces', ['root/interop',
+                                                        'root/cimv2']),
+                                  ('SourceNamespace', 'root/cimv3')]], ),
         ),
         None, None, OK
     ),
@@ -884,7 +942,7 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -906,13 +964,13 @@ TESTCASES_SUBMGR = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=[dict(server_id="http://FakedUrl:5988",
-                               source_namespace='root/interop',
+                               source_namespaces='root/interop',
                                query="SELECT * from blah",
                                query_language='WQL',
                                owned=True,
                                filter_id="Filter1", name=None),
                           dict(server_id="http://FakedUrl:5988",
-                               source_namespace='root/interop',
+                               source_namespaces='root/interop',
                                query="SELECT * from blah",
                                query_language='WQL',
                                owned=True,
@@ -1081,7 +1139,7 @@ TESTCASES_SUBMGR = [
         None, None, OK
     ),
     (
-        "Add multiple valid owned listener_destinations",
+        "Add multiple valid owned listener_destinations and remove server",
         dict(
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
@@ -1097,6 +1155,36 @@ TESTCASES_SUBMGR = [
             remove_server_attrs="http://FakedUrl:5988",
             exp_result=dict(server_id="http://FakedUrl:5988",
                             listener_count=2)
+        ),
+        None, None, OK
+    ),
+    (
+        "Remove multiple subscriptions with remove server",
+        dict(
+            submgr_id="ValidID",
+            connection_attrs=dict(url=None),
+            dest_attrs=dict(server_id="http://FakedUrl:5988",
+                            listener_urls=["http://localhost:5000",
+                                           "https://localhost:5000"],
+                            owned=True),
+            filter_attrs=dict(server_id="http://FakedUrl:5988",
+                              source_namespaces='root/interop',
+                              query="SELECT * from blah",
+                              query_language='WQL',
+                              owned=True,
+                              filter_id="Filter1", name=None),
+            subscription_attrs=dict(server_id="http://FakedUrl:5988",
+                                    filter_path=0,
+                                    destination_paths=[0, 1],
+                                    owned=True),
+            remove_destinations=None,
+            remove_filters=None,
+            remove_subscriptions=None,
+            remove_server_attrs="http://FakedUrl:5988",
+            exp_result=dict(server_id="http://FakedUrl:5988",
+                            listener_count=2,
+                            filter_count=1,
+                            subscription_count=2)
         ),
         None, None, OK
     ),
@@ -1129,7 +1217,7 @@ TESTCASES_SUBMGR = [
                             listener_urls="http://localhost:5000",
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1158,7 +1246,7 @@ TESTCASES_SUBMGR = [
                             listener_urls="http://localhost:5000",
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1187,7 +1275,7 @@ TESTCASES_SUBMGR = [
                             listener_urls="http://localhost:5000",
                             owned=False),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1216,7 +1304,7 @@ TESTCASES_SUBMGR = [
                             listener_urls="http://localhost:5000",
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=False,
@@ -1246,7 +1334,7 @@ TESTCASES_SUBMGR = [
                                            "https://localhost:5000"],
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1297,7 +1385,7 @@ TESTCASES_SUBMGR = [
                                            "https://localhost:5000"],
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1318,13 +1406,13 @@ TESTCASES_SUBMGR = [
         CIMError, None, OK
     ),
     (
-        "Test remove filter suceeds without subscription",
+        "Test remove filter succeeds without subscription",
         dict(
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             dest_attrs=None,
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1350,7 +1438,7 @@ TESTCASES_SUBMGR = [
                                            "https://localhost:5000"],
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1380,7 +1468,7 @@ TESTCASES_SUBMGR = [
                                            "https://localhost:5000"],
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1410,7 +1498,7 @@ TESTCASES_SUBMGR = [
                                            "https://localhost:5000"],
                             owned=True),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1437,8 +1525,6 @@ TESTCASES_SUBMGR = [
     # Tests that need to be added
     # Add server where param is not WBEMServer
     # add not_owned filters and destinations
-    # NOTE: The following tests will be added after merge with issue #2701
-    # NOTE: add tests that depend on providers see issue# 2704
     # NOTE: Eventually this should replace most of the unit tests.
 ]
 
@@ -1561,6 +1647,18 @@ def test_subscriptionmanager(testcase, submgr_id, connection_attrs,
         dest_props = exp_result['dest_props']
         created_instance = added_destinations[dest_props[0]]
         props = dest_props[1]
+        for prop, value in props:
+            # If None expect either property with None or no property
+            if value is None:
+                if prop in created_instance:
+                    assert created_instance[prop] == value
+            else:
+                assert created_instance[prop] == value
+
+    if 'filter_props' in exp_result:
+        filter_props = exp_result['filter_props']
+        created_instance = added_filters[filter_props[0]]
+        props = filter_props[1]
         for prop, value in props:
             # If None expect either property with None or no property
             if value is None:
@@ -1722,7 +1820,7 @@ TESTCASES_SUBMGR_MODIFY = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1750,7 +1848,7 @@ TESTCASES_SUBMGR_MODIFY = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1781,7 +1879,7 @@ TESTCASES_SUBMGR_MODIFY = [
             submgr_id="ValidID",
             connection_attrs=dict(url=None),
             filter_attrs=dict(server_id="http://FakedUrl:5988",
-                              source_namespace='root/interop',
+                              source_namespaces='root/interop',
                               query="SELECT * from blah",
                               query_language='WQL',
                               owned=True,
@@ -1807,7 +1905,7 @@ TESTCASES_SUBMGR_MODIFY = [
         CIMError, None, OK
     ),
 
-    # TODO:
+    # TODO: The following tests are not in the test list.
     # 1. Test for missing required_property. This one very difficult because
     #    list of required properties is also properties always set by
     #    SubscriptionManager

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -579,8 +579,6 @@ TESTCASES_SUBMGR = [
     #   * dest_attrs: dictionary of attributes for add_listener_destinations.
     #     Since add_listener_destination can add lists, there is no option
     #     to add a list for this item.
-    #   * modify_dest: dictionary of attributes for modify_instance of listener
-    #     destination.
     #   * subscription_attrs: dictionary or list dictionaries where each
     #     dictionary is a dictionary that defines either the attributes of
     #     the subscription or to make it simpler to define tests, an integer

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -74,7 +74,6 @@ SUBSCRIPTION_WBEM_SERVER_MOCK_DICT = {
                     'CIM_ReferencedProfile',
                     'CIM_ComputerSystem',
                     'CIM_IndicationSubscription',
-                    'CIM_ListenerDestination',
                     'CIM_ListenerDestinationCIMXML',
                     'CIM_IndicationFilter', ],
 


### PR DESCRIPTION
I mistakenly used CIM_ListenerDestination as the target class for subscription manager.  Since that class is abstract, the add_filter no longer works. This restores the target class to CIM_ListenerDestinationCIMXML.

