### PR TITLE
Simplified auto-generated Name of owned filter instances

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,6 +56,12 @@ Released: not yet
   the MOF compiler and pywbem_mock would build the instance
   (see issue # 2742).
 
+* The new simplified format of the automatically generated 'Name' property of
+  owned indication filters causes existing filters with the old format to
+  be ignored and a Python warning of type 'pywbem.OldNameFilterWarning' will be
+  issued. Such filter instances need to be cleaned up by the user.
+  (related to issue #2765)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -203,6 +209,18 @@ Released: not yet
 * Pylint: Removed pinning of Pylint to <2.7.0 because the performance issue
   can also be addressed by disabling the similarity checker, and addressed
   Pylint issues reported by Pylint 2.9. (issue #2672)
+
+* Simplified the format of the automatically generated 'Name' property of owned
+  indication filters from:
+  ``"pywbemfilter:" {ownership} ":" {client_host} ":" {submgr_id} ":" {filter_id} ":" {guid}``
+  to:
+  ``"pywbemfilter:" {submgr_id} ":" {filter_id}``.
+  The client host was removed in order to allow different client systems to be
+  used. The ownership was removed because filters with an auto-generated Name
+  are always owned. The GUID was removed to make the name predictable and the
+  uniqueness it attempted to guarantee is now achieved by rejecting the creation
+  of filters with the same name. Overall, this change makes the name much more
+  suitable for use in CLI tools such as pywbemcli. (issue #2765)
 
 **Cleanup:**
 

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -25,7 +25,7 @@ from ._exceptions import Error
 # This module is meant to be safe for 'import *'.
 
 __all__ = ['Warning', 'ToleratedServerIssueWarning',
-           'MissingKeybindingsWarning']
+           'MissingKeybindingsWarning', 'OldNameFilterWarning']
 
 
 class Warning(Error, six.moves.builtins.Warning):
@@ -52,5 +52,16 @@ class MissingKeybindingsWarning(Warning):
 
     A local creation of :class:`~pywbem.CIMinstanceName` objects without
     keybindings does not issue this warning.
+    """
+    pass
+
+
+class OldNameFilterWarning(Warning):
+    """
+    This warning indicates that an owned indication filter instance with an old
+    name format (prior to pywbem 1.3) was discovered on the WBEM server.
+
+    Such filters are ignored when discovering owned filters. They should be
+    cleaned up by the user.
     """
     pass

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -13,7 +13,8 @@ import pytest
 # pylint: disable=redefined-builtin
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
-from pywbem import Warning, ToleratedServerIssueWarning  # noqa: E402
+from pywbem import Warning, ToleratedServerIssueWarning, \
+    MissingKeybindingsWarning, OldNameFilterWarning  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
@@ -68,6 +69,8 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     # The warning classes for which the simple test should be done:
     Warning,
     ToleratedServerIssueWarning,
+    MissingKeybindingsWarning,
+    OldNameFilterWarning,
 ], scope='module')
 def simple_class(request):
     """


### PR DESCRIPTION
See commit message.

Note that this PR only addresses this for filter names (see issue #2765).
A separate PR will be made for destination names (see issue #2766).