### PR TITLE
1.6: Modify use of the safety utility to use their .safety_policy_file

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,162 @@
+# Safety policy file
+# For documentation, see https://docs.pyup.io/docs/safety-20-policy-file
+#
+# Generally package vulnerabilites listed in the ignore-vulnerabilities
+# list below are there because:
+# 1. There is no release that resolves the vulnerability.  In this case, there
+#    should also be an expire entry to remind the pywbem team to recheck
+# 2. The required version of a package to resolve the issue is not available
+#    for all of the python version supported by pywbem. In that case, the
+#    vulnerability will remain ignored until such time as the versions of
+#    python that cannot support the required version of the package are no
+#    longer supported by pywbem.
+#
+# The way to see python version limitations for package versions
+#    as defined for pywbem is to filter the file minimum-constraints.txt
+#    for the package name. Multiple entries for same package name imply
+#    different minimum versions for different python releases.
+
+# Configuration for the 'safety check' command
+security:
+
+    # Ignore certain severities.
+    # A number between 0 and 10, with the following significant values:
+    # - 9: ignore all vulnerabilities except CRITICAL severity
+    # - 7: ignore all vulnerabilities except CRITICAL & HIGH severity
+    # - 4: ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity
+    ignore-cvss-severity-below: 0
+
+    # Ignore unknown severities.
+    # Should be set to False.
+    ignore-cvss-unknown-severity: False
+
+    # List of specific vulnerabilities to ignore.
+    # {id}:                 # vulnerability ID
+    #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
+    #     expires: {date}   # optional: Date when this ignore will expire
+    ignore-vulnerabilities:
+        37504:
+            reason: Fixed Twine version requires Python>=3.6 and is used there
+        38330:
+            reason: Fixed Sphinx version requires Python>=3.5 and is used there
+        39611:
+            reason: PyYAML full_load method or FullLoader is not used
+        39621:
+            reason: Fixed Pylint version requires Python>=3.6 and is used there
+        40291:
+            reason: Fixed Pip version requires Python>=3.6 and is used there
+        42559:
+            reason: Fixed Pip version requires Python>=3.6 and is used there; Pip is not shipped with this package
+        43975:
+            reason: Fixed Urllib3 versions are excluded by requests
+        45185:
+            reason: Fixed Pylint version requires Python>=3.6.2 and is used there
+        45775:
+            reason: Fixed Sphinx version requires Python>=3.5 and is used there
+        47833:
+            reason: Fixed Click version requires Python>=3.6 and is used there
+        50885:
+            reason: Fixed Pygments version requires Python>=3.5 and is used there
+        50886:
+            reason: Fixed Pygments version requires Python>=3.5 and is used there
+        51457:
+            reason: Py package, affected <=1.11.0, not yet fixed (latest version 1.11.0)
+            expires: 2023-06-30
+        51499:
+            reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
+        52322:
+            reason: Fixed GitPython version requires Python>=3.7 and is used there
+        52365:
+            reason: Fixed Certifi version requires Python>=3.6 and is used there
+        52495:
+            reason: Fixed Setuptools version requires Python>=3.7 and is used there; Risk is on Pypi side
+        52518:
+            reason: Fixed GitPython version requires Python>=3.7 and is used there
+        38765:
+            reason: pip v 10.0.1l We want to test install with minimum pip versions.
+        39606:
+            reason: Cryptography < 3.3.2,cryptography cannot be upgraded to 3.3.2 on < py35
+        53305:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53306:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53298:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53299:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53301:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53302:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53303:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53304:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53307:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        53048:
+            reason: Cryptography, affected <39.0.1, python 2.7/3.5 do not support rqd. 39.0.1
+        43366:
+            reason: Lxml, affected <4.6.5, Only python 3.11 allows version 4.6.5
+        40072:
+            reason: Lxml, affected <4.6.3, Only python 3.10+ allows version 4.6.3
+        50748:
+            reason: Lxml, affected <4.9.1, Only python 3.11 allows version 4.9.1
+        44072:
+            reason: Lxml, affected <4.6.3, Only python 3.10+ allows version 4.6.5
+        51358:
+            reason: safety, affected <2.2.0, Python 2.7 and 3.5 limited to older versions
+        50571:
+            reason: dparse, affected <0.5.2, Python 2.7 and 3.5 limited to older versions
+        42203:
+            reason: Babel, affected <2.9.1, python 2.7 supports only to 2.9.0
+        53269:
+            reason: IPython, affected <8.10.0, python 2.7, 3.5, 3.6 limited to older versions
+        44634:
+            reason: IPython, affected <5.11, python 2.7, 3.5, 3.6 limited to older versions
+        50463:
+            reason: ipywidgets, affected <8.0.0rc2, python 2.7-3.6 limited to older versions
+        50664:
+            reason: ipywidgets, affected <8.0.0, python 2.7-3.6 limited to older versions
+        54717:
+            reason: Jupyter Core, affected <4.11.2
+        50792:
+            reason: Nbconvert, affected <6.5.1
+        42253:
+            reason: Jupyter Notebook, affected <5.7.1, python 2.7-3.5 limited to older versions
+        54713:
+            reason: Jupyter Notebook, affected <6.4.10, python 2.7-3.5 limited to older versions
+        40383:
+            reason: Jupyter Notebook, affected <5.7.6, python 2.7-3.5 limited to older versions
+        40384:
+            reason: Jupyter Notebook, affected <5.7.6, python 2.7-3.5 limited to older versions
+        40385:
+            reason: Jupyter Notebook, affected <5.7.3, python 2.7-3.5 limited to older versions
+        40380:
+            reason: Jupyter Notebook, affected <6.1.5, python 2.7-3.5 limited to older versions
+        40381:
+            reason: Jupyter Notebook, affected <6.0.2, python 2.7-3.5 limited to older versions
+        40386:
+            reason: Jupyter Notebook, affected <5.4.1, python 2.7-3.5 limited to older versions
+        54682:
+            reason: Jupyter Notebook, affected <5.5.0, python 2.7-3.5 limited to older versions
+        54689:
+            reason: Jupyter Notebook, affected <5.7.11, python 2.7-3.5 limited to older versions
+        54684:
+            reason: Jupyter Notebook, affected <6.4.12, python 2.7-3.5 limited to older versions
+        54678:
+            reason: Jupyter Notebook, affected <5.7.8, python 2.7-3.5 limited to older versions
+        42254:
+            reason: Jupyter Notebook, affected <5.7.2, python 2.7-3.5 limited to older versions
+        54687:
+            reason: pywin32, affected <301, python 2.7-3.9 limited to older versions
+        37765:
+            reason: psutil, affected <=5.6.5
+        39525:
+            reason: jinja2, affected <2.11.3
+        54679:
+            reason: jinja2, affected <2.10.1
+
+
+    # Continue with exit code 0 when vulnerabilities are found.
+    continue-on-vulnerability-error: False

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,9 @@ pylint_rc_file := pylintrc
 pylint_todo_opts := --disable=fixme
 pylint_no_todo_opts := --enable=fixme
 
