### PR TITLE
1.2: Fixed Pylint issues: Removed pinning to 2.7; Fixed 2.9 + 2.10; Cleanup of open(); Fixed object sizes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -63,14 +63,12 @@ autodocsumm>=0.1.13; python_version >= '3.5'
 # Pylint 1.x / astroid 1.x supports py27 and py34/35/36
 # Pylint 2.0 / astroid 2.0 removed py27, added py37
 # Pylint 2.4 / astroid 2.3 removed py34
-# Issue #2673: Pinning Pylint to <2.7.0 is a circumvention for Pylint issue
-#   https://github.com/PyCQA/pylint/issues/4120 that appears in Pylint 2.7.0.
 pylint>=1.6.4,<2.0.0; python_version == '2.7'
 pylint>=2.2.2,<2.4; python_version == '3.4'
-pylint>=2.5.2,<2.7.0; python_version >= '3.6'
+pylint>=2.5.2; python_version >= '3.6'
 astroid>=1.4.9,<2.0.0; python_version == '2.7'
 astroid>=2.1.0,<2.3; python_version == '3.4'
-astroid>=2.4.0,<2.5.0; python_version >= '3.6'
+astroid>=2.4.0; python_version >= '3.6'
 # typed-ast 1.4.0 removed support for Python 3.4.
 typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,6 +56,10 @@ Released: not yet
   CIM_ERR_NOT_SUPPORTED in this case, but at least one WBEM server returns
   CIM_ERR_FAILED. (issue #2736)
 
+* Pylint: Removed pinning of Pylint to <2.7.0 because the performance issue
+  can also be addressed by disabling the similarity checker, and addressed
+  Pylint issues reported by Pylint 2.9. (issue #2672)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+import io
 import re
 
 from pywbem._cim_constants import DEFAULT_NAMESPACE
@@ -28,7 +29,7 @@ def get_version(version_file):
     requirements list of this package (otherwise it cannot be executed in
     a fresh Python environment).
     """
-    with open(version_file, 'r') as fp:
+    with io.open(version_file, 'r', encoding='utf-8') as fp:
         version_source = fp.read()
     globals = {}
     exec(version_source, globals)

--- a/pylintrc
+++ b/pylintrc
@@ -79,6 +79,7 @@ disable=I0011, bad-option-value,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
         signature-differs, raise-missing-from, super-with-arguments,
+        redundant-u-string-prefix,
         R0801
 
 # Issue #2672: Disabling R0801 is a circumvention for Pylint issue

--- a/pylintrc
+++ b/pylintrc
@@ -35,7 +35,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-whitelist=termios,unicodedata
 
 # Allow optimization of some AST trees. This will activate a peephole AST
 # optimizer, which will apply various small optimizations. For instance, it can
@@ -83,7 +83,8 @@ disable=I0011, bad-option-value,
 
 # Issue #2672: Disabling R0801 is a circumvention for Pylint issue
 #   https://github.com/PyCQA/pylint/issues/4118 that appears in Pylint 2.7.0.
-#   Enable it again once the Pylint issue has been addressed.
+#   Enable it again once the Pylint issue has been addressed (expected for
+#   Pylint 2.10).
 
 # Note: "useless-object-inheritance" is python 3 only. In Python 2,
 #        "new-style" objects must inherit from object, or else
@@ -125,7 +126,7 @@ output-format=text
 files-output=no
 
 # Tells whether to display a full report or only the messages
-reports=yes
+reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -249,6 +249,7 @@ except ImportError:
 try:
     from collections.abc import ValuesView, ItemsView
 except ImportError:
+    # pylint: disable=deprecated-class
     from collections import ValuesView, ItemsView
 try:
     from builtins import type as builtin_type

--- a/pywbem/_cim_types.py
+++ b/pywbem/_cim_types.py
@@ -206,7 +206,7 @@ class SlottedPickleMixin(object):
     def __getstate__(self):
         ""  # Avoids docstring to be inherited
 
-        dct = dict()
+        dct = {}
         for attr in self.__slots__:
             dct[attr] = getattr(self, attr)
 

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -2015,9 +2015,7 @@ def _find_column(input_, token):
         if input_[i] == '\n':
             break
         i -= 1
-    column = lexpos - i - 1
-    if column < 0:
-        column = 0
+    column = max(lexpos - i - 1, 0)
     return column
 
 
@@ -2033,17 +2031,13 @@ def _get_error_context(input_, token):
     except ValueError:
         line = input_[lexpos]
 
-    i = input_.rfind('\n', 0, lexpos)
-    if i < 0:
-        i = 0
+    i = max(input_.rfind('\n', 0, lexpos), 0)
     line = input_[i:lexpos] + line
     lines = [line.strip('\r\n')]
     col = lexpos - i
     while len(lines) < 5 and i > 0:
         end = i
-        i = input_.rfind('\n', 0, i)
-        if i < 0:
-            i = 0
+        i = max(input_.rfind('\n', 0, i), 0)
         lines.insert(0, input_[i:end].strip('\r\n'))
     pointer = ''
     for dummy_ch in str(_value(token)):

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -102,7 +102,7 @@ from ._cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_INVALID_SUPERCLASS, CIM_ERR_INVALID_PARAMETER, \
     CIM_ERR_NOT_SUPPORTED
 from ._exceptions import Error, CIMError
-from ._utils import _format
+from ._utils import _format, _ensure_unicode
 
 __all__ = ['MOFCompileError', 'MOFParseError', 'MOFDependencyError',
            'MOFRepositoryError', 'MOFCompiler', 'BaseRepositoryConnection']
@@ -2743,7 +2743,8 @@ class MOFCompiler(object):
 
           log_func (:term:`callable`):
             A logger function that is invoked for each compiler message.
-            The logger function must take one parameter of string type.
+            The logger function must take one parameter of string type
+            (byte string or unicode string).
             The default logger function prints to stdout.
             If `None`, compiler messages are not logged.
         """  # noqa: E501
@@ -2825,7 +2826,7 @@ class MOFCompiler(object):
         :class:`~pywbem.MOFCompiler` object.
         """
         if self._log_func:
-            self._log_func(msg)
+            self._log_func(_ensure_unicode(msg))
 
     def compile_embedded_value(self, mof, ns, filename=None):
         """
@@ -3033,7 +3034,7 @@ class MOFCompiler(object):
                 raise IOError(
                     _format("No such file: {0!A}", filename))
             filename = rfilename
-        with open(filename, "r") as f:
+        with io.open(filename, "r", encoding='utf-8') as f:
             mof = f.read()
 
         return self.compile_string(mof, ns, filename=filename)

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -22,6 +22,7 @@ Operation recorder interface and implementations.
 """
 
 from __future__ import print_function, absolute_import
+import io
 from collections import namedtuple
 try:
     from collections import OrderedDict
@@ -42,9 +43,6 @@ from ._cim_types import CIMInt, CIMFloat, CIMDateTime
 from ._exceptions import CIMError
 from ._logging import LOGGER_API_CALLS_NAME, LOGGER_HTTP_NAME
 from ._utils import _ensure_unicode, _format
-
-if six.PY2:
-    import codecs  # pylint: disable=wrong-import-order
 
 
 __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
@@ -302,13 +300,8 @@ class BaseOperationRecorder(object):
 
             recorder_file.close()
         """
-        if six.PY2:
-            # Open with codecs to define text mode
-            # pylint: disable=consider-using-with
-            return codecs.open(filename, mode=file_mode, encoding='utf-8')
-
         # pylint: disable=consider-using-with
-        return open(filename, file_mode, encoding='utf8')
+        return io.open(filename, file_mode, encoding='utf-8')
 
     def reset(self, pull_op=None):
         """Reset all the attributes in the class. This also allows setting
@@ -813,18 +806,21 @@ class TestClientRecorder(BaseOperationRecorder):
             An open file that each test case will be written to.  This file
             should have been opened in text mode.
 
-            Since there are differences between python 2 and 3 in opening
+            Since there are differences between Python 2 and 3 in opening
             files in text mode, the static method
             :meth:`~pywbem.BaseOperationRecorder.open_file`
-            can be used to open the file or python 2/3 compatible open::
+            can be used to open the file.
 
-              from io import open
-                  f = open('blah.log', encoding='utf-8')
+            Alternatively, the Python 2/3 compatible :func:`py:io.open` can be
+            used.
 
-        Example::
+        Examples::
 
           recorder = TestClientRecorder(
               BaseOperationRecorder.open_file('recorder.log'))
+
+          recorder = TestClientRecorder(
+              io.open('recorder.log', mode='w', encoding='utf-8')
         """
         super(TestClientRecorder, self).__init__()
         self._fp = fp

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -304,8 +304,10 @@ class BaseOperationRecorder(object):
         """
         if six.PY2:
             # Open with codecs to define text mode
+            # pylint: disable=consider-using-with
             return codecs.open(filename, mode=file_mode, encoding='utf-8')
 
+        # pylint: disable=consider-using-with
         return open(filename, file_mode, encoding='utf8')
 
     def reset(self, pull_op=None):

--- a/pywbem/_statistics.py
+++ b/pywbem/_statistics.py
@@ -744,8 +744,8 @@ class Statistics(object):
         Return a human readable display of the contents, for debug purposes.
         """
         ret = "Statistics(\n"
-        for name in self._op_stats:
-            ret += _format("  {0!A}\n", self._op_stats[name])
+        for stats_value in self._op_stats.values():
+            ret += _format("  {0!A}\n", stats_value)
         ret += ")"
         return ret
 

--- a/pywbem/_tupletree.py
+++ b/pywbem/_tupletree.py
@@ -386,7 +386,7 @@ def check_invalid_utf8_sequences(utf8_string, meaning, conn_id=None):
     # before the str type gets decoded to unicode, because afterwards
     # surrogates produced from ill-formed UTF-8 cannot be distinguished from
     # legally produced surrogates (for code points above U+FFFF).
-    ifs_list = list()
+    ifs_list = []
     for m in _ILL_FORMED_UTF8_RE.finditer(utf8_string):
         ifs_pos = m.start(1)
         ifs_seq = m.group(1)
@@ -498,7 +498,7 @@ def check_invalid_xml_chars(xml_string, meaning, conn_id=None):
 
     # Check for Unicode characters that cannot legally be represented as XML
     # characters.
-    ixc_list = list()
+    ixc_list = []
     last_ixc_pos = -2
     for m in _ILLEGAL_XML_CHARS_RE.finditer(xml_string):
         ixc_pos = m.start(1)

--- a/pywbem/_units.py
+++ b/pywbem/_units.py
@@ -108,6 +108,7 @@ import re
 try:
     from collections.abc import Sequence
 except ImportError:
+    # pylint: disable=deprecated-class
     from collections import Sequence
 from nocasedict import NocaseDict
 import six
@@ -743,8 +744,7 @@ def _uc2ascii(uc_str):
     Return the input string, where Unicode characters are replaced with their
     7-bit ASCII replacements as defined in UC2ASCII.
     """
-    for uc in UC2ASCII:
-        ac = UC2ASCII[uc]
+    for uc, ac in UC2ASCII.items():
         uc_str = uc_str.replace(uc, ac)
     return uc_str
 

--- a/pywbem/_utils.py
+++ b/pywbem/_utils.py
@@ -33,6 +33,7 @@ except ImportError:  # py2
 try:
     from collections.abc import Mapping, Set, MutableSequence, Sequence
 except ImportError:  # py2
+    # pylint: disable=deprecated-class
     from collections import Mapping, Set, MutableSequence, Sequence
 
 __all__ = []

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -75,6 +75,7 @@ compiling DMTF CIM classes for any test significantly.
 """
 
 import os
+import io
 from zipfile import ZipFile
 import shutil
 import re
@@ -146,7 +147,7 @@ def build_schema_mof(class_names, schema_pragma_file):
         class_names = [class_names]
 
     schema_lines = []
-    with open(schema_pragma_file, 'r') as f:
+    with io.open(schema_pragma_file, 'r', encoding='utf-8') as f:
         schema_lines = f.readlines()
 
     # Build list  classname/line number pairs
@@ -460,7 +461,7 @@ class DMTFCIMSchema(object):
                     _format("DMTF Schema archive not found at url {0}: {1}",
                             self.schema_zip_url, ie))
 
-            with open(self.schema_zip_file, 'wb') as fp:
+            with io.open(self.schema_zip_file, 'wb') as fp:
                 for data in ufo:
                     fp.write(data)
 
@@ -482,7 +483,7 @@ class DMTFCIMSchema(object):
                     if not os.path.exists(dfile):
                         os.mkdir(dfile)
                 else:
-                    with open(dfile, 'w+b') as dfp:
+                    with io.open(dfile, 'w+b') as dfp:
                         dfp.write(zfp.read(file_))
 
     def build_schema_mof(self, class_names):

--- a/pywbem_mock/_dmtf_cim_schema.py
+++ b/pywbem_mock/_dmtf_cim_schema.py
@@ -474,21 +474,16 @@ class DMTFCIMSchema(object):
                 _format("Unpacking CIM Schema archive: {0}",
                         self.schema_zip_file))
 
