### PR TITLE
Issue #2742 - Add tests for instance create of abstract class

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,11 @@ Released: not yet
   'SourceNamespaces' instead of 'SourceNamespace'. See further comments below
   and issue #2725.
 
+* Added code to fail compile or creation in pywbem_mock of instance of 
+  Abstract class. Before this the WBEM server might fail the attempt but
+  the MOF compiler and pywbem_mock would build the instance 
+  (see issue # 2742).
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -86,6 +91,9 @@ Released: not yet
     which populates the destination PersistenceType property. (See issue #2712)
   - Add capability to mock subscription providers to execute ModifyInstance
     (See issue #2722)
+  - Fixed pywbem_mock and the MOF_compiler to test for creation or compile
+    of an instance with a creation class that has the Abstract qualifier. This
+    will fail since abstract classes cannot be instantiated. (see issue #2742)
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -2394,6 +2394,14 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                                 IncludeQualifiers=True)
             inst.path = CIMInstanceName.from_instance(
                 cls, inst, namespace=ns)
+
+        if "Abstract" in cls.qualifiers:
+            raise CIMError(
+                CIM_ERR_FAILED,
+                _format("CreateInstance failed. Cannot instantiate abstract "
+                        "class {0!A} in Namespace {1!A}.",
+                        inst.classname, ns))
+
         try:
             self.instances[ns].append(inst)
         except KeyError:  # namespace ns does not exist. Create it

--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -130,6 +130,8 @@ class InstanceWriteProvider(BaseProvider):
           class in the CIM repository, and have the same type-related
           attributes (i.e. type, is_array, embedded_object).
 
+        - The creation class of the new instance must not be an abstract class.
+
         Validation that should be performed by this provider method:
 
         - new_instance does not specify any properties that are not

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -40,7 +40,7 @@ except ImportError:  # py2
 
 from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMParameter, CIMError, CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, \
-    CIM_ERR_INVALID_CLASS, CIM_ERR_METHOD_NOT_FOUND, cimtype
+    CIM_ERR_INVALID_CLASS, CIM_ERR_METHOD_NOT_FOUND, cimtype, CIM_ERR_FAILED
 
 from pywbem._utils import _format
 from pywbem._nocasedict import NocaseDict
@@ -211,6 +211,13 @@ class ProviderDispatcher(BaseProvider):
                 CIM_ERR_INVALID_CLASS,
                 _format("Creation class {0!A} of new instance does not "
                         "exist in namespace {1!A} of the CIM repository.",
+                        NewInstance.classname, namespace))
+
+        if "Abstract" in creation_class.qualifiers:
+            raise CIMError(
+                CIM_ERR_FAILED,
+                _format("CreateInstance failed. Cannot instantiate abstract "
+                        "class {0!A} in Namespace {1!A}.",
                         NewInstance.classname, namespace))
 
         # Verify that the properties in the new instance are exposed by the


### PR DESCRIPTION
Adds validation on pywbem_mock and mof_compiler for attempts to create
an instance where the creation class has the Abstract qualifier.  Adds the validation, documents the new validation, and adds tests for both CreateInstance and compile of the instance into pywbem_mock.

This fails with CIMError CIM_ERR_FAILED.
