### PR TITLE
Fix issues with namespace provider.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -165,6 +165,10 @@ Released: not yet
 * Added security issues 50748, 50571, 50664, 50663, 50892, 50885, 50886 to
   Makefile ignore list of new security issue August and September 2022.
 
+* Fixed issue with mock namespace provider that would acreate the
+  same namespace twice under some conditions (i.e. same name property but
+  different path on CreateInstance. (see issue #2918)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbem_mock/_baseprovider.py
+++ b/pywbem_mock/_baseprovider.py
@@ -29,6 +29,9 @@ following functionality:
   * Methods that provide access to specific objects in the CIM repository
     including the processing consistent with filtering the returned objects.
     For example, `get_class(...)` the internal equilavent of the GetClass.
+
+  BaseProvider does not have direct access to the common methods
+  defined in _wbemconnection_mock
 """
 
 from __future__ import absolute_import, print_function
@@ -51,7 +54,7 @@ __all__ = ['BaseProvider']
 
 class BaseProvider(object):
     """
-    BaseProvider is the top level class in the provider hiearchy and includes
+    BaseProvider is the top level class in the provider hierarchy and includes
     methods required by both builtin providers and user-defined providers.
     This class is not intended to be executed directly.
     """
@@ -473,6 +476,30 @@ class BaseProvider(object):
         """
         class_store = self.cimrepository.get_class_store(namespace)
         return class_store.object_exists(classname)
+
+    def _get_instances(self, classname, namespace):
+        """
+        Get instances of classname from the CIMRepository.  It does not
+        get instances of subclasses.
+
+        Parameters:
+
+          classname (:term:`string`):
+            Name of class for which instances will be retrieved.
+
+          namespace (:term:`string`):
+            Repository namespace to search.
+
+        Returns:
+          List of instances in repository that represent classname
+        """
+        classnames = NocaseList(classname)
+        instance_store = self.cimrepository.get_instance_store(namespace)
+
+        insts = [self._get_bare_instance(inst.path, instance_store)
+                 for inst in instance_store.iter_values()
+                 if inst.path.classname in classnames]
+        return insts
 
     @staticmethod
     def filter_properties(obj, property_list):

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -663,7 +663,7 @@ TESTCASES_SUBMGR = [
             remove_server_attrs=None,
             exp_result=dict(server_id="http://FakedUrl:5988")
         ),
-        None, None, OK
+        None, None, RUN
     ),
     (
         "Valid submgr id and multiple server ids",


### PR DESCRIPTION
This fixes two issues:

1. Error caused by bad edit in pr# 2913
2. Fix issue #2918 - limitation where duplicate namespaces could be created.

The fix consists of modifying the test for existence of the namespace being created in the namespaceprovider rather than just the instance path of the new instance.  A method was added to baseprovider to accomplish this change and used in the namespace provider.

The test modifies and extends some of the tests for namespace provider installation

See commit for more details