### PR TITLE
Remove use of unittest.Mock from FakedWBEMConnection

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -94,6 +94,9 @@ Released: not yet
   - Fixed pywbem_mock and the MOF_compiler to test for creation or compile
     of an instance with a creation class that has the Abstract qualifier. This
     will fail since abstract classes cannot be instantiated. (see issue #2742)
+  - Removed use of unittest.Mock in pywbem_mock.FakedWBEMConnection to
+    use mock versions of _imethodcall and _methodcall and simply duck typed
+    the methods. (see issue #2755)
 
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -31,10 +31,10 @@ import os
 import time
 import re
 from xml.dom import minidom
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+# try:
+#    from unittest.mock import Mock
+# except ImportError:
+#    from mock import Mock
 import six
 
 
@@ -249,8 +249,8 @@ class FakedWBEMConnection(WBEMConnection):
         # instance of this class as the client interface.
         self._mofwbemconnection = _MockMOFWBEMConnection(self)
 
-        self._imethodcall = Mock(side_effect=self._mock_imethodcall)
-        self._methodcall = Mock(side_effect=self._mock_methodcall)
+        self._imethodcall = self._mock_imethodcall
+        self._methodcall = self._mock_methodcall
 
     @property
     def namespaces(self):


### PR DESCRIPTION
Change use of unittest.MOCK to duck typing mocked methods in FakedWBEMConnection

The use of Mock was causing issues with pywbemcli pickle and restore of
connection information when the connections were mocked.  Replacing the
Mock with simply duck typing the methods removed the problem

See pywbemtools issueL https://github.com/pywbem/pywbemtools/issues/1038
for a detailed description of the problem.

Note that there is no test for this since pywbem does not use pickle.