### PR TITLE
Fix security (safety) issues that appeared 1 Jan. 2023.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,10 @@ py_test_files := \
 # - 51499 Wheel CVE fix in version 0.38.0 yanked after release
 # - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
 # - 51457 py - Latest release has this safety issue i.e. <=1.11.0
+# - 52495 setuptools - 41.5.1 max version python <= 3.9
+# - 52365 certifi - 2020.6.20 max version for certifi
+# - 52518 GitPython - python 2.7 only supported by v < 3.0.0
+# - 52322 GitPython - All released versions affected
 
 safety_ignore_opts := \
 		-i 38100 \
@@ -364,6 +368,10 @@ safety_ignore_opts := \
 		-i 51499 \
 		-i 51358 \
 		-i 51457 \
+		-i 52365 \
+		-i 52495 \
+		-i 52518 \
+		-i 52322 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -61,9 +61,11 @@ docutils>=0.13.1,<0.17; python_version == '2.7'
 docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils>=0.14; python_version >= '3.10'
 sphinx-git>=10.1.1
-# GitPython 3.0.0 removed support for Python 2.7
-GitPython>=2.1.1,<3.0.0; python_version == '2.7'
-GitPython>=2.1.1; python_version >= '3.5'
+# GitPython version 3.0.0 and newer does not support python 2.7
+# GitPython version 3.1.24 requires python_version GE '3.7'' 
+# GitPython version 3.1.27 fixes safety issue #52518 
+GitPython>=2.1.1<3.0.0; python_version <= '3.5'
+GitPython>=3.1.27; python_version >= '3.6'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 Pygments>=2.1.3; python_version == "2.7"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -61,11 +61,12 @@ docutils>=0.13.1,<0.17; python_version == '2.7'
 docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils>=0.14; python_version >= '3.10'
 sphinx-git>=10.1.1
-# GitPython version 3.0.0 and newer does not support python 2.7
-# GitPython version 3.1.24 requires python_version GE '3.7'' 
-# GitPython version 3.1.27 fixes safety issue #52518 
-GitPython>=2.1.1<3.0.0; python_version <= '3.5'
-GitPython>=3.1.27; python_version >= '3.6'
+# GitPython version 3.0.0 and newer does not support Python 2.7
+# GitPython version 3.1.24 requires Python >=3.7
+# GitPython version 3.1.27 fixes safety issue #52518
+GitPython>=2.1.1,<3.0.0; python_version == '2.7'
+GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
+GitPython>=3.1.27; python_version >= '3.7'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 Pygments>=2.1.3; python_version == "2.7"

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -82,10 +82,12 @@ pip==22.2.2; python_version >= '3.11'
 
 # setuptools 41.5.0 fixes build errors with Visual C++ 14.0 on Windows
 # setuptools 41.5.1 fixes a py27 regression introduced by 41.5.0.
+# setuptools 44.0.0, last version that states py 2.7 requirement
 # setuptools 49.0.0 fixes the comparison of Python versions in requirements that was
 #   based on strings and thus ignored certain requirements on Python 3.10.
+# setuptools 65.5.1 fixes safety issue 52495
 setuptools==41.5.1; python_version <= '3.9'
-setuptools==49.0.0; python_version >= '3.10'
+setuptools==65.1.1; python_version >= '3.10'
 
 # wheel 0.36.2 fixes empty and invalid tag issues in archive file name, and supports get_platform() with args
 # wheel 0.38.1 fixes CVE issue 51499, and dropped support for Python <=3.6
@@ -212,7 +214,10 @@ docutils==0.13.1; python_version == '2.7'
 docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils==0.14; python_version >= '3.10'
 sphinx-git==10.1.1
-GitPython==2.1.1
+# GitPython version 3.0.0 and newer does not support python 2.7
+# GitPython version 3.1.27 fixes safety issue #52518
+GitPython==2.1.1; python_version <= '3.5'
+GitPython==3.1.27; python_version >= '3.6'
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 sphinxcontrib-applehelp==1.0.2; python_version >= '3.5'
@@ -393,8 +398,8 @@ Send2Trash==1.8.0
 sh==1.12.14
 simplegeneric==0.8.1
 singledispatch==3.7.0; python_version == '2.7'
-smmap==3.0.5; python_version == '2.7'
-smmap==5.0.0; python_version >= '3.5'
+# KS: issue with smmap 5.0.0 requiring gitdb >= 4 and gitdb 4.0.1
+smmap==3.0.5
 smmap2==2.0.1
 snowballstemmer==1.2.1
 soupsieve==2.3.1; python_version >= '3.5'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -214,10 +214,9 @@ docutils==0.13.1; python_version == '2.7'
 docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils==0.14; python_version >= '3.10'
 sphinx-git==10.1.1
-# GitPython version 3.0.0 and newer does not support python 2.7
-# GitPython version 3.1.27 fixes safety issue #52518
-GitPython==2.1.1; python_version <= '3.5'
-GitPython==3.1.27; python_version >= '3.6'
+GitPython==2.1.1; python_version == '2.7'
+GitPython==2.1.1; python_version >= '3.5' and python_version <= '3.6'
+GitPython==3.1.27; python_version >= '3.7'
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 sphinxcontrib-applehelp==1.0.2; python_version >= '3.5'
@@ -356,8 +355,10 @@ docopt==0.6.1
 enum34==1.1.10; python_version == '2.7'
 filelock==3.0.0
 futures==3.3.0; python_version == '2.7'