-            zfp = None
-            try:
-                zfp = ZipFile(self.schema_zip_file, 'r')
-                nlist = zfp.namelist()
-                for file_ in nlist:
-                    dfile = os.path.join(self.schema_mof_dir, file_)
-                    if dfile[-1] == '/':
-                        if not os.path.exists(dfile):
-                            os.mkdir(dfile)
-                    else:
-                        with open(dfile, 'w+b') as dfp:
-                            dfp.write(zfp.read(file_))
-            finally:
-                if zfp:
-                    zfp.close()
+        with ZipFile(self.schema_zip_file, 'r') as zfp:
+            nlist = zfp.namelist()
+            for file_ in nlist:
+                dfile = os.path.join(self.schema_mof_dir, file_)
+                if dfile[-1] == '/':
+                    if not os.path.exists(dfile):
+                        os.mkdir(dfile)
+                else:
+                    with open(dfile, 'w+b') as dfp:
+                        dfp.write(zfp.read(file_))
 
     def build_schema_mof(self, class_names):
         """

--- a/pywbem_mock/_providerdependentregistry.py
+++ b/pywbem_mock/_providerdependentregistry.py
@@ -50,7 +50,7 @@ class ProviderDependentRegistry(object):
         # Dictionary of registered provider dependent files.
         # Key: Normalized path name of mock script.
         # Value: List of normalized path names of provider dependent files.
-        self._registry = dict()
+        self._registry = {}
 
     def __repr__(self):
         return _format(

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -36,6 +36,7 @@ import six
 try:
     from collections.abc import Mapping, Sequence
 except ImportError:  # py2
+    # pylint: disable=deprecated-class
     from collections import Mapping, Sequence
 
 from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \

--- a/pywbem_mock/_utils.py
+++ b/pywbem_mock/_utils.py
@@ -24,12 +24,11 @@ Utility functionsto support pywbem_mock.
 
 from __future__ import absolute_import, print_function
 
-import locale
 import sys
-import six
+import io
+import locale
 
-if six.PY2:
-    import codecs  # pylint: disable=wrong-import-order
+import six
 
 STDOUT_ENCODING = getattr(sys.stdout, 'encoding', None)
 if not STDOUT_ENCODING:
@@ -71,16 +70,11 @@ def _uprint(dest, text):
         sys.stdout.write(text)
     elif isinstance(dest, (six.text_type, six.binary_type)):
         if isinstance(text, six.text_type):
-            open_kwargs = dict(mode='a', encoding='utf-8')
+            kw = dict(mode='a', encoding='utf-8')
         else:
-            open_kwargs = dict(mode='ab')
-        if six.PY2:
-            # Open with codecs to be able to set text mode
-            with codecs.open(dest, **open_kwargs) as f:
-                f.write(text)
-        else:
-            with open(dest, **open_kwargs) as f:
-                f.write(text)
+            kw = dict(mode='ab')
+        with io.open(dest, **kw) as f:  # pylint: disable=unspecified-encoding
+            f.write(text)
     else:
         raise TypeError(
             "dest must be None or a string, but is {0}".

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -555,7 +555,7 @@ class FakedWBEMConnection(WBEMConnection):
         # By default, error messages are always printed in addition to being
         # raised as MOFCompileError. We only want them to be printed in verbose
         # mode:
-        log_func_kwargs = dict()
+        log_func_kwargs = {}
         if not verbose:
             log_func_kwargs['log_func'] = None
 
@@ -631,7 +631,7 @@ class FakedWBEMConnection(WBEMConnection):
         # By default, error messages are always printed in addition to being
         # raised as MOFCompileError. We only want them to be printed in verbose
         # mode:
-        log_func_kwargs = dict()
+        log_func_kwargs = {}
         if not verbose:
             log_func_kwargs['log_func'] = None
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1170,8 +1170,7 @@ class FakedWBEMConnection(WBEMConnection):
                                 "pywbem.CIMParameter",
                                 methodname, localobject, type(param)))
         if params:
-            for pname in params:
-                pvalue = params[pname]
+            for pname, pvalue in params.items():
                 params_dict[pname] = CIMParameter(
                     pname, cimtype(pvalue), value=pvalue)
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ Setup script for pywbem project.
 
 import sys
 import os
+import io
 import re
 import fnmatch
 # setuptools needs to be imported before distutils in order to work.
@@ -47,7 +48,7 @@ def get_version(version_file):
     requirements list of this package (otherwise it cannot be executed in
     a fresh Python environment).
     """
-    with open(version_file, 'r') as fp:
+    with io.open(version_file, 'r', encoding='utf-8') as fp:
         version_source = fp.read()
     _globals = {}
     exec(version_source, _globals)  # pylint: disable=exec-used
@@ -60,7 +61,7 @@ def get_requirements(requirements_file):
     non-comment lines. The returned lines are without any trailing newline
     characters.
     """
-    with open(requirements_file, 'r') as fp:
+    with io.open(requirements_file, 'r', encoding='utf-8') as fp:
         lines = fp.readlines()
     reqs = []
     for line in lines:
@@ -75,7 +76,7 @@ def read_file(a_file):
     """
     Read the specified file and return its content as one string.
     """
-    with open(a_file, 'r') as fp:
+    with io.open(a_file, 'r', encoding='utf-8') as fp:
         content = fp.read()
     return content
 

--- a/tests/end2endtest/test_profile_snia_smis.py
+++ b/tests/end2endtest/test_profile_snia_smis.py
@@ -150,7 +150,7 @@ def test_snia_smis_profile_tree_not_circular(wbem_connection):  # noqa: F811
         # Profile ancestry for the each specification instance:
         # * key: std_uri of profile
         # * value: std_uri of its referencing profile (or spec, for the top)
-        profile_ancestry = dict()
+        profile_ancestry = {}
 
         for top_profile_inst in top_profiles:
 

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -5,6 +5,7 @@ Pytest fixtures for pywbem end2end tests.
 from __future__ import absolute_import
 
 import os
+import io
 import warnings
 from contextlib import contextmanager
 import json
@@ -39,7 +40,7 @@ PROFILES_YAML_FILE = os.path.join('tests', 'profiles', 'profiles.yml')
 # Profile definition list.
 # The list items are profile definition items, as described in the profile
 # definition file.
-with open(PROFILES_YAML_FILE, 'r') as _fp:
+with io.open(PROFILES_YAML_FILE, 'r', encoding='utf-8') as _fp:
     PROFILE_DEFINITION_LIST = yaml.safe_load(_fp)
 del _fp  # pylint: disable=undefined-loop-variable
 

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -100,12 +100,12 @@ class ServerObjectCache(object):
         # - value: dictionary of named lists:
         #   - key: list name
         #   _ value: list of CIM objects (e.g. CIMInstanceName, CIMClass)
-        self._server_dict = dict()
+        self._server_dict = {}
 
     def add_list(self, server_url, list_name, obj_list):
         """Add obj_list to the list named list_name"""
         if server_url not in self._server_dict:
-            self._server_dict[server_url] = dict()
+            self._server_dict[server_url] = {}
         list_dict = self._server_dict[server_url]
         if list_name in list_dict:
             raise KeyError(

--- a/tests/end2endtest/utils/utils.py
+++ b/tests/end2endtest/utils/utils.py
@@ -274,7 +274,7 @@ class WBEMConnectionAsserted(WBEMConnection):
         Return an AssertionError about the specified exception.
         """
         parm_list = ["{0!r}".format(a) for a in args]
-        parm_list.extend(["{0}={1!r}".format(k, kwargs[k]) for k in kwargs])
+        parm_list.extend(["{0}={1!r}".format(k, v) for k, v in kwargs.items()])
         parm_str = ", ".join(parm_list)
         return AssertionError(
             "Server {0} at {1}: WBEMConnection.{2}() failed and raised "
@@ -454,7 +454,7 @@ def server_func_asserted(server, funcname, *args, **kwargs):
         return func(*args, **kwargs)
     except Error as exc:
         parm_list = ["{0!r}".format(a) for a in args]
-        parm_list.extend(["{0}={1!r}".format(k, kwargs[k]) for k in kwargs])
+        parm_list.extend(["{0}={1!r}".format(k, v) for k, v in kwargs.items()])
         parm_str = ", ".join(parm_list)
         raise AssertionError(
             "Server {0} at {1}: Calling WBEMServer.{2}() failed and "

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -206,7 +206,7 @@ def patched_makefile(self, mode='r', bufsize=-1):
             timeout = self.timeout
         t.join(timeout)
         if t.is_alive():
-            raise socket.timeout
+            raise socket.timeout  # pylint: disable=no-member
 
     return self.fd
 

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -5870,9 +5870,8 @@ def consume_indication(indication, host):
     # pylint: disable=global-statement
     global RECEIVED_INDICATION_COUNT
     # increment count.
-    COUNTER_LOCK.acquire()
-    RECEIVED_INDICATION_COUNT += 1
-    COUNTER_LOCK.release()
+    with COUNTER_LOCK:
+        RECEIVED_INDICATION_COUNT += 1
 
 
 class TestSubscriptionsClass(PyWBEMServerClass):
@@ -5912,9 +5911,8 @@ class TestSubscriptionsClass(PyWBEMServerClass):
             # pylint: disable=global-statement
             global RECEIVED_INDICATION_COUNT
             # increment count.
-            COUNTER_LOCK.acquire()
-            RECEIVED_INDICATION_COUNT = 0
-            COUNTER_LOCK.release()
+            with COUNTER_LOCK:
+                RECEIVED_INDICATION_COUNT = 0
 
             listener.start()
         except Exception as ex:  # pylint: disable=broad-except

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import
 # pylint: disable=missing-docstring,superfluous-parens,no-self-use
 
 import sys
+import os
 import re
 from socket import getfqdn
-import os.path
 import threading
 import types
 from datetime import timedelta, datetime
@@ -27,6 +27,7 @@ from getpass import getpass
 import warnings
 import time
 import traceback
+
 from six.moves.urllib.parse import urlparse
 import six
 

--- a/tests/manualtest/run_response_performance.py
+++ b/tests/manualtest/run_response_performance.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, print_function
 
 import sys as _sys
 import os as _os
+import io
 import time
 import argparse as _argparse
 import datetime
@@ -34,9 +35,6 @@ except ImportError:
         """Compatible parse_cim() function"""
         tp = TupleParser()
         return tp.parse_cim(tt)
-
-if six.PY2:
-    import codecs  # pylint: disable=wrong-import-order
 
 # default input arguments.  These are small so a user who
 # just calls the code does not fall into long run.
@@ -91,16 +89,11 @@ def _uprint(dest, text):  # pylint: disable=too-many-branches
 
     elif isinstance(dest, (six.text_type, six.binary_type)):
         if isinstance(text, six.text_type):
-            open_kwargs = dict(mode='a', encoding='utf-8')
+            kw = dict(mode='a', encoding='utf-8')
         else:
-            open_kwargs = dict(mode='ab')
-        if six.PY2:
-            # Open with codecs to be able to set text mode
-            with codecs.open(dest, **open_kwargs) as fn:
-                fn.write(text)
-        else:
-            with open(dest, **open_kwargs) as fn:
-                fn.write(text)
+            kw = dict(mode='ab')
+        with io.open(dest, **kw) as fn:  # pylint: disable=unspecified-encoding
+            fn.write(text)
     else:
         raise TypeError(
             "dest must be None or a string, but is {0}".
@@ -364,7 +357,7 @@ class ExecuteTests(object):
 
         # if dest defined, output to file defined by dest
         if self.logfile:
-            with open(self.logfile, 'w') as stream:
+            with io.open(self.logfile, 'w', encoding='utf-8') as stream:
                 ps = pstats.Stats(profiler, stream=stream)
                 ps.strip_dirs()
                 ps.sort_stats(*self.cprofilesort)

--- a/tests/resourcetest/memory_utils.py
+++ b/tests/resourcetest/memory_utils.py
@@ -103,7 +103,7 @@ def total_sizeof(obj, iters=None):
     seen = set()  # Track which objects have already been seen
 
     default_size = sys.getsizeof(0)
-    ref_size = struct.calcsize('P')
+    ref_size = struct.calcsize('P')  # pylint: disable=no-member
 
     if DEBUG:
         nesting = [0]

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -1484,7 +1484,7 @@ TESTCASES_CIMINSTANCENAME_SETATTR = [
             item='keybindings',
             new_value=None,
             exp_attrs=dict(
-                keybindings=dict(),
+                keybindings={},
             ),
         ),
         None, None, True
@@ -2229,7 +2229,7 @@ TESTCASES_CIMINSTANCENAME_REPR = [
     (
         CIMInstanceName(
             classname='CIM_Foo',
-            keybindings=dict())
+            keybindings={})
     ),
     # (
     #    CIMInstanceName(
@@ -2330,7 +2330,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname only, with implied default args",
         dict(
             obj=CIMInstanceName('CIM_Foo'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo"/>',
             )
@@ -2386,7 +2386,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 'Birds', type='string')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2404,7 +2404,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 'Birds', type='char16')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2422,7 +2422,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', True, type='boolean')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2440,7 +2440,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='uint8')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2458,7 +2458,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='uint16')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2476,7 +2476,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='uint32')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2494,7 +2494,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='uint64')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2512,7 +2512,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='sint8')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2530,7 +2530,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='sint16')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2548,7 +2548,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='sint32')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2566,7 +2566,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42, type='sint64')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2584,7 +2584,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42.1, type='real32')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2602,7 +2602,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 [CIMProperty('Cheepy', 42.1, type='real64')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2622,7 +2622,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                              CIMDateTime('19980125133015.123456-300'),
                              type='datetime')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2642,7 +2642,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 [CIMProperty('Cheepy', CIMInstanceName('CIM_Ref'),
                              type='reference')]
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2659,7 +2659,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Char16 with unicode value",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Char16(u'Birds')}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2674,7 +2674,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Char16 with byte value",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Char16(b'Birds')}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2689,7 +2689,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of unicode string type",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': u'Birds'}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2704,7 +2704,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of byte string type",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': b'Birds'}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2719,7 +2719,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of boolean True",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': True}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2734,7 +2734,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of boolean False",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': False}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2749,7 +2749,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of int",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': 42}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2764,7 +2764,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Uint8",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Uint8(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2779,7 +2779,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Uint16",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Uint16(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2794,7 +2794,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Uint32",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Uint32(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2809,7 +2809,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Uint64",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Uint64(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2824,7 +2824,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Sint8",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Sint8(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2839,7 +2839,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Sint16",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Sint16(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2854,7 +2854,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Sint32",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Sint32(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2869,7 +2869,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Sint64",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Sint64(42)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2884,7 +2884,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of float",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': 42.1}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2899,7 +2899,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Real32",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Real32(42.1)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2914,7 +2914,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding with value of Real64",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': Real64(42.1)}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2932,7 +2932,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 {'Cheepy': CIMDateTime('19980125133015.123456-300')}
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2952,7 +2952,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 {'Cheepy': CIMInstanceName('CIM_Ref')}
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -2973,7 +2973,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 {'Cheepy': CIMInstanceName('CIM_Ref', namespace='root/cimv2')}
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -3001,7 +3001,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 {'Cheepy': CIMInstanceName('CIM_Ref', namespace='root/cimv2',
                                            host='woot')}
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -3027,7 +3027,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Classname with one keybinding, with implied default args",
         dict(
             obj=CIMInstanceName('CIM_Foo', {'Cheepy': 'Birds'}),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Cheepy">',
@@ -3104,7 +3104,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                     ('Ref', CIMInstanceName('CIM_Bar')),
                 ]),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCENAME CLASSNAME="CIM_Foo">',
                 '<KEYBINDING NAME="Name">',
@@ -3244,7 +3244,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 'CIM_Foo',
                 namespace='root/cimv2',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<LOCALINSTANCEPATH>',
                 '<LOCALNAMESPACEPATH>',
