### PR TITLE
1.6: Fixed Jupyter Notebook dependencies for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,12 +111,12 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -69,8 +69,10 @@ GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
 GitPython>=3.1.27; python_version >= '3.7'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
+# rich 13.3.5 depends on pygments>=2.13.0,<3.0.0
 Pygments>=2.1.3; python_version == "2.7"
-Pygments>=2.7.4; python_version >= "3.5"
+Pygments>=2.7.4; python_version == "3.5"
+Pygments>=2.13.0,<3.0.0; python_version >= '3.6'
 sphinx-rtd-theme>=0.5.0
 # autodocsumm 0.2.0 removed support for Python 2.7
 # autodocsumm 0.2.4 removed support for Python 3.5
@@ -98,8 +100,13 @@ pylint>=2.15.0; python_version >= '3.11'
 astroid>=2.4.0; python_version == '3.5'
 astroid>=2.7.2; python_version >= '3.6' and python_version <= '3.10'
 astroid>=2.12.4; python_version >= '3.11'
+
 # astroid 2.13.0 uses typing-extensions on Python<3.11 but misses to require it on 3.10. See https://github.com/PyCQA/astroid/issues/1942
-typing-extensions>=3.10; python_version <= '3.10'
+# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
+# typing-extensions 4.0.0 removed support for Python < 3.6
+typing-extensions>=3.10.0; python_version == '2.7'
+typing-extensions>=3.10.0; python_version == '3.5'
+typing-extensions>=4.0.0; python_version >= '3.6' and python_version <= '3.10'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 # lazy-object-proxy is used by astroid
 lazy-object-proxy>=1.4.3; python_version >= '3.5'
@@ -149,45 +156,104 @@ readme-renderer>=23.0
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter>=1.0.0
+
+# ipython 7.23.1 drives ipykernel 6.1 dependency
+# ipython 7.23 drives change to pexpect
 ipython>=5.1.0,<6.0; python_version == '2.7'
 ipython>=7.0,<7.10; python_version == '3.5'
-ipython>=7.16.3; python_version >= '3.6'
-ipykernel>=4.5.2
+ipython>=7.16.3; python_version == '3.6'
+ipython>=7.23.1; python_version >= '3.7'
+# ipython 7.16.3 depends on traitlets>=4.2
 
+# ipykernel 4.5.2 depends on tornado>=4.0; notebook 6.4.10 depends on tornado>=6.1
+# ipykernel 6.1.0 depends on ipython>=7.23.1,<8.0 and on jupyter-client<7.0
+# ipykernel 6.0.0 removed support for Python 3.5 and 3.6
+# Using ipkernel 6.2.0 gets us ipython 8.0 compatibility
 ipykernel>=4.5.2; python_version == '2.7'
-ipykernel>=4.5.2; python_version >= '3.5'
-# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
-# ipykernel 6.1.0 depends on ipython<8.0 and >=7.23.1
-ipykernel>=6.1; python_version >= '3.6'
+ipykernel>=4.5.2; python_version >= '3.5' and python_version <= '3.6'
+ipykernel>=6.1.0; python_version >= '3.7'
 
 ipython_genutils>=0.1.0
-ipywidgets>=5.2.2; python_version <= '3.6'
-# Safety issue 50463 affected versions <8.0.0
+
+# Safety issue 50463 affected ipywidgets < 8.0.0
+ipywidgets>=5.2.2; python_version == '2.7'
+ipywidgets>=5.2.2; python_version >= '3.5' and python_version <= '3.6'
 ipywidgets>=8.0.0; python_version >= '3.7'
 
 jupyter_console>=5.0.0,<6.0.0; python_version == '2.7'
 jupyter_console>=6.0.0; python_version >= '3.5'
-jupyter_client>=4.4.0
 
