### PR TITLE
Fix issues from new version of pylint (version 2.16.1)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,9 +46,9 @@ Released: 2023-01-14
 **Bug fixes:**
 
 * Fix issue where we could get HTTP retries upon HTTP read timeouts from
-  the server.  Changed to not allow urllib3 to do retries on post 
-  operations (the CIM/XML operations all use post and duplicates of 
-  some operations (invoke, update) could cause data integrity issues).  
+  the server.  Changed to not allow urllib3 to do retries on post
+  operations (the CIM/XML operations all use post and duplicates of
+  some operations (invoke, update) could cause data integrity issues).
   (see issue #2951)
 
 **Enhancements:**
@@ -73,6 +73,16 @@ Released: 2023-01-14
   2.14.3 located in the github OpenPegasus repository. This image is much
   smaller (110 mb) but the same set of models and providers as the previous
   image.
+
+* Modifications and pylint ignore statements for new pylint test for
+  dict form dict(a=1) which is slower than {'a':1} and other new tests in
+  pylint 2.16.0
+
+**Known issues:**
+
+* See `list of open issues`_.
+
+.. _`list of open issues`: https://github.com/pywbem/pywbem/issues
 
 
 pywbem 1.5.0

--- a/pylintrc
+++ b/pylintrc
@@ -426,8 +426,8 @@ preferred-modules=
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [REFACTORING]

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -197,14 +197,14 @@ with warnings.catch_warnings():
     else:
         RETRY_METHODS_PARM = 'method_whitelist'
 
-RETRY_KWARGS = dict(
-    total=HTTP_TOTAL_RETRIES,
-    connect=HTTP_CONNECT_RETRIES,
-    read=HTTP_READ_RETRIES,
-    status=HTTP_STATUS_RETRIES,
-    redirect=HTTP_MAX_REDIRECTS,
-    backoff_factor=HTTP_RETRY_BACKOFF_FACTOR
-)
+RETRY_KWARGS = {
+    'total': HTTP_TOTAL_RETRIES,
+    'connect': HTTP_CONNECT_RETRIES,
+    'read': HTTP_READ_RETRIES,
+    'status': HTTP_STATUS_RETRIES,
+    'redirect': HTTP_MAX_REDIRECTS,
+    'backoff_factor': HTTP_RETRY_BACKOFF_FACTOR
+}
 # The urllib3 default does not allow retries on POST operations. This definition
 # is urllib3 version dependent
 try:

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -230,7 +230,7 @@ def saved_term_attrs():
         term_fd = None
 
     if term_fd is not None:
-        count_dict = dict(count=0)  # Must be mutable
+        count_dict = {'count': 0}  # must be mutable
         saved_attrs = termios.tcgetattr(term_fd)
         atexit.register(restore_term_attrs, term_fd, saved_attrs, count_dict)
 

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -1113,16 +1113,16 @@ class WBEMServer(object):
                     break
                 # Some other error happened.
                 raise
-            else:
-                # Namespace class is implemented in the current namespace.
-                # Use the returned namespace name, if possible.
-                ns_names = [p.keybindings['name'] for p in inst_paths]
-                ns_dict = NocaseDict(list(zip(ns_names, ns_names)))
-                try:
-                    interop_ns = ns_dict[ns]
-                except KeyError:
-                    interop_ns = ns
-                break
+
+            # Namespace class is implemented in the current namespace.
+            # Use the returned namespace name, if possible.
+            ns_names = [p.keybindings['name'] for p in inst_paths]
+            ns_dict = NocaseDict(list(zip(ns_names, ns_names)))
+            try:
+                interop_ns = ns_dict[ns]
+            except KeyError:
+                interop_ns = ns
+            break
         if interop_ns is None:
             # Exhausted the possible namespaces
             raise ModelError(
@@ -1205,10 +1205,10 @@ class WBEMServer(object):
                     continue
                 # Some other error.
                 raise
-            else:
-                # Found a namespace class that is implemented.
-                ns_classname = classname
-                break
+
+            # Found a namespace class that is implemented.
+            ns_classname = classname
+            break
         if ns_insts is None:
             # Exhausted the possible class names
             raise ModelError(

--- a/pywbem_mock/_utils.py
+++ b/pywbem_mock/_utils.py
@@ -72,9 +72,9 @@ def _uprint(dest, text):
         sys.stdout.write(text)
     elif isinstance(dest, (six.text_type, six.binary_type)):
         if isinstance(text, six.text_type):
-            kw = dict(mode='a', encoding='utf-8')
+            kw = {'mode': 'a', 'encoding': 'utf-8'}
         else:
-            kw = dict(mode='ab')
+            kw = {'mode': 'ab'}
         with io.open(dest, **kw) as f:  # pylint: disable=unspecified-encoding
             f.write(text)
     else:

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,7 @@ package_version = get_version(os.path.join('pywbem', '_version.py'))
 #   highlight=setup#distutils.core.setup
 # * https://setuptools.readthedocs.io/en/latest/setuptools.html#
 #   new-and-changed-setup-keywords
+# pylint: disable=use-dict-literal
 setup_options = dict(
     name='pywbem',
     version=package_version,

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -267,7 +267,7 @@ def wbem_connection(request, es_server):
     ca_certs = es_server.secrets.get('ca_certs', None)
     cert_file = es_server.secrets.get('cert_file', None)
     key_file = es_server.secrets.get('key_file', None)
-    x509 = dict(cert_file=cert_file, key_file=key_file) \
+    x509 = {'cert_file': cert_file, 'key_file': key_file} \
         if cert_file and key_file else None
 
     image_port = None

--- a/tests/leaktest/test_leaks_cim_obj.py
+++ b/tests/leaktest/test_leaks_cim_obj.py
@@ -108,7 +108,7 @@ def test_leaks_CIMInstanceName_minimal():
         'CIM_Foo',
         namespace='root',
         host='woot.com',
-        keybindings=dict(P1='a', P2=42),
+        keybindings={'P1': 'a', 'P2': 42},
     )
 
 

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -253,11 +253,10 @@ class ClientTest(unittest.TestCase):
                     mofcomp.compile_file(PYWBEM_TEST_MOF_FILE, self.namespace)
                 except Error:
                     return False
-                else:
-                    return True
+
+                return True
             # Error other than NOT_FOUND. Just return False so tests continue
-            else:
-                return False
+            return False
 
     def assertClassNamesValid(self, classnames):
         """

--- a/tests/manualtest/run_response_performance.py
+++ b/tests/manualtest/run_response_performance.py
@@ -24,6 +24,7 @@ pywbem = import_installed('pywbem')
 from pywbem import _tupletree, __version__  # noqa: E402
 from pywbem._cliutils import SmartFormatter as _SmartFormatter  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+# pylint: disable=use-dict-literal
 
 # In pywbem 0.13, parse_cim() changed from a function to a method:
 try:

--- a/tests/unittest/pywbem/test_cim_http.py
+++ b/tests/unittest/pywbem/test_cim_http.py
@@ -17,6 +17,8 @@ pywbem = import_installed('pywbem')
 from pywbem import _cim_http, MissingKeybindingsWarning  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 # These defaults are defined separately from those in _cim_constants.py to
 # ensure that changes of the defaults are caught.

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -42,6 +42,8 @@ except ImportError:
     pass
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 # Allows use of lots of single character variable names.
 # pylint: disable=invalid-name,missing-docstring,too-many-statements

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -34,6 +34,9 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Name of null device
 DEV_NULL = 'nul' if sys.platform == 'win32' else '/dev/null'
 

--- a/tests/unittest/pywbem/test_cim_types.py
+++ b/tests/unittest/pywbem/test_cim_types.py
@@ -23,6 +23,8 @@ from pywbem import CIMType, CIMInt, CIMFloat, Uint8, Uint16, Uint32, Uint64, \
     cimtype, type_from_name  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 #
 # CIM Char16 data type

--- a/tests/unittest/pywbem/test_cim_xml.py
+++ b/tests/unittest/pywbem/test_cim_xml.py
@@ -20,7 +20,11 @@ from ..utils.pytest_extensions import simplified_test_function
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
 from pywbem import _cim_xml  # noqa: E402
-# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+# pylint: disable=enable=wrong-import-position, wrong-import-order, invalid-name
+
+# {"blah: 0} instead of dict(blah=0)  would be faster but same functionality
+# pylint: disable=use-dict-literal
 
 
 def iter_flattened(lst):

--- a/tests/unittest/pywbem/test_exceptions.py
+++ b/tests/unittest/pywbem/test_exceptions.py
@@ -21,6 +21,10 @@ from pywbem import Error, ConnectionError, AuthError, HTTPError, TimeoutError, \
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
+# pylint: disable=enable=wrong-import-position, wrong-import-order, invalid-name
+
+# {"blah: 0} instead of dict(blah=0)  would be faster but same functionality
+# pylint: disable=use-dict-literal
 
 # Test connection ID used for showing connection information in exception
 # messages

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -23,6 +23,9 @@ from pywbem import WBEMListener, ListenerPortError  # noqa: E402
 from pywbem._utils import _format  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Log level to be used. To enable logging, change this constant to the desired
 # log level, and add code to set or unset the log level of the root logger
 # globally or specifically in each test case.

--- a/tests/unittest/pywbem/test_itermethods.py
+++ b/tests/unittest/pywbem/test_itermethods.py
@@ -40,6 +40,9 @@ from pywbem._cim_operations import pull_inst_result_tuple, \
     pull_path_result_tuple, pull_query_result_tuple  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 @pytest.fixture
 def tst_class():

--- a/tests/unittest/pywbem/test_logging.py
+++ b/tests/unittest/pywbem/test_logging.py
@@ -52,6 +52,8 @@ from pywbem._logging import configure_loggers_from_string, configure_logger, \
     LOGGER_API_CALLS_NAME, LOGGER_HTTP_NAME  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 VERBOSE = False
 

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -40,6 +40,9 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Location of the schema for use by test_mof_compiler.
 # This should not change unless you intend to use another schema directory
 TEST_DIR = os.path.dirname(__file__)

--- a/tests/unittest/pywbem/test_nocasedict.py
+++ b/tests/unittest/pywbem/test_nocasedict.py
@@ -14,6 +14,9 @@ pywbem = import_installed('pywbem')
 from pywbem._nocasedict import NocaseDict  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 TESTCASES_NOCASEDICT_UNNAMEDKEYS = [
 

--- a/tests/unittest/pywbem/test_perf_equality.py
+++ b/tests/unittest/pywbem/test_perf_equality.py
@@ -27,6 +27,9 @@ pywbem = import_installed('pywbem')
 from pywbem import CIMInstanceName, CIMClass, CIMProperty, Uint8  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 TESTCASES_PERF_EQ = [
 

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -56,6 +56,10 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
+
 # Ordered dict type created by yamlloader.ordereddict loaders
 if sys.version_info[0:2] >= (3, 7):
     yaml_ordereddict = dict  # pylint: disable=invalid-name

--- a/tests/unittest/pywbem/test_statistics.py
+++ b/tests/unittest/pywbem/test_statistics.py
@@ -18,6 +18,9 @@ pywbem = import_installed('pywbem')
 from pywbem import Statistics  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# {"blah: 0} instead of dict(blah=0)  would be faster but same functionality
+# pylint: disable=use-dict-literal
+
 
 @pytest.fixture(params=[
     True,

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -44,6 +44,8 @@ from pywbem_mock.config import OBJECTMANAGERNAME, \
 pywbem_mock = import_installed('pywbem_mock')
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 # Location of DMTF schema directory used by all tests.
 # This directory is permanent and should not be removed.

--- a/tests/unittest/pywbem/test_tupleparse.py
+++ b/tests/unittest/pywbem/test_tupleparse.py
@@ -23,6 +23,9 @@ from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     __version__  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Tuple with pywbem version info (M, N, P), without any dev version.
 # Can be used in testcase conditions for version specific tests.
 # Note for dev versions (e.g. '0.15.0.dev12'):

--- a/tests/unittest/pywbem/test_units.py
+++ b/tests/unittest/pywbem/test_units.py
@@ -15,6 +15,8 @@ from pywbem import CIMProperty, CIMMethod, CIMParameter, CIMQualifier, \
     siunit_obj, siunit  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 # Some qualifier objects used for test cases
 TEST_QUAL_PUNIT1_BYTE = CIMQualifier('PUnit', value='byte')

--- a/tests/unittest/pywbem/test_utils.py
+++ b/tests/unittest/pywbem/test_utils.py
@@ -25,6 +25,9 @@ from pywbem._utils import _ascii2, _format, _integerValue_to_int  # noqa: E402
 from pywbem._cim_obj import NocaseDict  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Indicates whether binary strings are supported for the format string of
 # _ascii2()
 BYTE_FORMAT_SUPPORTED = six.PY2 or platform.python_implementation() == 'PyPy'

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -19,6 +19,9 @@ from pywbem import Warning, ToleratedServerIssueWarning, \
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: enable=redefined-builtin
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 # Test connection ID used for showing connection information in exception
 # messages

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -39,6 +39,8 @@ from pywbem import ValueMapping, CIMInstanceName, CIMError, \
 from pywbem._nocasedict import NocaseDict  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 VERBOSE = True
 

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -34,6 +34,9 @@ from pywbem_mock import InMemoryRepository  # noqa: E402
 from pywbem_mock._inmemoryrepository import InMemoryObjectStore  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# The literal {'a': 1} would be faster than dict(a=1) but same funtionality
+# pylint: disable=use-dict-literal
+
 
 def assert_equal(repo1, repo2):
     """

--- a/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
+++ b/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
@@ -49,6 +49,9 @@ from pywbem_mock import FakedWBEMConnection  # noqa:E402
 # List of initially existing namespaces in the CIM repository
 INITIAL_NAMESPACES = [DEFAULT_NAMESPACE]
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 #
 # Class mof for associations and endpoints. This is created in all namespaces.
 #

--- a/tests/unittest/pywbem_mock/test_providerdependentregistry.py
+++ b/tests/unittest/pywbem_mock/test_providerdependentregistry.py
@@ -28,6 +28,9 @@ pywbem_mock = import_installed('pywbem_mock')
 from pywbem_mock import FakedWBEMConnection  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 def assert_registry_equal(registry1, registry2):
     """

--- a/tests/unittest/pywbem_mock/test_providerregistry.py
+++ b/tests/unittest/pywbem_mock/test_providerregistry.py
@@ -29,6 +29,9 @@ from pywbem_mock import FakedWBEMConnection, MethodProvider, \
     InstanceWriteProvider, BaseProvider  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 
 def assert_provreg_equal(provreg1, provreg2):
     """

--- a/tests/unittest/pywbem_mock/test_system_providers.py
+++ b/tests/unittest/pywbem_mock/test_system_providers.py
@@ -44,6 +44,9 @@ from pywbem_mock.config import OBJECTMANAGERCREATIONCLASSNAME, \
     SYSTEMCREATIONCLASSNAME, OBJECTMANAGERNAME, SYSTEMNAME  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # Location of DMTF schema directory used by all tests.
 # This directory is permanent and should not be removed.
 TESTSUITE_SCHEMA_DIR = os.path.join('tests', 'schema')

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -84,6 +84,8 @@ from pywbem_mock.config import IGNORE_INSTANCE_IQ_PARAM, \
     IGNORE_INSTANCE_ICO_PARAM  # noqa: E402
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
 
 VERBOSE = False
 

--- a/tests/unittest/resourcetest/test_memory_utils.py
+++ b/tests/unittest/resourcetest/test_memory_utils.py
@@ -14,6 +14,9 @@ from ..utils.pytest_extensions import simplified_test_function
 from ...resourcetest import memory_utils
 from ...resourcetest.memory_utils import total_sizeof
 
+# Literal form {"blah: 0} faster than dict(blah=0) but same functionality
+# pylint: disable=use-dict-literal
+
 # pypy's implementation of sys.getsizeof() raises TypeError
 try:
     sys.getsizeof(None)


### PR DESCRIPTION
1. Fixed issue with new warning use-dict-literal about dict() where {"blah": 1} is faster than dict(blah=1). Fixed instances in pywbem and pywbem_mock and and set pylint ignore on the test_ files since there are hundreds of changes that  would have to be made and production code speed is the priority.
2. Fixed issue with unneeded pylint else statements warning.
3. Fixed issue with scope of pylint the oveovergeneral-exceptions where pylint now expects that module be included in definiton. Added builtins as module.