@@ -3328,7 +3328,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
                 namespace='root/cimv2',
                 host='woot.com',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCEPATH>',
                 '<NAMESPACEPATH>',
@@ -3417,7 +3417,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Keybinding value with invalid datetime type",
         dict(
             obj=CIMINSTANCENAME_INV_KEYBINDINGS_1,
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=None
         ),
         TypeError, None, True
@@ -3426,7 +3426,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Keybinding value with invalid CIMParameter type",
         dict(
             obj=CIMINSTANCENAME_INV_KEYBINDINGS_2,
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=None
         ),
         TypeError, None, True
@@ -3435,7 +3435,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
         "Keybinding value with invalid CIMProperty type",
         dict(
             obj=CIMINSTANCENAME_INV_KEYBINDINGS_3,
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=None
         ),
         TypeError, None, True
@@ -6779,7 +6779,7 @@ TESTCASES_CIMINSTANCE_SETATTR = [
             item='properties',
             new_value=None,
             exp_attrs=dict(
-                properties=dict(),
+                properties={},
             ),
         ),
         None, None, True
@@ -6923,7 +6923,7 @@ TESTCASES_CIMINSTANCE_SETATTR = [
             item='qualifiers',
             new_value=None,
             exp_attrs=dict(
-                qualifiers=dict(),
+                qualifiers={},
             ),
         ),
         None, None, True
@@ -7140,7 +7140,7 @@ TESTCASES_CIMINSTANCE_UPDATE_PROPERTY = [
         dict(
             obj_kwargs=dict(
                 classname='C1',
-                properties=dict(),
+                properties={},
                 path=CIMInstanceName(
                     'C1',
                     keybindings=dict(K1='V1')
@@ -7213,7 +7213,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
                 ),
             ),
             func_args=[],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1'),
@@ -7234,7 +7234,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 [('P1', 'V1new')],
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1new'),
@@ -7255,7 +7255,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 CIMInstanceName('C2', keybindings=dict(P1='V1new')),
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1new'),
@@ -7297,7 +7297,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 [('P2', 'V2new')],
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1'),  # P2 ignored
@@ -7318,7 +7318,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 CIMInstanceName('C2', keybindings=dict(P2='V2new')),
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1'),  # P2 ignored
@@ -7361,7 +7361,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 [('P1', 'V1new'), ('P2', 'V2new')],
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1new'),  # P2 ignored
@@ -7384,7 +7384,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
                 [('P1', 'V1new')],
                 [('P2', 'V2new')],
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1new'),  # P2 ignored
@@ -7406,7 +7406,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
             func_args=[
                 CIMInstanceName('C2', keybindings=dict(P1='V1new', P2='V2new'))
             ],
-            func_kwargs=dict(),
+            func_kwargs={},
             exp_attrs=dict(
                 properties=dict(
                     P1=CIMProperty('P1', 'V1new'),  # P2 ignored
@@ -8111,7 +8111,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
         "No path, implied default args",
         dict(
             obj=CIMInstance('CIM_Foo'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCE CLASSNAME="CIM_Foo"/>',
             )
@@ -8151,7 +8151,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMINSTANCENAME_CLASSNAME1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<VALUE.NAMEDINSTANCE>',
                 '<INSTANCENAME CLASSNAME="CIM_Foo"/>',
@@ -8203,7 +8203,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMINSTANCENAME_NAMESPACE1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<VALUE.OBJECTWITHLOCALPATH>',
                 '<LOCALINSTANCEPATH>',
@@ -8265,7 +8265,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMINSTANCENAME_HOST1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<VALUE.INSTANCEWITHPATH>',
                 '<INSTANCEPATH>',
@@ -8338,7 +8338,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                     CIMProperty('P2', 42, type='uint16'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCE CLASSNAME="CIM_Foo">',
                 '<PROPERTY NAME="P1" TYPE="string">',
@@ -8364,7 +8364,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                     CIMQualifier('Q1', True),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCE CLASSNAME="CIM_Foo">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -8394,7 +8394,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
                     CIMProperty('P1', 'bla'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<INSTANCE CLASSNAME="CIM_Foo">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -8420,7 +8420,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
         "With invalid property object (type string)",
         dict(
             obj=CIMINSTANCE_INV_PROPERTY_1,
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=None
         ),
         # raises TypeError since 0.12
@@ -8430,7 +8430,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
         "With invalid property object (type Uint16)",
         dict(
             obj=CIMINSTANCE_INV_PROPERTY_2,
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=None
         ),
         # raises TypeError since 0.12
@@ -8556,7 +8556,7 @@ TESTCASES_CIMINSTANCE_TOMOF = [
         "Instance without properties",
         dict(
             obj=CIMInstance(classname='C1'),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
 };
@@ -8573,7 +8573,7 @@ instance of C1 {
                     CIMProperty('p1', value=None, type='string'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = NULL;
@@ -8591,7 +8591,7 @@ instance of C1 {
                     CIMProperty('p1', value=None, type='string'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = NULL;
@@ -8609,7 +8609,7 @@ instance of C1 {
                     CIMProperty('p1', value='abc'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = "abc";
@@ -8627,7 +8627,7 @@ instance of C1 {
                     CIMProperty('p1', value=Uint8(7)),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = 7;
@@ -8645,7 +8645,7 @@ instance of C1 {
                     CIMProperty('p1', value=[Sint8(-1), Sint8(5)]),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = { -1, 5 };
@@ -8672,7 +8672,7 @@ instance of C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = "instance of EC {\\n   e1 = \\"abc\\";\\n};\\n";
@@ -8702,7 +8702,7 @@ instance of C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 =
@@ -8732,7 +8732,7 @@ instance of C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = "instance of EC {\\n   e1 = \\"abc\\";\\n};\\n";
@@ -8763,7 +8763,7 @@ instance of C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = "class EC {\\n\\n   uint32 e1;\\n\\n};\\n";
@@ -8790,7 +8790,7 @@ instance of C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
 instance of C1 {
    p1 = "/:RC.k1=\\"abc\\"";
@@ -14131,7 +14131,7 @@ TESTCASES_CIMPROPERTY_SETATTR = [
             item='qualifiers',
             new_value=None,
             exp_attrs=dict(
-                qualifiers=dict(),
+                qualifiers={},
             ),
         ),
         None, None, True
@@ -15005,7 +15005,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with ASCII characters, as byte string",
         dict(
             obj=CIMProperty(b'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="string"/>',
             )
@@ -15016,7 +15016,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with ASCII characters, as unicode string",
         dict(
             obj=CIMProperty(u'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="string"/>',
             )
@@ -15027,7 +15027,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as byte string",
         dict(
             obj=CIMProperty(b'Foo\xC3\xA9', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -15038,7 +15038,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as unicode string",
         dict(
             obj=CIMProperty(u'Foo\u00E9', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -15049,7 +15049,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with non-UCS-2 characters, as byte string",
         dict(
             obj=CIMProperty(b'Foo\xF0\x90\x85\x82', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -15060,7 +15060,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
         "Name with non-UCS-2 characters, as unicode string",
         dict(
             obj=CIMProperty(u'Foo\U00010142', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -15079,7 +15079,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                     CIMQualifier('Q1', True),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="string">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -15102,7 +15102,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='boolean', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="boolean"/>',
             )
@@ -15115,7 +15115,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='boolean', value=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="boolean">',
                 '<VALUE>TRUE</VALUE>',
@@ -15130,7 +15130,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='boolean', value=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="boolean">',
                 '<VALUE>FALSE</VALUE>',
@@ -15147,7 +15147,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='string', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="string"/>',
             )
@@ -15161,7 +15161,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='string', value='foo',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="string">',
                 '<VALUE>foo</VALUE>',
@@ -15177,7 +15177,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='string', value=u'foo\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo" TYPE="string">',
                 u'<VALUE>foo\u00E9</VALUE>',
@@ -15193,7 +15193,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='string', value=u'foo\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo" TYPE="string">',
                 u'<VALUE>foo\U00010142</VALUE>',
@@ -15211,7 +15211,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string',
                 value=CIMInstance('CIM_Emb'), embedded_object='instance',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY EmbeddedObject="instance"',
                 ' NAME="Foo" TYPE="string">',
@@ -15230,7 +15230,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string',
                 value=CIMInstance('CIM_Emb'), embedded_object='object',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY EmbeddedObject="object"',
                 ' NAME="Foo" TYPE="string">',
@@ -15249,7 +15249,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string',
                 value=CIMClass('CIM_Emb'), embedded_object='object',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY EmbeddedObject="object"',
                 ' NAME="Foo" TYPE="string">',
@@ -15269,7 +15269,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='char16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="char16"/>',
             )
@@ -15283,7 +15283,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='char16', value='f',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="char16">',
                 '<VALUE>f</VALUE>',
@@ -15299,7 +15299,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='char16', value=u'\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo" TYPE="char16">',
                 u'<VALUE>\u00E9</VALUE>',
@@ -15315,7 +15315,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='char16', value=u'\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY NAME="Foo" TYPE="char16">',
                 u'<VALUE>\U00010142</VALUE>',
@@ -15332,7 +15332,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint8"/>',
             )
@@ -15345,7 +15345,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint8', value=42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint8">',
                 '<VALUE>42</VALUE>',
@@ -15362,7 +15362,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint16"/>',
             )
@@ -15375,7 +15375,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint16', value=1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint16">',
                 '<VALUE>1234</VALUE>',
@@ -15392,7 +15392,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint32"/>',
             )
@@ -15405,7 +15405,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint32', value=12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint32">',
                 '<VALUE>12345678</VALUE>',
@@ -15422,7 +15422,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint64"/>',
             )
@@ -15435,7 +15435,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint64', value=123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="uint64">',
                 '<VALUE>123456789012</VALUE>',
@@ -15452,7 +15452,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint8"/>',
             )
@@ -15465,7 +15465,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint8', value=-42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint8">',
                 '<VALUE>-42</VALUE>',
@@ -15482,7 +15482,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint16"/>',
             )
@@ -15495,7 +15495,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint16', value=-1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint16">',
                 '<VALUE>-1234</VALUE>',
@@ -15512,7 +15512,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint32"/>',
             )
@@ -15525,7 +15525,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint32', value=-12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint32">',
                 '<VALUE>-12345678</VALUE>',
@@ -15542,7 +15542,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint64"/>',
             )
@@ -15555,7 +15555,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='sint64', value=-123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="sint64">',
                 '<VALUE>-123456789012</VALUE>',
@@ -15572,7 +15572,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32"/>',
             )
@@ -15585,7 +15585,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>0.42</VALUE>',
@@ -15601,7 +15601,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=1.2345678901,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>1.2345678901</VALUE>',
@@ -15616,7 +15616,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>42.0</VALUE>',
@@ -15631,7 +15631,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>-0.042</VALUE>',
@@ -15646,7 +15646,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>-42000.0</VALUE>',
@@ -15661,7 +15661,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>-4.2E-29</VALUE>',
@@ -15676,7 +15676,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>-4.2E+31</VALUE>',
@@ -15691,7 +15691,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>INF</VALUE>',  # must be upper case
@@ -15706,7 +15706,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>-INF</VALUE>',  # must be upper case
@@ -15721,7 +15721,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real32', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real32">',
                 '<VALUE>NaN</VALUE>',  # must be upper case
@@ -15738,7 +15738,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64"/>',
             )
@@ -15751,7 +15751,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>0.42</VALUE>',
@@ -15767,7 +15767,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=1.2345678901234567,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>1.2345678901234567</VALUE>',
@@ -15782,7 +15782,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>42.0</VALUE>',
@@ -15797,7 +15797,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>-0.042</VALUE>',
@@ -15812,7 +15812,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>-42000.0</VALUE>',
@@ -15827,7 +15827,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>-4.2E-29</VALUE>',
@@ -15842,7 +15842,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>-4.2E+31</VALUE>',
@@ -15857,7 +15857,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>INF</VALUE>',  # must be upper case
@@ -15872,7 +15872,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>-INF</VALUE>',  # must be upper case
@@ -15887,7 +15887,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='real64', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="real64">',
                 '<VALUE>NaN</VALUE>',  # must be upper case
@@ -15904,7 +15904,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='datetime', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="datetime"/>',
             )
@@ -15918,7 +15918,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='datetime',
                 value=datetime(2014, 9, 22, 10, 49, 20, 524789),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="datetime">',
                 '<VALUE>20140922104920.524789+000</VALUE>',
@@ -15934,7 +15934,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='datetime',
                 value=timedelta(10, 49, 20),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" TYPE="datetime">',
                 '<VALUE>00000010000049.000020:000</VALUE>',
@@ -15951,7 +15951,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='reference', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.REFERENCE NAME="Foo"/>',
             )
@@ -15965,7 +15965,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='reference',
                 value=CIMInstanceName('CIM_Foo'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.REFERENCE NAME="Foo">',
                 '<VALUE.REFERENCE>',
@@ -15985,7 +15985,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="boolean"/>',
             )
@@ -15999,7 +15999,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='boolean', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY/>',
@@ -16015,7 +16015,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='boolean', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -16033,7 +16033,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='boolean', value=[True],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -16051,7 +16051,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='boolean', value=[False],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -16071,7 +16071,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="string"/>',
             )
@@ -16085,7 +16085,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY/>',
@@ -16101,7 +16101,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY>',
@@ -16120,7 +16120,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=['foo'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY>',
@@ -16139,7 +16139,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=[u'foo\u00E9'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY.ARRAY NAME="Foo" TYPE="string">',
                 u'<VALUE.ARRAY>',
@@ -16158,7 +16158,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', value=[u'foo\U00010142'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY.ARRAY NAME="Foo" TYPE="string">',
                 u'<VALUE.ARRAY>',
@@ -16179,7 +16179,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', is_array=True,
                 value=[CIMInstance('CIM_Emb')], embedded_object='instance',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY EmbeddedObject="instance"',
                 ' NAME="Foo" TYPE="string">',
@@ -16201,7 +16201,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', is_array=True,
                 value=[CIMInstance('CIM_Emb')], embedded_object='object',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY EmbeddedObject="object"',
                 ' NAME="Foo" TYPE="string">',
@@ -16223,7 +16223,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='string', is_array=True,
                 value=[CIMClass('CIM_Emb')], embedded_object='object',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY EmbeddedObject="object"',
                 ' NAME="Foo" TYPE="string">',
@@ -16246,7 +16246,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="char16"/>',
             )
@@ -16260,7 +16260,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY/>',
@@ -16276,7 +16276,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY>',
@@ -16295,7 +16295,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=['f'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY>',
@@ -16314,7 +16314,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=[u'\u00E9'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY.ARRAY NAME="Foo" TYPE="char16">',
                 u'<VALUE.ARRAY>',
@@ -16333,7 +16333,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='char16', value=[u'\U00010142'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<PROPERTY.ARRAY NAME="Foo" TYPE="char16">',
                 u'<VALUE.ARRAY>',
@@ -16353,7 +16353,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint8', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint8"/>',
             )
@@ -16367,7 +16367,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint8', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY/>',
@@ -16383,7 +16383,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint8', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY>',
@@ -16401,7 +16401,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint8', value=[42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY>',
@@ -16421,7 +16421,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint16"/>',
             )
@@ -16435,7 +16435,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY/>',
@@ -16451,7 +16451,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY>',
@@ -16469,7 +16469,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint16', value=[1234],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY>',
@@ -16489,7 +16489,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint32"/>',
             )
@@ -16503,7 +16503,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY/>',
@@ -16519,7 +16519,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY>',
@@ -16537,7 +16537,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint32', value=[12345678],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY>',
@@ -16557,7 +16557,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint64"/>',
             )
@@ -16571,7 +16571,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY/>',
@@ -16587,7 +16587,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY>',
@@ -16605,7 +16605,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='uint64', value=[123456789012],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY>',
@@ -16625,7 +16625,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint8', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint8"/>',
             )
@@ -16639,7 +16639,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint8', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY/>',
@@ -16655,7 +16655,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint8', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY>',
@@ -16673,7 +16673,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint8', value=[-42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY>',
@@ -16693,7 +16693,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint16"/>',
             )
@@ -16707,7 +16707,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY/>',
@@ -16723,7 +16723,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY>',
@@ -16741,7 +16741,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint16', value=[-1234],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY>',
@@ -16761,7 +16761,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint32"/>',
             )
@@ -16775,7 +16775,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY/>',
@@ -16791,7 +16791,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY>',
@@ -16809,7 +16809,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint32', value=[-12345678],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY>',
@@ -16829,7 +16829,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint64"/>',
             )
@@ -16843,7 +16843,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY/>',
@@ -16859,7 +16859,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY>',
@@ -16877,7 +16877,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='sint64', value=[-123456789012],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY>',
@@ -16897,7 +16897,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32"/>',
             )
@@ -16911,7 +16911,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY/>',
@@ -16927,7 +16927,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -16945,7 +16945,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[0.42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -16964,7 +16964,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[1.2345678901],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -16983,7 +16983,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[42.0],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17002,7 +17002,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E-3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17021,7 +17021,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E+3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17040,7 +17040,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E-30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17059,7 +17059,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E+30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17078,7 +17078,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[float('inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17097,7 +17097,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[float('-inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17116,7 +17116,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real32', value=[float('nan')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -17136,7 +17136,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64"/>',
             )
@@ -17150,7 +17150,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY/>',
@@ -17166,7 +17166,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17184,7 +17184,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[0.42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17203,7 +17203,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[1.2345678901234567],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17222,7 +17222,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[42.0],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17241,7 +17241,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E-3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17260,7 +17260,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E+3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17279,7 +17279,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E-30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17298,7 +17298,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E+30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17317,7 +17317,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[float('inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17336,7 +17336,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[float('-inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17355,7 +17355,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='real64', value=[float('nan')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -17375,7 +17375,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='datetime', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="datetime"/>',
             )
@@ -17389,7 +17389,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='datetime', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY/>',
@@ -17405,7 +17405,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 'Foo', type='datetime', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -17424,7 +17424,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 value=[datetime(2014, 9, 22, 10, 49, 20, 524789)],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -17443,7 +17443,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
                 value=[timedelta(10, 49, 20)],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY.ARRAY NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -17464,7 +17464,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint32', value=None, class_origin='CIM_Origin',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY CLASSORIGIN="CIM_Origin" NAME="Foo" TYPE="uint32"/>',
             )
@@ -17477,7 +17477,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint32', value=None, propagated=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" PROPAGATED="true" TYPE="uint32"/>',
             )
@@ -17490,7 +17490,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
             obj=CIMProperty(
                 'Foo', type='uint32', value=None, propagated=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PROPERTY NAME="Foo" PROPAGATED="false" TYPE="uint32"/>',
             )
@@ -18096,7 +18096,7 @@ TESTCASES_CIMPROPERTY_TOMOF = [
         dict(
             obj=CIMProperty(
                 name='P1',
-                value=list(),
+                value=[],
                 type='uint32',
                 is_array=True,
             ),
@@ -20290,7 +20290,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with ASCII characters, as byte string",
         dict(
             obj=CIMQualifier(b'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string"/>',
             )
@@ -20301,7 +20301,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with ASCII characters, as unicode string",
         dict(
             obj=CIMQualifier(u'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string"/>',
             )
@@ -20312,7 +20312,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as byte string",
         dict(
             obj=CIMQualifier(b'Foo\xC3\xA9', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -20323,7 +20323,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as unicode string",
         dict(
             obj=CIMQualifier(u'Foo\u00E9', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -20334,7 +20334,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with non-UCS-2 characters, as byte string",
         dict(
             obj=CIMQualifier(b'Foo\xF0\x90\x85\x82', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -20345,7 +20345,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
         "Name with non-UCS-2 characters, as unicode string",
         dict(
             obj=CIMQualifier(u'Foo\U00010142', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -20361,7 +20361,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 propagated=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" PROPAGATED="true" TYPE="boolean"/>',
             )
@@ -20375,7 +20375,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 propagated=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" PROPAGATED="false" TYPE="boolean"/>',
             )
@@ -20391,7 +20391,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 overridable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" OVERRIDABLE="true" TYPE="boolean"/>',
             )
@@ -20405,7 +20405,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 overridable=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" OVERRIDABLE="false" TYPE="boolean"/>',
             )
@@ -20421,7 +20421,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 tosubclass=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TOSUBCLASS="true" TYPE="boolean"/>',
             )
@@ -20435,7 +20435,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 tosubclass=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TOSUBCLASS="false" TYPE="boolean"/>',
             )
@@ -20451,7 +20451,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 toinstance=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TOINSTANCE="true" TYPE="boolean"/>',
             )
@@ -20465,7 +20465,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 toinstance=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TOINSTANCE="false" TYPE="boolean"/>',
             )
@@ -20481,7 +20481,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 translatable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TRANSLATABLE="true" TYPE="boolean"/>',
             )
@@ -20495,7 +20495,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 translatable=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TRANSLATABLE="false" TYPE="boolean"/>',
             )
@@ -20510,7 +20510,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean"/>',
             )
@@ -20523,7 +20523,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE>TRUE</VALUE>',
@@ -20538,7 +20538,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE>FALSE</VALUE>',
@@ -20555,7 +20555,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string"/>',
             )
@@ -20569,7 +20569,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value='foo',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string">',
                 '<VALUE>foo</VALUE>',
@@ -20585,7 +20585,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=u'foo\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="string">',
                 u'<VALUE>foo\u00E9</VALUE>',
@@ -20601,7 +20601,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=u'foo\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="string">',
                 u'<VALUE>foo\U00010142</VALUE>',
@@ -20618,7 +20618,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16"/>',
             )
@@ -20632,7 +20632,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value='f',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16">',
                 '<VALUE>f</VALUE>',
@@ -20648,7 +20648,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=u'\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="char16">',
                 u'<VALUE>\u00E9</VALUE>',
@@ -20664,7 +20664,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=u'\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="char16">',
                 u'<VALUE>\U00010142</VALUE>',
@@ -20681,7 +20681,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8"/>',
             )
@@ -20694,7 +20694,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8">',
                 '<VALUE>42</VALUE>',
@@ -20711,7 +20711,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16"/>',
             )
@@ -20724,7 +20724,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16">',
                 '<VALUE>1234</VALUE>',
@@ -20741,7 +20741,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32"/>',
             )
@@ -20754,7 +20754,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32">',
                 '<VALUE>12345678</VALUE>',
@@ -20771,7 +20771,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64"/>',
             )
@@ -20784,7 +20784,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64">',
                 '<VALUE>123456789012</VALUE>',
@@ -20801,7 +20801,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8"/>',
             )
@@ -20814,7 +20814,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=-42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8">',
                 '<VALUE>-42</VALUE>',
@@ -20831,7 +20831,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16"/>',
             )
@@ -20844,7 +20844,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=-1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16">',
                 '<VALUE>-1234</VALUE>',
@@ -20861,7 +20861,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32"/>',
             )
@@ -20874,7 +20874,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=-12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32">',
                 '<VALUE>-12345678</VALUE>',
@@ -20891,7 +20891,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64"/>',
             )
