### PR TITLE
1.2: Fixed yamlloader error during setup.py install on Ubuntu with py27/34/35

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,9 @@ Released: not yet
   value when processing export requests to be consistent with DSP0200 which
   requires that WBEM listeners must support any value. (part of issue #2729)
 
+* Fixed installation with setup.py on ubuntu for Python 2.7, 3.4, 3.5, by
+  pinning yamlloader to <1.0.0. (issue #2745)
+
 **Enhancements:**
 
 * Added toleration support for WBEM servers that return a CIM status

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -97,6 +97,7 @@ six==1.14.0
 requests==2.22.0; python_version == '2.7'
 requests==2.20.1; python_version == '3.4'
 requests==2.22.0; python_version >= '3.5'
+yamlloader==0.5.5
 nocaselist==1.0.3
 nocasedict==1.0.1
 
@@ -149,7 +150,6 @@ virtualenv==20.0.0; python_version >= '3.8'  # requires six<2,>=1.12.0
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 decorator==4.0.11
-yamlloader==0.5.5
 # FormEncode is used for xml comparisons in unit test
 FormEncode==1.3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,9 @@ six>=1.14.0
 requests>=2.22.0; python_version == '2.7'
 requests>=2.20.1,<2.22.0; python_version == '3.4'
 requests>=2.22.0; python_version >= '3.5'
-yamlloader>=0.5.5
+# yamlloader 1.1.0 gets istalled by mistake on py27+34 on Ubuntu when using setup.py install. See issue #2745.
+yamlloader>=0.5.5,<1.0.0; python_version <= '3.5'
+yamlloader>=0.5.5; python_version >= '3.6'
 nocaselist>=1.0.3
 nocasedict>=1.0.1
 


### PR DESCRIPTION
Rolls back PR #2746 into 1.2.1.