### PR TITLE
1.6: Added Python 3.6 to normal test envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,16 @@ jobs:
               }, \
               { \
                 \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"minimum\" \
               }, \


### PR DESCRIPTION
Rolls back PR #3011 into 1.6.2.