### PR TITLE
1.2: Mitigated Pylint issues 'deprecated-method' and 'not-an-iterable'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -51,6 +51,9 @@ Released: not yet
 * Mitigated Pylint issue 'deprecated-method' when using time.perf_counter()
   on Python versions 3.6 and 3.7. (issue #2768)
 
+* Mitigated new Pylint error 'not-an-iterable' when using 'WBEMServer'
+  properties that return lists and use deferred initialization. (issue #2770)
+
 **Enhancements:**
 
 * Added toleration support for WBEM servers that return a CIM status

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,9 @@ Released: not yet
 * Fixed installation with setup.py on ubuntu for Python 2.7, 3.4, 3.5, by
   pinning yamlloader to <1.0.0. (issue #2745)
 
+* Mitigated Pylint issue 'deprecated-method' when using time.perf_counter()
+  on Python versions 3.6 and 3.7. (issue #2768)
+
 **Enhancements:**
 
 * Added toleration support for WBEM servers that return a CIM status

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -45,11 +45,14 @@ from nocaselist import NocaseList
 
 # pylint: disable=ungrouped-imports
 try:
-    # time.perf_counter() was added in Python 3.3
-    from time import perf_counter as delta_time
+    from time import perf_counter
 except ImportError:
-    # time.clock() was deprecated in Python 3.3
-    from time import clock as delta_time
+    # For Python <3.3, fall back to time.clock() (deprecated since Python 3.3).
+    # Note: On Python 3.6 and 3.7, Pylint 2.10.2 raises the warning
+    #       'deprecated-method' on the lines where perf_counter() is used.
+    #       Remove disabling that warning once Pylint issue
+    #       https://github.com/PyCQA/pylint/issues/4966 is resolved.
+    from time import clock as perf_counter
 # pylint: enable=ungrouped-imports
 
 from pywbem import CIMClass, CIMClassName, CIMInstanceName, \
@@ -2676,7 +2679,7 @@ class MainProvider(ResolverMixin, BaseProvider):
                 {'pull_type': pull_type,
                  'data': objects,
                  'namespace': namespace,
-                 'time': delta_time(),
+                 'time': perf_counter(),  # pylint: disable=deprecated-method
                  'interoptimeout': timeout,
                  'continueonerror': ContinueOnError}
             rtn_objects = objects[0:max_obj_cnt]

--- a/tests/end2endtest/test_profile_generic.py
+++ b/tests/end2endtest/test_profile_generic.py
@@ -104,6 +104,7 @@ def test_undefined_profiles(wbem_connection):  # noqa: F811
         'RegisteredOrganization')
 
     undefined_profile_ids = []
+    # pylint: disable=not-an-iterable
     for inst in server_prop_asserted(server, 'profiles'):
         org = org_vm.tovalues(inst['RegisteredOrganization'])
         name = inst['RegisteredName']

--- a/tests/end2endtest/test_profile_snia_server.py
+++ b/tests/end2endtest/test_profile_snia_server.py
@@ -140,6 +140,7 @@ class Test_SNIA_Server_Profile(ProfileTest):
             self.server, 'interop_ns').lower()
         if interop_ns_lower not in inst_names:
             inst_names.append(interop_ns_lower)
+        # pylint: disable=not-an-iterable
         determined_names = [ns.lower()
                             for ns in server_prop_asserted(
                                 self.server, 'namespaces')]

--- a/tests/end2endtest/test_server.py
+++ b/tests/end2endtest/test_server.py
@@ -38,6 +38,7 @@ def test_namespace_consistency(
     msg = "for server at URL {0!r}".format(wbem_connection.url)
 
     interop_ns_lower = server_prop_asserted(server, 'interop_ns').lower()
+    # pylint: disable=not-an-iterable
     namespaces_lower = [ns.lower()
                         for ns in server_prop_asserted(server, 'namespaces')]
     namespace_paths = server_prop_asserted(server, 'namespace_paths')
@@ -48,6 +49,7 @@ def test_namespace_consistency(
     # does not represent it as a CIM instance. In that case, server.namespaces
     # contains the Interop namespace while server.namespace_paths does not.
     # The following checks accomodate that.
+    # pylint: disable=not-an-iterable
     for ns_path in namespace_paths:
         assert ns_path.namespace.lower() == interop_ns_lower, msg
         ns_path_name_lower = ns_path['Name'].lower()
@@ -68,6 +70,7 @@ def test_namespace_getinstance(
 
     namespace_paths = server_prop_asserted(server, 'namespace_paths')
 
+    # pylint: disable=not-an-iterable
     for path in namespace_paths:
 
         inst = wbem_connection.GetInstance(
@@ -146,6 +149,7 @@ def test_profiles(
 
     interop_ns_lower = server_prop_asserted(server, 'interop_ns').lower()
 
+    # pylint: disable=not-an-iterable
     for profile_inst in profile_insts:
         assert profile_inst.path is not None, msg
         assert profile_inst.path.namespace.lower() == interop_ns_lower, msg
@@ -177,5 +181,6 @@ def test_get_selected_profiles_no_filter(
     all_profile_insts = server_func_asserted(server, 'get_selected_profiles')
 
     assert len(profile_insts) == len(all_profile_insts), msg
+    # pylint: disable=not-an-iterable
     for inst in profile_insts:
         assert inst in all_profile_insts, msg


### PR DESCRIPTION
Rolls back PR #2769 into 1.2.1.