### PR TITLE
Coverity corrections

### DIFF
--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -2052,6 +2052,7 @@ class CIMInstanceName(_CIMComparisonMixin, SlottedPickleMixin):
                 _format("WBEM URI has an invalid format for its keybindings: "
                         "{0!A}", keybindings_str))
 
+        kb_assigns = []
         if m.group(1):
             kb_assigns = [m.group(1)]
 

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -618,8 +618,8 @@ class LogOperationRecorder(BaseOperationRecorder):
             # Format the 'summary' and 'paths' detail_levels
             if self.api_detail_level == 'summary':  # pylint: disable=R1705
                 if isinstance(ret, list):
-                    if ret:
-                        ret_type = type(ret[0]).__name__ if ret else ""
+                    if len(ret) > 0:
+                        ret_type = type(ret[0]).__name__
                         return _format("list of {0}; count={1}",
                                        ret_type, len(ret))
                     return "Empty"


### PR DESCRIPTION
Running coverity on version 0.15.0 which is the latest packaged version for fedora is reporting some errors.  I believe this PR addresses some potential issues that should be considered for inclusion.