### PR TITLE
1.4: Ks/#2839 deep inheritance open enumerate instances parm missing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fix issue where the DeepInheritance parameter not passed to the mocker
+  OpenEnumerateInstances method so the result is that the mocker always
+  uses the default (DeepInheritance=True). (see issue #2839)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1771,6 +1771,7 @@ class FakedWBEMConnection(WBEMConnection):
         context_tuple = self._mainprovider.OpenEnumerateInstances(
             namespace=namespace,
             ClassName=_cvt_rqd_classname(params['ClassName']),
+            DeepInheritance=params.get('DeepInheritance', None),
             IncludeClassOrigin=params.get('IncludeClassOrigin', None),
             PropertyList=params.get('PropertyList', None),
             FilterQueryLanguage=params.get('FilterQueryLanguage', None),


### PR DESCRIPTION
Rolls back PR #2840 into 1.4.1.