### PR TITLE
Improved verbosity of namespace creation/deletion

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,11 @@ Released: not yet
 
 **Enhancements:**
 
+* Improved verbosity of namespace creation and deletion: Added optional
+  'verbose' parameters to the create_namecpace() and delete_namespace() methods
+  of WBEMServer, and to the add_namecpace() and remove_namespace() methods of
+  FakedWBEMConnection (and subsequently to BaseProvider) in the mock support.
+
 **Cleanup:**
 
 **Known issues:**

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -632,7 +632,8 @@ def p_mp_createClass(p):
                     assert not fixedNS  # Should not happen if we created it
                     if p.parser.verbose:
                         p.parser.log(
-                            _format("Creating namespace {0}", ns))
+                            _format("Creating namespace {0} (in MOF compiler)",
+                                    ns))
                     p.parser.server.create_namespace(ns)
                     fixedNS = True
                     continue  # Try again to create the class
@@ -894,7 +895,7 @@ def p_mp_setQualifier(p):
         if ce.status_code == CIM_ERR_INVALID_NAMESPACE:
             if p.parser.verbose:
                 p.parser.log(
-                    _format("Creating namespace {0}", ns))
+                    _format("Creating namespace {0} (in MOF compiler)", ns))
             p.parser.server.create_namespace(ns)
             if p.parser.verbose:
                 p.parser.log(
@@ -1117,7 +1118,7 @@ def p_qualifier(p):
                     cim_error=ce)
             if p.parser.verbose:
                 p.parser.log(
-                    _format("Creating namespace {0}", ns))
+                    _format("Creating namespace {0} (in MOF compiler)", ns))
             p.parser.server.create_namespace(ns)
             quals = None
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -381,7 +381,7 @@ class WBEMServer(object):
             self._determine_profiles()
         return self._profiles
 
-    def create_namespace(self, namespace):
+    def create_namespace(self, namespace, verbose=False):
         """
         Create the specified CIM namespace in the WBEM server and
         update this WBEMServer object to reflect the new namespace
@@ -420,6 +420,9 @@ class WBEMServer(object):
               The namespace may contain leading and a trailing slash, both of
               which will be ignored.
 
+            verbose (:class:`py:bool`):
+              Verbose mode: Print a message about the namespace creation.
+
         Returns:
 
           :term:`unicode string`: The specified CIM namespace name in its
@@ -432,6 +435,10 @@ class WBEMServer(object):
         """
 
         std_namespace = _ensure_unicode(namespace.strip('/'))
+
+        if verbose:
+            print("Creating namespace {} (in WBEMServer)".
+                  format(std_namespace))
 
         try:
             ws_profiles = self.get_selected_profiles('DMTF', 'WBEM Server')
@@ -525,7 +532,7 @@ class WBEMServer(object):
 
         return std_namespace
 
-    def delete_namespace(self, namespace):
+    def delete_namespace(self, namespace, verbose=False):
         """
         Delete the specified CIM namespace in the WBEM server and
         update this WBEMServer object to reflect the removed namespace
@@ -563,6 +570,9 @@ class WBEMServer(object):
               The namespace may contain leading and a trailing slash, both of
               which will be ignored.
 
+            verbose (:class:`py:bool`):
+              Verbose mode: Print a message about the namespace creation.
+
         Returns:
 
           :term:`unicode string`: The specified CIM namespace name in its
@@ -578,6 +588,10 @@ class WBEMServer(object):
         """
 
         std_namespace = _ensure_unicode(namespace.strip('/'))
+
+        if verbose:
+            print("Deleting namespace {} (in WBEMServer)".
+                  format(std_namespace))
 
         # Use approach 1: DeleteInstance of CIM class for namespaces
 
@@ -1106,8 +1120,8 @@ class WBEMServer(object):
         if interop_ns is None:
             # Exhausted the possible namespaces
             raise ModelError(
-                _format("Interop namespace could not be determined "
-                        "(tried {0!A})", self.INTEROP_NAMESPACES),
+                _format("Interop namespace does not exist (tried {0!A})",
+                        self.INTEROP_NAMESPACES),
                 conn_id=self.conn.conn_id)
         self._interop_ns = interop_ns
 

--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -153,7 +153,7 @@ class BaseProvider(object):
                 _format("Namespace does not exist in CIM repository: {0!A}",
                         namespace))
 
