### PR TITLE
1.2: Fixed error when installing virtualenv in install test on Python 2.7

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -69,6 +69,8 @@ Released: not yet
 
 * Fixed new issues raised by Pylint 2.12.1.
 
+* Fixed error when installing virtualenv in install test on Python 2.7.
+
 **Enhancements:**
 
 * Added toleration support for WBEM servers that return a CIM status

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -144,7 +144,7 @@ easy-server==0.7.0
 pytest-easy-server==0.7.0
 
 # Virtualenv
-virtualenv==14.0.0; python_version < '3.5'
+virtualenv==16.1.0; python_version < '3.5'
 virtualenv==16.1.0; python_version >= '3.5' and python_version < '3.8'
 virtualenv==20.0.0; python_version >= '3.8'  # requires six<2,>=1.12.0
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -65,6 +65,6 @@ lxml>=4.6.2; python_version >= '3.5'
 
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.
-virtualenv>=14.0.0,!=20.0.19; python_version < '3.5'
+virtualenv>=16.1.0,!=20.0.19; python_version < '3.5'
 virtualenv>=16.1.0; python_version >= '3.5' and python_version < '3.8'
 virtualenv>=20.0.0; python_version >= '3.8'


### PR DESCRIPTION
Rolls back PR #2811 into 1.2.1.