### PR TITLE
Mark new security(safety) issues for ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,12 @@ py_test_files := \
 # - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
 # - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
 # - 45185 Pylint cannot be upgraded on py27
+# - SEPT 2022
+# - 50748 lxml - NULL pointer dereference min ver 4.6.2 to 4.9.1
+# - 50571 dparse (used by safety). Impacts dparse 0.4.1 and 0.5.1. Null pointer deref & ReDos issue
+# - 50664 ipwidgets - User Jupyter. Min ver 5.2.2 to 8.0.0. Sanitize descriptions
+# - 50463 ipwidgets - from 5.2.2 to 8.0.0.rc2
+# - 50792 nbconvert - from 5.0.0 to 6.5.1
 
 safety_ignore_opts := \
     -i 38100 \
@@ -343,6 +349,11 @@ safety_ignore_opts := \
 		-i 45775 \
 		-i 47833 \
 		-i 45185 \
+		-i 50571 \
+		-i 50664 \
+		-i 50463 \
+		-i 50792 \
+		-i 50748 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \


### PR DESCRIPTION
New security issues on dparse, ipwidgets, nbconvert.  Marked all to be
ignored for now.

I just marked them  for ignore for the moment since they are all packages
that are part of test environment and not pywbem pip package.  I took this as the fastest approach to getting
CI running with number of outstanding Open PRs

===================
I tried to use dparse rather than just ignore it.  It would appear that this is not possible with
python 2.7 however. I changed the limits in dev-requirements and minimum-constraints for dparse dparse I enabled min version 0.5.2 for all but python 2.7 and put entry into ignore list (in the Makefile) for python 2.7.
However, that is not working correctly as of Friday afternoon.   

For example fails with python 3.10, ubuntu, minimum test but results show that it is installing dparse 0.5.2 but issueing
the security message about dparse 0.4.1.   Since I am trying to fix issue for Walker, I had to stop Frday evening for
now.

NOTE: That work not committed.

=====================

```
| REPORT                                                                       |
| checked 237 packages, using default DB                                       |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| lxml                       | 4.6.2     | <4.9.1                   | 50748    |
+==============================================================================+
| Lxml 4.9.1 include a fix for CVE-2022-2309: NULL Pointer Dereference allows  |
| attackers to cause a denial of service (or application crash). This only     |
| applies when lxml is used together with libxml2 2.9.10 through 2.9.14.       |
| Libxml2 2.9.9 and earlier versions are not affected. It allows triggering    |
| crashes through forged input data, given a vulnerable code sequence in the   |
| application. The vulnerability is caused by the iterwalk function (also used |
| by the canonicalize function). Such code shouldn't be in wide-spread use,    |
| given that parsing + iterwalk would usually be replaced with the more        |
| efficient iterparse function. However, an XML converter that serializes to   |
| C14N would also be vulnerable, for example, and there are legitimate use     |
| cases for this code sequence. If untrusted input is received (also remotely) |
| and processed via iterwalk function, a crash can be triggered.               |
+==============================================================================+
| lxml                       | 4.6.2     | <4.9.1                   | 50748    |
+==============================================================================+
| Lxml 4.9.1 include a fix for CVE-2022-2309: NULL Pointer Dereference allows  |
| attackers to cause a denial of service (or application crash). This only     |
| applies when lxml is used together with libxml2 2.9.10 through 2.9.14.       |
| Libxml2 2.9.9 and earlier versions are not affected. It allows triggering    |
| crashes through forged input data, given a vulnerable code sequence in the   |
| application. The vulnerability is caused by the iterwalk function (also used |
| by the canonicalize function). Such code shouldn't be in wide-spread use,    |
| given that parsing + iterwalk would usually be replaced with the more        |
| efficient iterparse function. However, an XML converter that serializes to   |
| C14N would also be vulnerable, for example, and there are legitimate use     |
| cases for this code sequence. If untrusted input is received (also remotely) |
| and processed via iterwalk function, a crash can be triggered.               |
+==============================================================================+
| lxml                       | 4.6.4     | <4.9.1                   | 50748    |
+==============================================================================+
| Lxml 4.9.1 include a fix for CVE-2022-2309: NULL Pointer Dereference allows  |
| attackers to cause a denial of service (or application crash). This only     |
| applies when lxml is used together with libxml2 2.9.10 through 2.9.14.       |
| Libxml2 2.9.9 and earlier versions are not affected. It allows triggering    |
| crashes through forged input data, given a vulnerable code sequence in the   |
| application. The vulnerability is caused by the iterwalk function (also used |
| by the canonicalize function). Such code shouldn't be in wide-spread use,    |
| given that parsing + iterwalk would usually be replaced with the more        |
| efficient iterparse function. However, an XML converter that serializes to   |
| C14N would also be vulnerable, for example, and there are legitimate use     |
| cases for this code sequence. If untrusted input is received (also remotely) |
| and processed via iterwalk function, a crash can be triggered.               |
+==============================================================================+
| dparse                     | 0.4.1     | <0.5.2                   | 50571    |
+==============================================================================+
| Dparse 0.5.2 fixes a possible ReDoS vulnerability. https://github.com/pyupio |
| /dparse/commit/8c990170bbd6c0cf212f1151e9025486556062d5                      |
+==============================================================================+
| dparse                     | 0.5.1     | <0.5.2                   | 50571    |
+==============================================================================+
| Dparse 0.5.2 fixes a possible ReDoS vulnerability. https://github.com/pyupio |
| /dparse/commit/8c990170bbd6c0cf212f1151e9025486556062d5                      |
+==============================================================================+
| ipywidgets                 | 5.2.2     | <8.0.0                   | 50664    |
+==============================================================================+
| Ipywidgets 8.0.0 sanitizes descriptions by default.                          |
| https://github.com/jupyter-widgets/ipywidgets/pull/2785                      |
+==============================================================================+
| ipywidgets                 | 5.2.2     | <8.0.0rc2                | 50463    |
+==============================================================================+
| Ipywidgets 8.0.0rc2 makes descriptions plaintext by default for security.    |
| https://github.com/jupyter-widgets/ipywidgets/pull/2785                      |
+==============================================================================+
| nbconvert                  | 5.0.0     | <6.5.1                   | 50792    |
+==============================================================================+
| Nbconvert 6.5.1 includes a fix for CVE-2021-32862: Multiple                  |
| sanitization/validation issues.                                              |
| https://github.com/jupyter/nbconvert/security/advisories/GHSA-9jmq-rx5f-8jwq |
+==============================================================================+
make: *** [Makefile:815: safety_py3.5.done] Error 255

```