@@ -20904,7 +20904,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=-123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64">',
                 '<VALUE>-123456789012</VALUE>',
@@ -20921,7 +20921,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32"/>',
             )
@@ -20934,7 +20934,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>0.42</VALUE>',
@@ -20950,7 +20950,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=1.2345678901,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>1.2345678901</VALUE>',
@@ -20965,7 +20965,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>42.0</VALUE>',
@@ -20980,7 +20980,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>-0.042</VALUE>',
@@ -20995,7 +20995,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>-42000.0</VALUE>',
@@ -21010,7 +21010,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>-4.2E-29</VALUE>',
@@ -21025,7 +21025,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>-4.2E+31</VALUE>',
@@ -21040,7 +21040,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>INF</VALUE>',  # must be upper case
@@ -21055,7 +21055,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>-INF</VALUE>',  # must be upper case
@@ -21070,7 +21070,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE>NaN</VALUE>',  # must be upper case
@@ -21087,7 +21087,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64"/>',
             )
@@ -21100,7 +21100,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>0.42</VALUE>',
@@ -21116,7 +21116,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=1.2345678901234567,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>1.2345678901234567</VALUE>',
@@ -21131,7 +21131,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>42.0</VALUE>',
@@ -21146,7 +21146,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>-0.042</VALUE>',
@@ -21161,7 +21161,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>-42000.0</VALUE>',
@@ -21176,7 +21176,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>-4.2E-29</VALUE>',
@@ -21191,7 +21191,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>-4.2E+31</VALUE>',
@@ -21206,7 +21206,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>INF</VALUE>',  # must be upper case
@@ -21221,7 +21221,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>-INF</VALUE>',  # must be upper case
@@ -21236,7 +21236,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE>NaN</VALUE>',  # must be upper case
@@ -21253,7 +21253,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='datetime', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime"/>',
             )
@@ -21267,7 +21267,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='datetime',
                 value=datetime(2014, 9, 22, 10, 49, 20, 524789),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE>20140922104920.524789+000</VALUE>',
@@ -21283,7 +21283,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='datetime',
                 value=timedelta(10, 49, 20),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE>00000010000049.000020:000</VALUE>',
@@ -21302,7 +21302,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean"/>',
             )
@@ -21315,7 +21315,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY/>',
@@ -21330,7 +21330,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -21347,7 +21347,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=[True],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -21364,7 +21364,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='boolean', value=[False],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="boolean">',
                 '<VALUE.ARRAY>',
@@ -21383,7 +21383,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string"/>',
             )
@@ -21396,7 +21396,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY/>',
@@ -21411,7 +21411,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY>',
@@ -21429,7 +21429,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=['foo'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="string">',
                 '<VALUE.ARRAY>',
@@ -21447,7 +21447,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=[u'foo\u00E9'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="string">',
                 u'<VALUE.ARRAY>',
@@ -21465,7 +21465,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='string', value=[u'foo\U00010142'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="string">',
                 u'<VALUE.ARRAY>',
@@ -21484,7 +21484,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16"/>',
             )
@@ -21497,7 +21497,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY/>',
@@ -21512,7 +21512,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY>',
@@ -21530,7 +21530,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=['f'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="char16">',
                 '<VALUE.ARRAY>',
@@ -21548,7 +21548,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=[u'\u00E9'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="char16">',
                 u'<VALUE.ARRAY>',
@@ -21566,7 +21566,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='char16', value=[u'\U00010142'],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER NAME="Foo" TYPE="char16">',
                 u'<VALUE.ARRAY>',
@@ -21585,7 +21585,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8"/>',
             )
@@ -21598,7 +21598,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY/>',
@@ -21613,7 +21613,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY>',
@@ -21630,7 +21630,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint8', value=[42],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint8">',
                 '<VALUE.ARRAY>',
@@ -21649,7 +21649,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16"/>',
             )
@@ -21662,7 +21662,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY/>',
@@ -21677,7 +21677,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY>',
@@ -21694,7 +21694,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint16', value=[1234],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint16">',
                 '<VALUE.ARRAY>',
@@ -21713,7 +21713,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32"/>',
             )
@@ -21726,7 +21726,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY/>',
@@ -21741,7 +21741,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY>',
@@ -21758,7 +21758,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint32', value=[12345678],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint32">',
                 '<VALUE.ARRAY>',
@@ -21777,7 +21777,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64"/>',
             )
@@ -21790,7 +21790,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY/>',
@@ -21805,7 +21805,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY>',
@@ -21822,7 +21822,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='uint64', value=[123456789012],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="uint64">',
                 '<VALUE.ARRAY>',
@@ -21841,7 +21841,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8"/>',
             )
@@ -21854,7 +21854,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY/>',
@@ -21869,7 +21869,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY>',
@@ -21886,7 +21886,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint8', value=[-42],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint8">',
                 '<VALUE.ARRAY>',
@@ -21905,7 +21905,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16"/>',
             )
@@ -21918,7 +21918,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY/>',
@@ -21933,7 +21933,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY>',
@@ -21950,7 +21950,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint16', value=[-1234],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint16">',
                 '<VALUE.ARRAY>',
@@ -21969,7 +21969,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32"/>',
             )
@@ -21982,7 +21982,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY/>',
@@ -21997,7 +21997,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY>',
@@ -22014,7 +22014,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint32', value=[-12345678],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint32">',
                 '<VALUE.ARRAY>',
@@ -22033,7 +22033,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64"/>',
             )
@@ -22046,7 +22046,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY/>',
@@ -22061,7 +22061,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY>',
@@ -22078,7 +22078,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='sint64', value=[-123456789012],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="sint64">',
                 '<VALUE.ARRAY>',
@@ -22097,7 +22097,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32"/>',
             )