-jupyter_core>=4.2.1; python_version == '2.7'
-jupyter_core>=4.2.1; python_version >= '3.5'
-# Safety issue 54717 affected <4.11.2
+# ipykernel 6.1.0 depends on jupyter-client<7.0, uses ipykernel 6.2.0
+# notebook 6.4.10 depends on jupyter-client>=5.3.4
+# nbclient 0.5.9 depends on jupyter-client>=6.1.5
+# nbclient 0.5.13 depends on jupyter-client>=6.1.5
+# jupyter_client 7.0 removed support for Python 3.5
+# jupyter-server 1.17.0 depends on jupyter-client>=6.1.12
+jupyter_client>=4.4.0; python_version == '2.7'
+jupyter_client>=4.4.0; python_version == '3.5'
+jupyter-client>=6.1.12; python_version >= '3.6'
+
+# Safety issue 54717 affected jupyter_core <4.11.2
 # NOTE: Jupyter_core does not exist for version 4.11.2 and python 3.5
-jupyter_core>=4.11.2; python_version >= '3.6'
+# jupyter_core 4.10 removed support for Pythton < 3.7
+# jupyter-client 6.1.5 depends on jupyter-core>=4.6.0
+# notebook 6.4.10 depends on jupyter-core>=4.6.1
+jupyter_core>=4.2.1; python_version == '2.7'
+jupyter_core>=4.2.1; python_version == '3.5'
+jupyter_core>=4.6.1; python_version == '3.6'
+jupyter_core>=4.11.2; python_version >= '3.7'
 
+jupyterlab-pygments>=0.1.2
+
+# ipywidgits 8 depends on jupyerlab-widgets>=3.0.0
+# jupyterlab-widgets 1.0.0 removed support for Python < 3.6
+# jupyterlab-widgets 3.0.0 removed support for Python 3.6
+jupyterlab-widgets>=0.6.5; python_version == '2.7'
+jupyterlab-widgets>=0.6.5; python_version == '3.5'
+jupyterlab-widgets>=1.0.2; python_version == '3.6'
+jupyterlab-widgets>=3.0.0; python_version >= '3.7'
+
+# nbclassic 0.4.7 depends on jupyter-server>=1.8
+# jupyter-server 1.17.1 solves several safety issues
+jupyter-server>=1.17.1; python_version >= '3.7'
+
+# jupyter-client 6.1.5 depends on jupyter-core>=4.6.0
+# jupyter-server 1.24.0 depends on jupyter-core!=5.0.* and >=4.12
+
+# notebook 6.5.1 started using nbclassic
+# notebook 6.5.1 depends on nbclassic==0.4.5
+# notebook 6.5.4 depends on nbclassic>=0.4.7
+nbclassic>=0.4.7; python_version >= '3.7'
+
+# nbclient 0.5.10 removed support for Python 3.6
+# nbconvert 5.0.0 depends on nbclient<0.6.0,>=0.5.0
+nbclient>=0.5.9; python_version == '3.6'
+nbclient>=0.5.13; python_version >= '3.7'
+
+# Safety issue 50792 affected nbconvert <6.5.1.
+# nbconvert>=6.5.1 also drives jinja2 min to 3.0.0 & traitlets to 5.0
+# nbconvert 6.1.0 removed support for Python 3.6
 nbconvert>=5.0.0,<=5.6.1; python_version == '2.7'
 nbconvert>=5.0.0,<=5.6.1; python_version == '3.5'
-# Safety issue 50792 affected versions <6.5.1
-nbconvert>=6.5.1; python_version >='3.6'
+nbconvert>=5.0.0; python_version == '3.6'
+nbconvert>=6.5.1; python_version >= '3.7'
 
