### PR TITLE
Adds end-end test for indications

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,6 +49,11 @@ Released: not yet
   filled up with that value, and extra items in the 'Values' qualifier are
   truncated. (issue #2991)
 
+* Add end-end test for indications where an OpenPegasus server in Docker
+  container is the WBEM Server and pywbem is both the client that creates
+  indication subscriptions the indication listener. This test uses the
+  OpenPegasus container used for other end-end tests.
+
 **Cleanup:**
 
 * Replaced the safety_ignore_opts in Makefile that is used as the basis for

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -299,7 +299,7 @@ def wbem_connection(request, es_server):
         # Check that the server can be reached and authenticated with, by
         # issuing some quick operation. Operation failures are tolerated
         # (e.g. GetQualifier is not supported on SFCB), and the connection and
-        # authgentication errors can still be detected because they will be
+        # authentication errors can still be detected because they will be
         # detected before the operation fails.
         try:
             conn.GetQualifier(


### PR DESCRIPTION
Adds a new end-end test for:

1. Managing indication subscriptions.
2. Receiving indications from the WBEM Server

This test is based on the OpenPegasus docker image defined for the other end-end tests.

See commit mesage for details

NOTE: This commit includes changes for the example pegasusindicaitonstest.py since basically the same code is in both the end to end test and the example and this made the two almost the same.

In order to get a consinstent pass of this test, I disabled python 2.7 and reduced python 3.7 to minimum.  We could have passed on the PACKAGE_LEVEL variable from Makefile but this establishes that the issues with quitting early are at least probably tied to python 2.7 and 3.7 We also know from earlier tests that it is probably tied to the minimum config.

I suggest we commit this and I have already filed a bug on the failures with python 2.7, etc.