-gitdb==4.0.1; python_version >= '3.5'
-gitdb2==2.0.0
+# gitdb2 is a mirror Pypi name for certain gitdb versions.
+gitdb2==2.0.0; python_version == '2.7'
+gitdb2==2.0.0; python_version >= '3.5' and python_version <= '3.6'
+gitdb==4.0.8; python_version >= '3.7'
 html5lib==0.999999999
 idna==2.5
 imagesize==0.7.1
@@ -398,9 +399,11 @@ Send2Trash==1.8.0
 sh==1.12.14
 simplegeneric==0.8.1
 singledispatch==3.7.0; python_version == '2.7'
-# KS: issue with smmap 5.0.0 requiring gitdb >= 4 and gitdb 4.0.1
-smmap==3.0.5
-smmap2==2.0.1
+# smmap2 is used by gitdb2
+# smmap is used by gitdb
+smmap2==2.0.1; python_version == '2.7'
+smmap2==2.0.1; python_version >= '3.5' and python_version <= '3.6'
+smmap==5.0.0; python_version >= '3.7'
 snowballstemmer==1.2.1
 soupsieve==2.3.1; python_version >= '3.5'
 stack-data==0.2.0; python_version >= '3.6'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -15,12 +15,12 @@ Sphinx>=4.2.0; python_version >= '3.10'
 docutils>=0.13.1,<0.17; python_version == '2.7'
 docutils>=0.13.1; python_version >= '3.5'
 sphinx-git>=10.1.1
-
-# GitPython version 3.0.0 and newer does not support python 2.7
-# GitPython version 3.1.24 requires python_version GE '3.7'' 
-# GitPython version 3.1.27 fixes safety issue #52518 
-GitPython>=2.1.1<3.0.0; python_version <= '3.5'
-GitPython>=3.1.27; python_version >= '3.6'
+# GitPython version 3.0.0 and newer does not support Python 2.7
+# GitPython version 3.1.24 requires Python >=3.7
+# GitPython version 3.1.27 fixes safety issue #52518
+GitPython>=2.1.1,<3.0.0; python_version == '2.7'
+GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
+GitPython>=3.1.27; python_version >= '3.7'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 sphinx-rtd-theme>=0.5.0

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -15,7 +15,12 @@ Sphinx>=4.2.0; python_version >= '3.10'
 docutils>=0.13.1,<0.17; python_version == '2.7'
 docutils>=0.13.1; python_version >= '3.5'
 sphinx-git>=10.1.1
-GitPython>=2.1.1
+
+# GitPython version 3.0.0 and newer does not support python 2.7
+# GitPython version 3.1.24 requires python_version GE '3.7'' 
+# GitPython version 3.1.27 fixes safety issue #52518 
+GitPython>=2.1.1<3.0.0; python_version <= '3.5'
+GitPython>=3.1.27; python_version >= '3.6'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 sphinx-rtd-theme>=0.5.0


### PR DESCRIPTION
There are 3 new safety issues:

1.  setuptools - new minimum 65.5.1 issue id 52495, added to ignore
   because different minimum with python 3.9
2. certifi - new minimum 2022.12.07 issue  id 52365, added to ignore
   because different min version for python 2.7
3. gitpython - new minimum 3.1.27 issue id 52518, added to ignore
   because diff min version for python 2.7.

Safety report:
```
-> setuptools, installed 41.5.1, affected <65.5.1, id 52495
Python Packaging Authority (PyPA) setuptools before 65.5.1 allows remote attackers to cause a denial of service via HTML in a crafted package or custom PackageIndex page. There is a Regular Expression Denial of Service (ReDoS) in package_index.py.
--
-> setuptools, installed 49.0.0, affected <65.5.1, id 52495
Python Packaging Authority (PyPA) setuptools before 65.5.1 allows remote attackers to cause a denial of service via HTML in a crafted package or custom PackageIndex page. There is a Regular Expression Denial of Service (ReDoS) in package_index.py.
--
-> certifi, installed 2019.11.28, affected <2022.12.07, id 52365
Certifi 2022.12.07 includes a fix for CVE-2022-23491: Certifi 2022.12.07 removes root certificates from "TrustCor" from the root store. These are in the process of being removed from Mozilla's trust store. TrustCor's root certificates are being removed pursuant to an investigation prompted by media reporting that TrustCor's ownership also operated a business that produced spyware. Conclusions of Mozilla's investigation can be found in the linked google group discussion.
https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8
https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ
--
-> gitpython, installed 2.1.1, affected <3.1.27, id 52518
Gitpython 3.1.27 includes a fix for a REDoS vulnerability.
https://github.com/gitpython-developers/GitPython/commit/75f4f63ab3856a552f06082aabf98845b5fa21e3
--
-> gitpython, installed 2.1.1, affected >0, id 52322
All versions of package gitpython are vulnerable to Remote Code Execution (RCE) due to improper user input validation, which makes it possible to inject a maliciously crafted remote URL into the clone command. Exploiting this vulnerability is possible because the library makes external calls to git without sufficient sanitization of input arguments.

```