### PR TITLE
fixes issue #2841 - Clarify reason host in interenumerateinstance ret…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -78,6 +78,9 @@ Released: not yet
   Changes included removing tests for extra parameters which now cause
   failure of api.
 
+* Clarify why the iterEnumerateInstances and IterEnumerateInstancePaths
+  always return the host name in the response. (see issue #2841)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -4674,8 +4674,8 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
         This method uses the corresponding pull operations if supported by the
         WBEM server or otherwise the corresponding traditional operation.
         This method is an alternative to using the pull operations directly,
-        that frees the user of having to know whether the WBEM server supports
-        pull operations.
+        that frees the user of having to know whether or not the WBEM server
+        supports pull operations.
 
         This method is a generator function that retrieves instances from
         the WBEM server and returns them one by one (using :keyword:`yield`)
@@ -4721,8 +4721,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
           WBEM server must support the pull operations and their filtering
           capability in order for the filtering to work.
 
-        * Setting the `ContinueOnError` parameter to `True` will be rejected if
-          the corresponding traditional operation is used by this method.
+        * Setting the `ContinueOnError` parameter to `True` will cause the
+        request to be rejected if the corresponding traditional operation is
+        used by this method.
 
         The enumeration session that is opened with the WBEM server when using
         pull operations is closed automatically when the returned generator
@@ -4907,8 +4908,9 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
           :term:`py:generator` iterating :class:`~pywbem.CIMInstance`:
           A generator object that iterates the resulting CIM instances.
-          These instances include an instance path that has its host and
-          namespace components set.
+          These instances include an instance path that always includes host and
+          namespace components. When EnumerateInstances operation is used,
+          host name is from WBEMConnection.host rather than the response.
 
         Example::
 
@@ -5012,7 +5014,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             namespace = ClassName.namespace
         namespace = self._iparam_namespace_from_namespace(namespace)
 
-        # Complete namespace and host components of the path
+        # Complete namespace and host components of the path if they are not
+        # provided from the host. This covers cases where the namespace might
+        # not be provided by the server and the case where EnumerateInstances
+        # is returned since it does not provide a host name (uses xml Element
+        # INSTANCENAME which does not include host)
         for inst in enum_rslt:
             if inst.path.namespace is None:
                 inst.path.namespace = namespace
@@ -5192,7 +5198,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
 
           :term:`py:generator` iterating :class:`~pywbem.CIMInstanceName`:
           A generator object that iterates the resulting CIM instance paths.
-          These instance paths have their host and namespace components set.
+          These instance paths always include their host and namespace
+          components. When this method uses the
+          EnumerateInstancesNames operation, the host name is inserted into
+          the response from the WBEMConnection.host attribute because DMTF
+          EnumerateInstanceNames does not return host name in the response.
 
         Example::
 
@@ -5282,7 +5292,11 @@ class WBEMConnection(object):  # pylint: disable=too-many-instance-attributes
             namespace = ClassName.namespace
         namespace = self._iparam_namespace_from_namespace(namespace)
 
-        # Complete namespace and host components of the path
+        # Complete namespace and host components of the path if they are not
+        # provided from the host. This covers cases where the namespace might
+        # not be provided by the server and the case where EnumerateInstances
+        # return does not provide a host name (uses xml Element INSTANCENAME
+        # which does not include host).
         for path in enum_rslt:
             if path.namespace is None:
                 path.namespace = namespace


### PR DESCRIPTION
Clarifies why the host name is always included in the return objects for
iterEnumerateInstances and iterEnumerateInstancePaths. There were no
code changes.