### PR TITLE
Fixed error in tolerating CIM_ERR_FAILED when not supporting pull ops

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -103,6 +103,9 @@ Released: not yet
   value when processing export requests to be consistent with DSP0200 which
   requires that WBEM listeners must support any value. (part of issue #2729)
 
+* Fixed installation with setup.py on ubuntu for Python 2.7, 3.4, 3.5, by
+  pinning yamlloader to <1.0.0. (issue #2745)
+
 **Enhancements:**
 
 * Improved the running of indication listeners via `WBEMListener.start()`:

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -97,6 +97,7 @@ six==1.14.0
 requests==2.22.0; python_version == '2.7'
 requests==2.20.1; python_version == '3.4'
 requests==2.22.0; python_version >= '3.5'
+yamlloader==0.5.5
 nocaselist==1.0.3
 nocasedict==1.0.1
 
@@ -149,7 +150,6 @@ virtualenv==20.0.0; python_version >= '3.8'  # requires six<2,>=1.12.0
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 decorator==4.0.11
-yamlloader==0.5.5
 # FormEncode is used for xml comparisons in unit test
 FormEncode==1.3.1
 

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -4922,23 +4922,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_enum_inst_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_enum_inst_pull_operations = False
                     else:
-                        assert self._use_enum_inst_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -5199,23 +5198,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_enum_path_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_enum_path_pull_operations = False
                     else:
-                        assert self._use_enum_path_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -5545,23 +5543,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_assoc_inst_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_assoc_inst_pull_operations = False
                     else:
-                        assert self._use_assoc_inst_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -5835,23 +5832,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_assoc_path_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_assoc_path_pull_operations = False
                     else:
-                        assert self._use_assoc_path_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -6145,23 +6141,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_ref_inst_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_ref_inst_pull_operations = False
                     else:
-                        assert self._use_ref_inst_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -6414,23 +6409,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_ref_path_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_ref_path_pull_operations = False
                     else:
-                        assert self._use_ref_path_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it
@@ -6710,23 +6704,22 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
                     return rtn
 
                 except CIMError as ce:
-                    # If the use of this kind of pull operations is still
-                    # undetermined and the status code indicates that they are
-                    # not supported, disable their use from now on.
-                    # Otherwise, the use of this kind of pull operations has
-                    # been requested and the server had some other issue, so the
+                    # If the use of this pull operation is still undetermined
+                    # and the status code indicates that it is not supported,
+                    # disable its use from now on.
+                    # Otherwise, the use of this pull operation has been
+                    # requested or the server had some other issue, so the
                     # returned CIM error is raised.
                     # Note that DSP0200 requires that servers return
                     # CIM_ERR_NOT_SUPPORTED for unsupported intrinsic
                     # operations. SFCB returns CIM_ERR_FAILED for the pull
-                    # operations. Pywbem treats that as meaning the pull
+                    # operations and pywbem treats that as meaning the pull
                     # operations are not supported.
                     if (self._use_query_pull_operations is None and
                             ce.status_code in
                             (CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED)):
                         self._use_query_pull_operations = False
                     else:
-                        assert self._use_query_pull_operations
                         raise
 
             # Cleanup if caller closes the iterator before exhausting it

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,9 @@ six>=1.14.0
 requests>=2.22.0; python_version == '2.7'
 requests>=2.20.1,<2.22.0; python_version == '3.4'
 requests>=2.22.0; python_version >= '3.5'
-yamlloader>=0.5.5
+# yamlloader 1.1.0 gets istalled by mistake on py27+34 on Ubuntu when using setup.py install. See issue #2745.
+yamlloader>=0.5.5,<1.0.0; python_version <= '3.5'
+yamlloader>=0.5.5; python_version >= '3.6'
 nocaselist>=1.0.3
 nocasedict>=1.0.1
 


### PR DESCRIPTION
See commit message for details.
Has priority since pywbemtools PRs fail due to this.