### PR TITLE
Issue #2786, Compiler ignores arrayness mismatches

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -126,6 +126,10 @@ Released: not yet
     use mock versions of _imethodcall and _methodcall and simply duck typed
     the methods. (see issue #2755)
 
+* Fixes MOF compiler issue  where the compiler was allowing array properties
+  to have corresponding instances instantiated with non-array values and
+  vice-versa. This now causes a parse error. (See issue # 2786)
+
 * Docs: Fixed an error with the autodocsumm and Sphinx 4.0.0. (issue #2697)
 
 * Jupyter Notebook: Ignored safety issues 40380..40386 in order to continue

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -1876,7 +1876,7 @@ def p_instanceDeclaration(p):
                                                    in allowed_types])
                             raise MOFParseError(
                                 msg=_format(
-                                    "Property {0|A} with value {1|A} embedded "
+                                    "Property {0!A} with value {1!A} embedded "
                                     "object type must be ((1}). Actual type "
                                     "is {2}", cprop.name, cls_names, type(obj)))
                     # If the compile produces no objects there must have
@@ -1885,7 +1885,7 @@ def p_instanceDeclaration(p):
                     if not objs:
                         raise MOFParseError(
                             msg=_format(
-                                "Property {0|A} with value {1|A} embedded"
+                                "Property {0!A} with value {1!A} embedded"
                                 " object compile produced no instances.",
                                 cprop.name, pval))
 
@@ -1893,6 +1893,19 @@ def p_instanceDeclaration(p):
                     pprop.value = objs if cprop.is_array else objs[0]
                     pprop.embedded_object = embedded_object_type
             else:
+                if pval:
+                    ival_is_array = isinstance(pval, list)
+                    if cprop.is_array != ival_is_array:
+                        raise MOFParseError(
+                            msg=_format(
+                                "Property {0!A} value {1!A} in instance of "
+                                "class {2!A} has class and instance array "
+                                "mismatch. The class definition is "
+                                "array={3} instance value type is array={4} "
+                                "for value type {5}",
+                                pname, pval, cc.classname, cprop.is_array,
+                                ival_is_array, type(pval)),
+                            parser_token=p)
                 pprop.value = cimvalue(pval, cprop.type)
             inst.properties[pname] = pprop
         except ValueError as ve:


### PR DESCRIPTION
Waiting on prs #2790 and #2791

The MOF compiler ignores issues of mismatch between the class definition of properties arrayness and the corresponding values in instances of the class. Thus, the compiler where a class with an array property is defined will accept a single value property value (and output it as a single value property value) and will accept an array value defintion for an instance and produce an array value in the CIMProperty.  This fix tests for this mismatch in the compiler and generates an error if found.

I chose the approach of adding a specific test for the issue to the compiler rather than fixing issue #2789 (which adds the test code to CIMProperty) because this isolates the change and I am not sure what all might break with the more complete change define in issue #2789.  Added note in compiler about issue #2789

This change does not add a test for this error because we have not yet created code to easily test for class/instance errors.

It was manually tested using pywbemcli.

