### PR TITLE
1.4: Ignored safety issue 43366 (lxml, code not used)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ py_test_files := \
 # - 42298 Bleach before 3.12, mutation XSS affects bleach.clean
 # - 42293 babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
 # - 42559 pip, before 21.1 CVE-2021-3572
+# - 43366 lxml, before 4.6.5 CVE-2021-43818, code not used
 
 safety_ignore_opts := \
     -i 38100 \
@@ -329,6 +330,7 @@ safety_ignore_opts := \
 		-i 42298 \
 		-i 42203 \
 		-i 42559 \
+		-i 43366 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \


### PR DESCRIPTION
Rolls back PR #2832 into 1.4.1.