### PR TITLE
Expand documentation on the WBEMListener host parameter

### DIFF
--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -722,14 +722,15 @@ class WBEMListener(object):
             IP address or host name to which this listener is bound (i.e. at
             which this listener can be reached).  If a listener is bound to a
             particular IP address it will only receive indications addressed to
-            that IP address (or to any IP address network interface containing
-            that address depending on the OS).  The IP address 0.0.0.0 will
-            bind the listener to any configured IPV4 address on the local
-            machine, Setting the host address to an empty string (i.e. "")
-            defines a listener that binds to the listener to all configured
-            network interfaces on the local machine.
+            that IP address (or to any IP address on the network interface
+            containing that address) depending on the OS.
 
-           http_port (:term:`string` or :term:`integer`):
+            Setting the host parameter to an empty string (i.e. "") defines a
+            listener that binds to all configured network interfaces on the
+            local machine. Binding to IPV4 or IPV6 network interfaces can be
+            defined with the IP addresses "0.0.0.0" for IPV4 or "::" for IPV6.
+
+          http_port (:term:`string` or :term:`integer`):
             HTTP port at which this listener can be reached. Note that at
             least one port (HTTP or HTTPS) must be set. Both the http and
             https ports can be set.

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -719,10 +719,15 @@ class WBEMListener(object):
         Parameters:
 
           host (:term:`string`):
-            IP address or host name to which this listener is bound (i.e.
-            at which this listener can be reached). Setting the host
-            address to IP address 0.0.0.0 defines a listener that binds to
-            all network interfaces.
+            IP address or host name to which this listener is bound (i.e. at
+            which this listener can be reached).  If a listener is bound to a
+            particular IP address it will only receive indications addressed to
+            that IP address (or to any IP address network interface containing
+            that address depending on the OS).  The IP address 0.0.0.0 will
+            bind the listener to any configured IPV4 address on the local
+            machine, Setting the host address to an empty string (i.e. "")
+            defines a listener that binds to the listener to all configured
+            network interfaces on the local machine.
 
            http_port (:term:`string` or :term:`integer`):
             HTTP port at which this listener can be reached. Note that at


### PR DESCRIPTION
This change clarifies the definition of the host parameter on the WBEMListener class to include the definition of how to define a listener that listens on multiple network addresses.

Note that there is still some ambiguity in that a. this does not discusss IPV6 and b) only briefly mentions that the actual behavior of a listener with a specific address may be OS or network dependent in that in some cases the test is limited to only pass requests with the specific address and in other cases, it will pass any address that is part of the specific network interface defined by the host parameter.