### PR TITLE
Ks/#2993 example indication updated

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -46,6 +46,9 @@ Released: not yet
 * Clarified the use of the host parameter on the WBEMListener class.  (see
   issue #2995)
 
+* Bring example pegasusindicationtest.py up to date and extend to be used
+  with WBEM server in a container. (see issue #2993)
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
NOTE: Fails because of the safety and urlparse issues.  This PR modifies example code but does not add any tests.

Fixed the code in examples directory for creating listener, and subscription and using pegasus provider to return a defined number of instances.

This has not been used in a long time and the interfaces were out of date.  Also updated the print statements and cleaned up some questionable code. Finally rewrote it into a single class where the test is executed off of the instance creation and to
bring out the arguments through argparse.

Note the example would not work with a container because it assumed that the server was running in the host machine and not a container, etc. so I expanded the definition of listener to allow hostname of the server and of the listener.  The problem was that localost is not the name of the listener destination host in the case of a listener.  It must be public ip or hostname of the host machine.

Tested with our pegasus container.

We will create container test based on this code as next PR.

Also, It would be fine with me if we hold this pr until the the corresponding container based test is finished