### PR TITLE
Fix mocker issue with create association instance.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -114,6 +114,11 @@ Released: not yet
 * Fixed a RecursionError exception raised by flake8 on Python 3.6 and 3.7.
   (issue #2922)
 
+* Fixed issue in pywbem_mock instancewrite providers where Create/Modify of
+  an instance with reference properties fails if host set in reference property
+  (i.e. CIMInstanceName). Now issues a warning and ignores the host value since
+  pywbem_mock does not handle cross-host associations. (see issue #2920)
+
 **Enhancements:**
 
 * Added support for the new 'CIM_WBEMServerNamespace' class used in the

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -6512,6 +6512,20 @@ class TestInstanceOperations(object):
              MOFRepositoryError(
                  r"Cannot compile instance .* CreateInstance", None,
                  CIMError(CIM_ERR_INVALID_PARAMETER))],
+
+            # Test assoc with reference property containing host element
+            ['instance of TST_Person as $Sofi { name = "Sofi"; };\n'
+             'instance of TST_FamilyCollection as $Family1 '
+             '{ name = "family1"; };\n'
+             'instance of TST_MemberOfFamilyCollection as $Family1Sofi'
+             '{ family = $Family1; };\n',
+             ('TST_MemberOfFamilyCollection',
+              {'family': CIMInstanceName('TST_FamilyCollection',
+                                         {'name': 'family1'}, host="fred"),
+               'member': CIMInstanceName('TST_Person', {'name': "Sofi"})}),
+             MOFRepositoryError(
+                 r"Cannot compile instance .* CreateInstance", None,
+                 CIMError(CIM_ERR_INVALID_PARAMETER))],
         ]
     )
     def test_compile_instances_path(self, conn, tst_assoc_class_mof, ns,


### PR DESCRIPTION
Fix issue #2920 in pywbem_mock where CreateInstance or ModifyInstance on an association instance fails if a reference property CIMInstanceName property includes host name in the path.

Modified to fail with correct message if any reference property of an association includes the host element in the CIMInstanceName

This seemed logical since otherwise, the user would have an instance that they created which differed from the path we create in CreateInstance.

Added test for this failure for CreateInstance