### PR TITLE
Use a new docker image in tests.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,12 @@ Released: not yet
   versions 3.5 and 3.6 cannot be installed with setup-python github action for
   CI tests and ubuntu-22.04. (see pywbemtools issue # 1245 for details)
 
+* Update the version of the OpenPegasus server Docker image used in tests to
+  the docker image kschopmeyer/openpegasus-server:0.1.2 which used OpenPegasus
+  2.14.3 located in the github OpenPegasus repository. This image is much
+  smaller (110 mb) but the same set of models and providers as the previous
+  image.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/tests/end2endtest/es_server.yml
+++ b/tests/end2endtest/es_server.yml
@@ -95,7 +95,7 @@ servers:
   pegasus_https:
     description: Local OpenPegasus container with HTTPS port
     user_defined:
-      docker_image: keyporttech/smi-server:0.1.2
+      docker_image: kschopmeyer/openpegasus-server:0.1.2
       docker_port_mapping:
         image: 5989
         host: 15989
@@ -109,7 +109,7 @@ servers:
   pegasus_http:
     description: Local OpenPegasus container with HTTP port
     user_defined:
-      docker_image: keyporttech/smi-server:0.1.2
+      docker_image: kschopmeyer/openpegasus-server:0.1.2
       docker_port_mapping:
         image: 5988
         host: 15988


### PR DESCRIPTION
Updates the docker image to use the image kschopmeyer/openpegasus-server:0.1.2 which was created using the OpenPegasus 3.14.3 release located in the github repository https://github.com/OpenPegasus/OpenPegasus, built with the Docker files in https://github.com/OpenPegasus/OpenPegasusDocker.

This docker file uses the same CIM model and providers as the previous image.  However it is several hundred megabytes smaller (now ~ 100 mb).