### PR TITLE
Update pywbem config files for new safety issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,19 @@ py_test_files := \
 # - 52365 certifi - 2020.6.20 max version for certifi
 # - 52518 GitPython - python 2.7 only supported by v < 3.0.0
 # - 52322 GitPython - All released versions affected
+# - 53305, 53306, 53298, 53299, 53301, 53302, 53303, 53304, 53307, 53048, 53305,
+#   53306, 53298, 53299, 53301, 53302, 53303, 53304, 53307, 53048, 53305, 53306,
+#   53298, 53299, 53301, 53302, 53303, 53304, 53307,
+#   53048, Cryptography - python 2.7/3.5 do not support rqd 39.0.1
+# - 53269 IPython - command injection vulnerability in all prev versions
+# - 54717 jupyter-core - prior to version 4.11.2 contains an arbitrary code execution vulnerability
+# - 54713 notebook - Server log issue rior to version 6.4.9
+# - 54682 notebook - before 5.5.0 does not use a CSP header
+# - 54684 notebook - befoe xxx notebook configurations allowing authenticated access to files
+# - 54678 notebook - before 5.7.8, an open redirect can occur
+# - 54689 notebook - before x.x.x untrusted notebook can execute code on load
+# - 54687 pywin32 - Attacker could crash process because integer oveflow
+# - 54679 jinja2 - 2.10.1, str.format_map allows a sandbox escape
 
 safety_ignore_opts := \
 		-i 38100 \
@@ -372,6 +385,45 @@ safety_ignore_opts := \
 		-i 52495 \
 		-i 52518 \
 		-i 52322 \
+		-i 53305 \
+		-i 53306 \
+		-i 53298 \
+		-i 53299 \
+		-i 53301 \
+		-i 53302 \
+		-i 53303 \
+		-i 53304 \
+		-i 53307 \
+		-i 53048 \
+		-i 53305 \
+		-i 53306 \
+		-i 53298 \
+		-i 53299 \
+		-i 53301 \
+		-i 53302 \
+		-i 53303 \
+		-i 53304 \
+		-i 53307 \
+		-i 53048 \
+		-i 53305 \
+		-i 53306 \
+		-i 53298 \
+		-i 53299 \
+		-i 53301 \
+		-i 53302 \
+		-i 53303 \
+		-i 53304 \
+		-i 53307 \
+		-i 53048 \
+		-i 53269 \
+		-i 54717 \
+		-i 54713 \
+		-i 54682 \
+		-i 54684 \
+		-i 54678 \
+		-i 54689 \
+		-i 54687 \
+		-i 54679
 
 # Python source files for test (unit test and function test)
 test_src_files := \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -149,7 +149,7 @@ readme-renderer>=23.0
 jupyter>=1.0.0
 ipython>=5.1.0,<6.0; python_version == '2.7'
 ipython>=7.0,<7.10; python_version == '3.5'
-ipython>=7.16.3; python_version >= '3.6'
+ipython>=8.1.0; python_version >= '3.6'
 ipykernel>=4.5.2
 ipython_genutils>=0.1.0
 ipywidgets>=5.2.2

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Add more safety issue ignores to Makefile and more version limitations to
+  minimum_constraints.txt and dev-requirements.txt
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -127,7 +127,8 @@ urllib3==1.26.5; python_version >= '3.10'
 # From easy-vault:
 cryptography==3.3; python_version == '2.7'
 cryptography==3.2.1; python_version == '3.5'
-cryptography==3.4.7; python_version >= '3.6'
+# TODO Review versions 3.6 forward
+cryptography==39.0.1; python_version >= '3.6'
 keyring==18.0.0
 
 
@@ -281,14 +282,21 @@ ipywidgets==5.2.2
 jupyter_console==5.0.0; python_version == '2.7'
 jupyter_console==6.0.0; python_version >= '3.5'
 jupyter_client==4.4.0
-jupyter_core==4.2.1
+# TODO Review old versions
+# jupyter_core==4.2.1 TODO Remove
+jupyter_core==4.2.1; python_version == '2.7'
+# TODO confirm v 3.5
+jupyter_core==4.11.2; python_version == '3.5'
+jupyter_core==4.11.2; python_version >= '3.5'
 jupyterlab-pygments==0.1.2; python_version >= '3.5'
 jupyterlab-widgets==1.0.2; python_version >= '3.5'
 nbclassic==0.4.0; python_version >= '3.7'  # notebook 6.5.1 started using nbclassic
 nbclient==0.5.13; python_version >= '3.5'
 nbconvert==5.0.0
 nbformat==4.2.0
-notebook==4.3.1
+# TODO review old versions
+notebook==4.3.1; python_version <= '3.5'
+notebook==6.4.10; python_version >= '3.6'
 pyrsistent==0.14.0
 
 # Pywin32 is used (at least?) by jupyter.


### PR DESCRIPTION
Updated Makefile to add a number of new safety issues that we have to ignore because older python versions we use do not support the new safety version minimums.  This does not change to use the policy file but just ignores the new issues