### PR TITLE
1.4: Fixed installtest error by pinning certifi; fixed safety issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,7 @@ py_test_files := \
 # - 44634 ipython >=6.0.0a0,<7.16.3 CVE-2022-21699, partly updated, not recognized properly by safety
 # - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
 # - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
+# - 45185 Pylint cannot be upgraded on py27
 
 safety_ignore_opts := \
     -i 38100 \
@@ -339,6 +340,7 @@ safety_ignore_opts := \
 		-i 44634 \
 		-i 45775 \
 		-i 47833 \
+		-i 45185 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,11 @@ Released: not yet
 * Fixed that the added setup.py commands (test, leaktest, installtest) were not
   displayed. They are now displayed at verbosity level 1 (using '-v').
 
+* Pinned "certifi" to <2020.6.20 on Python 2.7 because the install test
+  using "setup.py install" started failing because it installed a version
+  of certifi on Python 2.7 that properly declares that it requires
+  Python >=3.6.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -353,7 +353,7 @@ importlib-resources==5.4.0; python_version >= '3.4'
 iniconfig==1.1.1; python_version >= '3.4'
 ipaddress==1.0.23; python_version == '2.7'
 jedi==0.17.2; python_version >= '3.5'
-Jinja2==2.8; python_version <= '3.9'
+Jinja2==2.8.1; python_version <= '3.9'
 Jinja2==2.10.2; python_version >= '3.10'
 jsonschema==2.6.0
 linecache2==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,8 @@ urllib3>=1.26.5; python_version >= '3.10'
 
 # setuptools 61.0.0 breaks "setup.py install", see https://github.com/pypa/setuptools/issues/3198
 setuptools!=61.0.0; python_version >= '3.7'
+
+# certifi 2020.6.20 removed support for Python 2.7 but does not declare it
+certifi>=2019.11.28,<2020.6.20; python_version == '2.7'
+certifi>=2019.11.28,<2020.6.20; python_version == '3.4'
+certifi>=2019.11.28; python_version >= '3.5'


### PR DESCRIPTION
Rolls back PR #2889 (with both commits) into 1.4.2.