### PR TITLE
Set version limit on more-itertools in dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,6 +23,10 @@ pytest-cov>=2.7.0; python_version == '2.7' or python_version >= '3.5'
 git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
 coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
 
+# version 8.11 requires python 3.6, See issue #2796
+more-itertools>=4.0.0,!=8.11.0; python_version < '3.6'
+more-itertools>=4.0.0; python_version >= '3.6'
+
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 and 3.4 (and now also enforces that)
 safety>=1.8.7,<1.9.0; python_version <= '3.4'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -164,6 +164,9 @@ Released: not yet
 
 * Modified dev-requirements and rtd-requirements to require Sphinx >= 3.54.
 
+* Modify dev-requirements.txt to limit version of more-itertools to  < 8.10.1
+  for python < 3.6. See issue #2796
+
 **Enhancements:**
 
 * Improved the running of indication listeners via `WBEMListener.start()`:

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -136,6 +136,8 @@ requests-mock==1.6.0
 requests-toolbelt==0.8.0
 yagot==0.5.0
 
+more-itertools==4.0.0
+
 # Easy-server packages
 easy-vault==0.7.0
 easy-server==0.8.0
@@ -177,7 +179,7 @@ tox==2.5.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6; python_version <= '3.4'
-Sphinx>= 3.5.4; python_version >= '3.5'
+Sphinx==3.5.4; python_version >= '3.5'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0


### PR DESCRIPTION
Fix issue #2796 that does not limit the version of more-itertools which causes test failures and fix an issue with use of >= in minimum-constraints.

This limits the version of more-itertools version 8.11.0 to python > 3.6

NOTE: I assume that the developers will correct the issue and either rerelease 8.11.0 or release an 8.11.1 since there is already a PR defined.

Priority because issue # 2796 it breaks tests.

Also fixes issue # 2792 where there is a invalid comparison error in minimum-constraints.txt.  That, however, was not a test breaking issue.

NOTE: more-tools has a PR up to fix this problem (https://github.com/more-itertools/more-itertools/pull/579) but if we assume that the fix in by creating a new version (several users have requested that they reissue 8.11.0) we will have another change to modify dev-requirements but this PR needed just to get our tests running again.

COMMENT: I marked this one for rollback but not sure it is really requredbecause:

1. This is tests only because it is all tied to pytest. The change is only in dev-requirements for the fix that causes test failure.
2. This is probably going to change again soon because more-tools should be issuing fix that would modify the change to dev-requirements.

NOTE: This also impacts pytest-easy-server since it uses pytest.