### PR TITLE
Fix several security issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,15 +309,18 @@ py_test_files := \
 # - 50792 nbconvert - from 5.0.0 to 6.5.1
 # - 50885 pygments Pygments 2.7.4 cannot be used on Python 2.7
 # - 50886 pygments Pygments 2.7.4 cannot be used on Python 2.7
+# - 51499 Wheel CVE fix in version 0.38.0 yanked after release
+# - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
+# - 51457 py - Latest release has this safety issue i.e. <=1.11.0
 
 safety_ignore_opts := \
-    -i 38100 \
+		-i 38100 \
 		-i 38834 \
 		-i 38765 \
 		-i 38892 \
 		-i 38224 \
-    -i 37504 \
-    -i 37765 \
+		-i 37504 \
+		-i 37765 \
 		-i 38107 \
 		-i 38330 \
 		-i 39194 \
@@ -358,6 +361,9 @@ safety_ignore_opts := \
 		-i 50748 \
 		-i 50885 \
 		-i 50886 \
+		-i 51499 \
+		-i 51358 \
+		-i 51457 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,10 +32,13 @@ more-itertools>=4.0.0; python_version >= '3.6'
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
 safety>=1.8.7,<1.9.0; python_version == '2.7'
 safety>=1.9.0; python_version >= '3.5'
+safety>=2.2.0; python_version >= '3.6'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.5.1; python_version >= '3.5'
+# ver 0.6.2 min requirement by safety 2.2.0
+dparse>=0.6.2; python_version >= '3.6'
 
 # Tox
 tox>=2.5.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -31,12 +31,12 @@ more-itertools>=4.0.0; python_version >= '3.6'
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
 safety>=1.8.7,<1.9.0; python_version == '2.7'
-safety>=1.9.0; python_version >= '3.5'
+safety>=1.9.0; python_version == '3.5'
 safety>=2.2.0; python_version >= '3.6'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
-dparse>=0.5.1; python_version >= '3.5'
+dparse>=0.5.1; python_version == '3.5'
 # ver 0.6.2 min requirement by safety 2.2.0
 dparse>=0.6.2; python_version >= '3.6'
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Ignore new safety issues for wheel, safety, and py packages and update
+  values in minimum-requirements.txt.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -84,7 +84,9 @@ setuptools==41.5.1; python_version <= '3.9'
 setuptools==49.0.0; python_version >= '3.10'
 wheel==0.30.0; python_version == '2.7'
 # wheel 0.36.2 fixes empty and invalid tag issues in archive file name
-wheel==0.36.2; python_version >= '3.5'
+wheel==0.36.2; python_version >= '3.5' and python_version <= '3.7'
+# wheel 0.38.1 fixes CVE issue 51499.  Dropped support python 3.5 at wheel 37
+wheel==0.38.1; python_version >= '3.8'
 
 
 # Direct dependencies for installation (must be consistent with requirements.txt)
@@ -132,7 +134,9 @@ build==0.5.1
 Cython==0.29.22
 
 # Unit test (imports into testcases):
-packaging==19.0
+packaging==19.0; python_version <= '3.6'
+# Packaging 21.0 required by safety 2.2.0
+packaging==21.0; python_version >= '3.7'
 funcsigs==1.0.2; python_version < '3.3'
 pytest==4.3.1; python_version <= '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
@@ -182,9 +186,15 @@ coveralls==2.1.2; python_version >= '3.5'
 
 # Safety CI by pyup.io
 safety==1.8.7; python_version == '2.7'
-safety==1.9.0; python_version >= '3.5'
+# version 2. not compatible with python 3.5
+safety==1.9.0; python_version == '3.5'
+# safety 2.2.0 resolves safety issue #51358
+safety==2.2.0; python_version >= '3.6'
+
 dparse==0.4.1; python_version == '2.7'
-dparse==0.5.1; python_version >= '3.5'
+dparse==0.5.1; python_version == '3.5'
+# dparse version 0.6.2 required by safety 2.2.0
+dparse==0.6.2; python_version >= '3.6'
 
 # Tox
 tox==2.5.0
@@ -311,7 +321,9 @@ backports.shutil-get-terminal-size==1.0.0; python_version == '2.7'
 backports.statistics==0.1.0; python_version == '2.7'
 beautifulsoup4==4.10.0; python_version >= '3.5'
 cffi==1.14.5
-Click==7.1.1
+# Click used by easy-vault (8.0.2) and safety (7.1.1).
+Click==7.1.1; python_version <= '3.5'
+Click==8.0.2; python_version >= '3.6'
 clint==0.5.1
 configparser==4.0.2; python_version == '2.7'
 contextlib2==0.6.0.post1; python_version == '2.7'
@@ -350,7 +362,8 @@ platformdirs==2.2.0
 prometheus-client==0.13.1
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
-py==1.10.0
+# Safety issue # 51457, min version 1.11.0
+py==1.11.0
 pycparser==2.21
 pyparsing==2.4.7; python_version == '2.7'
 pyparsing==2.4.7; python_version == '3.5'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,8 @@
 
 
 # Unit test (imports into testcases):
-packaging>=19.0
+packaging>=19.0; python_version <= '3.6'
+packaging>=21.0; python_version >= '3.7'
 funcsigs>=1.0.2; python_version < '3.3'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels


### PR DESCRIPTION
Fixes safety issues for py, safety, and wheel from November 2022 safety report.

This PR will not complete tests successfully because of issues fixed by pro #2954. It was rebased into that PR to test together.

This generate a conflict in version requirements between safety (>=8.0.2) and easy-vault
(>=7.1.1) on click minimum version causes failure with 2.10 minimum because
we specify  click==7.1.1 in minimum. Moved to specify click min = 8.0.2

It generates a second conflict because safety 2.2.0 requires packaging 21.0 and the definition in minimum-constrants is 19.0. Fix

NOTE: These are the same fixes made for pywbemtools in November except for the issues with easy-vault and packaging