-nbformat>=4.2.0; python_version < '3.6'
-# Because nbconvert 6.5.1 (used with py >= 3.6) depends on nbformat>=5.1
-nbformat>=5.1; python_version >='3.6'
+# nbconvert 6.5.1 (used with py >= 3.6) depends on nbformat>=5.1
+# jupyter-server 1.17.0 depends on nbformat>=5.2.0
+# nbformat 5.1.0 to 5.1.2 are yanked
+# nbformat 5.2.0 removed support for Python 3.5 and 3.6
+nbformat>=4.2.0; python_version == '2.7'
+nbformat>=4.2.0; python_version == '3.5'
+nbformat>=5.1.3; python_version == '3.6'
+nbformat>=5.2.0; python_version >= '3.7'
 
 # Notebook 6.1.0 introduced usage of f-strings (which requires py>=3.6) but still required py>=3.5.
-notebook>=4.3.1,<6.1.0; python_version <= '3.5'
 # Safety issue 54713 and others affected <6.4.10
-notebook>=6.4.10; python_version >= '3.6'
+notebook>=4.3.1,<6.1.0; python_version == '2.7'
+notebook>=4.3.1,<6.1.0; python_version == '3.5'
+notebook>=6.4.10; python_version == '3.6'
+notebook>=6.5.4; python_version >= '3.7'
+
 pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
 pyrsistent>=0.14.0; python_version >= '3.5'
 
@@ -267,3 +333,24 @@ bleach>=3.3.0; python_version >= '3.5'
 # pywinpty 1.0 requires maturin which requires py>=3.6 and on py>=3.7 it fails installation
 #   with missing winpty.h, see https://stackoverflow.com/q/51260909
 pywinpty>=0.5,<1.0; os_name == "nt"
+
+# Dependencies to reduce backtracking time
+anyio>=3.1.0; python_version >= '3.7'
+cryptography>=3.3; python_version == '2.7'
+cryptography>=3.2.1; python_version == '3.5'
+cryptography>=3.4.7; python_version >= '3.6'
+distlib>=0.3.4
+filelock>=3.0.0
+# gitdb2 4.0.2 requires gitdb>=4.0.1 for installation, see https://github.com/gitpython-developers/gitdb/issues/86
+gitdb2>=2.0.6,<4.0; python_version == '2.7'
+gitdb2>=2.0.6,<4.0; python_version >= '3.5' and python_version <= '3.6'
+gitdb>=4.0.8; python_version >= '3.7'
+idna>=2.8
+# jupyter-server 1.17.0 depends on traitlets>=5.1
+traitlets>=4.3.1; python_version == '2.7'
+traitlets>=4.3.1; python_version == '3.5'
+traitlets>=4.3.1; python_version == '3.6'
+traitlets>=5.1.0; python_version >= '3.7'
+
+# TODOs:
+# importlib-resources 5.12.0 depends on zipp>=3.1.0; python_version < "3.10"

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -238,7 +238,8 @@ sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
 Pygments==2.1.3; python_version == "2.7"
-Pygments==2.7.4; python_version >= "3.5"
+Pygments==2.7.4; python_version == "3.5"
+Pygments>=2.13.0,<3.0.0; python_version >= '3.6'
 sphinx-rtd-theme==0.5.0
 autodocsumm==0.1.13; python_version == '2.7'
 autodocsumm==0.1.13; python_version == '3.5'
@@ -255,7 +256,12 @@ pylint==2.15.0; python_version >= '3.11'
 astroid==2.4.0; python_version == '3.5'
 astroid==2.7.2; python_version >= '3.6' and python_version <= '3.10'
 astroid==2.12.4; python_version >= '3.11'
-typing-extensions==3.10; python_version <= '3.10'
+
+# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
+# typing-extensions 4.0.0 removed support for Python < 3.6
+typing-extensions==3.10.0; python_version == '2.7'
+typing-extensions==3.10.0; python_version == '3.5'
+typing-extensions==4.0.0; python_version >= '3.6' and python_version <= '3.10'
 typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 lazy-object-proxy==1.4.3; python_version >= '3.5'
 wrapt==1.12; python_version >= '3.5' and python_version <= '3.10'
@@ -285,59 +291,65 @@ pkginfo==1.4.2
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 jupyter==1.0.0
+
 ipython==5.1.0; python_version == '2.7'
 ipython==7.0; python_version == '3.5'
