### PR TITLE
Transitioned build of dist archive to use 'build'  package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,14 +744,14 @@ $(sdist_file): setup.py MANIFEST.in $(dist_dependent_files) $(moftab_files)
 	@echo "Makefile: Creating the source distribution archive: $(sdist_file)"
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) setup.py sdist -d $(dist_dir)
+	$(PYTHON_CMD) -m build --sdist --outdir $(dist_dir) .
 	@echo "Makefile: Done creating the source distribution archive: $(sdist_file)"
 
 $(bdist_file): setup.py MANIFEST.in $(dist_dependent_files) $(moftab_files)
 	@echo "Makefile: Creating the normal wheel distribution archive: $(bdist_file)"
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) setup.py bdist_wheel -d $(dist_dir) --universal
+	$(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal .
 	@echo "Makefile: Done creating the normal wheel distribution archive: $(bdist_file)"
 
 $(bdistc_file): setup.py MANIFEST.in $(dist_dependent_files) $(moftab_files)
@@ -759,9 +759,9 @@ $(bdistc_file): setup.py MANIFEST.in $(dist_dependent_files) $(moftab_files)
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
 ifeq ($(PLATFORM),Windows_native)
-	cmd /c "set CFLAGS=$(cython_cflags) & $(PYTHON_CMD) setup.py bdist_wheel -d $(dist_dir) --universal --cythonized"
+	cmd /c "set CFLAGS=$(cython_cflags) & $(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal -C--cythonized ."
 else
-	CFLAGS='$(cython_cflags)' $(PYTHON_CMD) setup.py bdist_wheel -d $(dist_dir) --universal --cythonized
+	CFLAGS='$(cython_cflags)' $(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal -C--cythonized .
 endif
 	@echo "Makefile: Done creating the cythonized wheel distribution archive: $(bdistc_file)"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,9 @@
 
 # Direct dependencies:
 
+# Build distribution archive
+build>=0.5.1
+
 # Cythonize
 Cython>=0.29.22
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -132,6 +132,8 @@ Released: not yet
 * Clarify why the iterEnumerateInstances and IterEnumerateInstancePaths
   always return the host name in the response. (see issue #2841)
 
+* Changed build process for distribution archives to use the `build` package.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -125,11 +125,14 @@ keyring==18.0.0
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
 
+# Build distribution archive
+build==0.5.1
+
 # Cythonize
 Cython==0.29.22
 
 # Unit test (imports into testcases):
-packaging==17.0
+packaging==19.0
 funcsigs==1.0.2; python_version < '3.3'
 pytest==4.3.1; python_version <= '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
@@ -154,9 +157,7 @@ easy-server==0.8.0
 pytest-easy-server==0.8.0
 
 # Virtualenv
-virtualenv==16.1.0; python_version < '3.5'
-virtualenv==16.1.0; python_version >= '3.5' and python_version < '3.8'
-virtualenv==20.0.0; python_version >= '3.8'  # requires six<2,>=1.12.0
+virtualenv==20.0.35
 
 # Unit test (indirect dependencies):
 pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
@@ -325,8 +326,7 @@ gitdb2==2.0.0
 html5lib==0.999999999
 idna==2.5
 imagesize==0.7.1
-importlib-resources==3.3.1; python_version == '2.7'
-importlib-resources==5.4.0; python_version >= '3.5'
+importlib-resources==3.2.1; python_version <= '3.8'  # used by virtualenv 20.0.35
 iniconfig==1.1.1; python_version >= '3.5'
 ipaddress==1.0.23; python_version == '2.7'
 jedi==0.17.2; python_version >= '3.5'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@
 
 
 # Unit test (imports into testcases):
-packaging>=17.0
+packaging>=19.0
 funcsigs>=1.0.2; python_version < '3.3'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
@@ -69,6 +69,5 @@ lxml>=4.6.2; python_version >= '3.5' and python_version <= '3.9'
 lxml>=4.6.4; python_version >= '3.10'
 
 # Virtualenv
-virtualenv>=16.1.0,!=20.0.19; python_version == '2.7'
-virtualenv>=16.1.0; python_version >= '3.5' and python_version < '3.8'
-virtualenv>=20.0.0; python_version >= '3.8'
+# virtualenv 20.0.35 is required by build
+virtualenv>=20.0.35


### PR DESCRIPTION
For details, see the commit message.
No rollback needed, since that would require support for Python 3.4 (and build 0.5.1 requires py27 or py>=35)