### PR TITLE
Issue between Sphinx 1.85 and docutils 0.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,14 @@ py_test_files := \
 # - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
 # - 40291: pip cannot be upgraded to 21.1 py<3.6
 # - 40380..40386: notebook issues fixed in 6.1.5 which would prevent using notebook on py2
+# NOV 2021
+# - 42218 pip <21.1 - unicode separators in git references
+# - 42253 Notebook, before 5.7.1 allows XSS via untrusted notebook
+# - 42254 Notebook before 5.7.2, allows XSS via crafted directory name
+# - 42297 Bleach before 3.11, a mutation XSS afects user calling bleach.clean
+# - 42298 Bleach before 3.12, mutation XSS affects bleach.clean
+# - 42293 babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
+
 
 safety_ignore_opts := \
     -i 38100 \
@@ -314,6 +322,12 @@ safety_ignore_opts := \
 		-i 40384 \
 		-i 40385 \
 		-i 40386 \
+		-i 42218 \
+		-i 42253 \
+		-i 42254 \
+		-i 42297 \
+		-i 42298 \
+		-i 42203 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -41,8 +41,11 @@ tox>=2.5.0
 # Keep in sync with rtd-requirements.txt
 # Sphinx 2.0.0 removed support for Python 2.7 and 3.4
 # Sphinx 4.0.0 breaks autodocsumm (issue #2697)
+# Sphinx 3.5.4 started including test for docutils version
 Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
-Sphinx>=3.0.4,<4.0.0; python_version >= '3.5'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+# Issue #2787 docutils v=0.18/Sphinx incompatibility
+docutils<0.18; python_version <= '3.4'
 sphinx-git>=10.1.1
 # GitPython 3.0.0 removed support for Python 2.7
 GitPython>=2.1.1,<3.0.0; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -153,7 +153,12 @@ Released: not yet
 
 * Security - Added 42218 42253 42254 42297 42298 42203 to safety ignore list.
   These were new safety issues 1 Nov 2021. The modules are all in development,
-   and Jupyter notebook.
+  and Jupyter notebook.
+
+* Fix incompatibility between Sphinx 1.8.5 (version for python <= 3.5) and
+  docutils 0.18.  (See issue # 2787).
+
+* Modified dev-requirements and rtd-requirements to require Sphinx >= 3.54.
 
 **Enhancements:**
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -151,6 +151,10 @@ Released: not yet
 * Mitigated new Pylint error 'not-an-iterable' when using 'WBEMServer'
   properties that return lists and use deferred initialization. (issue #2770)
 
+* Security - Added 42218 42253 42254 42297 42298 42203 to safety ignore list.
+  These were new safety issues 1 Nov 2021. The modules are all in development,
+   and Jupyter notebook.
+
 **Enhancements:**
 
 * Improved the running of indication listeners via `WBEMListener.start()`:

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -177,7 +177,7 @@ tox==2.5.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6; python_version <= '3.4'
-Sphinx==3.0.4; python_version >= '3.5'
+Sphinx>= 3.5.4; python_version >= '3.5'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -9,7 +9,9 @@
 # Keep in sync with dev-requirements.txt
 
 Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
-Sphinx>=3.0.4,<4.0.0; python_version >= '3.5'
+Sphinx>=3.5.4, !=4.0.0; python_version >= '3.5'
+# Issue #2787 docutils v=0.18/Sphinx < python < 3.5 incompatibility
+docutils<0.18; python_version <= '3.4'
 sphinx-git>=10.1.1
 GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
Includes commit for pr #2791,  update to safety checks.

Docutils created incompatible change with version 0.18. Sphinx fixing
this for Sphinx V 4,3.0 but not for older versions. Since we use Sphinx 1.8.5 for python < 3.5 we need to use docutils < 0.18
for these tests.