### PR TITLE
Fix issue with create instance of abstract class

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,13 @@ Released: not yet
 * Removed support for Python 3.4. It had been deprecated since pywbem 1.0.0.
   (issue #2829)
 
+* Modified compiler and pywbem_mock to allow creating instances from
+  abstract classes because SNIA ignored DMTF rule making this illegal and many
+  MOF compilers also ignored it.  Pywbem now issue a warning from the MOF
+  compiler if an instance of an abstract class is compiled but complete
+  the compile and another warning from pywbem_mock.CreateInstance if the
+  instance is for an abstract class. (see issue #2825)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -79,6 +79,7 @@ import os
 import io
 import re
 import tempfile
+import warnings
 
 from abc import ABCMeta, abstractmethod
 try:
@@ -103,6 +104,7 @@ from ._cim_constants import CIM_ERR_NOT_FOUND, CIM_ERR_FAILED, \
     CIM_ERR_NOT_SUPPORTED
 from ._exceptions import Error, CIMError
 from ._utils import _format, _ensure_unicode
+from ._warnings import ToleratedSchemaIssueWarning
 
 __all__ = ['MOFCompileError', 'MOFParseError', 'MOFDependencyError',
            'MOFRepositoryError', 'MOFCompiler', 'BaseRepositoryConnection']
@@ -2404,11 +2406,11 @@ class MOFWBEMConnection(BaseRepositoryConnection):
                 cls, inst, namespace=ns)
 
         if "Abstract" in cls.qualifiers:
-            raise CIMError(
-                CIM_ERR_FAILED,
-                _format("CreateInstance failed. Cannot instantiate abstract "
-                        "class {0!A} in Namespace {1!A}.",
-                        inst.classname, ns))
+            warnings.warn(
+                _format("Tolerating instance creation of abstract class {0} "
+                        " in namepace {1} which is forbidden by DMTF DSP0004.",
+                        inst.classname, ns),
+                ToleratedSchemaIssueWarning, 1)
 
         try:
             self.instances[ns].append(inst)

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -32,6 +32,7 @@ provider class defined in the provider registry.
 from __future__ import absolute_import, print_function
 
 from copy import deepcopy
+import warnings
 import six
 try:
     from collections.abc import Mapping, Sequence
@@ -41,7 +42,8 @@ except ImportError:  # py2
 
 from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     CIMParameter, CIMError, CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER, \
-    CIM_ERR_INVALID_CLASS, CIM_ERR_METHOD_NOT_FOUND, cimtype, CIM_ERR_FAILED
+    CIM_ERR_INVALID_CLASS, CIM_ERR_METHOD_NOT_FOUND, cimtype, \
+    ToleratedSchemaIssueWarning
 
 from pywbem._utils import _format
 from pywbem._nocasedict import NocaseDict
@@ -215,11 +217,11 @@ class ProviderDispatcher(BaseProvider):
                         NewInstance.classname, namespace))
 
         if "Abstract" in creation_class.qualifiers:
-            raise CIMError(
-                CIM_ERR_FAILED,
-                _format("CreateInstance failed. Cannot instantiate abstract "
-                        "class {0!A} in Namespace {1!A}.",
-                        NewInstance.classname, namespace))
+            warnings.warn(
+                _format("Tolerating instance creation of abstract class {0} "
+                        " in namepace {1} which is forbidden by DMTF DSP0004.",
+                        NewInstance.classname, namespace),
+                ToleratedSchemaIssueWarning, 1)
 
         # Verify that the properties in the new instance are exposed by the
         # creation class and have the correct type-related attributes.


### PR DESCRIPTION
Change code to allow the CreateInstance of an abstract class but issue a warning.  Note that
there are two places this occurs:

1. The create instance from the compiler
2. Pywbem_mock CreateInstance

Add tests to mof_compiler for this change.