-# version 7.23.1 drives iplernel 6.1 dependency
-# version 7.23 drives change to pexpect
-ipython==7.23.1; python_version >= '3.6'
+ipython==7.16.3; python_version == '3.6'
+ipython==7.23.1; python_version >= '3.7'
 
 ipykernel==4.5.2; python_version == '2.7'
-ipykernel==4.5.2; python_version == '3.5'
-# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
-# ipykernel 6.1.0 depends on ipython<8.0 and >=7.23.1
-# Using ipkernel 6.2.0 gets us ipython 8.0 compatibility
-ipykernel==6.2.0; python_version >= '3.6'
+ipykernel==4.5.2; python_version >= '3.5' and python_version <= '3.6'
+ipykernel==6.1.0; python_version >= '3.7'
+
 ipython_genutils==0.1.0
 
-ipywidgets==5.2.2; python_version <= '3.6'
-# Safety issue #50463 affected <8.0.0
+ipywidgets==5.2.2; python_version == '2.7'
+ipywidgets==5.2.2; python_version >= '3.5' and python_version <= '3.6'
 ipywidgets==8.0.0; python_version >= '3.7'
+
 jupyter_console==5.0.0; python_version == '2.7'
 jupyter_console==6.0.0; python_version >= '3.5'
 
 jupyter_client==4.4.0; python_version == '2.7'
 jupyter_client==4.4.0; python_version == '3.5'
-# ipykernel 6.1.0 depends on jupyter-client<7.0, uses ipykernel 6.2.0
-jupyter_client==7.0; python_version >= '3.6'
+jupyter-client==6.1.12; python_version >= '3.6'
 
 jupyter_core==4.2.1; python_version == '2.7'
 jupyter_core==4.2.1; python_version == '3.5'
-# Safety issue #54717 affects jupyter_core <4.11.2
-# NOTE: Jupyter_core version 4.11.2 does not exist for python <=3.5
-jupyter_core==4.11.2; python_version >= '3.6'
-jupyterlab-pygments==0.1.2; python_version >= '3.5'
-jupyterlab-widgets==1.0.2; python_version == '2.7'
-# Update to reflect that ipywidgits 8 depends on jupyerlab-widgets>=3.0.0
-jupyterlab-widgets==3.0.0; python_version >= '3.5'
-nbclassic==0.4.0; python_version >= '3.7'  # notebook 6.5.1 started using nbclassic
-nbclient==0.5.13; python_version >= '3.5'
+jupyter_core==4.6.1; python_version == '3.6'
+jupyter_core==4.11.2; python_version >= '3.7'
+
+jupyterlab-pygments==0.1.2
+
+jupyterlab-widgets==0.6.5; python_version == '2.7'
+jupyterlab-widgets==0.6.5; python_version == '3.5'
+jupyterlab-widgets==1.0.2; python_version == '3.6'
+jupyterlab-widgets==3.0.0; python_version >= '3.7'
+
+jupyter-server==1.17.1; python_version >= '3.7'
+
+nbclassic==0.4.7; python_version >= '3.7'
+
+nbclient==0.5.9; python_version == '3.6'
+nbclient==0.5.13; python_version >= '3.7'
 
 nbconvert==5.0.0; python_version == '2.7'
 nbconvert==5.0.0; python_version == '3.5'
-# Safety issue 50792 affected <6.5.1. This also drives jinja2 min to 3.0.0 &
-# traitlets to 5.0
-nbconvert==6.5.1; python_version >='3.6'
+nbconvert==5.0.0; python_version == '3.6'
+nbconvert==6.5.1; python_version >= '3.7'
 
 nbformat==4.2.0; python_version == '2.7'
 nbformat==4.2.0; python_version == '3.5'
