### PR TITLE
1.2: Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
 * Mitigated new Pylint error 'not-an-iterable' when using 'WBEMServer'
   properties that return lists and use deferred initialization. (issue #2770)
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 * Added toleration support for WBEM servers that return a CIM status

--- a/pylintrc
+++ b/pylintrc
@@ -79,7 +79,7 @@ disable=I0011, bad-option-value,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
         signature-differs, raise-missing-from, super-with-arguments,
-        redundant-u-string-prefix,
+        redundant-u-string-prefix, consider-using-f-string,
         R0801
 
 # Issue #2672: Disabling R0801 is a circumvention for Pylint issue


### PR DESCRIPTION
Rolls back PR #2774 into 1.2.1.