### PR TITLE
1.2: Relaxed wrapt pinning to just py27 on windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,9 +84,10 @@ typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and 
 lazy-object-proxy>=1.4.3; python_version == '2.7'
 lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
 lazy-object-proxy>=1.4.3; python_version >= '3.6'
-wrapt>=1.12,<1.13; python_version == '2.7'
-wrapt>=1.12,<1.13; python_version == '3.4'
-wrapt>=1.12; python_version >= '3.5'
+# wrapt 1.13.0 started depending on MS Visual C++ 9.0 on Python 2.7 on Windows,
+#   which is not available by default on GitHub Actions
+wrapt>=1.12,<1.13; sys_platform == 'win32' and python_version == '2.7'
+wrapt>=1.12; python_version >= '3.4'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -72,7 +72,8 @@ Released: not yet
 * Fixed install error of PyYAML 6.0b1 on Python 2.7 during installtest, by
   pinning it to <6.0.
 
-* Fixed install error of wrapt 1.13.0 on Python 2.7/3.4, by pinning it to <1.13.
+* Fixed install error of wrapt 1.13.0 on Python 2.7 on Windows due to lack of
+  MS Visual C++ 9.0 on GitHub Actions, by pinning it to <1.13.
 
 * Fixed install error of yanked jsonschema 4.0.0 on Python <3.7, by excluding it.
 


### PR DESCRIPTION
Rolls back PR #2778 into 1.2.1.