### PR TITLE
pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -215,8 +215,9 @@ pipdeptree>=2.2.0
 #   not yet have proper dependency handling, so we do not install pip-check-reqs
 #   on Python 2.7.
 # pip-check-reqs 2.3.2 is needed to have proper support for pip>=21.3 and below.
+# pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
 pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.10'
-pip-check-reqs>=2.4.0; python_version >= '3.11'
+pip-check-reqs>=2.4.3; python_version >= '3.11'
 
 pyzmq>=16.0.4; python_version <= '3.8'
 pyzmq>=20.0.0; python_version >= '3.9' and python_version <= '3.10'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -306,7 +306,7 @@ psutil==5.6.0; sys_platform != 'cygwin' and platform_python_implementation == 'P
 # Package dependency management tools
 pipdeptree==2.2.0
 pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.10'
-pip-check-reqs==2.4.0; python_version >= '3.11'
+pip-check-reqs==2.4.3; python_version >= '3.11'
 
 pyzmq==16.0.4; python_version <= '3.8'
 pyzmq==20.0.0; python_version >= '3.9' and python_version <= '3.10'


### PR DESCRIPTION
No review needed.