### PR TITLE
Extend inter-namespace  mock associations to be bidirectional

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -35,6 +35,12 @@ Released: not yet
   cause name errors in your code, if you were using them.
   (related to issue #2888)
 
+* The pywbem_mock default instance writer (pywbem_mock/_instancewriteprovider.py)
+  added checks for creation/modification of instances to validate that the
+  reference properties of associations define existing instances if the
+  property values exist. Previously they validated only the correct value type.
+  (see issue #2908, extension to bidirectional inter-namespace associations)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -115,6 +121,11 @@ Released: not yet
   Exceeding the 'WBEMConnection' timeout now results in raising
   'pywbem.TimeoutError' in some cases where previously 'pywbem.ConnectionError'
   was raised. (issue #2853)
+
+* Extend pywbem_mock creation of instances of associations to provide for
+  bidirectional inter-namespace associations.  Previously cross-namespace
+  associations created in pywbem_mock were only visible in the namespace
+  in which they were created. (see issue #2908)
 
 **Cleanup:**
 

--- a/pywbem_mock/_instancewriteprovider.py
+++ b/pywbem_mock/_instancewriteprovider.py
@@ -56,16 +56,42 @@ Because the provider in this example does not implement the
 use their default implementations from
 :class:`~pywbem_mock.InstanceWriteProvider`.
 
+NOTE: Bidirectional association support was added in pywbem version 1.5.
+originally the association was visible only in the target namespace for the
+CreateInstance so Associations and References only handled reference properties
+in that namespace.
+
+This instance provider handles association instances that cross namespaces.
+Since the association must be available in all of the namespaces defined by the
+reference properties of a new instance (References and Associations requests
+can be issued using any of the reference properties in the instance), the
+CreateInstance creates the association instance in each namespace defined in a
+reference property of the instance (it creates shadow instances of the
+association in each namespace defined by a reference property in the
+association), ModifyInstance modifies the instance and shadow instances, and
+DeleteInstance deletes the instance and shadow instances. References and
+Association requests can be executed on instances defined in any namespace
+where the association is defined.
+
+These shadow instances are visible in each affected namespaces with the
+GetInstance and EnumerateInstance requests.
+
+This is transparent. The association instance is visible in each of the
+affected namespaces and References and Associations requests can be issued
+using any of the reference properties and the operation source instance.
+
 The provider in this example does not need to implement an ``__init__()``
 method, because no additional init parameters are needed.
 """
 
 from __future__ import absolute_import, print_function
 
-from pywbem import CIMInstanceName, CIMError, \
-    CIM_ERR_INVALID_PARAMETER, CIM_ERR_ALREADY_EXISTS
+from pywbem import CIMInstanceName, CIMInstance, CIMError, CIMClass, \
+    CIM_ERR_INVALID_PARAMETER, CIM_ERR_ALREADY_EXISTS, CIM_ERR_INVALID_CLASS, \
+    CIM_ERR_NOT_FOUND
 
 from pywbem._utils import _format
+from pywbem._nocasedict import NocaseDict
 
 from ._baseprovider import BaseProvider
 
@@ -88,7 +114,9 @@ class InstanceWriteProvider(BaseProvider):
     the same signature.
 
     Note that user-defined providers may, in turn, call the default providers
-    in this class.
+    in this class to complete the CreateInstance, ModifyInstance, or
+    DeleteInstance, in particular for instance providers that dynamically
+    Create or Modify an instance.
     """
 
     #: :term:`string`: Keyword defining the type of request the provider will
@@ -152,6 +180,10 @@ class InstanceWriteProvider(BaseProvider):
           exist, so this check can be delegated to the repository once the
           new instance path has been determined.
 
+        - If new_instance is an association, the reference properties must
+          define existing end-point paths to instances or have value
+          None.
+
         Parameters:
 
           namespace (:term:`string`):
@@ -199,36 +231,42 @@ class InstanceWriteProvider(BaseProvider):
         # Get the creation class with all exposed properties and qualifiers.
         # Since the existence of the class has already been verified, this
         # will always succeed.
+
         class_store = self.cimrepository.get_class_store(namespace)
         creation_class = class_store.get(new_instance.classname, copy=False)
 
+        # Validate association class references have valid end points
+        # paths or None
+        if self.is_association(creation_class):
+            for pn in new_instance:
+                prop = new_instance.properties[pn]
+                if prop.type == 'reference':
+                    if prop.value is None:
+                        continue
+                    # Exception if end point does not exist
+                    self.validate_reference_property_endpoint_exists(prop)
+
+        # If association class and references multiple namespaces, add instance
+        # to each namespace defined in the reference properties
+        if self.is_association(creation_class):
+            assoc_namespaces = self.find_multins_association_ref_namespaces(
+                new_instance, namespace)
+            if assoc_namespaces:
+                # It is a multi-namespace association instance. Validate
+                # characteristics of other namespaces and insert the same
+                # instance in each of these namespaces with specific path.
+                return self.create_multi_namespace_instance(
+                    new_instance, namespace, assoc_namespaces)
+
+        # Otherwise create a single new instance.
         # This default provider determines the instance path from the key
-        # properties in the new instance. A user-defined provider may do that
-        # as well, or invent key properties such as InstanceID.
+        # properties in the new instance. A user-defined provider may do
+        # that as well, or invent key properties such as InstanceID.
         # Specifying strict=True in from_instance() verifies that all key
         # properties exposed by the class are specified in the new instance,
         # and raises ValueError if key properties are missing.
-        try:
-            new_instance.path = CIMInstanceName.from_instance(
-                creation_class, new_instance, namespace=namespace, strict=True)
-        except ValueError as exc:
-            raise CIMError(CIM_ERR_INVALID_PARAMETER, str(exc))
-
-        # Get the instance store of the CIM repository. Since the existence of
-        # the namespace has already been verified, this will always succeed.
-        instance_store = self.cimrepository.get_instance_store(namespace)
-
-        # Store the new instance in the CIM repository, verifying that it does
-        # not exist yet.
-        try:
-            instance_store.create(new_instance.path, new_instance)
-        except ValueError:
-            raise CIMError(
-                CIM_ERR_ALREADY_EXISTS,
-                _format("New instance {0!A} already exists in namespace "
-                        "{1!A}.", new_instance.path, namespace))
-
-        # CreateInstance returns the instance path of the new instance
+        self.create_new_instance_path(creation_class, new_instance, namespace)
+        self.add_new_instance(new_instance)
         return new_instance.path
 
     def ModifyInstance(self, modified_instance, IncludeQualifiers=None):
@@ -281,11 +319,23 @@ class InstanceWriteProvider(BaseProvider):
 
         - No key properties are requested to change their values.
 
+        - If there was a property list for the request, only properties defined
+          in that property list are included in the modified_instance.
+
         Validation that should be performed by this provider method:
 
         - modified_instance does not specify any changed values for
           properties that are not allowed to be changed by the client,
           depending on the model implemented by the provider.
+
+        Validation executed for this default provider:
+
+        - Validate that any reference properties to be modified that are not
+          keys define an association end point instance that currently exists
+          and that the en-point instances exist.
+
+        - If the association crosses namespaces, validate that the association
+          already exists in all namespaces defined in the reference properties.
 
         Parameters:
 
@@ -332,20 +382,55 @@ class InstanceWriteProvider(BaseProvider):
 
         # Get a copy of the instance to be modified from the CIM repository.
         instance_store = self.cimrepository.get_instance_store(namespace)
-        instance = instance_store.get(modified_instance.path)
+        # Copied because this will be used as the instance to update.
+        original_instance = instance_store.get(modified_instance.path)
 
-        # Modify the properties of the local instance copy. The implemented
-        # approach is intentionally careful, to ensure that only the property
-        # values get updated.
-        for pn in modified_instance.properties:
-            mod_prop = modified_instance.properties[pn]
-            inst_prop = instance.properties[pn]
-            inst_prop.value = mod_prop.value  # Update the property value
+        # Get class defined for modified instance.
+        class_store = self.cimrepository.get_class_store(namespace)
+        creation_class = class_store.get(modified_instance.classname,
+                                         copy=False)
 
-        # Note that IncludeQualifiers is completely ignored.
+        # Test for modified reference properties and validate if corresponding
+        # instances exist. This is behavior for this default provider.
+        # A specific provider may behave differently, ex. ignore non-existend
+        # end-point instances
+        if self.is_association(creation_class):
+            for pn in modified_instance:
+                prop = modified_instance.properties[pn]
+                if prop.type == 'reference':
+                    # Do not allow setting ref property value to None. Would
+                    # mean significant extra work removing shadow instances
+                    if prop.value is None:
+                        raise CIMError(
+                            CIM_ERR_INVALID_PARAMETER,
+                            _format("Reference property {0!A} association "
+                                    "end {1!A} with None value not allowed ",
+                                    prop.name, prop.value))
+                    if prop.value != original_instance[pn]:
+                        self.validate_reference_property_endpoint_exists(prop)
+
+        # Update the properties in the original instance from properties
+        # in the modified instance
+        original_instance.update(modified_instance.properties)
+
+        # Note: IncludeQualifiers is completely ignored per DMTF spec.
+
+        # If association class and reference properties define multiple
+        # namespaces, modify instance in each namespace defined in the
+        # instance.
+        if self.is_association(creation_class):
+            assoc_namespaces = self.find_multins_association_ref_namespaces(
+                original_instance, namespace)
+            if assoc_namespaces:
+                # It is a multi-namespace association instance. Validate
+                # characteristics of other namespaces and insert the same
+                # instance in each of these namespaces with specific path.
+                self.modify_multi_namespace_instance(
+                    original_instance, assoc_namespaces)
+                return
 
         # Replace the instance in the CIM repository with the local copy.
-        instance_store.update(modified_instance.path, instance)
+        instance_store.update(original_instance.path, original_instance)
 
     def DeleteInstance(self, InstanceName):
         """
@@ -394,17 +479,36 @@ class InstanceWriteProvider(BaseProvider):
         """
 
         namespace = InstanceName.namespace
-        instance_store = self.cimrepository.get_instance_store(namespace)
 
-        # Delete the instance from the CIM repository
-        instance_store.delete(InstanceName)
+        class_store = self.cimrepository.get_class_store(namespace)
+        creation_class = class_store.get(InstanceName.classname, copy=False)
+
+        if not self.is_association(creation_class):
+            # Delete the instance from the CIM repository
+            instance_store = self.cimrepository.get_instance_store(namespace)
+            instance_store.delete(InstanceName)
+
+        else:
+            multi_ns = self.find_multins_association_ref_namespaces(
+                InstanceName, namespace)
+            if multi_ns:
+                multi_ns.append(namespace)
+                instance_name_copy = InstanceName.copy()
+                for ns in multi_ns:
+                    instance_name_copy.namespace = ns
+                    instance_store = self.cimrepository.get_instance_store(ns)
+                    instance_store.delete(instance_name_copy)
+            else:
+                instance_store = \
+                    self.cimrepository.get_instance_store(namespace)
+                instance_store.delete(InstanceName)
 
     def post_register_setup(self, conn):
         """
         Method called by provider registration after registation of provider
         is successful. Using this method is optional for registration cases
         where the provider must execute some activity (ex. modify the
-        CIM repository after successful provider registration).
+        CIM repository) after successful provider registration).
 
         Override this method in the user-defined provider subclass to execute
         this method.
@@ -415,3 +519,344 @@ class InstanceWriteProvider(BaseProvider):
             Current connection which allows client methods to be executed
             from within this method.
         """
+
+    #####################################################################
+    #
+    # Support methods.  The following methods are support for the
+    # Create/Modify/Delete instance default implementations above.
+    # They are shown as public because they an be useful in building
+    # alternates to the this default Create/Modify/Delete instance
+    # implementation.
+    #
+    #####################################################################
+    def find_multins_association_ref_namespaces(self, cim_object,
+                                                target_namespace):
+        """
+        Return list of namespaces in which this association participates
+        excluding the target namespace.  If an empty list is returned, this
+        is not a multi-namespace association.
+
+        Parameters:
+          cim_object (:class:`CIMInstance` or :class:`CIMInstanceName)
+            object from which references/keybindings searched to determine
+            if multinamespace object. Must be an association.
+
+          target_namespace (:term:`string`):
+            The namespace name provided with the request call
+            (ex. CreateInstance)
+
+        Returns:
+            List of namespace names of namespaces in which this
+            association instance participates if there are multiple namespaces.
+            If no other namespaces are defined by reference properties, it
+            returns None.
+        """
+        if isinstance(cim_object, CIMInstanceName):
+            instance_store = self.cimrepository.get_instance_store(
+                target_namespace)
+            cim_object = instance_store.get(cim_object, copy=False)
+
+        assert isinstance(cim_object, CIMInstance)
+        creation_class = self.get_required_class(cim_object,
+                                                 target_namespace)
+        assert self.is_association(creation_class)
+
+        ref_namespaces = set()
+        for inst_prop in cim_object.properties.values():
+            if inst_prop.type == 'reference':
+                refprop_namespace = inst_prop.value.namespace
+                assert refprop_namespace is not None, \
+                    _format("Invalid namespace value None found in reference "
+                            "property: {0|A}", inst_prop.value)
+
+                # Add to list if namespace exists and not same as
+                # target_namespace
+                if refprop_namespace:
+                    if refprop_namespace != target_namespace:
+                        ref_namespaces.add(inst_prop.value.namespace)
+
+        return list(ref_namespaces)
+
+    def get_required_class(self, instance, namespace):
+        """
+        Get the class defined by instance.classname from the repository. This
+        is the common method to validate the class for create instance.
+
+        If the class  does not exist, generate a CIMError.
+        """
+        class_store = self.cimrepository.get_class_store(namespace)
+
+        try:
+            return class_store.get(instance.classname)
+        except KeyError:
+            raise CIMError(
+                CIM_ERR_INVALID_CLASS,
+                _format("Creation class {0!A} of new multi-namespace "
+                        "association instance does not "
+                        "exist in namespace {1!A} of the CIM repository.",
+                        instance.classname, namespace))
+
+    @staticmethod
+    def is_association(klass):
+        """
+        Test if klass is an association class.
+
+        Return True if klass is an association class and value is True.
+        If association qualifier exists but is False or does not exist return
+        False.
+        """
+        assert isinstance(klass, CIMClass)
+        return klass.qualifiers.get('Association', False)
+
+    def create_multi_namespace_instance(self, new_instance, orig_ns,
+                                        assoc_namespaces):
+        """
+        Creates an instance of association new_instance in each namespace
+        defined by reference properties of the association instance where the
+        namespace in the reference property is not the namespace defined with
+        the create instance call.
+
+        Each instance is the same as the original instance except that each
+        has its own namespace definition in the CIMInstanceName and the
+        reference properties differ if any reference property does not include
+        the namespace in its definition.
+
+        Confirm that this is a multi-namespace association instance, that
+        the class exists in all namespaces. If these tests are OK,
+        confirm that the instance does not exist in any other namespace.
+        Then, place the instance in the remote namespaces
+
+        Any case where the instances cannot be created for all required
+        namespaces causes an exception.
+
+        Parameters:
+          new_instance ((:class:`~pywbem.CIMInstance`):)
+            The new instance that will be created
+
+          orig_ns (:term:`string`):
+            The namespace name attached to the CreateInstance request
+
+          assoc_namespaces (list of :term:`string`):
+            List of the namespaces defined in reference properties including
+            the original namespace (orig_ns)
+
+        Returns:
+          If the instance is created, the CIM_InstanceName for the created
+          instance is returned.
+
+        Asserts:
+            CIMError if error occurs in validity of other namespaces, class
+            in other namespaces, or creating of instance in other namespaces.
+        """
+
+        # Add the original namespace to the list.
+        assoc_namespaces.append(orig_ns)
+
+        # Validate that the class exists in all of the namespaces.  It was
+        # already tested for existence in the namespace defined with the
+        # create.
+        for ns in assoc_namespaces:
+            # Verify that the class exists in the namespace
+            creation_class = self.get_required_class(new_instance, ns)
+
+        # Class exists in all target namespaces.  Confirm instances are correct.
+        new_instance_paths = {}
+        for ns in assoc_namespaces:
+            # Set new path in the instance for namespace ns
+            # This is the default behavior. A provider may chose to
+            # define the path otherwise since it may also be building the
+            # instance to be created dynamically.
+            # FUTURE: How do we handle that or should we require that this is
+            # the only multi-ns method.
+            try:
+                inst_path = CIMInstanceName.from_instance(
+                    creation_class, new_instance, namespace=ns,
+                    strict=True)
+                new_instance_paths[ns] = inst_path
+            except ValueError as exc:
+                raise CIMError(CIM_ERR_INVALID_PARAMETER, str(exc))
+
+        # Confirm the new instance does not exist in any of the namespaces.
+        for ns, path in new_instance_paths.items():
+            instance_store = self.cimrepository.get_instance_store(ns)
+            if instance_store.object_exists(path):
+                raise CIMError(
+                    CIM_ERR_ALREADY_EXISTS,
+                    _format("New instance {0!A} already exists in namespace "
+                            "{1!A}. Cannot create new instance.", path, ns))
+
+        # Add the new instance with path for each ns to each of the namespaces.
+        for ns, path in new_instance_paths.items():
+            instance_store = self.cimrepository.get_instance_store(ns)
+            new_instance.path = path
+            self.add_new_instance(new_instance)
+
+        return new_instance_paths[orig_ns]
+
+    def add_new_instance(self, new_instance):
+        """
+        Add the new instance to the repository.  If the instance already exists
+        raises CIMError exception
+        """
+        namespace = new_instance.path.namespace
+        # Get the instance store of the CIM repository. Since the existence of
+        # the namespace has already been verified, this will always succeed.
+        instance_store = self.cimrepository.get_instance_store(namespace)
+
+        # Store the new instance in the CIM repository, verifying that it does
+        # not exist yet.
+        # NOTE: This is where we have invalid repository issue
+        try:
+            instance_store.create(new_instance.path, new_instance)
+        except ValueError:
+            raise CIMError(
+                CIM_ERR_ALREADY_EXISTS,
+                _format("New instance {0!A} already exists in namespace "
+                        "{1!A}.", new_instance.path, namespace))
+
+    def modify_multi_namespace_instance(self, modified_instance,
+                                        assoc_namespaces):
+        """
+        Modifies the instance of association modified_instance in each
+        namespace defined by reference properties of the association instance
+        where the namespace in the reference property is not the namespace
+        defined with the create instance call.
+
+        The instances are the same except the instance path contains the
+        namespace in which the instance exists.
+
+        Any case where the instances cannot be modified for all required
+        namespaces causes an exception.
+
+        Parameters:
+          modified_instance ((:class:`~pywbem.CIMInstance`):)
+            The modified instance that is to replace the original
+            instance in the repository
+
+          assoc_namespaces (list of :term:`string`):
+            List of the namespaces defined in reference properties including
+            the original namespace (orig_ns)
+
+        Returns:
+          If the instance is created, the CIM_InstanceName for the created
+          instance is returned.
+
+        Asserts:
+            CIMError if error occurs in validity of other namespaces, class
+            in other namespaces, or creating of instance in other namespaces.
+        """
+
+        # Add the original namespace as the last in list.
+        assoc_namespaces.append(modified_instance.path.namespace)
+
+        # Validate that the class exists in all of the namespaces.  It was
+        # already tested for existence in the namespace defined with the
+        # create.
+        for ns in assoc_namespaces:
+            # Verify that the class exists in the namespace
+            _ = self.get_required_class(modified_instance, ns)
+
+        # Confirm instances are correct and build dict of instance names for
+        # all the assoc intance names
+        modified_instance_paths = NocaseDict()  # used to keep dict order
+        for ns in assoc_namespaces:
+            # Set new path in the instance for namespace ns
+            modified_path = modified_instance.copy().path
+            modified_path.namespace = ns
+            modified_instance_paths[ns] = modified_path
+
+        # Confirm the modified instance exists in all of the namespaces.
+        for ns, path in modified_instance_paths.items():
+            instance_store = self.cimrepository.get_instance_store(ns)
+            if not instance_store.object_exists(path):
+                raise CIMError(
+                    CIM_ERR_NOT_FOUND,
+                    _format("Modified instance {0!A} does not exist in "
+                            "namespace {1!A}. Modify Failed", path, ns))
+
+        # Modify the instance path for each namespace
+        for ns, path in modified_instance_paths.items():
+            instance_store = self.cimrepository.get_instance_store(ns)
+            modified_instance.path = path
+            instance_store.update(modified_instance.path, modified_instance)
+
+    @staticmethod
+    def create_new_instance_path(creation_class, new_instance, namespace):
+        """
+        Create the path for the new instance and insert it into the
+        new_instance.path.
+
+        This default provider determines the instance path from the key
+        properties in the new instance. A user-defined provider may do that
+        as well, or invent key properties such as InstanceID.
+        Specifying strict=True from_instance() verifies that all key
+        properties exposed by the class are specified in the new instance,
+        and raises ValueError if key properties are missing.
+
+        Parameters:
+          creation_class (:class:`~pywbem.CIMClass`):
+          The CIM class from which the instance was created. Used to determine
+          the key properties.
+
+          new_instance (:class:`~pywbem.CIMInstance`):
+            The instance from which the CIMInstanceName will be derived.
+
+          namespace: (:term:`string`):
+            The namespace in which the instance will be added.
+
+        Raises:
+            CIMError if instance name cannot be created from instance.
+
+        """
+        try:
+            new_instance.path = CIMInstanceName.from_instance(
+                creation_class, new_instance, namespace=namespace,
+                strict=True)
+
+        except ValueError as exc:
+            raise CIMError(CIM_ERR_INVALID_PARAMETER, str(exc))
+
+    def validate_instance_exists(self, path):
+        """
+        Confirm that the path defined by the path exists in the namespace
+        defined for that path. Null value for path allowed (i.e. no path
+        defined). Returns True if the object exists or the path is empty
+        otherwise False.
+
+        Parameters:
+            path (:class:`pywbem.CIMInstanceName`)
+                path to instance to be tested including namespace.
+
+        Returns:
+            True if path exists in instance store or path is Null.
+            False if path exists and is not in instance store.
+        """
+        if not path:
+            return True
+
+        try:
+            inst_store = self.cimrepository.get_instance_store(path.namespace)
+        except KeyError as ke:
+            raise CIMError(CIM_ERR_INVALID_PARAMETER, str(ke))
+
+        return inst_store.object_exists(path)
+
+    def validate_reference_property_endpoint_exists(self, prop):
+        """
+        Validate that the path defined for the reference property prop
+        exists.  Generates INVALID_PARAMETER if it does not exist.
+
+        Parameters:
+          prop (:class:`pywbem.CIMInstanceName`):
+            Reference property containing CIMInstanceName as value or
+            Null Value
+
+        Raises:
+            CIMError if value of property is not a valid instance or Null
+        """
+        if not self.validate_instance_exists(prop.value):
+            raise CIMError(
+                CIM_ERR_INVALID_PARAMETER,
+                _format("Reference property {0!A} association "
+                        "end point {1!A} does not exist ",
+                        prop.name, prop.value))

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -2471,7 +2471,6 @@ class MainProvider(ResolverMixin, BaseProvider):
 
             :exc:`~pywbem.CIMError`: (CIM_ERR_INVALID_NAMESPACE)
         """
-
         # Parameter types are already checked by WBEMConnection operation
         assert isinstance(namespace, six.string_types)
         assert isinstance(ObjectName, (six.string_types, CIMInstanceName))
@@ -2488,14 +2487,14 @@ class MainProvider(ResolverMixin, BaseProvider):
 
         if isinstance(ObjectName, CIMInstanceName):
             self._validate_instancename_namespace(namespace, ObjectName)
-            assoc_names = self._get_associated_instancenames(namespace,
-                                                             ObjectName,
-                                                             AssocClass,
-                                                             ResultClass,
-                                                             ResultRole, Role)
+            assoc_names = self._get_associated_instancenames(
+                namespace, ObjectName, AssocClass, ResultClass, ResultRole,
+                Role)
+
             results = []
-            instance_store = self.cimrepository.get_instance_store(namespace)
             for obj_name in assoc_names:
+                ns = obj_name.namespace
+                instance_store = self.cimrepository.get_instance_store(ns)
                 results.append(self._get_instance(
                     obj_name, instance_store,
                     INSTANCE_RETRIEVE_LOCAL_ONLY,

--- a/pywbem_mock/_mockmofwbemconnection.py
+++ b/pywbem_mock/_mockmofwbemconnection.py
@@ -166,7 +166,7 @@ class _MockMOFWBEMConnection(ResolverMixin, BaseRepositoryConnection):
 
         mod_inst = args[0] if args else kwargs['ModifiedInstance']
 
-        self.conn.ModifyInstance(mod_inst.path)
+        self.conn.ModifyInstance(mod_inst)
 
     def DeleteInstance(self, *args, **kwargs):
         """

--- a/pywbem_mock/_providerdispatcher.py
+++ b/pywbem_mock/_providerdispatcher.py
@@ -218,10 +218,11 @@ class ProviderDispatcher(BaseProvider):
                         "exist in namespace {1!A} of the CIM repository.",
                         NewInstance.classname, namespace))
 
-        if "Abstract" in creation_class.qualifiers:
+        if creation_class.qualifiers.get("Abstract", False):
             warnings.warn(
-                _format("Tolerating instance creation of abstract class {0} "
-                        " in namepace {1} which is forbidden by DMTF DSP0004.",
+                _format("Tolerating instance creation of abstract "
+                        "class {0} in namepace {1} which is forbidden "
+                        "by DMTF DSP0004.",
                         NewInstance.classname, namespace),
                 ToleratedSchemaIssueWarning, 1)
 
@@ -350,9 +351,7 @@ class ProviderDispatcher(BaseProvider):
 
             prop_inst = ModifiedInstance.properties[pn]
             prop_cls = creation_class.properties[pn]
-            # See issue #2449. This test never executed since if the key
-            # properties changed, the original instance get would have already
-            # failed.
+
             if prop_cls.qualifiers.get('key', False) and \
                     prop_inst.value != instance[pn]:
                 raise CIMError(

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -1205,9 +1205,9 @@ class FakedWBEMConnection(WBEMConnection):
 
     ########################################################################
     #
-    #   Pywbem functions mocked. WBEMConnection only mocks the WBEMConnection
-    #   _imethodcall and _methodcall methods.  This captures all calls
-    #   to the wbem server.
+    #   Pywbem functions mocked. FakedWBEMConnection only mocks the
+    #   WBEMConnection _imethodcall and _methodcall methods.  This captures
+    #   all calls to the wbem server.
     #
     ########################################################################
 
@@ -1358,6 +1358,10 @@ class FakedWBEMConnection(WBEMConnection):
     #  InstanceWriteProvider. All other methods are rounted to the
     #  MainProvider.
     #
+    #  In general, the namespace that is the target of each operation is
+    #  provided as a separate parameter even if the public API defines
+    #  the namespace as part of the target object definition
+    #
     #####################################################################
 
     # Instance Operations
@@ -1370,6 +1374,10 @@ class FakedWBEMConnection(WBEMConnection):
 
         Parameters:
 
+          namespace (:term:`string_type`):
+            The namespace from which the instance namess are to be retrieved.
+            Must not be None.
+
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
@@ -1378,7 +1386,6 @@ class FakedWBEMConnection(WBEMConnection):
           Tuple with instance paths comatible with imethodcall
 
         Raises:
-
           Error: Exceptions from the call
         """
         instance_paths = self._mainprovider.EnumerateInstanceNames(
@@ -1394,15 +1401,17 @@ class FakedWBEMConnection(WBEMConnection):
 
         Parameters:
 
+          namespace (:term:`string_type`):
+            The namespace from which the instance is to be retrieved. Must not
+            be None.
+
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Returns:
-
           Tuple with instances comatible with imethodcall
 
         Raises:
-
           Error: Exceptions from the call
         """
         instances = self._mainprovider.EnumerateInstances(
@@ -1426,15 +1435,17 @@ class FakedWBEMConnection(WBEMConnection):
 
         Parameters:
 
-          params (class:`py:dict`):
+          namespace (:term:`string_type`):
+            The namespace from which the instance is to be retrieved. Must not
+            be None.
 
+          params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Returns:
           Tuple with instance comatible with imethodcall
 
         Raises:
-
           Error: Exceptions from the call
         """
         instance_name = params['InstanceName']
@@ -1459,11 +1470,14 @@ class FakedWBEMConnection(WBEMConnection):
 
         Parameters:
 
+          namespace (:term:`string`):
+            Namespace in which the instance will be created
+            Must not be None.
+
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Raises:
-
           Error: Exceptions from the call
         """
 
@@ -1478,19 +1492,19 @@ class FakedWBEMConnection(WBEMConnection):
         parameters defined for that method and map response to tuple response
         for imethodcall.
 
-        The method called includes the namespace within the ModifiedInstance
-        rather than as a separate element.
 
         This method allows user providers and therefore is passed to the
         :class:`ProviderDispatcher`.
 
         Parameters:
+          namespace (:term:`string`):
+            Namespace in containing the instance to be modified
+            Must not be None.
 
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Raises:
-
           Error: Exceptions from the call
         """
         modified_instance = params['ModifiedInstance']
@@ -1508,19 +1522,18 @@ class FakedWBEMConnection(WBEMConnection):
         parameters defined for that method and map response to tuple response
         for imethodcall.
 
-        The method called includes the namespace within the InstanceName
-        rather than as a separate element.
-
         This method allows user providers and therefore is passed to the
         :class:`ProviderDispatcher`.
 
         Parameters:
+          namespace (:term:`string`):
+            Namespace containing the instance to be deleted
+            Must not be None.
 
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Raises:
-
           Error: Exceptions from the call
         """
         instance_name = params['InstanceName']
@@ -1537,16 +1550,17 @@ class FakedWBEMConnection(WBEMConnection):
         for imethodcall.
 
         Parameters:
+          namespace (:term:`string`):
+            Namespace containing the class and method
+            Must not be None.
 
           params (class:`py:dict`):
             Dictionary of parameters for the method called.
 
         Returns:
-
           Tuple with instances compatible with imethodcall
 
         Raises:
-
           Error: Exceptions from the call
         """
         # pylint: disable=assignment-from-no-return

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -1733,7 +1733,8 @@ TESTCASES_SUBMGR_MODIFY = [
     #   * modify_filter_attrs: defines inst/properties properties to modify
     #     where instances are modified on the server external to
     #     SubscriptionManager (i.e. directly with conn.ModifyInstance)
-    #     The attributes are:
+    #     It can be either a pair of attributes or a CIMProperty
+    #     If it is a pair of attributes the attributes are:
     #       1. The index to the filter_dest to modify
     #       2. dict of properties to modify
     #   * modify_listener_dest_attrs: defines inst/properties properties to
@@ -1773,7 +1774,7 @@ TESTCASES_SUBMGR_MODIFY = [
             exp_result=dict(server_id="http://FakedUrl:5988",
                             listener_count=1)
         ),
-        CIMError, None, FAIL
+        CIMError, None, OK
     ),
     (
         "Modify OK. Property modified",

--- a/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
+++ b/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
@@ -1,0 +1,1631 @@
+# -*- coding: utf-8 -*-
+#
+# (C) Copyright 2022 InovaDevelopment.com
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+# Author: Karl  Schopmeyer <inovadevelopment.com>
+#
+
+"""
+Pywbem mock tests for associations that crosses namespaces.  These
+tests are separate because the multi-namespace capability was added in pywbem
+1.1 so it was simpler to add a new test file. The tests
+provide a test of the logic of processing these associations.
+"""
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from ...utils import skip_if_moftab_regenerated
+from ..utils.pytest_extensions import simplified_test_function
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+from pywbem._utils import _format  # noqa: E402
+
+from ...utils import import_installed
+pywbem = import_installed('pywbem')
+
+from pywbem import DEFAULT_NAMESPACE, CIMInstanceName, CIMProperty, \
+    CIMInstance, CIMError, CIM_ERR_NOT_FOUND, MOFRepositoryError, \
+    Uint32  # noqa: E402
+
+pywbem_mock = import_installed('pywbem_mock')
+from pywbem_mock import FakedWBEMConnection  # noqa:E402
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+# List of initially existing namespaces in the CIM repository
+INITIAL_NAMESPACES = [DEFAULT_NAMESPACE]
+
+#
+# Class mof for associations and endpoints. This is created in all namespaces.
+#
+TST_CLASSES_MOF = """
+    Qualifier Association : boolean = false,
+        Scope(association),
+        Flavor(DisableOverride, ToSubclass);
+
+    Qualifier Description : string = null,
+        Scope(any),
+        Flavor(EnableOverride, ToSubclass, Translatable);
+
+    Qualifier Key : boolean = false,
+        Scope(property, reference),
+        Flavor(DisableOverride, ToSubclass);
+
+    class TST_Person{
+            [Key, Description ("This is key prop")]
+        string name;
+        string extraProperty = "defaultvalue";
+    };
+
+    class TST_Personsub : TST_Person{
+        string secondProperty = "empty";
+        uint32 counter;
+    };
+
+    [ Description("Third endpoint for TST_MemberOfGroup3EP") ]
+    class TST_THIRD_EP {
+            [Key, Description ("This is key prop and endpoint name")]
+        string name;
+    };
+
+    [ Description("Collection of Persons into a group") ]
+    class TST_Group {
+            [Key, Description ("This is key prop and group name")]
+        string name;
+    };
+
+    [Association, Description("Association defines the relationship "
+        "between people and groups with InstanceID as key.") ]
+    class TST_MemberOfGroup {
+        [key] string InstanceID;
+        TST_Person ref member;
+        TST_Group ref group;
+            [Description("Extra parameter to allow ModifyInstance test")]
+        string ExtraPropStr;
+        uint32 ExtraPropInt;
+    };
+
+    [Association, Description(" Association defines the relationship "
+        "between people and groups with reference properties as keys.") ]
+    class TST_MemberOfGroupNoID {
+        [key] TST_Person ref member;
+        [key] TST_Group ref group;
+            [Description("Extra parameter to allow ModifyInstance test")]
+        string ExtraPropStr;
+        uint32 ExtraPropInt;
+    };
+
+    [Association, Description(" Association defines the 3-way relationship "
+        "between people, groups, and 3ep with reference properties as keys.") ]
+    class TST_MemberOfGroup3EP {
+        [key] string InstanceID;
+        TST_Person ref member;
+        TST_Group ref group;
+        TST_THIRD_EP ref ep_3;
+            [Description("Extra parameter to allow ModifyInstance test")]
+        string ExtraPropStr;
+        uint32 ExtraPropInt;
+
+    };
+
+"""
+
+# MOF of Simple cross namespace association endpoint where association key is
+# InstanceID. This defines the instances for one of the association endpoints,
+# normally TST_Person
+INSTANCE_INITIAL_ENDPOINTS = """
+instance of TST_Person as $Mike { name = "Mike"; };
+
+"""
+
+# This defines the common endpoint and the association of
+# TST_MemberOfGroup in ns1.
+ASSOCIATION_MOF_SAME_NS = """
+// association in same namespace
+
+instance of TST_Group as $NS1G1
+{
+    name = "ns1group1";
+};
+
+instance of TST_MemberOfGroup as $G1MikeNS1
+{
+    InstanceID = "G1MikeNS1";
+    member = $Mike;
+    group = $NS1G1;
+};
+
+"""
+
+# Association TST_MemberOfGroup in ns1 with person in ns1, group in ns2,
+# and the association in ns1
+ASSOCIATION_MOF_CROSS_NS = """
+// association crosses namespaces
+
+#pragma namespace ("ns2")
+// target instance
+instance of TST_Group as $NS2G1
+{
+    name = "ns2group1";
+};
+
+#pragma namespace ("ns1")
+instance of TST_MemberOfGroup as $G1MikeNS2
+{
+    InstanceID = "G1MikeNS1";
+    member = $Mike;
+    group = $NS2G1;
+    ExtraPropStr = "OrigValue";
+    ExtraPropInt = 999;
+};
+"""
+
+# Association TST_MemberOfGroup in ns1 with person in ns1, group in ns2,
+# and the association in ns1 with extra properties in association. Used to
+# test modify instance
+ASSOCIATION_MOF_CROSS_NS_NO_EXTRAPROPS = """
+// association crosses namespaces
+
+#pragma namespace ("ns2")
+// target instance
+instance of TST_Group as $NS2G1
+{
+    name = "ns2group1";
+};
+
+#pragma namespace ("ns1")
+instance of TST_MemberOfGroup as $G1MikeNS2
+{
+    InstanceID = "G1MikeNS1";
+    member = $Mike;
+    group = $NS2G1;
+
+};
+"""
+
+# Association TST_MemberOfGroup in ns1 with person in ns1 and group in ns2
+ASSOCIATION_MOF_CROSS_NS_CAUSES_CLASSERROR = """
+// association crosses namespaces
+
+#pragma namespace ("ns2")
+// target instance
+instance of TST_Group as $NS2G1
+{
+    name = "ns2group1";
+};
+
+#pragma namespace ("ns1")
+instance of TST_MemberOfGroup as $G1MikeNS2
+{
+    InstanceID = "G1MikeNS1";
+    member = $Mike;
+    group = $NS2G1;
+};
+"""
+
+# Association TST_MemberOfGroupNoID in ns1 with person in ns1 and group in ns2
+# Assoc key is ref properties
+ASSOCNOID_MOF_CROSS_NS = """
+// association crosses namespaces
+
+#pragma namespace ("ns2")
+// target instance
+instance of TST_Group as $NS2G1
+{
+    name = "ns2group1";
+};
+
+#pragma namespace ("ns1")
+instance of TST_MemberOfGroupNoID as $G1MikeNS2A2
+{
+    member = $Mike;
+    group = $NS2G1;
+};
+
+"""
+
+
+# Association 3-way with TST_THIRD_EP endpoint and instance of
+# TST_MemberOfGroup3EP
+ASSOCIATIONX_3WAY_MOF_CROSS_NS = """
+// association crosses namespaces
+
+#pragma namespace ("ns2")
+// target instance
+instance of TST_Group as $NS2G1
+{
+    name = "ns2group1";
+};
+
+#pragma namespace ("ns3")
+// target instance  of class TST_THIRD_EP
+instance of TST_THIRD_EP as $NS3X1
+{
+    name = "ns3X1";
+};
+
+#pragma namespace ("ns1")
+instance of TST_MemberOfGroup3EP as $G1MikeAxNs3
+{
+    InstanceID = "G1MikeAxNs3";
+    member = $Mike;
+    group = $NS2G1;
+    ep_3 = $NS3X1;
+};
+
+"""
+
+
+# Instance paths for instances of MenberOfGroupNoID, the association that
+# uses the references as keys.  Too long to insert into tests themselves.
+COMMON_MEMBEROFGROUPNOID = 'TST_MemberOfGroupNoID.group="/ns2:TST_Group.' \
+    'name=\\"ns2group1\\"",member="/ns1:TST_Person.name=\\"Mike\\""'
+
+MEMBEROFGROUPNOIDNS1 = '/ns1:' + COMMON_MEMBEROFGROUPNOID
+MEMBEROFGROUPNOIDNS2 = '/ns2:' + COMMON_MEMBEROFGROUPNOID
+
+# test variables to allow selectively executing tests.
+OK = True
+RUN = True
+FAIL = False
+VERBOSE = False
+
+
+def create_repository(conn, namespaces, class_mof, inst_mof, assoc_inst_mof):
+    """
+    Create the namespaces, qualdecls, classes, instances for the test
+    """
+    # Create remaining namespaces
+    for ns in namespaces:
+        if ns not in conn.namespaces:
+            conn.add_namespace(ns)
+
+    skip_if_moftab_regenerated()
+
+    # Compile the class mof in all namespaces
+    for ns in namespaces:
+        for mof in class_mof:
+            conn.compile_mof_string(mof, ns)
+
+    # Compile all instance mof together to utilize compiler alias capability
+    # each of the components is a list.
+    all_inst_mof = "\n".join(inst_mof) + "\n".join(assoc_inst_mof)
+
+    conn.compile_mof_string(all_inst_mof)
+
+
+def val_act_exp_paths(act_rtns, exp_rtn, ns, operation, source_cln):
+    """
+    Test that the  actual instance paths are exactly the same as
+    the expected returns in exp_rtn[ns][operation][source_cln].
+
+    Ignores host parameter of returned instance paths
+    """
+
+    assert isinstance(act_rtns, list)
+
+    # Get expected returns for this ns, operation, and source_cln
+    # from exp_rtn dictionary
+    exp_rtns = exp_rtn[ns][operation][source_cln]
+
+    # Convert URIs in exp_rtns to CIMInstanceName objects
+    exp_objs = [CIMInstanceName.from_wbem_uri(p) for p in exp_rtns]
+
+    assert len(act_rtns) == len(exp_rtns), \
+        _format("ns:{}, operation:{}, source_cln:{}", ns, operation, source_cln)
+
+    for instname in act_rtns:
+        instname.host = None
+
+    assert set(act_rtns) == set(exp_objs), \
+        _format("ns:{}, operation:{}, tst_class:{}", ns, operation, source_cln)
+
+
+def validate_instance_enumeration(conn, namespaces, enum_clns, exp_rtn):
+    """
+    Validate that EnumerateInstances returns correct instances. Note we only
+    test instance names. The enum_clns is the list of all classnames for which
+    EnumerateInstanceNames is to be executed.
+    """
+    for ns in namespaces:
+        # Test EnumerateInstanceNames for all classes in enumeration
+        for tst_cln in enum_clns:
+            inst_paths = conn.EnumerateInstanceNames(tst_cln, namespace=ns)
+            val_act_exp_paths(inst_paths, exp_rtn, ns, 'ENUM', tst_cln)
+
+
+def validate_instance_associations(conn, namespaces, source_clns, exp_rtn):
+    """
+    Test that AssociationNames and ReferenceNames return correct instance
+    paths
+    """
+    for ns in namespaces:
+        # Test References and Associators for each classname in source_clns
+        # This tests associations in both directions.
+        for source_cln in source_clns:
+            # Test only if there is an instance of source_cln
+            if conn.EnumerateInstances(source_cln):
+                source_paths = conn.EnumerateInstanceNames(source_cln,
+                                                           namespace=ns)
+
+                for source_path in source_paths:
+                    # Compare ReferenceNames and AssociatonNames requests
+                    inst_paths = conn.ReferenceNames(source_path)
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'REF',
+                                      source_cln)
+                    inst_paths = conn.AssociatorNames(source_path)
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'ASSOC',
+                                      source_cln)
+
+                    # Compare paths of References returns
+                    insts = conn.References(source_path)
+                    # Validate path and reference property same values
+                    for inst in insts:
+                        keys = inst.path.keybindings
+                        for prop in inst.properties.values():
+                            if prop.type == 'references':
+                                if prop.name in keys:
+                                    assert prop.value == keys[prop.name]
+                    inst_paths = [i.path for i in insts]
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'REF',
+                                      source_cln)
+
+                    # Compare paths of Associator returns
+                    insts = conn.Associators(source_path)
+                    inst_paths = [r.path for r in insts]
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'ASSOC',
+                                      source_cln)
+
+
+# pylint: disable=bad-continuation
+
+
+TESTCASES_MULTI_NAMESPACES = [
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * namespaces - List of namespaces in mock environment
+    #   * class_mof - list of strings containing qualdecl and class mof to
+    #     be compiled
+    #   * inst_mof - list of strings containing instance mof to be compiled
+    #   * assoc_inst_mof - list of strings  containing instances defining
+    #     associations to be compiled. These strings must define the namespace
+    #     for components that are not in the default namespace.
+    #   * source classnames for ENUM, REF, ASSOC tests - The classnames that
+    #     are the source classes for these operations
+    #   * assoc_clns - The classname of the reference class being tested
+    #   * delete_ns - If not None, defnes namespace from which association
+    #     is deleted in delete test.  If None, deleted from creation ns.
+    #   * exp_rtn: dictionary containing expected return objects (primarily
+    #     CIMInstanceNames). The dictionary is defined as
+    #     {<namespace>: <operation>: <source_class>: list of results instance
+    #     names.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    (
+        "Test association in one namespace. Assures model/test works",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_SAME_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': ['/ns1:TST_Group.name="ns1group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"'],
+                         'TST_Group':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Person': ['/ns1:TST_Group.name="ns1group1"']}, },
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup': []},
+                     'REF':
+                        {'TST_Person': []},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': []}, },
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association cross namespaces with MemberOfGroup",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association cross namespaces with MemberOfGroup delete from "
+        "alternate namespace",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns='ns2',
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association TST_MemberOfGroupNoID (refs as keys) cross ns",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCNOID_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroupNoID',
+            delete_ns=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroupNoID': [MEMBEROFGROUPNOIDNS1]},
+                     'REF':
+                        {'TST_Person': [MEMBEROFGROUPNOIDNS1]},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroupNoID': [MEMBEROFGROUPNOIDNS2]},
+                     'REF':
+                        {'TST_Group': [MEMBEROFGROUPNOIDNS2]},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test 3way association TST_MemberOfGroup3EP cross  3 namespaces",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2', 'ns3'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATIONX_3WAY_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group', 'TST_THIRD_EP'],
+            assoc_clns='TST_MemberOfGroup3EP',
+            delete_ns='ns1',
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': [],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Person':
+                            ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeAxNs3"']},
+                     'ASSOC':
+                        {'TST_Person': ['/ns2:TST_Group.name="ns2group1"',
+                                        '/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': []}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         "TST_THIRD_EP": [],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns2:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeAxNs3"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"',
+                                       '/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_THIRD_EP': []}},
+                'ns3':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': ['/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns3:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': ['/ns1:TST_Person.name="Mike"',
+                                          '/ns2:TST_Group.name="ns2group1"']}},
+            },
+        ),
+        None, None, OK
+    ),
+
+    # TODO: Needs the following tests.
+    #  Test with other instances and more associations in the test
+    #  Lower priority:
+    #    Test 3 way association.
+
+]
+# pylint: enable=bad-continuation
+
+# Disabled because it is unhappy with indentation of multilevel dictionary
+# lower levels.  Note that this occurs with minimum version tests but not with
+# latest version tests
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_MULTI_NAMESPACES)
+@simplified_test_function
+def test_multiple_namespace_assoc(testcase, namespaces, class_mof, inst_mof,
+                                  assoc_inst_mof, source_clns, assoc_clns,
+                                  delete_ns, exp_rtn):
+    # pylint: disable=unused-argument
+    """
+    Test the creation and deletion of instances of association that cross
+    namespaces.
+    """
+    conn = FakedWBEMConnection(default_namespace=namespaces[0])
+
+    # Create the repository from test components.  Creates qualdecls,
+    # classes, endpoint instances, association instances in multiple
+    # namespaces
+    create_repository(conn, namespaces, class_mof, inst_mof, assoc_inst_mof)
+
+    assert len(namespaces) == len(exp_rtn)
+
+    # Create list of all classes for enumeration test. Note: This
+    # creates a new list.  list() forces create of new object
+    enum_clns = list(source_clns)
+    enum_clns.append(assoc_clns)
+
+    # Test that the creation of instances was correct.
+    validate_instance_enumeration(conn, namespaces, enum_clns, exp_rtn)
+
+    validate_instance_associations(conn, namespaces, source_clns, exp_rtn)
+
+    # Test delete of association instances
+
+    # delete the instance names of the associations in namespace defined by
+    # delete_ns.  This should delete each of these associations in each
+    # namespace
+    deleted_assocs = []
+    if delete_ns:
+        ns = delete_ns
+        inst_names = conn.EnumerateInstanceNames(assoc_clns, namespace=ns)
+        for inst_name in inst_names:
+            _ = conn.GetInstance(inst_name)
+            conn.DeleteInstance(inst_name)
+            deleted_assocs.append(inst_name)
+
+        # Confirm inst_name deleted in all namespaces
+        for namespace in namespaces:
+            for assoc_name in deleted_assocs:
+                try:
+                    assoc_name.namespace = namespace
+                    conn.GetInstance(assoc_name)
+                    assert False, _format(
+                        "Instance {} should not exist in ns {} after delete",
+                        assoc_name, namespace)
+                except CIMError as ce:
+                    assert ce.status_code == CIM_ERR_NOT_FOUND
+
+
+# pylint: disable=bad-continuation
+
+TESTCASES_MULTI_NAMESPACES_ERRORS = [
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * namespaces - List of namespaces in mock environment
+    #   * class_mof - list of strings containing qualdecl and class mof to
+    #     be compiled
+    #   * classes to remove from namespaces (dict <ns>: [<class names>]) before
+    #     attempting to compile instances.
+    #   * inst_mof - list of strings containing instance mof to be compiled
+    #   * assoc_inst_mof
+    #   * assoc_inst_obj - Instance definition in python. Used to create
+    #     invalid instances
+    #   * src_clns -
+    #   * assoc_clns -
+    #   * delete_ns -
+    #   * exp_rtn -
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    (
+        "Test fails with assoc class missing from second namespace",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            remove_classes={'ns2': ['TST_MemberOfGroup']},
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            assoc_inst_obj=None,
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroupNoID',
+            delete_ns=None,
+            exp_rtn=None
+        ),
+        MOFRepositoryError, None, OK
+    ),
+
+    (
+        "Test fails,assoc instance already exists",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            remove_classes={'ns2': ['TST_MemberOfGroup']},
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            assoc_inst_obj=None,
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroupNoID',
+            delete_ns=None,
+            exp_rtn=None
+        ),
+        MOFRepositoryError, None, OK
+    ),
+
+    (
+        "Test  bad end-points paths (do not exist) fails",
+        dict(
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            remove_classes={'ns2': ['TST_MemberOfGroup']},
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[],
+            # Association instance with  invalid reference properties
+            assoc_inst_obj=CIMInstance(
+                'TST_MemberOfGroup',
+                path=CIMInstanceName(
+                    "TST_MemberOfGroup", keybindings=dict(InstanceID="blah"),
+                    namespace='ns1'),
+                properties=dict(
+                    InstanceID=CIMProperty("InstanceID", "blah"),
+                    member=CIMProperty(
+                        "member",
+                        CIMInstanceName('TST_PERSON',
+                                        keybindings=dict(name="fred"),
+                                        namespace='ns1')),
+                    group=CIMProperty(
+                        'group',
+                        CIMInstanceName('TST_Group',
+                                        keybindings=dict(name="john"),
+                                        namespace='ns2')))),
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns=None,
+            exp_rtn=None
+        ),
+        CIMError, None, OK
+    ),
+
+    (
+        "Test  bad 2nd end-point path (instance does not exist) fails",
+        dict(
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            remove_classes={'ns2': ['TST_MemberOfGroup']},
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[],
+            # Association instance with  invalid reference properties
+            assoc_inst_obj=CIMInstance(
+                'TST_MemberOfGroup',
+                path=CIMInstanceName(
+                    "TST_MemberOfGroup", keybindings=dict(InstanceID="blah"),
+                    namespace='ns1'),
+                properties=dict(
+                    InstanceID=CIMProperty("InstanceID", "blah"),
+                    member=CIMProperty(
+                        "member",
+                        CIMInstanceName('TST_PERSON',
+                                        keybindings=dict(name="Mike"),
+                                        namespace='ns1')),
+                    group=CIMProperty(
+                        'group',
+                        CIMInstanceName('TST_Group',
+                                        keybindings=dict(name="john"),
+                                        namespace='ns2')))),
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns=None,
+            exp_rtn=None
+        ),
+        CIMError, None, OK
+    ),
+
+    (
+        "Test bad 2nd end-point path  namespace does not exist) fails",
+        dict(
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            remove_classes={'ns2': ['TST_MemberOfGroup']},
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[],
+            # Association instance with  invalid reference properties
+            assoc_inst_obj=CIMInstance(
+                'TST_MemberOfGroup',
+                path=CIMInstanceName(
+                    "TST_MemberOfGroup", keybindings=dict(InstanceID="blah"),
+                    namespace='ns1'),
+                properties=dict(
+                    InstanceID=CIMProperty("InstanceID", "blah"),
+                    member=CIMProperty(
+                        "member",
+                        CIMInstanceName('TST_PERSON',
+                                        keybindings=dict(name="Mike"),
+                                        namespace='ns1')),
+                    group=CIMProperty(
+                        'group',
+                        CIMInstanceName('TST_Group',
+                                        keybindings=dict(name="ns2group1"),
+                                        namespace='InvalidNS')))),
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            delete_ns=None,
+            exp_rtn=None
+        ),
+        CIMError, None, OK
+    ),
+
+
+    #  Test fail mode, Create assoc instance where instance already exists.
+    #  Test fail mode where on create assoc instance exists already in
+    #  second namespace
+
+]
+# pylint: enable=bad-continuation
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_MULTI_NAMESPACES_ERRORS)
+@simplified_test_function
+def test_multiple_namespace_assoc_errs(testcase, namespaces, class_mof,
+                                       remove_classes, inst_mof,
+                                       assoc_inst_mof, assoc_inst_obj,
+                                       source_clns, assoc_clns,
+                                       delete_ns, exp_rtn):
+
+    # pylint: disable=unused-argument
+    """
+    Test the creation and deletion of instances of association that cross
+    namespaces.
+    """
+    conn = FakedWBEMConnection(default_namespace=namespaces[0])
+
+    # Create namespaces
+    for ns in namespaces:
+        if ns not in conn.namespaces:
+            conn.add_namespace(ns)
+
+    skip_if_moftab_regenerated()
+
+    # Compile the class mof in all namespaces
+    for ns in namespaces:
+        for mof in class_mof:
+            conn.compile_mof_string(mof, ns)
+
+    # Delete classes defined by remove_classes to set up compile failures
+    for ns, clns in remove_classes.items():
+        for cln in clns:
+            conn.DeleteClass(cln, ns)
+
+    # Compile all instance mof together to utilize compiler alias capability
+    # each of the components is a list.
+    all_inst_mof = "\n".join(inst_mof) + "\n".join(assoc_inst_mof)
+
+    conn.compile_mof_string(all_inst_mof, verbose=VERBOSE)
+
+    # Create list of all classes for enumeration test. Note: This
+    # creates a new list.
+    enum_clns = list(source_clns)
+    enum_clns.append(assoc_clns)
+
+    # Create instance defined by assoc_inst_obj.
+    if assoc_inst_obj:
+        conn.CreateInstance(assoc_inst_obj)
+
+    # Test that the creation of instances was correct.
+    for ns in namespaces:
+        # Test EnumerateInstanceNames for all classes in enumeration
+        for tst_cln in enum_clns:
+            inst_paths = conn.EnumerateInstanceNames(tst_cln, namespace=ns)
+            val_act_exp_paths(inst_paths, exp_rtn, ns, 'ENUM', tst_cln)
+
+        # Test References and Associators for each classname in source_clns
+        for source_cln in source_clns:
+            # Test only if there is an instance of source_cln
+            if conn.EnumerateInstances(source_cln):
+                source_paths = conn.EnumerateInstanceNames(source_cln,
+                                                           namespace=ns)
+
+                for source_path in source_paths:
+                    # Compare ..Names requests
+                    inst_paths = conn.ReferenceNames(source_path)
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'REF',
+                                      source_cln)
+                    inst_paths = conn.AssociatorNames(source_path)
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'ASSOC',
+                                      source_cln)
+
+                    # Compare paths of References returns
+                    insts = conn.References(source_path)
+                    # Validate path and reference property same values
+                    for inst in insts:
+                        keys = inst.path.keybindings
+                        for prop in inst.properties.values():
+                            if prop.type == 'references':
+                                if prop.name in keys:
+                                    assert prop.value == keys[prop.name]
+                    inst_paths = [i.path for i in insts]
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'REF',
+                                      source_cln)
+
+                    # Compare paths of Associator returns
+                    insts = conn.Associators(source_path)
+                    inst_paths = [r.path for r in insts]
+                    val_act_exp_paths(inst_paths, exp_rtn, ns, 'ASSOC',
+                                      source_cln)
+
+
+# pylint: disable=bad-continuation
+
+TESTCASES_MULTI_NAMESPACES_MODIFY_INSTANCE = [
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * namespaces - List of namespaces in mock environment
+    #   * class_mof - list of strings containing qualdecl and class mof to
+    #     be compiled
+    #   * inst_mof - list of strings containing instance mof to be compiled.
+    #     These are the endpoint instances to be installed in ns1
+    #   * assoc_inst_mof - list of strings  containing instances defining
+    #     associations and other endpoints to be compiled. These strings must
+    #     define the namespace for components that are not in the ns1 namespace.
+    #   * source classnames for ENUM, REF, ASSOC tests - The classnames that
+    #     are the source classes for these operations
+    #   * assoc_clns - The classname of the reference class being tested
+    #   * delete_ns - If not None, defnes namespace from which association
+    #     is deleted in delete test.  If None, deleted from creation ns.
+    #   * property_mods - If None defines a set of modifications to properties
+    #     of an instance defined in a tuple where item 0 is the path to the
+    #     instance to modify and item 1 is is a tuple with either:
+    #     * one or more tuples where each tuple defines the property name and
+    #       new value for the modification.
+    #     * a CIMProperty that defines the name, type and value of the
+    #       replacement property value.
+    #     Prop_list to be passed to ModifyInstance. None, modify all properties
+    #     defined as different (see property_mods), list of strings, modify
+    #     only properties in the list, empty list, modify no properties.
+    #   * del_assoc_instance_test: defines instance path of one assoc instance
+    #     to delete (one of the shadowed instances) to test modify when
+    #     shadow insts not complete.
+    #   * exp_rtn: dictionary containing expected return objects (primarily
+    #     CIMInstanceNames). The dictionary is defined as
+    #     {<namespace>: <operation>: <source_class>: list of results instance
+    #     names.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for
+    #   debugger
+
+    (
+        "Test association Modify in one namespace. Modify ExtraPropStr prop",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_SAME_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           (("ExtraPropStr", "NewStringVal"),)),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': ['/ns1:TST_Group.name="ns1group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"'],
+                         'TST_Group':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Person': ['/ns1:TST_Group.name="ns1group1"']}, },
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup': []},
+                     'REF':
+                        {'TST_Person': []},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': []}, },
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup. No prop "
+        "values in instance",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS_NO_EXTRAPROPS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           (("ExtraPropStr", "NewStringVal"),
+                            ("ExtraPropInt", Uint32(88888)))),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup modifiy 2 "
+        "properties",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           (("ExtraPropStr", "NewStringVal"),
+                            ("ExtraPropInt", Uint32(88888)))),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup mod 2 prop"
+        " and property list with both properties",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           (("ExtraPropStr", "NewStringVal"),
+                            ("ExtraPropInt", Uint32(88888)))),
+            prop_list=["ExtraPropStr", "ExtraPropInt"],
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup delete "
+        "from alternate namespace",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           (("ExtraPropStr", "NewStringVal"),)),
+            prop_list=None,
+            delete_ns='ns2',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association modify TST_MemberOfGroupNoID (refs as keys) cross ns",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCNOID_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroupNoID',
+            property_mods=(MEMBEROFGROUPNOIDNS1,
+                           (("ExtraPropStr", "NewStringVal"),)),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroupNoID':
+                             [MEMBEROFGROUPNOIDNS1]},
+                     'REF':
+                        {'TST_Person':
+                             [MEMBEROFGROUPNOIDNS1]},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroupNoID':
+                             [MEMBEROFGROUPNOIDNS2]},
+                     'REF':
+                        {'TST_Group':
+                            [MEMBEROFGROUPNOIDNS2]},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test 3way association modify TST_MemberOfGroup3EP cross  3 namespaces",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2', 'ns3'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATIONX_3WAY_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group', 'TST_THIRD_EP'],
+            assoc_clns='TST_MemberOfGroup3EP',
+            property_mods=('/ns1:TST_MemberOfGroup3EP.InstanceID="G1MikeAxNs3"',
+                           (("ExtraPropStr", "NewStringVal"),)),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': [],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Person':
+                            ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeAxNs3"']},
+                     'ASSOC':
+                        {'TST_Person': ['/ns2:TST_Group.name="ns2group1"',
+                                        '/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': []}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         "TST_THIRD_EP": [],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns2:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns1:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeAxNs3"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"',
+                                       '/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_THIRD_EP': []}},
+                'ns3':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': ['/ns3:TST_THIRD_EP.name="ns3X1"'],
+                         'TST_MemberOfGroup3EP':
+                             ['/ns3:TST_MemberOfGroup3EP.InstanceID='
+                              '"G1MikeAxNs3"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup3EP.InstanceID='
+                             '"G1MikeAxNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': [],
+                         'TST_THIRD_EP': ['/ns1:TST_Person.name="Mike"',
+                                          '/ns2:TST_Group.name="ns2group1"']}},
+            },
+        ),
+        None, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup and"
+        "ref prop modification",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=(
+                '/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                # Modify group reference property
+                (("group", CIMInstanceName("TST_Group", namespace='ns2',
+                                           keybindings={"name":
+                                                        "NotExist"})), )),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        CIMError, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with a shadow assoc inst "
+        "missing",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           ((CIMProperty("member", type="reference",
+                                         value=None),))),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        CIMError, None, OK
+    ),
+
+    (
+        "Test association modify cross namespaces with MemberOfGroup mod "
+        "ref to Null",
+        dict(
+            # first namespace becomes the default namespace
+            namespaces=['ns1', 'ns2'],
+            class_mof=[TST_CLASSES_MOF],
+            inst_mof=[INSTANCE_INITIAL_ENDPOINTS],
+            assoc_inst_mof=[ASSOCIATION_MOF_CROSS_NS],
+            source_clns=['TST_Person', 'TST_Group'],
+            assoc_clns='TST_MemberOfGroup',
+            property_mods=('/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"',
+                           ((CIMProperty("member", type="reference",
+                                         value=None),))),
+            prop_list=None,
+            delete_ns='ns1',
+            delete_assoc_inst_test=None,
+            exp_rtn={
+                'ns1':
+                    {'ENUM':
+                        {'TST_Person': ['/ns1:TST_Person.name="Mike"'],
+                         'TST_Group': [],
+                         'TST_MemberOfGroup':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Person':
+                             ['/ns1:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Group': [],
+                         'TST_Person': ['/ns2:TST_Group.name="ns2group1"']}},
+                'ns2':
+                    {'ENUM':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns2:TST_Group.name="ns2group1"'],
+                         'TST_MemberOfGroup':
+                             ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'REF':
+                        {'TST_Group':
+                            ['/ns2:TST_MemberOfGroup.InstanceID="G1MikeNS1"']},
+                     'ASSOC':
+                        {'TST_Person': [],
+                         'TST_Group': ['/ns1:TST_Person.name="Mike"']}}
+            },
+        ),
+        CIMError, None, RUN
+    ),
+
+
+    # TODO: Needs the following tests.
+
+
+]
+# pylint: enable=bad-continuation
+
+# Disabled this pylint because it is unhappy with indentation of multilevel
+# dictionary lower levels.  Note that this occurs with minimum version tests
+# but not with latest version tests
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_MULTI_NAMESPACES_MODIFY_INSTANCE)
+@simplified_test_function
+def test_multiple_namespace_assoc_modify(testcase, namespaces, class_mof,
+                                         inst_mof, assoc_inst_mof, source_clns,
+                                         assoc_clns, property_mods, prop_list,
+                                         delete_ns, delete_assoc_inst_test,
+                                         exp_rtn):
+    # pylint: disable=unused-argument
+    """
+    Test the ModifyInstance of multi-namespace association instances defined
+    in pywbem_mock.
+    """
+    conn = FakedWBEMConnection(default_namespace=namespaces[0])
+
+    # Create the repository from test components.  Creates qualdecls,
+    # classes, endpoint instances, association instances in multiple
+    # namespaces
+    create_repository(conn, namespaces, class_mof, inst_mof, assoc_inst_mof)
+
+    assert len(namespaces) == len(exp_rtn)
+
+    # Create list of all classes for enumeration test. Note: This
+    # creates a new list.  list() forces create of new object
+    enum_clns = list(source_clns)
+    enum_clns.append(assoc_clns)
+
+    # Test that the creation of instances was correct.
+    validate_instance_enumeration(conn, namespaces, enum_clns, exp_rtn)
+
+    validate_instance_associations(conn, namespaces, source_clns, exp_rtn)
+
+    # if delete_assoc_inst_test exists delete the instance defined for the
+    # test from the repository.  The modify should then fail.
+    if delete_assoc_inst_test:
+        ns = delete_assoc_inst_test.namespace
+        instance_store = conn.repository.cimrepository.get_instance_store(ns)
+        instance_store.delete(delete_assoc_inst_test)
+
+    # Modify the association instance defined. Test by getting it from repo and
+    # comparing values
+    if property_mods:
+        inst_name = CIMInstanceName.from_wbem_uri(property_mods[0])
+        modified_inst = conn.GetInstance(inst_name)
+        mods = property_mods[1]
+        for pmod in mods:
+            if isinstance(pmod, tuple):
+                modified_inst[pmod[0]] = pmod[1]
+            elif isinstance(pmod, CIMProperty):
+                modified_inst[pmod.name] = pmod
+            else:
+                assert False, "Invalid property_mod test parameter"
+
+        if prop_list is None:
+            conn.ModifyInstance(modified_inst)
+        else:
+            conn.ModifyInstance(modified_inst, PropertyList=prop_list)
+
+        modified_inst_rtn = conn.GetInstance(modified_inst.path)
+        for prop in modified_inst:
+            assert modified_inst_rtn[prop] == modified_inst[prop]
+
+        for pmod in mods:
+            if prop_list and pmod in prop_list:
+                assert modified_inst_rtn[pmod[0]] == pmod[1]
+
+    # validate enumeration and associations with modified instance
+    validate_instance_enumeration(conn, namespaces, enum_clns, exp_rtn)
+
+    validate_instance_associations(conn, namespaces, source_clns, exp_rtn)
+
+    # Test delete of association instances
+
+    # delete the instance names of the associations in namespace defined by
+    # delete_ns.  This should delete each of these associations in each
+    # namespace
+    deleted_assocs = []
+    if delete_ns:
+        ns = delete_ns
+        inst_names = conn.EnumerateInstanceNames(assoc_clns, namespace=ns)
+        for inst_name in inst_names:
+            _ = conn.GetInstance(inst_name)
+            conn.DeleteInstance(inst_name)
+            deleted_assocs.append(inst_name)
+
+        # Confirm inst_name deleted in all namespaces
+        for namespace in namespaces:
+            for assoc_name in deleted_assocs:
+                try:
+                    assoc_name.namespace = namespace
+                    conn.GetInstance(inst_name)
+                    assert False, _format("Instance {} should not exist in "
+                                          "ns {} after delete", inst_name,
+                                          namespace)
+                except CIMError as ce:
+                    assert ce.status_code == CIM_ERR_NOT_FOUND
+
+
+# pylint: disable=bad-continuation

--- a/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
+++ b/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
@@ -1566,7 +1566,7 @@ def test_multiple_namespace_assoc_modify(testcase, namespaces, class_mof,
     # test from the repository.  The modify should then fail.
     if delete_assoc_inst_test:
         ns = delete_assoc_inst_test.namespace
-        instance_store = conn.repository.cimrepository.get_instance_store(ns)
+        instance_store = conn.cimrepository.get_instance_store(ns)
         instance_store.delete(delete_assoc_inst_test)
 
     # Modify the association instance defined. Test by getting it from repo and

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -6346,12 +6346,15 @@ class TestInstanceOperations(object):
         Test compile generates warning compiling instance of abstract class
         """
         tst_mof = """
-            Qualifier Abstract : boolean = false,
+            Qualifier Abstract : boolean = true,
                 Scope(class),
                 Flavor(DisableOverride, ToSubclass);
+        Qualifier Key : boolean = false,
+            Scope(property, reference),
+            Flavor(DisableOverride, ToSubclass);
 
              [ Abstract ]
-        class CIM_Abstract {string InstanceID;};
+        class CIM_Abstract {[key] string InstanceID;};
         instance of CIM_Abstract {InstanceID="blah";};
         """
         skip_if_moftab_regenerated()


### PR DESCRIPTION
Waiting pr #2916, the latest security issues so should fail if resubmitted before that issue is fixed

Extends creation, modification, and deletion of association instances in
pywbem_mock where the instance reference defines cross namespace
associations to build a corresponding instance of the association in
each namespace.

See Commit message for details

NOTE: This pr also fixed some pylint issues that apparently popped up with new version of pylint and added test for existence of association endpoints when creating/modifying new instances in pywbem_mock
Prviously it would pass end points path definitions that were invalid. 