### PR TITLE
Change Sphinx target in minimum-constraints.txt

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -177,7 +177,7 @@ tox==2.5.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6; python_version <= '3.4'
-Sphinx>= 3.5.4; python_version >= '3.5'
+Sphinx==3.5.4; python_version >= '3.5'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0


### PR DESCRIPTION
Somewhere I dropped the change from >= to == for the Sphinx target in
minimum-requirements.txt.

One line fix to change Sphinx>= to Sphinx==

Used as base for other prs