### PR TITLE
Limit max version of urllib3 to lt 2.0.0

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -118,8 +118,13 @@ certifi==2019.11.28
 # requests>=2.26.0 uses charset-normalizer instead of chardet; both are not used by any other package
 chardet==3.0.2; python_version <= '3.9'
 charset-normalizer==2.0.0; python_version >= '3.10'
+# urllib3 >= 2.0.0 minimum python == '3.7'
 urllib3==1.25.9; python_version == '2.7'
-urllib3==1.25.9; python_version >= '3.5' and python_version <= '3.9'
+urllib3==1.25.9; python_version == '3.5'
+urllib3==1.25.9; python_version == '3.6'
+# TODO issue #3006. Update the following to include urllib3 version 2
+# for python version >= 3.7 when issue #3006 resolved.
+urllib3==1.25.9; python_version >= '3.7' and python_version <= '3.9'
 urllib3==1.26.5; python_version >= '3.10'
 
 # funcsigs; is covered in direct deps for develop, from mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,9 +43,14 @@ nocasedict>=1.0.1
 # urllib3 1.25.9 addressed issue 38834 reported by safety
 # urllib3 needs to be pinned to <1.25 for requests <2.22.0
 # urllib3 1.26.5 vendors six 1.16.0 which is needed on Python 3.10 to remove ImportWarning
-urllib3>=1.25.9; python_version == '2.7'
-urllib3>=1.25.9; python_version >= '3.5' and python_version <= '3.9'
-urllib3>=1.26.5; python_version >= '3.10'
+# urllib3 2.0 requires py>=3.7
+urllib3>=1.25.9,<2.0.0; python_version == '2.7'
+urllib3>=1.25.9,<2.0.0; python_version == '3.5'
+urllib3>=1.25.9,<2.0.0; python_version == '3.6'
+# TODO: Following limits use of urllib3<= 2.0 until issues about this upgrade
+# resolved. Issue #3006 failed to update urllib3 to version 2.0.0 for python >= '3.7'
+urllib3>=1.25.9,<2.0.0; python_version >= '3.7' and python_version <= '3.9'
+urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
 
 # setuptools 61.0.0 breaks "setup.py install", see https://github.com/pypa/setuptools/issues/3198
 setuptools!=61.0.0; python_version >= '3.7'


### PR DESCRIPTION
Limit the max version of urllib3 to lt 2.0 since there are a number of issues in this change that will cause our tests to fail including

1. no longer supports python 2.7, 3.5, 3.6
2. pool module removed

as a minimum  

For the time being we will limit the versions we use to < 2.0 but have filed issue #3006 to determine the overall impact of the new version and changes we will make to support it.

Note: This will only pass the tests when run with pr # 3005, the update to safety (with the policy file)