-# Because nbconvert 6.5.1 (used with py >= 3.6) depends on nbformat>=5.1
-nbformat==5.1; python_version >='3.6'
+nbformat==5.1.3; python_version == '3.6'
+nbformat==5.2.0; python_version >= '3.7'
 
 notebook==4.3.1; python_version == '2.7'
 notebook==4.3.1; python_version == '3.5'
-# Safety issue 54713 and others affected <6.4.10
-notebook==6.4.10; python_version >= '3.6'
-pyrsistent==0.14.0
+notebook==6.4.10; python_version == '3.6'
+notebook==6.5.4; python_version >= '3.7'
+
+pyrsistent==0.14.0; python_version == '2.7'
+pyrsistent==0.14.0; python_version >= '3.6'
 
 # Pywin32 is used (at least?) by jupyter.
 pywin32==222; sys_platform == 'win32' and python_version == '2.7'
@@ -375,6 +387,8 @@ pywinpty==0.5; os_name == "nt"
 # Indirect dependencies for develop (not in dev-requirements.txt)
 
 alabaster==0.7.9
+# jupyter-server 1.24.0 depends on anyio>=3.1.0,<4
+anyio==3.1.0; python_version >= '3.7'
 appnope==0.1.0
 appdirs==1.4.3
 argon2-cffi==21.2.0; python_version >= '3.6'
@@ -407,11 +421,12 @@ filelock==3.0.0
 future==0.18.3
 futures==3.3.0; python_version == '2.7'
 # gitdb2 is a mirror Pypi name for certain gitdb versions.
-gitdb2==2.0.0; python_version == '2.7'
-gitdb2==2.0.0; python_version >= '3.5' and python_version <= '3.6'
+gitdb2==2.0.6; python_version == '2.7'
+gitdb2==2.0.6; python_version >= '3.5' and python_version <= '3.6'
 gitdb==4.0.8; python_version >= '3.7'
 html5lib==0.999999999
-idna==2.5
+# anyio 3.1.0 depends on idna>=2.8
+idna==2.8
 imagesize==0.7.1
 importlib-resources==3.2.1; python_version <= '3.8'  # used by virtualenv 20.0.35
 iniconfig==1.1.1; python_version >= '3.5'
@@ -424,8 +439,10 @@ Jinja2==2.8.1; python_version <= '3.5'
 Jinja2==3.0.0; python_version >= '3.6'
 jsonschema==2.6.0
 linecache2==1.0.0
-MarkupSafe==1.1.0; python_version <= '3.6'
+
 # MarkupSafe version depends on nbconvert min version 6.5.1 requirement
+# Jinja2 3.0.0 depends on MarkupSafe>=2.0.0rc2
+MarkupSafe==1.1.0; python_version <= '3.5'
 MarkupSafe==2.0.0; python_version >= '3.6'
 matplotlib-inline==0.1.3; python_version >= '3.5'
 mistune==0.8.1
@@ -486,15 +503,19 @@ tornado==6.1; python_version >= '3.6'
 
 tqdm==4.14
 traceback2==1.4.0
+
+# nbconvert 6.5.1 depends on traitlets>=5.0
+# traitlets 5.0.0 removed support for Python 3.6
+# jupyter-server 1.17.0 depends on traitlets>=5.1
 traitlets==4.3.1; python_version == '2.7'
 traitlets==4.3.1; python_version == '3.5'
-# The following is because of nbconvert version 6.5.1
-traitlets==5.0.0; python_version >= '3.6'
+traitlets==4.3.1; python_version == '3.6'
+traitlets==5.1.0; python_version >= '3.7'
+
 typing==3.10.0.0; python_version == '2.7'
-typing-extensions==3.10.0
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==1.2.6; python_version <= '3.6'
 # multiple versions because of version issues with ipywidgets
-widgetsnbextension==4.0.0; python_version >='3.7'
+widgetsnbextension==4.0.0; python_version >= '3.7'
 zipp==1.2.0


### PR DESCRIPTION
Rolls back PR #3015 into 1.6.2.