### PR TITLE
1.6: Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,6 +299,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true
         COVERALLS_FLAG_NAME: "${{ matrix.os }},${{ matrix.python-version }},${{ matrix.package_level }}"
+        COVERALLS_SERVICE_NAME: github
+        COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls
     - name: Run installtest
@@ -357,5 +360,6 @@ jobs:
     - name: Send coverage finish to coveralls.io
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls --finish

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,7 @@ coverage>=5.0
 pytest-cov>=2.7.0
 # coveralls 2.0 has removed support for Python 2.7
 git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
+coveralls>=3.3.0; python_version >= '3.5'
 
 # version 8.11 requires python 3.6, See issue #2796
 more-itertools>=4.0.0,!=8.11.0; python_version <= '3.5'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -189,7 +189,7 @@ coverage==5.0
 pytest-cov==2.7.0
 # Links are not allowed in constraint files - minimum ensured by dev-requirements.txt:
 # git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls==2.1.2; python_version >= '3.5'
+coveralls==3.3.0; python_version >= '3.5'
 
 # Safety CI by pyup.io
 safety==1.8.7; python_version == '2.7'


### PR DESCRIPTION
Rolls back PR #2998 into 1.6.2