### PR TITLE
Fix issue with HTTP retries of cim-xml operations.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,12 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fix issue where we could get HTTP retries upon HTTP read timeouts from
+  the server.  Changed to not allow urllib3 to do retries on post 
+  operations (the CIM/XML operations all use post and duplicates of 
+  some operations (invoke, update) could cause data integrity issues).  
+  (see issue #2951)
+
 **Enhancements:**
 
 * Support for Python 3.11. (issue #2904)

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -205,7 +205,13 @@ RETRY_KWARGS = dict(
     redirect=HTTP_MAX_REDIRECTS,
     backoff_factor=HTTP_RETRY_BACKOFF_FACTOR
 )
-RETRY_KWARGS[RETRY_METHODS_PARM] = {'POST'}
+# The urllib3 default does not allow retries on POST operations. This definition
+# is urllib3 version dependent
+try:
+    RETRY_KWARGS[RETRY_METHODS_PARM] = urllib3.Retry.DEFAULT_ALLOWED_METHODS
+except (DeprecationWarning, AttributeError):
+    RETRY_KWARGS[RETRY_METHODS_PARM] = urllib3.Retry.DEFAULT_METHOD_WHITELIST
+
 if URLLIB3_VERSION_INFO >= (1, 26, 0):
     RETRY_KWARGS['other'] = HTTP_OTHER_RETRIES
 


### PR DESCRIPTION
Fixes an issue in the parameters for  HTTP POST retries within urllib3 where the retry values defined in CIM_operations  allowed the retry of a CIM/XML request that such as
invokemethod, update, etc. where it is critical that the operation only be issued once.  This is because all CIM/XML operations use POST.

Changes the retry to not allow retries on POST operations.

Issue documented in #2951