-    def add_namespace(self, namespace):
+    def add_namespace(self, namespace, verbose=False):
         """
         Add a CIM namespace to the CIM repository.
 
@@ -169,6 +169,9 @@ class BaseProvider(object):
             The name of the CIM namespace in the CIM repository. Must not be
             `None`. Any leading or trailing slash characters are removed before
             the string is used to define the namespace name.
+
+          verbose (:class:`py:bool`):
+            Verbose mode: Print a message about the namespace creation.
 
         Raises:
 
@@ -193,6 +196,9 @@ class BaseProvider(object):
                     _format("An Interop namespace {0!A} already exists in the "
                             "CIM repository. {1!A} cannot be added. ",
                             self.find_interop_namespace(), namespace))
+        if verbose:
+            print("Creating namespace {} (in mock support)".
+                  format(namespace))
         try:
             self.cimrepository.add_namespace(namespace)
         except ValueError:
@@ -201,7 +207,7 @@ class BaseProvider(object):
                 _format("Namespace {0!A} already exists in the CIM repository ",
                         namespace))
 
-    def remove_namespace(self, namespace):
+    def remove_namespace(self, namespace, verbose=False):
         """
         Remove a CIM namespace from the CIM repository.
 
@@ -215,6 +221,9 @@ class BaseProvider(object):
             The name of the CIM namespace in the CIM repository (case
             insensitive). Must not be `None`. Leading or trailing
             slash characters are ignored.
+
+          verbose (:class:`py:bool`):
+            Verbose mode: Print a message about the namespace deletion.
 
         Raises:
 
@@ -246,6 +255,9 @@ class BaseProvider(object):
                 _format("The Interop namespace {0!A} cannot be removed from "
                         "the CIM repository.", namespace))
 
+        if verbose:
+            print("Deleting namespace {} (in mock support)".
+                  format(namespace))
         try:
             self.cimrepository.remove_namespace(namespace)
         # KeyError cannot happen because existence was already verified

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -406,7 +406,7 @@ class FakedWBEMConnection(WBEMConnection):
     # so they can be access with call to the methods from instance of
     # this class. they are considered part of the external API.
 
-    def add_namespace(self, namespace):
+    def add_namespace(self, namespace, verbose=False):
         """
         Add a CIM namespace to the CIM repository of the faked connection.
 
@@ -419,15 +419,18 @@ class FakedWBEMConnection(WBEMConnection):
             Must not be `None`. Any leading or trailing slash characters are
             removed before the string is used to define the namespace name.
 
+          verbose (:class:`py:bool`):
+            Verbose mode: Print a message about the namespace creation.
+
         Raises:
 
           ValueError: Namespace argument must not be None.
           :exc:`~pywbem.CIMError`: CIM_ERR_ALREADY_EXISTS if the namespace
             already exists in the CIM repository.
         """
-        self._mainprovider.add_namespace(namespace)
+        self._mainprovider.add_namespace(namespace, verbose=verbose)
 
-    def remove_namespace(self, namespace):
+    def remove_namespace(self, namespace, verbose=False):
         """
         Remove a CIM namespace from the CIM repository of the faked connection.
 
@@ -440,6 +443,9 @@ class FakedWBEMConnection(WBEMConnection):
             insensitive). Must not be `None`. Leading or trailing
             slash characters are ignored.
 
+          verbose (:class:`py:bool`):
+            Verbose mode: Print a message about the namespace deletion.
+
         Raises:
 
           ValueError: Namespace argument must not be None
@@ -451,7 +457,7 @@ class FakedWBEMConnection(WBEMConnection):
             to delete the default connection namespace.  This namespace cannot
             be deleted from the CIM repository
         """
-        self._mainprovider.remove_namespace(namespace)
+        self._mainprovider.remove_namespace(namespace, verbose=verbose)
 
     def is_interop_namespace(self, namespace):
         """


### PR DESCRIPTION
See commit message for details.
This is needed for the namespace creation tests in pywbemtools (PR https://github.com/pywbem/pywbemtools/pull/1114)

**DISCUSSION:**

There are two options on how to deal with this PR:

* Release pywbem 1.4.0 with this change quickly and have the namespace creation tests in pywbemtools 1.0.0
* Defer this change until after pywbem 1.4.0 and defer the namespace creation tests in pywbemtools until after pywbemtools 1.0.0
  * Then we need to decide what we do with the changes in the mock scripts in pywbemtools