### PR TITLE
1.4: Ignore security issues and fix new issue with flake8 2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ py_test_files := \
 # - For packages that are direct or indirect development or test requirements,
 #   upgrade the package version only if possible w.r.t. the supported
 #   environments and add to the ignore list otherwise.
-# Current safety ignore list, with reasons:
+# Current safety ignore list, with reasons why marked ignore rather than modify
+# the requirements files:
 # Runtime dependencies:
 # - 38100: PyYAML on py34 cannot be upgraded; no issue since PyYAML FullLoader is not used
 # - 38834: urllib3 on py34 cannot be upgraded -> remains an issue on py34
@@ -299,12 +300,13 @@ py_test_files := \
 # - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
 # - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
 # - 45185 Pylint cannot be upgraded on py27
-# - SEPT 2022
 # - 50748 lxml - NULL pointer dereference min ver 4.6.2 to 4.9.1
 # - 50571 dparse (used by safety). Impacts dparse 0.4.1 and 0.5.1. Null pointer deref & ReDos issue
 # - 50664 ipwidgets - User Jupyter. Min ver 5.2.2 to 8.0.0. Sanitize descriptions
 # - 50463 ipwidgets - from 5.2.2 to 8.0.0.rc2
 # - 50792 nbconvert - from 5.0.0 to 6.5.1
+# - 50885 pygments Pygments 2.7.4 cannot be used on Python 2.7
+# - 50886 pygments Pygments 2.7.4 cannot be used on Python 2.7
 
 safety_ignore_opts := \
     -i 38100 \
@@ -352,6 +354,8 @@ safety_ignore_opts := \
 		-i 50463 \
 		-i 50792 \
 		-i 50748 \
+		-i 50885 \
+		-i 50886 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -66,7 +66,7 @@ sphinxcontrib-websupport>=1.1.2
 # Pygments 2.4.0 has removed support for Python 3.4
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.1.3,<2.4.0; python_version == '3.4'
-Pygments>=2.1.3; python_version >= '3.5'
+Pygments>=2.7.4; python_version >= "3.5"
 sphinx-rtd-theme>=0.5.0
 # autodocsumm before 0.2.5 fails on Python 3.10 with TypeError
 autodocsumm>=0.1.13,<0.2.0; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -60,6 +60,9 @@ Released: not yet
 * Fixed a RecursionError exception raised by flake8 on Python 3.6 and 3.7.
   (issue #2922)
 
+* Added security issues 50748, 50571, 50664, 50663, 50892, 50885, 50886 to
+  Makefile ignore list of new security issue August and September 2022.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -217,7 +217,9 @@ sphinxcontrib-htmlhelp==2.0.0; python_version >= '3.10'
 sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
-Pygments==2.1.3
+Pygments==2.1.3; python_version == "2.7"
+Pygments==2.1.3; python_version == "3.4"
+Pygments==2.7.4; python_version >= "3.5"
 sphinx-rtd-theme==0.5.0
 autodocsumm==0.1.13; python_version <= '3.9'
 autodocsumm==0.2.5; python_version >= '3.10'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -41,8 +41,13 @@ jsonschema>=2.6.0,!=4.0.0
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0
 yagot>=0.5.0
-importlib-metadata>=0.12; python_version <= '3.7'
+
+#  flake8 fails with python 3.7. in importlib-metadata. See issue #2931
+#  Issue with importlib-metadata 5.0.0
+importlib-metadata>=0.22,<5.0.0; python_version < '3.7'
+importlib-metadata>=0.22,<5.0.0; python_version == '3.7'
 importlib-metadata>=1.1.0; python_version >= '3.8'
+
 # pytz before 2019.1 fails on Python 3.10 because it uses collections.Mapping
 pytz>=2016.10; python_version <= '3.9'
 pytz>=2019.1; python_version >= '3.10'


### PR DESCRIPTION
Rolls back PR #2929 into 1.4.2.