### PR TITLE
Changes for creating listener destinations in WBEMSubscriptionManager

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -59,8 +59,22 @@ Released: not yet
 * The new simplified format of the automatically generated 'Name' property of
   owned indication filters causes existing filters with the old format to
   be ignored and a Python warning of type 'pywbem.OldNameFilterWarning' will be
-  issued. Such filter instances need to be cleaned up by the user.
-  (related to issue #2765)
+  issued. Such owned filter instances need to be either removed as owned filters
+  with a prior version of pywbem, or as permanent filters with this version of
+  pywbem. (issue #2765)
+
+* Removed the 'pywbem.WBEMSubscriptionManager.add_listener_destinations()'
+  method, because the new naming approach for listener destinations requires
+  either a name or an ID and that does not work well with supporting multiple
+  destinations in one method call. Use the new 'add_destination()' method
+  instead. (issue #2766)
+
+* The new simplified format of the automatically generated 'Name' property of
+  owned listener destinations causes existing destinations with the old format
+  to be ignored and a Python warning of type 'pywbem.OldNameDestinationWarning'
+  will be issued. Such owned destination instances need to be either removed as
+  owned destinations with a prior version of pywbem, or as permanent
+  destinations with this version of pywbem. (issue #2766)
 
 **Deprecations:**
 
@@ -226,6 +240,23 @@ Released: not yet
   The new `ToleratedSchemaIssueWarning` is expected to be used where the
   MOF compiler or code detects issues in the CIM Schema that are either
   tolerated or corrected.
+
+* Added a 'pywbem.WBEMSubscriptionManager.add_destination()' method
+  that makes the way the 'Name' property is created for listener destination
+  intances consistent with how that is now done for indication filters: There is
+  a new parameter 'name' that directly sets the 'Name' property for permanent
+  destinations, and a new parameter 'destination_id' that is used for creating
+  the 'Name' property for owned destinations. The format of the generated 'Name'
+  property has been changed from:
+  ``"pywbemdestination:" {ownership} ":" {client_host} ":" {submgr_id} ":" {guid}``
+  to:
+  ``"pywbemdestination:" {submgr_id} ":" {destination_id}``.
+  The client host was removed in order to allow different client systems to be
+  used. The ownership was removed because destinations with an auto-generated
+  Name are always owned. The GUID was removed to make the name predictable and
+  the uniqueness it attempted to guarantee is now achieved by rejecting the
+  creation of destinations with the same name. Overall, this change makes the
+  name much more suitable for use in CLI tools such as pywbemcli. (issue #2766)
 
 **Cleanup:**
 
@@ -2477,7 +2508,7 @@ This version contains all fixes up to pywbem 0.12.6.
 
 * Add tests for the `WBEMSubscriptionManager` class using the pywbem mock
   support.  This involved
-  changing the tests for the `WBEMServer` class using pywbem_mock because the the
+  changing the tests for the `WBEMServer` class using pywbem_mock because the
   WBEMSubscriptionManager class depends on the existence of the classes and
   instances that support the pywbem WbemServer class existing in the WBEM
   server.  A new file (wbemserver_mock.py) was added to the tests

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -25,8 +25,8 @@ from ._exceptions import Error
 # This module is meant to be safe for 'import *'.
 
 __all__ = ['Warning', 'ToleratedServerIssueWarning',
-           'MissingKeybindingsWarning', 'OldNameFilterWarning',
-           'ToleratedSchemaIssueWarning']
+           'ToleratedSchemaIssueWarning', 'MissingKeybindingsWarning',
+           'OldNameFilterWarning', 'OldNameDestinationWarning']
 
 
 class Warning(Error, six.moves.builtins.Warning):
@@ -41,6 +41,14 @@ class ToleratedServerIssueWarning(Warning):
     """
     This warning indicates an issue with the WBEM server that has been
     tolerated by pywbem.
+    """
+    pass
+
+
+class ToleratedSchemaIssueWarning(Warning):
+    """
+    This warning indicates that a component in a DMTF CIM Schema is
+    invalid but the issue is tolerated or corrected by pywbem.
     """
     pass
 
@@ -68,9 +76,12 @@ class OldNameFilterWarning(Warning):
     pass
 
 
-class ToleratedSchemaIssueWarning(Warning):
+class OldNameDestinationWarning(Warning):
     """
-    This warning indicates that a component in a DMTF CIM Schema is
-    invalid but the issue is tolerated or corrected by pywbem.
+    This warning indicates that an owned listener destination instance with an
+    old name format (prior to pywbem 1.3) was discovered on the WBEM server.
+
+    Such destinations are ignored when discovering owned destinations. They
+    should be cleaned up by the user.
     """
     pass

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -6023,7 +6023,8 @@ class TestSubscriptionsClass(PyWBEMServerClass):
         for subscription_path in subscription_paths:
             self.assertTrue(subscription_path in all_sub_paths)
 
-    def add_peg_filter(self, sub_mgr, server_id, filter_id, owned=True):
+    def add_peg_filter(
+            self, sub_mgr, server_id, filter_id=None, name=None, owned=True):
         """
         Create a single filter definition in the sub_mgr and return it.
         This creates a filter specifically for OpenPegasus tests using the
@@ -6042,6 +6043,7 @@ class TestSubscriptionsClass(PyWBEMServerClass):
                                      self.test_query,
                                      query_language="DMTF:CQL",
                                      filter_id=filter_id,
+                                     name=name,
                                      owned=owned)
         return filter_
 
@@ -6175,11 +6177,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
                 try:
                     server_id = sub_mgr.add_server(server)
 
-                    sub_mgr.add_listener_destinations(server_id,
-                                                      self.listener_url)
+                    sub_mgr.add_destination(
+                        server_id, self.listener_url, owned=True,
+                        destination_id='dest1')
 
-                    filter_ = self.add_peg_filter(sub_mgr, server_id, 'NotUsed',
-                                                  owned=True)
+                    filter_ = self.add_peg_filter(
+                        sub_mgr, server_id, filter_id='filter1', owned=True)
 
                     subscriptions = sub_mgr.add_subscriptions(server_id,
                                                               filter_.path)
@@ -6246,10 +6249,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
 
                 server_id = sub_mgr.add_server(server)
 
-                sub_mgr.add_listener_destinations(server_id, self.listener_url)
+                sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=True,
+                    destination_id='dest1')
 
-                filter_ = self.add_peg_filter(sub_mgr, server_id, 'MyfilterId',
-                                              owned=True)
+                filter_ = self.add_peg_filter(
+                    sub_mgr, server_id, filter_id='filter1', owned=True)
 
                 # NOTE: The uuid from uuid4 is actually 36 char but not we
                 # made it  30-40 in case the format changes in future.
@@ -6332,10 +6337,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
             with WBEMSubscriptionManager(subscription_manager_id=sm) as sub_mgr:
 
                 server_id = sub_mgr.add_server(server)
-                sub_mgr.add_listener_destinations(server_id, self.listener_url)
+                sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=True,
+                    destination_id='dest1')
 
-                filter_ = self.add_peg_filter(sub_mgr, server_id, 'fred',
-                                              owned=True)
+                filter_ = self.add_peg_filter(
+                    sub_mgr, server_id, filter_id='filter1', owned=True)
 
                 subscriptions = sub_mgr.add_subscriptions(server_id,
                                                           filter_.path)
@@ -6354,9 +6361,9 @@ class TestSubscriptionsClass(PyWBEMServerClass):
                 self.assertTrue(filter_.path in owned_filter_paths)
 
                 # Confirm format of second dynamic filter name property
-                filter2 = self.add_peg_filter(sub_mgr, server_id,
-                                              'test_id_attributes1',
-                                              owned=True)
+                filter2 = self.add_peg_filter(
+                    sub_mgr, server_id, filter_id='test_id_attributes1',
+                    owned=True)
 
                 self.assert_regexp_matches(
                     filter2.path.keybindings['Name'],
@@ -6437,10 +6444,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
             with WBEMSubscriptionManager(subscription_manager_id=sm) as sub_mgr:
 
                 server_id = sub_mgr.add_server(server)
-                sub_mgr.add_listener_destinations(server_id, self.listener_url)
+                sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=True,
+                    destination_id='dest1')
 
-                filter_ = self.add_peg_filter(sub_mgr, server_id, 'fred',
-                                              owned=True)
+                filter_ = self.add_peg_filter(
+                    sub_mgr, server_id, filter_id='filter1', owned=True)
 
                 subscriptions = sub_mgr.add_subscriptions(server_id,
                                                           filter_.path)
@@ -6506,13 +6515,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
             server_id = sub_mgr.add_server(server)
 
             # Create non-owned subscription
-            dests = sub_mgr.add_listener_destinations(server_id,
-                                                      self.listener_url,
-                                                      owned=False)
+            dests = sub_mgr.add_destination(
+                server_id, self.listener_url, owned=False, name='name1')
             dest_paths = [inst.path for inst in dests]
 
-            filter_ = self.add_peg_filter(sub_mgr, server_id, 'notowned',
-                                          owned=False)
+            filter_ = self.add_peg_filter(
+                sub_mgr, server_id, name='name1', owned=False)
 
             subscriptions = sub_mgr.add_subscriptions(
                 server_id,
@@ -6577,13 +6585,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
                 server_id = sub_mgr.add_server(server)
 
                 # Create non-owned subscription
-                dests = sub_mgr.add_listener_destinations(server_id,
-                                                          self.listener_url,
-                                                          owned=False)
+                dests = sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=False, name='name1')
                 dest_paths = [inst.path for inst in dests]
 
-                filter_ = self.add_peg_filter(sub_mgr, server_id, 'notowned',
-                                              owned=False)
+                filter_ = self.add_peg_filter(
+                    sub_mgr, server_id, name='name1', owned=False)
 
                 subscriptions = sub_mgr.add_subscriptions(
                     server_id,
@@ -6673,10 +6680,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
                     subscription_manager_id='test_both_indications')
                 server_id = sub_mgr.add_server(server)
 
-                sub_mgr.add_listener_destinations(server_id, self.listener_url)
+                sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=True,
+                    destination_id='dest1')
 
-                filter_owned = self.add_peg_filter(sub_mgr, server_id, 'owned',
-                                                   owned=True)
+                filter_owned = self.add_peg_filter(
+                    sub_mgr, server_id, filter_id='filter1', owned=True)
 
                 subscriptions_owned = sub_mgr.add_subscriptions(
                     server_id, filter_owned.path)
@@ -6688,13 +6697,12 @@ class TestSubscriptionsClass(PyWBEMServerClass):
 
                 # Create non-owned dest, filter, subscription
 
-                n_owned_dests = sub_mgr.add_listener_destinations(
-                    server_id, self.listener_url, owned=False)
+                n_owned_dests = sub_mgr.add_destination(
+                    server_id, self.listener_url, owned=False, name='name1')
                 n_owned_dest_paths = [inst.path for inst in n_owned_dests]
 
-                n_owned_filter = self.add_peg_filter(sub_mgr, server_id,
-                                                     'notowned',
-                                                     owned=False)
+                n_owned_filter = self.add_peg_filter(
+                    sub_mgr, server_id, name='name1', owned=False)
 
                 n_owned_subscriptions = sub_mgr.add_subscriptions(
                     server_id,

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -14,8 +14,8 @@ import pytest
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
 from pywbem import Warning, ToleratedServerIssueWarning, \
-    MissingKeybindingsWarning, OldNameFilterWarning, \
-    ToleratedSchemaIssueWarning  # noqa: E402
+    ToleratedSchemaIssueWarning, MissingKeybindingsWarning, \
+    OldNameFilterWarning, OldNameDestinationWarning  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
@@ -70,9 +70,10 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     # The warning classes for which the simple test should be done:
     Warning,
     ToleratedServerIssueWarning,
+    ToleratedSchemaIssueWarning,
     MissingKeybindingsWarning,
     OldNameFilterWarning,
-    ToleratedSchemaIssueWarning,
+    OldNameDestinationWarning,
 ], scope='module')
 def simple_class(request):
     """


### PR DESCRIPTION
See commit message.

Particular review points might be:
* I left the `owned` parameter in the new `add_destination()` method, because I found it too implicit that the ownership type is determined just by the choice of `name` vs `destination_id` parameter, and for consistency with `add_filter()`.
**COMMENT/KS:** I agreed with you until I went through the code and API.  Now I begin to think that the owned parameter is redundant because it offers the user an option that does not really exist (mixing ownership and xxxx_id vs name)  By definition owned must be True if xxxx_id parameter exists and False if name parameter exists.  Having the owned parameter implies that the user could do owned=True/name=fred or owned=False/destination_id=fred so we have to add tests to disallow it..  I made comment about this in review.  I understand the reasoning about wanting to show the owned/permanent as a concept in the API but I think now that the redundancy overrides this.   Note that this is not a basic issue, the code works either way.  However, it is an issue we need to resolve to get on with pywbem tools prhttps://github.com/pywbem/pywbemtools/pull/987 **DISCUSSION**
* Other than discussed in the meeting, I had second thoughts on singularizing `add_subscriptions()` and left it as it is, because it works well with the other two add functions.  **COMMENT/KS:** Agree