### PR TITLE
1.2: Fixed install errors of PyYAML,wrapt,jsonschema on older Python versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,6 +84,9 @@ typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and 
 lazy-object-proxy>=1.4.3; python_version == '2.7'
 lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
 lazy-object-proxy>=1.4.3; python_version >= '3.6'
+wrapt>=1.12,<1.13; python_version == '2.7'
+wrapt>=1.12,<1.13; python_version == '3.4'
+wrapt>=1.12; python_version >= '3.5'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -69,6 +69,13 @@ Released: not yet
   can also be addressed by disabling the similarity checker, and addressed
   Pylint issues reported by Pylint 2.9. (issue #2672)
 
+* Fixed install error of PyYAML 6.0b1 on Python 2.7 during installtest, by
+  pinning it to <6.0.
+
+* Fixed install error of wrapt 1.13.0 on Python 2.7/3.4, by pinning it to <1.13.
+
+* Fixed install error of yanked jsonschema 4.0.0 on Python <3.7, by excluding it.
+
 **Cleanup:**
 
 **Known issues:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -199,6 +199,7 @@ typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and impleme
 lazy-object-proxy==1.4.3; python_version == '2.7'
 lazy-object-proxy==1.4.3; python_version == '3.4'
 lazy-object-proxy==1.4.3; python_version >= '3.6'
+wrapt==1.12
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ ply>=3.10
 # PyYAML 5.3 fixed narrow build error on Python 2.7
 # PyYAML 5.3.1 addressed issue 38100 reported by safety
 # PyYAML 5.2 addressed issue 38639 reported by safety
-PyYAML>=5.3.1; python_version == '2.7'
+# PyYAML 6.0 removed support for Python 2.7, but 6.0b1 installs in installtest
+PyYAML>=5.3.1,<6.0; python_version == '2.7'
 PyYAML>=5.2,<5.3; python_version == '3.4'
 PyYAML>=5.3.1; python_version > '3.4'
 # virtualenv 20.0.0 (required on py3.8+) requires six>=0.12.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -32,6 +32,7 @@ colorama>=0.4.0; python_version >= '3.5'
 easy-vault>=0.7.0
 easy-server>=0.7.0
 pytest-easy-server>=0.7.0
+jsonschema>=2.6.0,!=4.0.0
 
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0


### PR DESCRIPTION
Rolls back PR #2776 into 1.2.1.