### PR TITLE
Fixes issue # 2782, handling of add_destination duplicates.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -125,6 +125,12 @@ Released: not yet
   - Removed use of unittest.Mock in pywbem_mock.FakedWBEMConnection to
     use mock versions of _imethodcall and _methodcall and simply duck typed
     the methods. (see issue #2755)
+  - Fixed issue in pywbem SubscriptionManager where duplicate add_destination()
+    resulted in good return rather than CIMError.  The code where the
+    Name property is different but the URL the same was modified to test for
+    both URL and persistence type equality before returning the existing
+    instance. (See issue $ 2782)
+
 
 * Fixes MOF compiler issue  where the compiler was allowing array properties
   to have corresponding instances instantiated with non-array values and


### PR DESCRIPTION
Wating on priority prs #2795

Moves the test for duplicated name property to before the test for
duplicated URL and adds PersistenceType as test for equality between new
and existing owned destination instances.

Fixed test_subscriptionmanager.py to account for possible multiple
destination definitions in test since the code has been changed to now
allow only a single destination for each call.

NOTE: It would not bother me if we changed the code to return ValueError if the URL matched or even just to
remove the test for URL code.  I chose returning the existing instance as one of 3 generally almost equal
choices.

Added tests specifically for duplicated destination destination_id and
for returning instance if url and persistence type match.