### PR TITLE
Disable CI test failure upon safety check failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -838,10 +838,11 @@ flake8_$(pymn).done: develop_$(pymn).done Makefile $(flake8_rc_file) $(py_src_fi
 	echo "done" >$@
 	@echo "Makefile: Done running Flake8"
 
+# The safety test failure does not cause a CI test failure. Issue # 2970
 safety_$(pymn).done: develop_$(pymn).done Makefile minimum-constraints.txt
 	@echo "Makefile: Running pyup.io safety check"
 	-$(call RM_FUNC,$@)
-	safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
+	-safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
 	echo "done" >$@
 	@echo "Makefile: Done running pyup.io safety check"
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,7 +39,10 @@ Released: not yet
 * Update github actions matrix to restore tests to running after github
   update of ubuntu-latest to v 22.04.  This is because python
   versions 3.5 and 3.6 cannot be installed with setup-python github action for
-  CI tests and ubuntu-22.04. (see pywbemtools issue # 1245 for details)
+  CI tests and ubuntu-22.04. (see pywbemtools issue # 1245 for details).
+
+* Modify Makefile so safety check does not cause fatal github test failure.
+  (see issue #2970)
 
 **Known issues:**
 


### PR DESCRIPTION
This is the first step in correcting the issue where we have test failures each month as new security issues are defined.

This simply ignores the failure status return from the safety check target in the Makefile.

See Issue #2970 for more information. This does not close issue # 2970 since there is a second step.