@@ -22110,7 +22110,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY/>',
@@ -22125,7 +22125,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22142,7 +22142,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[0.42],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22160,7 +22160,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[1.2345678901],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22178,7 +22178,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[42.0],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22196,7 +22196,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[-42.0E-3],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22214,7 +22214,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[-42.0E+3],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22232,7 +22232,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[-42.0E-30],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22250,7 +22250,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[-42.0E+30],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22268,7 +22268,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[float('inf')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22286,7 +22286,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[float('-inf')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22304,7 +22304,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real32', value=[float('nan')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real32">',
                 '<VALUE.ARRAY>',
@@ -22323,7 +22323,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64"/>',
             )
@@ -22336,7 +22336,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY/>',
@@ -22351,7 +22351,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22368,7 +22368,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[0.42],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22386,7 +22386,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[1.2345678901234567],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22404,7 +22404,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[42.0],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22422,7 +22422,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[-42.0E-3],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22440,7 +22440,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[-42.0E+3],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22458,7 +22458,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[-42.0E-30],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22476,7 +22476,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[-42.0E+30],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22494,7 +22494,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[float('inf')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22512,7 +22512,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[float('-inf')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22530,7 +22530,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='real64', value=[float('nan')],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="real64">',
                 '<VALUE.ARRAY>',
@@ -22549,7 +22549,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='datetime', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime"/>',
             )
@@ -22562,7 +22562,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='datetime', value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY/>',
@@ -22577,7 +22577,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
             obj=CIMQualifier(
                 'Foo', type='datetime', value=[None],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -22595,7 +22595,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='datetime',
                 value=[datetime(2014, 9, 22, 10, 49, 20, 524789)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -22613,7 +22613,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
                 'Foo', type='datetime',
                 value=[timedelta(10, 49, 20)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER NAME="Foo" TYPE="datetime">',
                 '<VALUE.ARRAY>',
@@ -23896,7 +23896,7 @@ TESTCASES_CIMCLASSNAME_TOCIMXML = [
         "Classname only, with implied default args",
         dict(
             obj=CIMClassName('CIM_Foo'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASSNAME NAME="CIM_Foo"/>',
             )
@@ -23952,7 +23952,7 @@ TESTCASES_CIMCLASSNAME_TOCIMXML = [
                 'CIM_Foo',
                 namespace='root/cimv2',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<LOCALCLASSPATH>',
                 '<LOCALNAMESPACEPATH>',
@@ -24036,7 +24036,7 @@ TESTCASES_CIMCLASSNAME_TOCIMXML = [
                 namespace='root/cimv2',
                 host='woot.com',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASSPATH>',
                 '<NAMESPACEPATH>',
@@ -25848,7 +25848,7 @@ TESTCASES_CIMCLASS_SETATTR = [
             item='properties',
             new_value=None,
             exp_attrs=dict(
-                properties=dict(),
+                properties={},
             ),
         ),
         None, None, True
@@ -25988,7 +25988,7 @@ TESTCASES_CIMCLASS_SETATTR = [
             item='methods',
             new_value=None,
             exp_attrs=dict(
-                methods=dict(),
+                methods={},
             ),
         ),
         None, None, True
@@ -26120,7 +26120,7 @@ TESTCASES_CIMCLASS_SETATTR = [
             item='qualifiers',
             new_value=None,
             exp_attrs=dict(
-                qualifiers=dict(),
+                qualifiers={},
             ),
         ),
         None, None, True
@@ -26891,7 +26891,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
         "No path",
         dict(
             obj=CIMClass('CIM_Foo'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo"/>',
             )
@@ -26905,7 +26905,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMCLASSNAME_CLASSNAME1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo"/>',
             )
@@ -26919,7 +26919,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMCLASSNAME_NAMESPACE1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo"/>',
             )
@@ -26933,7 +26933,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                 'CIM_Foo',
                 path=CIMCLASSNAME_HOST1,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo"/>',
             )
@@ -26952,7 +26952,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                     CIMProperty('P2', 42, type='uint16'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo">',
                 '<PROPERTY NAME="P1" TYPE="string">',
@@ -26978,7 +26978,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                     CIMMethod('M1', return_type='uint32'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo">',
                 '<METHOD NAME="M2" TYPE="string"/>',
@@ -27000,7 +27000,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                     CIMQualifier('Q1', True),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -27034,7 +27034,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
                     CIMMethod('M1', return_type='uint32'),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<CLASS NAME="CIM_Foo">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -27208,7 +27208,7 @@ TESTCASES_CIMCLASS_TOMOF = [
                 ],
                 path=None
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof="""\
    [q1 ( "qv1" )]
 class C1 : C2 {
@@ -27250,7 +27250,7 @@ class C1 : C2 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 class C1 {
 
@@ -27286,7 +27286,7 @@ class C1 {
                     ),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             # pylint: disable=line-too-long
             exp_mof=u"""\
 class C1 {
@@ -28343,7 +28343,7 @@ TESTCASES_CIMMETHOD_SETATTR = [
             item='parameters',
             new_value=None,
             exp_attrs=dict(
-                parameters=dict(),
+                parameters={},
             ),
         ),
         None, None, True
@@ -28487,7 +28487,7 @@ TESTCASES_CIMMETHOD_SETATTR = [
             item='qualifiers',
             new_value=None,
             exp_attrs=dict(
-                qualifiers=dict(),
+                qualifiers={},
             ),
         ),
         None, None, True
@@ -29079,7 +29079,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with ASCII characters, as byte string",
         dict(
             obj=CIMMethod(b'Foo', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="string"/>',
             )
@@ -29090,7 +29090,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with ASCII characters, as unicode string",
         dict(
             obj=CIMMethod(u'Foo', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="string"/>',
             )
@@ -29101,7 +29101,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as byte string",
         dict(
             obj=CIMMethod(b'Foo\xC3\xA9', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<METHOD NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -29112,7 +29112,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with non-ASCII UCS-2 characters, as unicode string",
         dict(
             obj=CIMMethod(u'Foo\u00E9', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<METHOD NAME="Foo\u00E9" TYPE="string"/>',
             )
@@ -29123,7 +29123,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with non-UCS-2 characters, as byte string",
         dict(
             obj=CIMMethod(b'Foo\xF0\x90\x85\x82', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<METHOD NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -29134,7 +29134,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
         "Name with non-UCS-2 characters, as unicode string",
         dict(
             obj=CIMMethod(u'Foo\U00010142', return_type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<METHOD NAME="Foo\U00010142" TYPE="string"/>',
             )
@@ -29153,7 +29153,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
                     CIMQualifier('Q1', True),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="string">',
                 '<QUALIFIER NAME="Q2" TYPE="string">',
@@ -29176,7 +29176,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='boolean',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="boolean"/>',
             )
@@ -29189,7 +29189,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='string',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="string"/>',
             )
@@ -29202,7 +29202,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='real32',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="real32"/>',
             )
@@ -29215,7 +29215,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='sint64',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="sint64"/>',
             )
@@ -29228,7 +29228,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='datetime',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="datetime"/>',
             )
@@ -29247,7 +29247,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
                     CIMParameter('P1', type='string', is_array=True),
                 ],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" TYPE="uint32">',
                 '<PARAMETER NAME="P2" TYPE="boolean"/>',
@@ -29265,7 +29265,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='uint32', class_origin='CIM_Origin',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD CLASSORIGIN="CIM_Origin" NAME="Foo" TYPE="uint32"/>',
             )
@@ -29278,7 +29278,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='uint32', propagated=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" PROPAGATED="true" TYPE="uint32"/>',
             )
@@ -29291,7 +29291,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
             obj=CIMMethod(
                 'Foo', return_type='uint32', propagated=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<METHOD NAME="Foo" PROPAGATED="false" TYPE="uint32"/>',
             )
@@ -32874,7 +32874,7 @@ TESTCASES_CIMPARAMETER_SETATTR = [
             item='qualifiers',
             new_value=None,
             exp_attrs=dict(
-                qualifiers=dict(),
+                qualifiers={},
             ),
         ),
         None, None, True
@@ -33428,7 +33428,7 @@ TESTCASES_CIMPARAMETER_TOCIMXML = [
         "Argument as_value defaults to False",
         dict(
             obj=CIMParameter(b'Foo', type='string', value=None),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<PARAMETER NAME="Foo" TYPE="string"/>',
             )
@@ -39722,7 +39722,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_SETATTR = [
             item='scopes',
             new_value=OrderedDict(),
             exp_attrs=dict(
-                scopes=dict(),
+                scopes={},
             ),
         ),
         None, None, True
@@ -39754,7 +39754,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_SETATTR = [
             item='scopes',
             new_value=None,
             exp_attrs=dict(
-                scopes=dict(),
+                scopes={},
             ),
         ),
         None, None, True
@@ -40645,7 +40645,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
         "Name with ASCII characters, as byte string",
         dict(
             obj=CIMQualifierDeclaration(b'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="string"/>',
@@ -40657,7 +40657,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
         "Name with ASCII characters, as unicode string",
         dict(
             obj=CIMQualifierDeclaration(u'Foo', value=None, type='string'),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="string"/>',
@@ -40671,7 +40671,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 b'Foo\xC3\xA9', value=None, type='string'
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo\u00E9"',
                 ' TYPE="string"/>',
@@ -40685,7 +40685,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 u'Foo\u00E9', value=None, type='string'
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo\u00E9"',
                 u' TYPE="string"/>',
@@ -40699,7 +40699,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 b'Foo\xF0\x90\x85\x82', value=None, type='string'
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo\U00010142"',
                 u' TYPE="string"/>',
@@ -40713,7 +40713,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 u'Foo\U00010142', value=None, type='string'
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo\U00010142"',
                 u' TYPE="string"/>',
@@ -40730,7 +40730,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 scopes=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean"/>',
@@ -40745,7 +40745,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 scopes=[('ASSOCIATION', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -40762,7 +40762,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 scopes=[('ASSOCIATION', True), ('PROPERTY', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -40779,7 +40779,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 scopes=[('ANY', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -40800,7 +40800,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 overridable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' OVERRIDABLE="true" TYPE="boolean"/>',
@@ -40815,7 +40815,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 overridable=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' OVERRIDABLE="false" TYPE="boolean"/>',
@@ -40832,7 +40832,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 tosubclass=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TOSUBCLASS="true" TYPE="boolean"/>',
@@ -40847,7 +40847,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 tosubclass=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TOSUBCLASS="false" TYPE="boolean"/>',
@@ -40864,7 +40864,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 toinstance=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TOINSTANCE="true" TYPE="boolean"/>',
@@ -40879,7 +40879,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 toinstance=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TOINSTANCE="false" TYPE="boolean"/>',
@@ -40896,7 +40896,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 translatable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TRANSLATABLE="true" TYPE="boolean"/>',
@@ -40911,7 +40911,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 translatable=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TRANSLATABLE="false" TYPE="boolean"/>',
@@ -40927,7 +40927,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='boolean', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean"/>',
@@ -40941,7 +40941,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='boolean', value=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -40957,7 +40957,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='boolean', value=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -40975,7 +40975,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='string', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="string"/>',
@@ -40990,7 +40990,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='string', value='foo',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="string">',
@@ -41007,7 +41007,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='string', value=u'foo\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 u' TYPE="string">',
@@ -41024,7 +41024,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='string', value=u'foo\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 u' TYPE="string">',
@@ -41042,7 +41042,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='char16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="char16"/>',
@@ -41057,7 +41057,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='char16', value='f',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="char16">',
@@ -41074,7 +41074,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='char16', value=u'\u00E9',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 u' TYPE="char16">',
@@ -41092,7 +41092,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='char16', value=u'\U00010142',
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 u' TYPE="char16">',
@@ -41110,7 +41110,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint8"/>',
@@ -41125,7 +41125,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint8', value=42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint8">',
@@ -41143,7 +41143,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint16"/>',
@@ -41158,7 +41158,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint16', value=1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint16">',
@@ -41176,7 +41176,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint32"/>',
@@ -41191,7 +41191,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint32', value=12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint32">',
@@ -41209,7 +41209,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint64"/>',
@@ -41224,7 +41224,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='uint64', value=123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="uint64">',
@@ -41242,7 +41242,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint8', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint8"/>',
@@ -41257,7 +41257,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint8', value=-42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint8">',
@@ -41275,7 +41275,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint16', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint16"/>',
@@ -41290,7 +41290,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint16', value=-1234,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint16">',
@@ -41308,7 +41308,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint32"/>',
@@ -41323,7 +41323,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint32', value=-12345678,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint32">',
@@ -41341,7 +41341,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint64"/>',
@@ -41356,7 +41356,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='sint64', value=-123456789012,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="sint64">',
@@ -41374,7 +41374,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32"/>',
@@ -41388,7 +41388,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41405,7 +41405,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=1.2345678901,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41422,7 +41422,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41439,7 +41439,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41456,7 +41456,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41473,7 +41473,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41490,7 +41490,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41506,7 +41506,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41522,7 +41522,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41538,7 +41538,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real32', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real32">',
@@ -41556,7 +41556,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64"/>',
@@ -41570,7 +41570,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=0.42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41587,7 +41587,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=1.2345678901234567,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41604,7 +41604,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=42.0,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41621,7 +41621,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=-42.0E-3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41638,7 +41638,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=-42.0E+3,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41655,7 +41655,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=-42.0E-30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41672,7 +41672,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=-42.0E+30,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41688,7 +41688,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=float('inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41704,7 +41704,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=float('-inf'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41720,7 +41720,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='real64', value=float('nan'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="real64">',
@@ -41738,7 +41738,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
             obj=CIMQualifierDeclaration(
                 'Foo', type='datetime', value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="datetime"/>',
@@ -41753,7 +41753,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='datetime',
                 value=datetime(2014, 9, 22, 10, 49, 20, 524789),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -41770,7 +41770,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='datetime',
                 value=timedelta(10, 49, 20),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="false" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -41791,7 +41791,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="boolean"/>',
@@ -41806,7 +41806,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -41824,7 +41824,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -41844,7 +41844,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=[True],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -41864,7 +41864,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='boolean', value=[False],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="boolean">',
@@ -41885,7 +41885,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string"/>',
@@ -41900,7 +41900,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string">',
@@ -41918,7 +41918,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string">',
@@ -41938,7 +41938,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=['foo'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string">',
@@ -41958,7 +41958,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=[u'foo\u00E9'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string">',
@@ -41978,7 +41978,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='string', value=[u'foo\U00010142'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="string">',
@@ -41999,7 +41999,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="char16"/>',
@@ -42014,7 +42014,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="char16">',
@@ -42032,7 +42032,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="char16">',
@@ -42052,7 +42052,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=['f'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="char16">',
@@ -42072,7 +42072,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=[u'\u00E9'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 u' TYPE="char16">',
@@ -42093,7 +42093,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='char16', value=[u'\U00010142'],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 u'<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 u' TYPE="char16">',
@@ -42114,7 +42114,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint8', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint8"/>',
@@ -42129,7 +42129,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint8', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint8">',
@@ -42146,7 +42146,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint8', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint8">',
@@ -42166,7 +42166,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint8', value=[42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint8">',
@@ -42187,7 +42187,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint16"/>',
@@ -42202,7 +42202,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint16">',
@@ -42220,7 +42220,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint16">',
@@ -42240,7 +42240,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint16', value=[1234],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint16">',
@@ -42261,7 +42261,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint32"/>',
@@ -42276,7 +42276,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint32">',
@@ -42294,7 +42294,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint32">',
@@ -42314,7 +42314,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint32', value=[12345678],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint32">',
@@ -42335,7 +42335,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint64"/>',
@@ -42350,7 +42350,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint64">',
@@ -42368,7 +42368,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint64">',
@@ -42388,7 +42388,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='uint64', value=[123456789012],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="uint64">',
@@ -42409,7 +42409,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint8', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint8"/>',
@@ -42424,7 +42424,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint8', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint8">',
@@ -42441,7 +42441,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint8', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint8">',
@@ -42461,7 +42461,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint8', value=[-42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint8">',
@@ -42482,7 +42482,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint16', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint16"/>',
@@ -42497,7 +42497,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint16', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint16">',
@@ -42515,7 +42515,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint16', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint16">',
@@ -42535,7 +42535,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint16', value=[-1234],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint16">',
@@ -42556,7 +42556,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint32"/>',
@@ -42571,7 +42571,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint32">',
@@ -42589,7 +42589,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint32">',
@@ -42609,7 +42609,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint32', value=[-12345678],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint32">',
@@ -42630,7 +42630,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint64"/>',
@@ -42645,7 +42645,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint64">',
@@ -42663,7 +42663,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint64">',
@@ -42683,7 +42683,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='sint64', value=[-123456789012],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="sint64">',
@@ -42704,7 +42704,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32"/>',
@@ -42719,7 +42719,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42737,7 +42737,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42757,7 +42757,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[0.42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42777,7 +42777,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[1.2345678901],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42797,7 +42797,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[42.0],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42817,7 +42817,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E-3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42837,7 +42837,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E+3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42857,7 +42857,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E-30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42877,7 +42877,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[-42.0E+30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42897,7 +42897,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[float('inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42917,7 +42917,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[float('-inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42937,7 +42937,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real32', value=[float('nan')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real32">',
@@ -42958,7 +42958,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64"/>',
@@ -42973,7 +42973,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -42991,7 +42991,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43011,7 +43011,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[0.42],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43031,7 +43031,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[1.2345678901234567],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43051,7 +43051,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[42.0],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43071,7 +43071,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E-3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43091,7 +43091,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E+3],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43111,7 +43111,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E-30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43131,7 +43131,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[-42.0E+30],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43151,7 +43151,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[float('inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43171,7 +43171,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[float('-inf')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43191,7 +43191,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='real64', value=[float('nan')],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="real64">',
@@ -43212,7 +43212,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='datetime', value=None,
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="datetime"/>',
@@ -43227,7 +43227,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='datetime', value=[],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -43245,7 +43245,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 'Foo', type='datetime', value=[None],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -43266,7 +43266,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 value=[datetime(2014, 9, 22, 10, 49, 20, 524789)],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -43287,7 +43287,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
                 value=[timedelta(10, 49, 20)],
                 is_array=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_xml_str=(
                 '<QUALIFIER.DECLARATION ISARRAY="true" NAME="Foo"',
                 ' TYPE="datetime">',
@@ -43434,7 +43434,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOMOF = [
                 toinstance=True,
                 translatable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string[5] = { "abc" },
     Scope(property, method, parameter),
@@ -43451,7 +43451,7 @@ Qualifier Q1 : string[5] = { "abc" },
                 type='string',
                 value=None,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope();
@@ -43467,7 +43467,7 @@ Qualifier Q1 : string,
                 type='string',
                 value="dq=\",sq=\',bs=\\",
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string = "dq=\\",sq=\\',bs=\\\\",
     Scope();
@@ -43483,7 +43483,7 @@ Qualifier Q1 : string = "dq=\\",sq=\\',bs=\\\\",
                 type='string',
                 value="bt=\b,tb=\t,nl=\n,vt=\f,cr=\r",
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string = "bt=\\b,tb=\\t,nl=\\n,vt=\\f,cr=\\r",
     Scope();
@@ -43499,7 +43499,7 @@ Qualifier Q1 : string = "bt=\\b,tb=\\t,nl=\\n,vt=\\f,cr=\\r",
                 type='char16',
                 value="\n",
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : char16 = '\\n',
     Scope();
@@ -43515,7 +43515,7 @@ Qualifier Q1 : char16 = '\\n',
                 type='boolean',
                 value=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : boolean = false,
     Scope();
@@ -43531,7 +43531,7 @@ Qualifier Q1 : boolean = false,
                 type='uint32',
                 value=42,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : uint32 = 42,
     Scope();
@@ -43547,7 +43547,7 @@ Qualifier Q1 : uint32 = 42,
                 type='real32',
                 value=Real32(42.1),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : real32 = 42.1,
     Scope();
@@ -43564,7 +43564,7 @@ Qualifier Q1 : real32 = 42.1,
                 type='datetime',
                 value=CIMDateTime('20140924193040.654321+120'),
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : datetime = "20140924193040.654321+120",
     Scope();
@@ -43582,7 +43582,7 @@ Qualifier Q1 : datetime = "20140924193040.654321+120",
                 array_size=None,
                 value=[],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string[] = {  },
     Scope();
@@ -43600,7 +43600,7 @@ Qualifier Q1 : string[] = {  },
                 array_size=None,
                 value=["abc", "def"],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string[] = { "abc", "def" },
     Scope();
@@ -43618,7 +43618,7 @@ Qualifier Q1 : string[] = { "abc", "def" },
                 array_size=5,
                 value=["abc", "def"],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string[5] = { "abc", "def" },
     Scope();
@@ -43634,7 +43634,7 @@ Qualifier Q1 : string[5] = { "abc", "def" },
                 type='string',
                 scopes=[('CLASS', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(class);
@@ -43653,7 +43653,7 @@ Qualifier Q1 : string,
                         ('REFERENCE', True), ('METHOD', True),
                         ('PARAMETER', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             # pylint: disable=line-too-long
             exp_mof=u"""\
 Qualifier Q1 : string,
@@ -43671,7 +43671,7 @@ Qualifier Q1 : string,
                 type='string',
                 scopes=[('ANY', True)],
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(any);
@@ -43687,7 +43687,7 @@ Qualifier Q1 : string,
                 type='string',
                 overridable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43705,7 +43705,7 @@ Qualifier Q1 : string,
                 overridable=True,
                 tosubclass=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43722,7 +43722,7 @@ Qualifier Q1 : string,
                 type='string',
                 overridable=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43739,7 +43739,7 @@ Qualifier Q1 : string,
                 type='string',
                 tosubclass=False,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43756,7 +43756,7 @@ Qualifier Q1 : string,
                 type='string',
                 tosubclass=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43773,7 +43773,7 @@ Qualifier Q1 : string,
                 type='string',
                 translatable=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope(),
@@ -43790,7 +43790,7 @@ Qualifier Q1 : string,
                 type='string',
                 toinstance=True,
             ),
-            kwargs=dict(),
+            kwargs={},
             exp_mof=u"""\
 Qualifier Q1 : string,
     Scope();
@@ -43891,7 +43891,7 @@ TESTCASES_CIMVALUE = [
         "Verify order of positional arguments",
         dict(
             args=[u'a', 'string'],
-            kwargs=dict(),
+            kwargs={},
             exp_obj=u'a',
         ),
         None, None, True,
@@ -44951,7 +44951,7 @@ TESTCASES_MOFSTR = [
                 False,
                 u'"',
             ],
-            kwargs=dict(),
+            kwargs={},
             exp_result=(u'"abcdefgh"', 12),
         ),
         None, None, True,

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -287,7 +287,9 @@ class TestCreateConnection(object):
 
         try:
             for fname in files:
-                open(fname, 'a').close()  # create empty file
+                # create empty file
+                with open(fname, 'a'):
+                    pass
 
             if exp_exc is not None:
                 with pytest.raises(exp_exc) as exc_info:

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -8,6 +8,7 @@ Unittest functions in _cim_operations.
 from __future__ import print_function, absolute_import
 
 import os
+import io
 import re
 import pytest
 
@@ -52,7 +53,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
     (
         "No optional init parameters, test defaults",
         [],
-        dict(),
+        {},
         dict(
             creds=None,
             default_namespace='root/cimv2',
@@ -133,7 +134,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file='mykeyfile.tmp',
             ),
         ),
-        dict(),
+        {},
         IOError, "Client certificate file .* not found"
     ),
     (
@@ -146,7 +147,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file='nonexistingkeyfile.tmp',
             ),
         ),
-        dict(),
+        {},
         IOError, "Client key file .* not found"
     ),
     (
@@ -159,7 +160,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file=None,
             ),
         ),
-        dict(),
+        {},
         TypeError, "cert_file.* must be a string"
     ),
     (
@@ -172,7 +173,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file=None,
             ),
         ),
-        dict(),
+        {},
         TypeError, "The 'cert_file' item in the x509 parameter must be a string"
     ),
     (
@@ -185,7 +186,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file=3,
             ),
         ),
-        dict(),
+        {},
         TypeError, "The 'key_file' item in the x509 parameter must be a string",
     ),
     (
@@ -197,7 +198,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
                 key_file=None,
             ),
         ),
-        dict(),
+        {},
         ValueError, "The x509 parameter does not have the required key "
         "'cert_file'"
     ),
@@ -208,7 +209,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
         dict(
             x509='mycertfile.tmp',
         ),
-        dict(),
+        {},
         TypeError, "x509 .* must be a dictionary"
     ),
     (
@@ -228,7 +229,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
         dict(
             ca_certs=42,
         ),
-        dict(),
+        {},
         TypeError, "ca_certs .* invalid type"
     ),
     (
@@ -237,7 +238,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
         dict(
             ca_certs='mycacertfile.tmp',
         ),
-        dict(),
+        {},
         IOError, "file or directory not found"
     ),
     (
@@ -263,7 +264,7 @@ TESTCASES_INIT_WBEMCONNECTION = [
         dict(
             proxies=42,
         ),
-        dict(),
+        {},
         TypeError, "proxies .* must be a dictionary .*"
     ),
 ]
@@ -288,7 +289,7 @@ class TestCreateConnection(object):
         try:
             for fname in files:
                 # create empty file
-                with open(fname, 'a'):
+                with io.open(fname, 'a', encoding='utf-8'):
                     pass
 
             if exp_exc is not None:
@@ -349,7 +350,7 @@ class TestCreateConnection(object):
 
     @pytest.mark.parametrize(
         'kwargs, exp_default_namespace', [
-            (dict(), DEFAULT_NAMESPACE),
+            ({}, DEFAULT_NAMESPACE),
             (dict(default_namespace=None), DEFAULT_NAMESPACE),
             (dict(default_namespace=DEFAULT_NAMESPACE), DEFAULT_NAMESPACE),
             (dict(default_namespace='blah'), 'blah'),

--- a/tests/unittest/pywbem/test_cim_types.py
+++ b/tests/unittest/pywbem/test_cim_types.py
@@ -927,7 +927,7 @@ TESTCASES_MINUTESFROMUTC_INIT = [
         "Test with missing required arguments",
         dict(
             args=[],
-            kwargs=dict(),
+            kwargs={},
             exp_offset=None,
         ),
         TypeError, None, True
@@ -936,7 +936,7 @@ TESTCASES_MINUTESFROMUTC_INIT = [
         "Test with minimal number of positional arguments",
         dict(
             args=[30],
-            kwargs=dict(),
+            kwargs={},
             exp_offset=30,
         ),
         None, None, True
@@ -956,7 +956,7 @@ TESTCASES_MINUTESFROMUTC_INIT = [
         "Test with too many positional arguments",
         dict(
             args=[30, 0],
-            kwargs=dict(),
+            kwargs={},
             exp_offset=None,
         ),
         TypeError, None, True

--- a/tests/unittest/pywbem/test_cim_xml.py
+++ b/tests/unittest/pywbem/test_cim_xml.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 try:
     from collections.abc import Iterable
 except ImportError:  # py2
+    # pylint: disable=deprecated-class
     from collections import Iterable
 import six
 import pytest

--- a/tests/unittest/pywbem/test_exceptions.py
+++ b/tests/unittest/pywbem/test_exceptions.py
@@ -140,7 +140,7 @@ def message_arg(request):
 
 @pytest.fixture(params=[
     # Tuple of (conn_id_kwarg, exp_conn_str)
-    (dict(), TEST_CONN_STR_NONE),
+    ({}, TEST_CONN_STR_NONE),
     (dict(conn_id=None), TEST_CONN_STR_NONE),
     (dict(conn_id=TEST_CONN_ID), TEST_CONN_STR),
 ], scope='module')
@@ -158,7 +158,7 @@ def conn_info(request):
 
 @pytest.fixture(params=[
     # Tuple of (request_data_kwarg, exp_request_data)
-    (dict(), None),
+    ({}, None),
     (dict(request_data=None), None),
     (dict(request_data=b'<CIM/>'), b'<CIM/>'),
 ], scope='module')
@@ -177,7 +177,7 @@ def request_data_info(request):
 
 @pytest.fixture(params=[
     # Tuple of (response_data_kwarg, exp_request_data)
-    (dict(), None),
+    ({}, None),
     (dict(response_data=None), None),
     (dict(response_data=b'<CIM/>'), b'<CIM/>'),
 ], scope='module')

--- a/tests/unittest/pywbem/test_logging.py
+++ b/tests/unittest/pywbem/test_logging.py
@@ -21,6 +21,7 @@ Unit test logging functionality in _logging.py
 from __future__ import absolute_import, print_function
 
 import os
+import io
 import re
 import logging
 
@@ -482,7 +483,7 @@ class TestLoggerOutput(BaseLoggingExecutionTests):
             format(LOGGER_API_CALLS_NAME),
         ]
 
-        with open(TEST_OUTPUT_LOG, "r") as log_fp:
+        with io.open(TEST_OUTPUT_LOG, "r", encoding='utf-8') as log_fp:
             log_lines = log_fp.readlines()
         assert len(log_lines) == len(exp_line_patterns)
         for i, pattern in enumerate(exp_line_patterns):
@@ -543,11 +544,11 @@ class TestLoggerPropagate(object):
 
         pkg_logger.removeHandler(pkg_handler)
 
-        with open(logger_filename) as logger_fp:
+        with io.open(logger_filename, encoding='utf-8') as logger_fp:
             logger_line = logger_fp.read()
         assert re.match(r'.*-%s\..*-Connection:' % logger_name, logger_line)
 
-        with open(pkg_filename) as pkg_fp:
+        with io.open(pkg_filename, encoding='utf-8') as pkg_fp:
             pkg_line = pkg_fp.read()
         if propagate:
             assert re.match(r'.*-pywbem.*-Connection:', pkg_line)

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -74,6 +74,7 @@ class MOFTest(unittest.TestCase):
             print(msg, file=self.logfile)
 
         moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
+        # pylint: disable=consider-using-with
         self.logfile = open(moflog_file, 'w')
         self.mofcomp = MOFCompiler(
             MOFWBEMConnection(),
@@ -91,6 +92,7 @@ class MOFTest(unittest.TestCase):
             print(msg, file=self.logfile2)
 
         moflog_file2 = os.path.join(TEST_DIR, 'moflog2.txt')
+        # pylint: disable=consider-using-with
         self.logfile2 = open(moflog_file2, 'w')
         self.mofcomp2 = MOFCompiler(
             MOFWBEMConnection(),
@@ -2243,6 +2245,8 @@ class TestFullSchema(MOFTest):
 
         # Create file for mof output
         mofout_filename = os.path.join(TEST_DIR, TMP_FILE)
+
+        # pylint: disable=consider-using-with
         mof_out_hndl = open(mofout_filename, 'w')
 
         # Output and verify the qualifier declarations
@@ -2732,6 +2736,7 @@ class Test_CreateInstanceWithDups(unittest.TestCase):
             print(msg, file=self.logfile)
 
         moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
+        # pylint: disable=consider-using-with
         self.logfile = open(moflog_file, 'w')
         self.mofcomp = MOFCompiler(
             MOFWBEMConnectionInstDups(),

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 
 import os
+import io
 import unittest
 import re
 import pytest
@@ -75,7 +76,7 @@ class MOFTest(unittest.TestCase):
 
         moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
         # pylint: disable=consider-using-with
-        self.logfile = open(moflog_file, 'w')
+        self.logfile = io.open(moflog_file, 'w', encoding='utf-8')
         self.mofcomp = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],
@@ -93,7 +94,7 @@ class MOFTest(unittest.TestCase):
 
         moflog_file2 = os.path.join(TEST_DIR, 'moflog2.txt')
         # pylint: disable=consider-using-with
-        self.logfile2 = open(moflog_file2, 'w')
+        self.logfile2 = io.open(moflog_file2, 'w', encoding='utf-8')
         self.mofcomp2 = MOFCompiler(
             MOFWBEMConnection(),
             search_paths=None, verbose=False,
@@ -2247,7 +2248,7 @@ class TestFullSchema(MOFTest):
         mofout_filename = os.path.join(TEST_DIR, TMP_FILE)
 
         # pylint: disable=consider-using-with
-        mof_out_hndl = open(mofout_filename, 'w')
+        mof_out_hndl = io.open(mofout_filename, 'w', encoding='utf-8')
 
         # Output and verify the qualifier declarations
         orig_qual_decls = repo.qualifiers[NAME_SPACE]
@@ -2308,7 +2309,7 @@ class TestPartialSchema(MOFTest):
         Build  a schema include file that has a subset of the files in
         a complete DMTF schema.
         """
-        schema_mof = """
+        schema_mof = u"""
             #pragma locale ("en_US")
             #pragma include ("Interop/CIM_RegisteredProfile.mof")
             #pragma include ("Interop/CIM_ObjectManager.mof")
@@ -2349,7 +2350,7 @@ class TestPartialSchema(MOFTest):
         self.partial_schema_file = 'test_partial_schema.mof'
         test_schemafile = os.path.join(TEST_DMTF_CIMSCHEMA_MOF_DIR,
                                        self.partial_schema_file)
-        with open(test_schemafile, "w") as sf:
+        with io.open(test_schemafile, "w", encoding='utf-8') as sf:
             sf.write(schema_mof)
 
         self.mofcomp.compile_file(test_schemafile, NAME_SPACE)
@@ -2737,7 +2738,7 @@ class Test_CreateInstanceWithDups(unittest.TestCase):
 
         moflog_file = os.path.join(TEST_DIR, 'moflog.txt')
         # pylint: disable=consider-using-with
-        self.logfile = open(moflog_file, 'w')
+        self.logfile = io.open(moflog_file, 'w', encoding='utf-8')
         self.mofcomp = MOFCompiler(
             MOFWBEMConnectionInstDups(),
             search_paths=[TEST_DMTF_CIMSCHEMA_MOF_DIR],

--- a/tests/unittest/pywbem/test_perf_equality.py
+++ b/tests/unittest/pywbem/test_perf_equality.py
@@ -6,6 +6,8 @@ Measure performance of equality tests.
 
 from __future__ import absolute_import
 
+import io
+
 import pytest
 import six
 try:
@@ -116,7 +118,7 @@ def test_perf_eq(desc, obj1, obj2):
 
     stdev_pct = 100.0 * stdev_us / t_us if t_us != 0 else 0.0
 
-    with open(outfile, 'a') as fp:
+    with io.open(outfile, 'a', encoding='utf-8') as fp:
         fp.write("{}: {:.3f} us (std.dev. {:.1f}% in {} runs with {} "
                  "outliers)\n".
                  format(desc, t_us, stdev_pct, num_runs, num_out))

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -9,11 +9,10 @@ from __future__ import absolute_import, print_function
 # pylint: disable=too-many-lines,no-self-use
 import sys
 import os
-import os.path
+import io
 import logging
 import logging.handlers
 import warnings
-from io import open as _open
 from datetime import datetime, timedelta
 
 import pytest
@@ -764,7 +763,7 @@ def load_recorder_yaml_file():
     Load the test YAML file created by the test recorder and return its content
     as a dict.
     """
-    with _open(TEST_YAML_FILE, encoding="utf-8") as fp:
+    with io.open(TEST_YAML_FILE, encoding="utf-8") as fp:
         yaml_content = yaml.load(
             fp, Loader=yamlloader.ordereddict.CSafeLoader)
     return yaml_content
@@ -797,7 +796,7 @@ def test_BaseOperationRecorder_init():
     assert is_inherited_from(
         'enabled', _TestClientRecorder, BaseOperationRecorder)
 
-    with open(os.devnull, 'w') as fp:
+    with io.open(os.devnull, 'w', encoding='utf-8') as fp:
 
         # The code to be tested
         recorder = _TestClientRecorder(fp)
@@ -821,7 +820,7 @@ def test_BaseOperationRecorder_enable_disable():
     assert is_inherited_from(
         'enabled', _TestClientRecorder, BaseOperationRecorder)
 
-    with open(os.devnull, 'w') as fp:
+    with io.open(os.devnull, 'w', encoding='utf-8') as fp:
 
         recorder = _TestClientRecorder(fp)
 
@@ -924,7 +923,7 @@ def test_BaseOperationRecorder_open_file(testcase, text, exp_bytes):
     fp.write(text)
     fp.close()
 
-    with open(tmp_filename, 'rb') as fp:
+    with io.open(tmp_filename, 'rb') as fp:
         act_bytes = fp.read()
     assert act_bytes == exp_bytes
 
@@ -1287,7 +1286,7 @@ def test_TestClientRecorder_toyaml(testcase, obj, exp_yaml):
     Test function for TestClientRecorder.toyaml()
     """
 
-    with open(os.devnull, 'w') as fp:
+    with io.open(os.devnull, 'w', encoding='utf-8') as fp:
 
         recorder = _TestClientRecorder(fp)
         recorder.reset()

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -797,16 +797,12 @@ def test_BaseOperationRecorder_init():
     assert is_inherited_from(
         'enabled', _TestClientRecorder, BaseOperationRecorder)
 
-    try:
-        fp = open(os.devnull, 'w')
+    with open(os.devnull, 'w') as fp:
 
         # The code to be tested
         recorder = _TestClientRecorder(fp)
 
         assert recorder.enabled is True
-
-    finally:
-        fp.close()
 
 
 def test_BaseOperationRecorder_enable_disable():
@@ -825,8 +821,7 @@ def test_BaseOperationRecorder_enable_disable():
     assert is_inherited_from(
         'enabled', _TestClientRecorder, BaseOperationRecorder)
 
-    try:
-        fp = open(os.devnull, 'w')
+    with open(os.devnull, 'w') as fp:
 
         recorder = _TestClientRecorder(fp)
 
@@ -845,9 +840,6 @@ def test_BaseOperationRecorder_enable_disable():
         # The code to be tested
         recorder.enable()
         assert recorder.enabled is True
-
-    finally:
-        fp.close()
 
 
 TESTCASES_BASEOPERATIONRECORDER_OPEN_FILE = [
@@ -1295,8 +1287,7 @@ def test_TestClientRecorder_toyaml(testcase, obj, exp_yaml):
     Test function for TestClientRecorder.toyaml()
     """
 
-    try:
-        fp = open(os.devnull, 'w')
+    with open(os.devnull, 'w') as fp:
 
         recorder = _TestClientRecorder(fp)
         recorder.reset()
@@ -1304,9 +1295,6 @@ def test_TestClientRecorder_toyaml(testcase, obj, exp_yaml):
 
         # The code to be tested
         act_yaml = recorder.toyaml(obj)
-
-    finally:
-        fp.close()
 
     assert act_yaml == exp_yaml
 

--- a/tests/unittest/pywbem/test_units.py
+++ b/tests/unittest/pywbem/test_units.py
@@ -40,7 +40,7 @@ TESTCASES_SIUNIT_OBJ = [
     (
         "No input argument (cim_obj is required)",
         dict(
-            in_kwargs=dict(),
+            in_kwargs={},
             exp_result=None,
         ),
         TypeError, None, True
@@ -199,7 +199,7 @@ TESTCASES_SIUNIT_GENERAL = [
     (
         "No input arguments",
         dict(
-            in_kwargs=dict(),
+            in_kwargs={},
             exp_result=None,
         ),
         None, None, True

--- a/tests/unittest/pywbem/test_utils.py
+++ b/tests/unittest/pywbem/test_utils.py
@@ -261,7 +261,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=u"",
             format_args=[],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="",
         ),
         None, None, True
@@ -271,7 +271,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=b"",
             format_args=[],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="",
         ),
         None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
@@ -281,7 +281,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="",
             format_args=[],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="",
         ),
         None, None, True
@@ -291,7 +291,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=u"{0}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result=u"abc",
         ),
         None, None, True
@@ -301,7 +301,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=b"{0}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result=u"abc",
         ),
         None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
@@ -311,7 +311,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result=u"abc",
         ),
         None, None, True
@@ -321,7 +321,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=u"{0}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None, None, True
@@ -331,7 +331,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=b"{0}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None if BYTE_FORMAT_SUPPORTED else TypeError, None, True
@@ -341,7 +341,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None, None, True
@@ -351,7 +351,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=u"{0!s}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="abc" if six.PY2 else "b'abc'",
         ),
         None, None, True
@@ -361,7 +361,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str=u"{0!s}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="abc",
         ),
         None, None, True
@@ -371,7 +371,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!r}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'abc'" if six.PY2 else "b'abc'",
         ),
         None, None, True
@@ -381,7 +381,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!r}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="u'abc'" if six.PY2 else "'abc'",
         ),
         None, None, True
@@ -391,7 +391,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!a}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'abc'" if six.PY2 else "b'abc'",
         ),
         None, None, True
@@ -401,7 +401,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!a}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="u'abc'" if six.PY2 else "'abc'",
         ),
         None, None, True
@@ -411,7 +411,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[b"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'abc'",
         ),
         None, None, True
@@ -421,7 +421,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[u"abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'abc'",
         ),
         None, None, True
@@ -431,7 +431,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[u"a\u00E0b"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'a\\u00e0b'",
         ),
         None, None, True
@@ -441,7 +441,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[u"a\u0412b"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'a\\u0412b'",
         ),
         None, None, True
@@ -451,7 +451,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[u"a\U0001D122b"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="'a\\U0001d122b'",
         ),
         None, None, True
@@ -461,7 +461,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[['a', 'b']],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="['a', 'b']",
         ),
         None, None, True
@@ -471,7 +471,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[('a', 'b')],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="('a', 'b')",
         ),
         None, None, True
@@ -481,7 +481,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[set(['a'])],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="{'a'}",
         ),
         None, None, True
@@ -491,7 +491,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[{'a': 1}],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="{'a': 1}",
         ),
         None, None, True
@@ -501,7 +501,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[OrderedDict([('a', 1), ('b', 2)])],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="OrderedDict({'a': 1, 'b': 2})",
         ),
         None, None, True
@@ -511,7 +511,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!A}",
             format_args=[NocaseDict([('a', 1), ('b', 2)])],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result="NocaseDict({'a': 1, 'b': 2})",
         ),
         None, None, True
@@ -521,7 +521,7 @@ TESTCASES_FORMAT_FIXED = [
         dict(
             format_str="{0!x}",
             format_args=["abc"],
-            format_kwargs=dict(),
+            format_kwargs={},
             exp_result=None,
         ),
         ValueError, None, True

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -97,7 +97,7 @@ def simple_args(request):
 
 @pytest.fixture(params=[
     # Tuple of (conn_id_kwarg, exp_conn_str)
-    (dict(), TEST_CONN_STR_NONE),
+    ({}, TEST_CONN_STR_NONE),
     (dict(conn_id=None), TEST_CONN_STR_NONE),
     (dict(conn_id=TEST_CONN_ID), TEST_CONN_STR),
 ], scope='module')

--- a/tests/unittest/pywbem_mock/test_complexassoc.py
+++ b/tests/unittest/pywbem_mock/test_complexassoc.py
@@ -28,6 +28,7 @@ of processing complex associations including ternary associations (more than
 from __future__ import absolute_import, print_function
 
 import os
+import io
 
 import pytest
 
@@ -225,10 +226,11 @@ def save_data(conn, mof, request, response, exp_response):
             conn.display_repository(dest=COMPLEX_MODEL_OUT_MOF)
 
         if not os.path.exists(COMPLEX_MODEL_MOF):
-            with open('complex_association_model.mof', 'w') as f:
+            with io.open('complex_association_model.mof', 'w',
+                         encoding='utf-8') as f:
                 print(mof, file=f)
 
-        with open(PYWBEMCLI_CMDS, 'a') as f:
+        with io.open(PYWBEMCLI_CMDS, 'a', encoding='utf-8') as f:
             print('%s ' % request, file=f)
             print("Resp : %s" % response, file=f)
             print("ExpResp : %s" % exp_response, file=f)
@@ -336,7 +338,7 @@ def test_complexref_classnames(conn, ns, target, r, rc, mof, exp_rslt,
     if cond == 'pdb':
         # pylint: disable=import-outside-toplevel
         import pdb
-        pdb.set_trace()  # pylint: disable=no-member
+        pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
     rtn_clns = conn.ReferenceNames(target, ResultClass=rc, Role=r)
     exp_ns = ns or conn.default_namespace
@@ -488,7 +490,7 @@ def test_complexref_instnames(conn, ns, target, r, rc, mof, exp_rslt,
     if cond == 'pdb':
         # pylint: disable=import-outside-toplevel
         import pdb
-        pdb.set_trace()  # pylint: disable=no-member
+        pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
     target_inst = CIMInstanceName(target[0],
                                   keybindings={'InstanceID': target[1]},
@@ -621,7 +623,7 @@ def test_complexassoc_classnames(conn, ns, target, r, rr, ac,
     if cond == 'pdb':
         # pylint: disable=import-outside-toplevel
         import pdb
-        pdb.set_trace()  # pylint: disable=no-member
+        pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
     rtn_clns = conn.AssociatorNames(target,
                                     AssocClass=ac,
@@ -1146,7 +1148,7 @@ def test_complexassoc_instnames(conn, ns, target, r, rr, ac,
     if cond == 'pdb':
         # pylint: disable=import-outside-toplevel
         import pdb
-        pdb.set_trace()  # pylint: disable=no-member
+        pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
     skip_if_moftab_regenerated()
 

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -523,7 +523,7 @@ def test_repository_valid_methods(desc, args, condition, capsys):
                 .format(desc, name)
 
             rtnd_obj = xxx_repo.get(name)
-            assert rtnd_obj == input_items[type_dict][name]
+            assert rtnd_obj == obj
 
             # update each object with the same object as originally installed.
             xxx_repo.update(name, obj)
@@ -537,10 +537,10 @@ def test_repository_valid_methods(desc, args, condition, capsys):
 
         # Test iter_names and iter_values
         names = list(xxx_repo.iter_names())
-        assert set(names) == set(input_items[type_dict].keys())
+        assert set(names) == set(obj_dict.keys())
 
         objs = list(xxx_repo.iter_values())
-        assert set(objs) == set(input_items[type_dict].values())
+        assert set(objs) == set(obj_dict.values())
 
         for name, obj in obj_dict.items():
             xxx_repo.delete(name)

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -31,6 +31,7 @@ simplified_test_function completely controls the test parameters.
 from __future__ import absolute_import, print_function
 
 import os
+import io
 import shutil
 import re
 from copy import deepcopy
@@ -1649,7 +1650,7 @@ class TestRepoMethods(object):
         conn.display_repository(dest=tst_file)
 
         assert os.path.isfile(tst_file)
-        with open(tst_file, 'r') as f:
+        with io.open(tst_file, 'r', encoding='utf-8') as f:
             data = f.read()
         # test key parts of resulting file.
         assert data.startswith(
@@ -1724,7 +1725,7 @@ class TestRepoMethods(object):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         conn.add_cimobjects(tst_classeswqualifiers, namespace=ns)
         conn.add_cimobjects(tst_instances, namespace=ns)
@@ -2782,7 +2783,7 @@ class TestUserDefinedProviders(object):
 
         if condition == "pdb":
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         add_objects_to_repo(conn, ns, tst_classeswqualifiersandinsts)
 
@@ -2928,7 +2929,7 @@ class TestUserDefinedProviders(object):
 
         if condition == "pdb":
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         skip_if_moftab_regenerated()
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
@@ -3054,7 +3055,7 @@ class TestUserDefinedProviders(object):
 
         if condition == "pdb":
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         nss = []
         for item in inputs:
@@ -3524,7 +3525,7 @@ class TestClassOperations(object):
         rslt_pl = rslt_cl.properties.keys()
         assert set(rslt_pl) == set(exp_pl)
 
-        tst_cls_dict = dict()
+        tst_cls_dict = {}
         for cl in tst_classes:
             tst_cls_dict[cl.classname] = resolve_class(conn, cl, ns)
 
@@ -6157,7 +6158,7 @@ class TestInstanceOperations(object):
             (
                 "Create namespace with missing Name property in instance",
                 ['root/blah'],
-                CIMInstance('CIM_Namespace', properties=dict()),
+                CIMInstance('CIM_Namespace', properties={}),
                 None, CIMError(CIM_ERR_INVALID_PARAMETER)
             ),
         ]
@@ -6423,7 +6424,7 @@ class TestInstanceOperations(object):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers, tst_instances])
 
@@ -9575,7 +9576,7 @@ class TestInvokeMethod(object):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         if not exp_exc:
             # Two calls to account for **params
@@ -9784,7 +9785,7 @@ class TestBaseProvider(object):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()  # pylint: disable=no-member
+            pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
         add_objects_to_repo(conn, ns, [tst_classeswqualifiers])
 

--- a/tests/unittest/resourcetest/test_memory_utils.py
+++ b/tests/unittest/resourcetest/test_memory_utils.py
@@ -46,7 +46,7 @@ if ENABLE_TESTS:
     SIZE_SET = size_obj(set())
     SIZE_CLASS = size_obj(EC_OBJ)
     SIZE_CLASS_DICT = size_obj(EC_OBJ.__dict__)
-    SIZE_REF = struct.calcsize('P')
+    SIZE_REF = struct.calcsize('P')  # pylint: disable=no-member
 
     TESTCASES_TOTAL_SIZEOF = [
 

--- a/tests/unittest/resourcetest/test_memory_utils.py
+++ b/tests/unittest/resourcetest/test_memory_utils.py
@@ -36,16 +36,6 @@ if ENABLE_TESTS:
         """
         return sys.getsizeof(obj)
 
-    EC_OBJ = EmptyClass()
-
-    SIZE_NONE = size_obj(None)
-    SIZE_INT = size_obj(42)
-    SIZE_TUPLE = size_obj(tuple())
-    SIZE_LIST = size_obj([])
-    SIZE_DICT = size_obj({})
-    SIZE_SET = size_obj(set())
-    SIZE_CLASS = size_obj(EC_OBJ)
-    SIZE_CLASS_DICT = size_obj(EC_OBJ.__dict__)
     SIZE_REF = struct.calcsize('P')  # pylint: disable=no-member
 
     TESTCASES_TOTAL_SIZEOF = [
@@ -66,7 +56,7 @@ if ENABLE_TESTS:
             "Test None",
             dict(
                 obj=None,
-                exp_size=SIZE_NONE,
+                exp_size=size_obj(None),
             ),
             None, None, True
         ),
@@ -74,7 +64,7 @@ if ENABLE_TESTS:
             "Test int",
             dict(
                 obj=2020,
-                exp_size=SIZE_INT,
+                exp_size=size_obj(2020),
             ),
             None, None, True
         ),
@@ -124,7 +114,7 @@ if ENABLE_TESTS:
             "Test empty tuple",
             dict(
                 obj=tuple(),
-                exp_size=SIZE_TUPLE,
+                exp_size=size_obj(tuple()),
             ),
             None, None, True
         ),
@@ -132,7 +122,7 @@ if ENABLE_TESTS:
             "Test tuple with one int item",
             dict(
                 obj=(2000,),
-                exp_size=SIZE_TUPLE + 1 * (SIZE_REF + SIZE_INT),
+                exp_size=size_obj((42,)) + size_obj(42),
             ),
             None, None, True
         ),
@@ -140,7 +130,7 @@ if ENABLE_TESTS:
             "Test tuple with two int items",
             dict(
                 obj=(2000, 2001),
-                exp_size=SIZE_TUPLE + 2 * (SIZE_REF + SIZE_INT),
+                exp_size=size_obj((42, 43)) + 2 * size_obj(42),
             ),
             None, None, True
         ),
@@ -149,7 +139,7 @@ if ENABLE_TESTS:
             "Test empty list",
             dict(
                 obj=[],
-                exp_size=SIZE_LIST,
+                exp_size=size_obj([]),
             ),
             None, None, True
         ),
@@ -157,7 +147,7 @@ if ENABLE_TESTS:
             "Test list with one int item",
             dict(
                 obj=[2000],
-                exp_size=SIZE_LIST + 1 * (SIZE_REF + SIZE_INT),
+                exp_size=size_obj([42]) + size_obj(42),
             ),
             None, None, True
         ),
@@ -165,7 +155,7 @@ if ENABLE_TESTS:
             "Test list with two int items",
             dict(
                 obj=[2000, 2001],
-                exp_size=SIZE_LIST + 2 * (SIZE_REF + SIZE_INT),
+                exp_size=size_obj([42, 43]) + 2 * size_obj(42),
             ),
             None, None, True
         ),
@@ -174,7 +164,7 @@ if ENABLE_TESTS:
             "Test empty dict",
             dict(
                 obj={},
-                exp_size=SIZE_DICT,
+                exp_size=size_obj({}),
             ),
             None, None, True
         ),
@@ -182,7 +172,7 @@ if ENABLE_TESTS:
             "Test dict with one int/int item",
             dict(
                 obj={2000: 2001},
-                exp_size=SIZE_DICT + 2 * SIZE_INT,
+                exp_size=size_obj({42: 43}) + 2 * size_obj(42),
             ),
             None, None, True
         ),
@@ -190,7 +180,7 @@ if ENABLE_TESTS:
             "Test dict with two int/int items",
             dict(
                 obj={2000: 2001, 2002: 2003},
-                exp_size=SIZE_DICT + 4 * SIZE_INT,
+                exp_size=size_obj({42: 43, 44: 45}) + 4 * size_obj(42),
             ),
             None, None, True
         ),
@@ -235,7 +225,7 @@ if ENABLE_TESTS:
                         'Q1', type='string', value=None)) +
                     size_obj(u'Q1') +  # _name
                     size_obj(u'string') +  # _type
-                    SIZE_NONE +  # _value (first None object)
+                    size_obj(None) +  # _value (first None object)
                     SIZE_REF +  # _propagated
                     SIZE_REF +  # _overridable
                     SIZE_REF +  # _tosubclass

--- a/tests/unittest/resourcetest/test_memory_utils.py
+++ b/tests/unittest/resourcetest/test_memory_utils.py
@@ -41,8 +41,8 @@ if ENABLE_TESTS:
     SIZE_NONE = size_obj(None)
     SIZE_INT = size_obj(42)
     SIZE_TUPLE = size_obj(tuple())
-    SIZE_LIST = size_obj(list())
-    SIZE_DICT = size_obj(dict())
+    SIZE_LIST = size_obj([])
+    SIZE_DICT = size_obj({})
     SIZE_SET = size_obj(set())
     SIZE_CLASS = size_obj(EC_OBJ)
     SIZE_CLASS_DICT = size_obj(EC_OBJ.__dict__)
@@ -148,7 +148,7 @@ if ENABLE_TESTS:
         (
             "Test empty list",
             dict(
-                obj=list(),
+                obj=[],
                 exp_size=SIZE_LIST,
             ),
             None, None, True
@@ -173,7 +173,7 @@ if ENABLE_TESTS:
         (
             "Test empty dict",
             dict(
-                obj=dict(),
+                obj={},
                 exp_size=SIZE_DICT,
             ),
             None, None, True

--- a/tests/unittest/utils/pytest_extensions.py
+++ b/tests/unittest/utils/pytest_extensions.py
@@ -133,6 +133,7 @@ def simplified_test_function(test_func):
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
+                            # pylint: disable=forgotten-debug-statement
                             pdb.set_trace()
 
                         test_func(testcase, **kwargs)  # expecting an exception
@@ -143,6 +144,7 @@ def simplified_test_function(test_func):
                     # exception).
                 else:
                     if condition == 'pdb':
+                        # pylint: disable=forgotten-debug-statement
                         pdb.set_trace()
 
                     test_func(testcase, **kwargs)  # not expecting an exception
@@ -155,6 +157,7 @@ def simplified_test_function(test_func):
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
+                            # pylint: disable=forgotten-debug-statement
                             pdb.set_trace()
 
                         test_func(testcase, **kwargs)  # expecting an exception
@@ -162,6 +165,7 @@ def simplified_test_function(test_func):
                     ret = None  # Debugging hint
                 else:
                     if condition == 'pdb':
+                        # pylint: disable=forgotten-debug-statement
                         pdb.set_trace()
 
                     test_func(testcase, **kwargs)  # not expecting an exception

--- a/tests/unittest/utils/validate.py
+++ b/tests/unittest/utils/validate.py
@@ -127,6 +127,7 @@ def validate_cim_xml(cim_xml_str, root_elem_name=None):
     else:
         xmllint_cmd = 'xmllint --dtdvalid {0} --noout -'.format(dtd_file_fw)
 
+    # pylint: disable=consider-using-with
     p = Popen(xmllint_cmd, stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True)
 
     cim_xml_str = _ensure_bytes(cim_xml_str)

--- a/tests/unittest/utils/validate.py
+++ b/tests/unittest/utils/validate.py
@@ -62,7 +62,7 @@ Note: Changes in DSP0203 2.4.0, compared to 2.3.1:
 
 from __future__ import print_function, absolute_import
 
-import os.path
+import os
 import re
 from subprocess import Popen, PIPE, STDOUT
 

--- a/tools/ipython_toc.py
+++ b/tools/ipython_toc.py
@@ -7,12 +7,13 @@ Returns string to paste into notebook.
 '''
 
 import sys
+import io
 import json
 
 
 def main(ifilepath):
 
-    with open(ifilepath, 'r') as infile:
+    with io.open(ifilepath, 'r', encoding='utf-8') as infile:
         notebook = json.loads(infile.read())
 
     cells = notebook['cells']


### PR DESCRIPTION
Rolls back PRs #2754 and #2759 into 1.2.1.