### PR TITLE
Fixed issue with Python 3.5+3.6 no longer supported in ubuntu_latest; Updated the version of setup-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,11 @@ jobs:
       id: select_matrix
       # Select full matrix when scheduled or when releasing, and normal matrix
       # otherwise. The matrix is defined as a JSON string.
-      # TODO: Find a way to define this with less escapes.
+      # This technique documented in:
+      #    https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
+      # NOTE: Ubuntu 20.04 used because in some tests Ubuntu:latest fails with
+      # Python 3.5 and 3.6. See pywbemtools issue 1245 for explanation.
+      # TODO: Find a way to define this with fewer escapes.
       run: |
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "::set-output name=matrix::{ \
@@ -37,12 +41,52 @@ jobs:
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
               { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"windows-latest\", \
                 \"python-version\": \"3.5\", \
                 \"package_level\": \"minimum\" \
               } \
             ], \
             \"include\": [ \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
               { \
                 \"os\": \"windows-2019\", \
                 \"python-version\": \"3.5\", \
@@ -57,17 +101,12 @@ jobs:
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.5\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.5\", \
                 \"package_level\": \"latest\" \
               }, \
@@ -154,7 +193,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,11 @@ Released: not yet
 * Ignore new safety issues for wheel, safety, and py packages and update
   values in minimum-requirements.txt.
 
+* Update github actions matrix to restore tests to running after github
+  update of ubuntu-latest to v 22.04.  This is because python
+  versions 3.5 and 3.6 cannot be installed with setup-python github action for
+  CI tests and ubuntu-22.04. (see pywbemtools issue # 1245 for details)
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
This PR is rebased on PR # 2953, that fixes new security issues and changes only the requirements files (i.e. minimum-constrains.txt).  The changes to fix the issues CI testing with the ubuntu version are in the file test.yaml.  Did this so we could get a running version with these two separate issues since each of them breaks the CI tests.

CI tests fail because github moved to use ubuntu-22.04 as ubuntu-latest and the setup_python github action does not support versions of python older than version 3.7 with this ubuntu version.  This means that the github actions matrix had to be updated to reflect the use of ubuntu-20.04 for tests with the older versions of ubuntu.  This is documented in pywbemtools issue #1245

Modified github actions matrix to use ubuntu 20.04 in whereever python <= 3.5 is defined.