+# Safety policy file
+safety_policy_file := .safety-policy.yml
+
 # Flake8 config file
 flake8_rc_file := .flake8
 
@@ -254,124 +257,6 @@ py_test_files := \
     $(wildcard $(test_dir)/*/*.py) \
     $(wildcard $(test_dir)/*/*/*.py) \
     $(wildcard $(test_dir)/*/*/*/*.py) \
-
-# Issues reported by safety command that are ignored.
-# Package upgrade strategy due to reported safety issues:
-# - For packages that are direct or indirect runtime requirements, upgrade
-#   the package version only if possible w.r.t. the supported environments and
-#   if the issue affects pywbem, and add to the ignore list otherwise.
-# - For packages that are direct or indirect development or test requirements,
-#   upgrade the package version only if possible w.r.t. the supported
-#   environments and add to the ignore list otherwise.
-# Current safety ignore list, with reasons why marked ignore rather than modify
-# the requirements files:
-# Runtime dependencies:
-# - 38100: PyYAML on py34 cannot be upgraded; no issue since PyYAML FullLoader is not used
-# - 38834: urllib3 on py34 cannot be upgraded -> remains an issue on py34
-# Development and test dependencies:
-# - 38765: We want to test install with minimum pip versions.
-# - 38892: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
-# - 38224: pylint cannot be upgraded on py27+py34
-# - 37504: twine cannot be upgraded on py34
-# - 37765: psutil cannot be upgraded on PyPy
-# - 38107: bleach cannot be upgraded on py34
-# - 38330: Sphinx cannot be upgraded on py27+py34
-# - 39194: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
-# - 39195: lxml cannot be upgraded on py34; no issue since output file paths do not come from untrusted sources
-# - 39462: The CVE for tornado will be replaced by a CVE for Python, see https://github.com/tornadoweb/tornado/issues/2981
-# - 39611: PyYAML cannot be upgraded on py34+py35; We are not using the FullLoader.
-# - 39621: Pylint cannot be upgraded on py27+py34
-# - 39525: Jinja2 cannot be upgraded on py34
-# - 40072: lxml HTML cleaner in lxml 4.6.3 no longer includes the HTML5 'formaction'
-# - 38932: cryptography cannot be upgraded to 3.2 on py34
-# - 39252: cryptography cannot be upgraded to 3.3 on py34+py35
-# - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
-# - 40291: pip cannot be upgraded to 21.1 py<3.6
-# - 40380..40386: notebook issues fixed in 6.1.5 which would prevent using notebook on py2
-# NOV 2021
-# - 42218 pip <21.1 - unicode separators in git references
-# - 42253 Notebook, before 5.7.1 allows XSS via untrusted notebook
-# - 42254 Notebook before 5.7.2, allows XSS via crafted directory name
-# - 42297 Bleach before 3.11, a mutation XSS afects user calling bleach.clean
-# - 42298 Bleach before 3.12, mutation XSS affects bleach.clean
-# - 42293 babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
-# - 42559 pip, before 21.1 CVE-2021-3572
-# - 43366 lxml, before 4.6.5 CVE-2021-43818, code not used
-# - 43975 urllib3, before 1.26.5 CVE-2021-33503, not important
-# - 44634 ipython >=6.0.0a0,<7.16.3 CVE-2022-21699, partly updated, not recognized properly by safety
-# - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
-# - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
-# - 45185 Pylint cannot be upgraded on py27
-# - 50748 lxml - NULL pointer dereference min ver 4.6.2 to 4.9.1
-# - 50571 dparse (used by safety). Impacts dparse 0.4.1 and 0.5.1. Null pointer deref & ReDos issue
-# - 50664 ipwidgets - User Jupyter. Min ver 5.2.2 to 8.0.0. Sanitize descriptions
-# - 50463 ipwidgets - from 5.2.2 to 8.0.0.rc2
-# - 50792 nbconvert - from 5.0.0 to 6.5.1
-# - 50885 pygments Pygments 2.7.4 cannot be used on Python 2.7
-# - 50886 pygments Pygments 2.7.4 cannot be used on Python 2.7
-# - 51499 Wheel CVE fix in version 0.38.0 yanked after release
-# - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
-# - 51457 py - Latest release has this safety issue i.e. <=1.11.0
-# - 52495 setuptools - 41.5.1 max version python <= 3.9
-# - 52365 certifi - 2020.6.20 max version for certifi
-# - 52518 GitPython - python 2.7 only supported by v < 3.0.0
-# - 52322 GitPython - All released versions affected
-
-safety_ignore_opts := \
-		-i 38100 \
-		-i 38834 \
-		-i 38765 \
-		-i 38892 \
-		-i 38224 \
-		-i 37504 \
-		-i 37765 \
-		-i 38107 \
-		-i 38330 \
-		-i 39194 \
-		-i 39195 \
-		-i 39462 \
-		-i 39611 \
-		-i 39621 \
-		-i 39525 \
-		-i 40072 \
-		-i 38932 \
-		-i 39252 \
-		-i 39606 \
-		-i 40291 \
-		-i 40380 \
-		-i 40381 \
-		-i 40382 \
-		-i 40383 \
-		-i 40384 \
-		-i 40385 \
-		-i 40386 \
-		-i 42218 \
-		-i 42253 \
-		-i 42254 \
-		-i 42297 \
-		-i 42298 \
-		-i 42203 \
-		-i 42559 \
-		-i 43366 \
-		-i 43975 \
-		-i 44634 \
-		-i 45775 \
-		-i 47833 \
-		-i 45185 \
-		-i 50571 \
-		-i 50664 \
-		-i 50463 \
-		-i 50792 \
-		-i 50748 \
-		-i 50885 \
-		-i 50886 \
-		-i 51499 \
-		-i 51358 \
-		-i 51457 \
-		-i 52365 \
-		-i 52495 \
-		-i 52518 \
-		-i 52322 \
 
 # Python source files for test (unit test and function test)
 test_src_files := \
@@ -451,7 +336,7 @@ help:
 	@echo "  check_reqs - Perform missing dependency checks"
 	@echo "  build      - Build the source and wheel distribution archives in: $(dist_dir)"
 	@echo "  builddoc   - Build documentation in: $(doc_build_dir)"
-	@echo "  check      - Run Flake8 on sources"
+	@echo "  check      - Run Flake8 on sources and safety on minimum_constraints.txt"
 	@echo "  pylint     - Run PyLint on sources"
 	@echo "  installtest - Run install tests"
 	@echo "  test       - Run unit and function tests (in tests/unittest and tests/functiontest)"
@@ -839,12 +724,30 @@ flake8_$(pymn).done: develop_$(pymn).done Makefile $(flake8_rc_file) $(py_src_fi
 	@echo "Makefile: Done running Flake8"
 
 # The safety test failure does not cause a CI test failure. Issue # 2970
-safety_$(pymn).done: develop_$(pymn).done Makefile minimum-constraints.txt
-	@echo "Makefile: Running pyup.io safety check"
+#safety_$(pymn).done: develop_$(pymn).done Makefile minimum-constraints.txt
+#	@echo "Makefile: Running pyup.io safety check"
+#	-$(call RM_FUNC,$@)
+#	-safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
+#	echo "done" >$@
+#	@echo "Makefile: Done running pyup.io safety check"
+
+# NEW safety -----------------
+safety_$(pymn).done: develop_$(pymn).done Makefile $(safety_policy_file) minimum-constraints.txt
+ifeq ($(python_m_version),2)
+	@echo "Makefile: Warning: Skipping Safety on Python $(python_version)" >&2
+else
+ifeq ($(python_mn_version),3.5)
+	@echo "Makefile: Warning: Skipping Safety on Python $(python_version)" >&2
+else
+	@echo "Makefile: Running Safety"
 	-$(call RM_FUNC,$@)
-	-safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
+	safety check --policy-file $(safety_policy_file) -r minimum-constraints.txt --full-report
 	echo "done" >$@
-	@echo "Makefile: Done running pyup.io safety check"
+	@echo "Makefile: Done running Safety"
+endif
+endif
+
+# END ---------------------
 
 ifdef TEST_INSTALLED
   test_deps =

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -80,7 +80,9 @@ autodocsumm>=0.1.13,<0.2.0; python_version == '2.7'
 autodocsumm>=0.1.13,<0.2.4; python_version == '3.5'
 autodocsumm>=0.2.5; python_version >= '3.6'
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
-Babel>=2.7.0
+Babel==2.7.0; python_version == '2.7'
+# Safety issue #42203
+Babel>=2.9.1; python_version >= '3.5'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -151,17 +153,41 @@ ipython>=5.1.0,<6.0; python_version == '2.7'
 ipython>=7.0,<7.10; python_version == '3.5'
 ipython>=7.16.3; python_version >= '3.6'
 ipykernel>=4.5.2
+
+ipykernel>=4.5.2; python_version == '2.7'
+ipykernel>=4.5.2; python_version >= '3.5'
+# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
+# ipykernel 6.1.0 depends on ipython<8.0 and >=7.23.1
+ipykernel>=6.1; python_version >= '3.6'
+
 ipython_genutils>=0.1.0
-ipywidgets>=5.2.2
+ipywidgets>=5.2.2; python_version <= '3.6'
+# Safety issue 50463 affected versions <8.0.0
+ipywidgets>=8.0.0; python_version >= '3.7'
+
 jupyter_console>=5.0.0,<6.0.0; python_version == '2.7'
 jupyter_console>=6.0.0; python_version >= '3.5'
 jupyter_client>=4.4.0
-jupyter_core>=4.2.1
-nbconvert>=5.0.0
-nbformat>=4.2.0
+
+jupyter_core>=4.2.1; python_version == '2.7'
+jupyter_core>=4.2.1; python_version >= '3.5'
+# Safety issue 54717 affected <4.11.2
+# NOTE: Jupyter_core does not exist for version 4.11.2 and python 3.5
+jupyter_core>=4.11.2; python_version >= '3.6'
+
+nbconvert>=5.0.0,<=5.6.1; python_version == '2.7'
+nbconvert>=5.0.0,<=5.6.1; python_version == '3.5'
+# Safety issue 50792 affected versions <6.5.1
+nbconvert>=6.5.1; python_version >='3.6'
+
+nbformat>=4.2.0; python_version < '3.6'
+# Because nbconvert 6.5.1 (used with py >= 3.6) depends on nbformat>=5.1
+nbformat>=5.1; python_version >='3.6'
+
 # Notebook 6.1.0 introduced usage of f-strings (which requires py>=3.6) but still required py>=3.5.
 notebook>=4.3.1,<6.1.0; python_version <= '3.5'
-notebook>=4.3.1; python_version >= '3.6'
+# Safety issue 54713 and others affected <6.4.10
+notebook>=6.4.10; python_version >= '3.6'
 pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
 pyrsistent>=0.14.0; python_version >= '3.5'
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,13 @@ Released: not yet
 
 **Cleanup:**
 
+* Replaced the safety_ignore_opts in Makefile that is used as the basis for
+  ignoring safety issues with the use of a .safety_policy_file defined by
+  the safety utility.
+
+* Add a number of new ignores for additions to the safety issues lise May
+  2003
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -85,9 +85,9 @@ pip==22.2.2; python_version >= '3.11'
 # setuptools 44.0.0, last version that states py 2.7 requirement
 # setuptools 49.0.0 fixes the comparison of Python versions in requirements that was
 #   based on strings and thus ignored certain requirements on Python 3.10.
-# setuptools 65.5.1 fixes safety issue 52495
+# setuptools safety issue 52495 affects 65.1.1
 setuptools==41.5.1; python_version <= '3.9'
-setuptools==65.1.1; python_version >= '3.10'
+setuptools==65.2.0; python_version >= '3.10'
 
 # wheel 0.36.2 fixes empty and invalid tag issues in archive file name, and supports get_platform() with args
 # wheel 0.38.1 fixes CVE issue 51499, and dropped support for Python <=3.6
@@ -124,6 +124,8 @@ urllib3==1.25.9; python_version == '3.5'
 urllib3==1.25.9; python_version == '3.6'
 # TODO issue #3006. Update the following to include urllib3 version 2
 # for python version >= 3.7 when issue #3006 resolved.
+# TODO issue #3006. Update the following to include urllib3 version 2 for
+# python >= python 3.7 when issue resolved.
 urllib3==1.25.9; python_version >= '3.7' and python_version <= '3.9'
 urllib3==1.26.5; python_version >= '3.10'
 
@@ -157,7 +159,8 @@ testfixtures==6.3.0; python_version == '3.5'
 testfixtures==6.9.0; python_version >= '3.6'
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.5; python_version >= '3.5'
-importlib-metadata==0.22; python_version <= '3.7'
+# Using 0.22 caused failure where at least argcompete requires 0.23
+importlib-metadata==0.23; python_version <= '3.7'
 importlib-metadata==1.1.0; python_version >= '3.8'
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
@@ -176,7 +179,8 @@ pytest-easy-server==0.8.0
 virtualenv==20.0.35
 
 # Unit test (indirect dependencies):
-pluggy==0.7.1; python_version >= '2.7' and python_version <= '3.6'
+pluggy==0.7.1; python_version == '2.7'
+pluggy==0.7.1; python_version >= '3.5' and python_version <= '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 decorator==4.0.11
 # FormEncode is used for xml comparisons in unit test
@@ -214,6 +218,7 @@ tox==2.5.0
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6; python_version == '2.7'
 Sphinx==3.5.4; python_version >= '3.5' and python_version <= '3.9'
+# See dev-requirements.txt for reason to use 4.2.0 as minimum for py 3.10
 Sphinx==4.2.0; python_version >= '3.10'
 docutils==0.13.1; python_version == '2.7'
 docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
@@ -238,7 +243,10 @@ sphinx-rtd-theme==0.5.0
 autodocsumm==0.1.13; python_version == '2.7'
 autodocsumm==0.1.13; python_version == '3.5'
 autodocsumm==0.2.5; python_version >= '3.6'
-Babel==2.7.0
+Babel==2.7.0; python_version == '2.7'
+# Safety issue #42203  affected < 2.9.1
+Babel==2.9.1; python_version >= '3.5'
+
 
 # PyLint (no imports, invoked via pylint script):
 pylint==2.5.2; python_version == '3.5'
@@ -279,21 +287,56 @@ pkginfo==1.4.2
 jupyter==1.0.0
 ipython==5.1.0; python_version == '2.7'
 ipython==7.0; python_version == '3.5'
-ipython==7.16.3; python_version >= '3.6'
-ipykernel==4.5.2
+# version 7.23.1 drives iplernel 6.1 dependency
+# version 7.23 drives change to pexpect
+ipython==7.23.1; python_version >= '3.6'
+
+ipykernel==4.5.2; python_version == '2.7'
+ipykernel==4.5.2; python_version == '3.5'
+# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
+# ipykernel 6.1.0 depends on ipython<8.0 and >=7.23.1
+# Using ipkernel 6.2.0 gets us ipython 8.0 compatibility
+ipykernel==6.2.0; python_version >= '3.6'
 ipython_genutils==0.1.0
-ipywidgets==5.2.2
+
+ipywidgets==5.2.2; python_version <= '3.6'
+# Safety issue #50463 affected <8.0.0
+ipywidgets==8.0.0; python_version >= '3.7'
 jupyter_console==5.0.0; python_version == '2.7'
 jupyter_console==6.0.0; python_version >= '3.5'
-jupyter_client==4.4.0
-jupyter_core==4.2.1
+
+jupyter_client==4.4.0; python_version == '2.7'
+jupyter_client==4.4.0; python_version == '3.5'
+# ipykernel 6.1.0 depends on jupyter-client<7.0, uses ipykernel 6.2.0
+jupyter_client==7.0; python_version >= '3.6'
+
+jupyter_core==4.2.1; python_version == '2.7'
+jupyter_core==4.2.1; python_version == '3.5'
+# Safety issue #54717 affects jupyter_core <4.11.2
+# NOTE: Jupyter_core version 4.11.2 does not exist for python <=3.5
+jupyter_core==4.11.2; python_version >= '3.6'
 jupyterlab-pygments==0.1.2; python_version >= '3.5'
-jupyterlab-widgets==1.0.2; python_version >= '3.5'
+jupyterlab-widgets==1.0.2; python_version == '2.7'
+# Update to reflect that ipywidgits 8 depends on jupyerlab-widgets>=3.0.0
+jupyterlab-widgets==3.0.0; python_version >= '3.5'
 nbclassic==0.4.0; python_version >= '3.7'  # notebook 6.5.1 started using nbclassic
 nbclient==0.5.13; python_version >= '3.5'
-nbconvert==5.0.0
-nbformat==4.2.0
-notebook==4.3.1
+
+nbconvert==5.0.0; python_version == '2.7'
+nbconvert==5.0.0; python_version == '3.5'
+# Safety issue 50792 affected <6.5.1. This also drives jinja2 min to 3.0.0 &
+# traitlets to 5.0
+nbconvert==6.5.1; python_version >='3.6'
+
+nbformat==4.2.0; python_version == '2.7'
+nbformat==4.2.0; python_version == '3.5'
+# Because nbconvert 6.5.1 (used with py >= 3.6) depends on nbformat>=5.1
+nbformat==5.1; python_version >='3.6'
+
+notebook==4.3.1; python_version == '2.7'
+notebook==4.3.1; python_version == '3.5'
+# Safety issue 54713 and others affected <6.4.10
+notebook==6.4.10; python_version >= '3.6'
 pyrsistent==0.14.0
 
 # Pywin32 is used (at least?) by jupyter.
@@ -318,7 +361,8 @@ pipdeptree==2.2.0
 pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.10'
 pip-check-reqs==2.4.3; python_version >= '3.11'
 
-pyzmq==16.0.4; python_version <= '3.8'
+# notebook 6.4.10 depends on pyzmq>=17
+pyzmq==17.0.0; python_version <= '3.8'
 pyzmq==23.2.1; python_version >= '3.9'
 
 # Indirect dependencies for develop that need constraints
@@ -359,6 +403,8 @@ distlib==0.3.4
 docopt==0.6.1
 enum34==1.1.10; python_version == '2.7'
 filelock==3.0.0
+# Safety issue #52510 affected <=0.18.2
+future==0.18.3
 futures==3.3.0; python_version == '2.7'
 # gitdb2 is a mirror Pypi name for certain gitdb versions.
 gitdb2==2.0.0; python_version == '2.7'
@@ -371,23 +417,35 @@ importlib-resources==3.2.1; python_version <= '3.8'  # used by virtualenv 20.0.3
 iniconfig==1.1.1; python_version >= '3.5'
 ipaddress==1.0.23; python_version == '2.7'
 jedi==0.17.2; python_version >= '3.5'
-Jinja2==2.8.1; python_version <= '3.9'
-Jinja2==2.10.2; python_version >= '3.10'
+Jinja2==2.8.1; python_version <= '3.5'
+# Jinja2 version for python 3.6 is 3.0.0 because nbconvert 6.5.1 requirment
+# that changes at python 36
+# Safety issues #39525 affects <2.11.3 and #54679 affects <2.10.1
+Jinja2==3.0.0; python_version >= '3.6'
 jsonschema==2.6.0
 linecache2==1.0.0
-MarkupSafe==1.1.0
+MarkupSafe==1.1.0; python_version <= '3.6'
+# MarkupSafe version depends on nbconvert min version 6.5.1 requirement
+MarkupSafe==2.0.0; python_version >= '3.6'
 matplotlib-inline==0.1.3; python_version >= '3.5'
 mistune==0.8.1
 nest-asyncio==1.5.4; python_version >= '3.5'
 pandocfilters==1.4.1
 parso==0.7.0; python_version >= '3.5'
 pathlib2==2.3.7.post1
-pexpect==4.2.1
+
+pexpect==4.2.1; python_version == '2.7'
+pexpect==4.2.1; python_version == '3.5'
+# ipython 7.23.1 depends on pexpect>4.3, sys_platform != "win32"
+# pexpect==4.3.1; python_version >= '3.6' and sys_platform != "win32"
+pexpect==4.4.0; python_version >= '3.6'
 pickleshare==0.7.4
-prometheus-client==0.13.1
+prometheus-client==0.12.0; python_version == '2.7'
+prometheus-client==0.12.0; python_version == '3.5'
+prometheus-client==0.13.1; python_version >= '3.6'
 prompt-toolkit==2.0.1
 ptyprocess==0.5.1
-# Safety issue # 51457, min version 1.11.0
+# Safety issue 51457, min version 1.11.0
 py==1.11.0
 pycparser==2.21
 pyparsing==2.4.7; python_version == '2.7'
@@ -412,17 +470,31 @@ smmap==5.0.0; python_version >= '3.7'
 snowballstemmer==1.2.1
 soupsieve==2.3.1; python_version >= '3.5'
 stack-data==0.2.0; python_version >= '3.6'
-terminado==0.6
+
+terminado==0.6; python_version == '2.7'
+terminado==0.6; python_version == '3.5'
+# This version caused by notebook 6.4.10 depends on terminado>=0.8.3
+terminado==0.8.3; python_version >= '3.6'
 testpath==0.3
 toml==0.10.0
 tomli==2.0.1; python_version >= '3.5'
-tornado==4.4.2
+
+tornado==4.4.2; python_version == '2.7'
+tornado==4.4.2; python_version == '3.5'
+# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
+tornado==6.1; python_version >= '3.6'
+
 tqdm==4.14
 traceback2==1.4.0
-traitlets==4.3.1
+traitlets==4.3.1; python_version == '2.7'
+traitlets==4.3.1; python_version == '3.5'
+# The following is because of nbconvert version 6.5.1
+traitlets==5.0.0; python_version >= '3.6'
 typing==3.10.0.0; python_version == '2.7'
 typing-extensions==3.10.0
 wcwidth==0.1.7
 webencodings==0.5.1
-widgetsnbextension==1.2.6
+widgetsnbextension==1.2.6; python_version <= '3.6'
+# multiple versions because of version issues with ipywidgets
+widgetsnbextension==4.0.0; python_version >='3.7'
 zipp==1.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -54,7 +54,8 @@ pytz>=2019.1; python_version >= '3.10'
 
 # Unit test (indirect dependencies):
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
-pluggy>=0.7.1; python_version >= '2.7' and python_version <= '3.6'
+pluggy>=0.7.1; python_version == '2.7'
+pluggy>=0.7.1; python_version >= '3.5' and python_version <= '3.6'
 pluggy>=0.13.0; python_version >= '3.7'
 
 # Decorator version 5.0 no longer supports python < 3.5


### PR DESCRIPTION
Rolls back PR #3005 into 1.6.2.