### PR TITLE
1.4: Fixed flake8 RecursionError on Python 3.6+3.7; Added Python 3.7 to general tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,11 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"2.7\", \
                 \"package_level\": \"latest\" \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,9 +107,12 @@ tomlkit>=0.10.1; python_version >= '3.7'
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal
 # well with its pinned dependencies, so we need to repeat these for py34.
 # flake8 4.0.0 fixes an AttributeError on Python 3.10.
-flake8>=3.8.0; python_version == '2.7'
+# flake8 4.0.0 pins importlib-metadata to <4.3 on Python <3.8. This causes
+#   version conflicts with Sphinx>=4.4.0 and virtualenv>=20.0.35
+flake8>=3.8.0,<4.0.0; python_version == '2.7'
 flake8>=3.8.0,<3.9.0; python_version == '3.4'
-flake8>=3.8.0; python_version >= '3.5' and python_version <= '3.9'
+flake8>=3.8.0,<4.0.0; python_version >= '3.5' and python_version <= '3.7'
+flake8>=3.8.0; python_version >= '3.8' and python_version <= '3.9'
 flake8>=4.0.0; python_version >= '3.10'
 mccabe>=0.6.0; python_version == '2.7'
 mccabe>=0.6.0,<0.7.0; python_version == '3.4'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -57,6 +57,9 @@ Released: not yet
 
 * Fixed new formatting issues raised by flake8 5.0.
 
+* Fixed a RecursionError exception raised by flake8 on Python 3.6 and 3.7.
+  (issue #2922)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -149,6 +149,7 @@ testfixtures==6.9.0; python_version >= '3.6'
 colorama==0.3.9; python_version <= '3.4'
 colorama==0.4.0; python_version >= '3.5'
 importlib-metadata==0.12; python_version <= '3.7'
+importlib-metadata==1.1.0; python_version >= '3.8'
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
 requests-mock==1.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -41,7 +41,8 @@ jsonschema>=2.6.0,!=4.0.0
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0
 yagot>=0.5.0
-importlib-metadata<1,>=0.12; python_version <= '3.7'
+importlib-metadata>=0.12; python_version <= '3.7'
+importlib-metadata>=1.1.0; python_version >= '3.8'
 # pytz before 2019.1 fails on Python 3.10 because it uses collections.Mapping
 pytz>=2016.10; python_version <= '3.9'
 pytz>=2019.1; python_version >= '3.10'


### PR DESCRIPTION
Rolls back PR #2921 into 1.4.2.