### PR TITLE
Add Warning class for TolerateSchemaIssuesWarning

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -222,6 +222,11 @@ Released: not yet
   of filters with the same name. Overall, this change makes the name much more
   suitable for use in CLI tools such as pywbemcli. (issue #2765)
 
+* Added a `ToleratedSchemaIssueWarning` class with its base class `Warning`.
+  The new `ToleratedSchemaIssueWarning` is expected to be used where the
+  MOF compiler or code detects issues in the CIM Schema that are either
+  tolerated or corrected.
+
 **Cleanup:**
 
 * Extend tests for SubscriptionManager to utilize pytest and cover error cases.

--- a/pywbem/_warnings.py
+++ b/pywbem/_warnings.py
@@ -25,7 +25,8 @@ from ._exceptions import Error
 # This module is meant to be safe for 'import *'.
 
 __all__ = ['Warning', 'ToleratedServerIssueWarning',
-           'MissingKeybindingsWarning', 'OldNameFilterWarning']
+           'MissingKeybindingsWarning', 'OldNameFilterWarning',
+           'ToleratedSchemaIssueWarning']
 
 
 class Warning(Error, six.moves.builtins.Warning):
@@ -63,5 +64,13 @@ class OldNameFilterWarning(Warning):
 
     Such filters are ignored when discovering owned filters. They should be
     cleaned up by the user.
+    """
+    pass
+
+
+class ToleratedSchemaIssueWarning(Warning):
+    """
+    This warning indicates that a component in a DMTF CIM Schema is
+    invalid but the issue is tolerated or corrected by pywbem.
     """
     pass

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -14,7 +14,8 @@ import pytest
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
 from pywbem import Warning, ToleratedServerIssueWarning, \
-    MissingKeybindingsWarning, OldNameFilterWarning  # noqa: E402
+    MissingKeybindingsWarning, OldNameFilterWarning, \
+    ToleratedSchemaIssueWarning  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
@@ -71,6 +72,7 @@ def _assert_connection(exc, conn_id_kwarg, exp_conn_str):
     ToleratedServerIssueWarning,
     MissingKeybindingsWarning,
     OldNameFilterWarning,
+    ToleratedSchemaIssueWarning,
 ], scope='module')
 def simple_class(request):
     """


### PR DESCRIPTION
Adds a new warnings class to pywbem and adds that class to the unit
test.  This is expected to be used in the future in the MOF compiler and
by pywbem tools to warn the user about issues in the schema that are
either repaired or which do not warrent a failure.