### PR TITLE
1.6: Fixed missing dependencies in minimum-constraints.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,7 +84,7 @@ autodocsumm>=0.2.5; python_version >= '3.6'
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
 Babel==2.7.0; python_version == '2.7'
 # Safety issue #42203
-Babel>=2.9.1; python_version >= '3.5'
+Babel>=2.10.0; python_version >= '3.6'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -170,8 +170,8 @@ ipython>=7.23.1; python_version >= '3.7'
 # ipykernel 6.0.0 removed support for Python 3.5 and 3.6
 # Using ipkernel 6.2.0 gets us ipython 8.0 compatibility
 ipykernel>=4.5.2; python_version == '2.7'
-ipykernel>=4.5.2; python_version >= '3.5' and python_version <= '3.6'
-ipykernel>=6.1.0; python_version >= '3.7'
+ipykernel>=4.5.2; python_version == '3.6'
+ipykernel>=6.2.0; python_version >= '3.7'
 
 ipython_genutils>=0.1.0
 
@@ -191,17 +191,17 @@ jupyter_console>=6.0.0; python_version >= '3.5'
 # jupyter-server 1.17.0 depends on jupyter-client>=6.1.12
 jupyter_client>=4.4.0; python_version == '2.7'
 jupyter_client>=4.4.0; python_version == '3.5'
-jupyter-client>=6.1.12; python_version >= '3.6'
+jupyter-client>=6.1.12; python_version == '3.6'
+jupyter-client>=7.4.4; python_version >= '3.7'
 
-# Safety issue 54717 affected jupyter_core <4.11.2
-# NOTE: Jupyter_core does not exist for version 4.11.2 and python 3.5
-# jupyter_core 4.10 removed support for Pythton < 3.7
+# Safety issue 54717 affected jupyter-core<4.11.2
+# jupyter-core 4.10 removed support for Pythton < 3.7
 # jupyter-client 6.1.5 depends on jupyter-core>=4.6.0
 # notebook 6.4.10 depends on jupyter-core>=4.6.1
-jupyter_core>=4.2.1; python_version == '2.7'
+jupyter-core>=4.2.1; python_version == '2.7'
 jupyter_core>=4.2.1; python_version == '3.5'
-jupyter_core>=4.6.1; python_version == '3.6'
-jupyter_core>=4.11.2; python_version >= '3.7'
+jupyter-core>=4.6.1; python_version == '3.6'
+jupyter-core>=4.12.0; python_version >= '3.7'
 
 jupyterlab-pygments>=0.1.2
 
@@ -215,7 +215,8 @@ jupyterlab-widgets>=3.0.0; python_version >= '3.7'
 
 # nbclassic 0.4.7 depends on jupyter-server>=1.8
 # jupyter-server 1.17.1 solves several safety issues
-jupyter-server>=1.17.1; python_version >= '3.7'
+jupyter-server>=1.24.0; python_version == '3.7'
+jupyter-server>=2.4.0; python_version >= '3.8'
 
 # jupyter-client 6.1.5 depends on jupyter-core>=4.6.0
 # jupyter-server 1.24.0 depends on jupyter-core!=5.0.* and >=4.12
@@ -245,7 +246,7 @@ nbconvert>=6.5.1; python_version >= '3.7'
 nbformat>=4.2.0; python_version == '2.7'
 nbformat>=4.2.0; python_version == '3.5'
 nbformat>=5.1.3; python_version == '3.6'
-nbformat>=5.2.0; python_version >= '3.7'
+nbformat>=5.3.0; python_version >= '3.7'
 
 # Notebook 6.1.0 introduced usage of f-strings (which requires py>=3.6) but still required py>=3.5.
 # Safety issue 54713 and others affected <6.4.10
@@ -253,6 +254,16 @@ notebook>=4.3.1,<6.1.0; python_version == '2.7'
 notebook>=4.3.1,<6.1.0; python_version == '3.5'
 notebook>=6.4.10; python_version == '3.6'
 notebook>=6.5.4; python_version >= '3.7'
+
+notebook-shim>=0.2.0; python_version >= '3.7'
+
+jupyterlab-server>=2.22.1,<3; python_version >= '3.8'
+
+jupyterlab>=4.0.2,<5; python_version >= '3.8'
+
+jupyterlab-server>=2.22.1,<3; python_version >= '3.8'
+
+jupyterlab>=4.0.2,<5; python_version >= '3.8'
 
 pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
 pyrsistent>=0.14.0; python_version >= '3.5'
@@ -285,8 +296,9 @@ pywin32>=303; sys_platform == 'win32' and python_version >= '3.10'
 #   since it only appears on Python 2.
 #   This issue has been circumvented by pinning the Tornado version to <5.0 on
 #   Python 2.
-tornado>=4.4.2,<5.0; python_version <= '2.7'
-tornado>=4.4.2; python_version >= '3.5'
+tornado>=4.4.2,<5.0; python_version == '2.7'
+tornado>=6.1; python_version == '3.6'
+tornado>=6.2; python_version >= '3.7'
 
 # Table output formatter used by the manual performance tests to display
 # timing results
@@ -314,8 +326,8 @@ pipdeptree>=2.2.0
 pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.10'
 pip-check-reqs>=2.4.3; python_version >= '3.11'
 
-pyzmq>=16.0.4; python_version <= '3.8'
-pyzmq>=23.2.1; python_version >= '3.9'
+pyzmq>=17.0.0; python_version <= '3.6'
+pyzmq>=24.0.0; python_version >= '3.7'
 
 # Indirect dependencies are not specified in this file unless constraints are needed.
 
@@ -350,7 +362,7 @@ idna>=2.8
 traitlets>=4.3.1; python_version == '2.7'
 traitlets>=4.3.1; python_version == '3.5'
 traitlets>=4.3.1; python_version == '3.6'
-traitlets>=5.1.0; python_version >= '3.7'
+traitlets>=5.6.0; python_version >= '3.7'
 
 # TODOs:
 # importlib-resources 5.12.0 depends on zipp>=3.1.0; python_version < "3.10"

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,8 @@ Released: not yet
 * Circumvented the removal of Python 2.7 from the Github Actions plugin
   setup-python, by using the Docker container python:2.7.18-buster instead.
 
+* Fixed missing dependencies in minimum-constraints.txt.
+
 **Enhancements:**
 
 * The 'pywbem.ValueMapping' class now allows controlling what should happen

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -105,8 +105,8 @@ PyYAML==5.3.1; python_version >= '3.5'
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 requests==2.22.0; python_version == '2.7'
-requests==2.22.0; python_version >= '3.5' and python_version <= '3.9'
-requests==2.25.0; python_version >= '3.10'
+requests==2.22.0; python_version >= '3.5' and python_version <= '3.6'
+requests==2.28.0; python_version >= '3.7'
 yamlloader==0.5.5
 nocaselist==1.0.3
 nocasedict==1.0.1
@@ -149,9 +149,10 @@ Cython==0.29.33
 # Unit test (imports into testcases):
 packaging==19.0; python_version <= '3.5'
 # Packaging 21.0 required by safety 2.2.0
-packaging==21.0; python_version >= '3.6'
-funcsigs==1.0.2; python_version < '3.3'
-pytest==4.3.1; python_version <= '3.6'
+packaging==21.3; python_version >= '3.6'
+funcsigs==1.0.2; python_version == '2.7'
+pytest==4.3.1; python_version == '2.7'
+pytest==4.3.1; python_version == '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
 testfixtures==6.9.0; python_version == '2.7'
@@ -246,7 +247,8 @@ autodocsumm==0.1.13; python_version == '3.5'
 autodocsumm==0.2.5; python_version >= '3.6'
 Babel==2.7.0; python_version == '2.7'
 # Safety issue #42203  affected < 2.9.1
-Babel==2.9.1; python_version >= '3.5'
+Babel==2.9.1; python_version == '3.5'
+Babel==2.10.0; python_version >= '3.6'
 
 
 # PyLint (no imports, invoked via pylint script):
@@ -299,7 +301,7 @@ ipython==7.23.1; python_version >= '3.7'
 
 ipykernel==4.5.2; python_version == '2.7'
 ipykernel==4.5.2; python_version >= '3.5' and python_version <= '3.6'
-ipykernel==6.1.0; python_version >= '3.7'
+ipykernel==6.2.0; python_version >= '3.7'
 
 ipython_genutils==0.1.0
 
@@ -312,12 +314,13 @@ jupyter_console==6.0.0; python_version >= '3.5'
 
 jupyter_client==4.4.0; python_version == '2.7'
 jupyter_client==4.4.0; python_version == '3.5'
-jupyter-client==6.1.12; python_version >= '3.6'
+jupyter-client==6.1.12; python_version == '3.6'
+jupyter-client==7.4.4; python_version >= '3.7'
 
-jupyter_core==4.2.1; python_version == '2.7'
+jupyter-core==4.2.1; python_version == '2.7'
 jupyter_core==4.2.1; python_version == '3.5'
-jupyter_core==4.6.1; python_version == '3.6'
-jupyter_core==4.11.2; python_version >= '3.7'
+jupyter-core==4.6.1; python_version == '3.6'
+jupyter-core==4.12.0; python_version >= '3.7'
 
 jupyterlab-pygments==0.1.2
 
@@ -326,7 +329,8 @@ jupyterlab-widgets==0.6.5; python_version == '3.5'
 jupyterlab-widgets==1.0.2; python_version == '3.6'
 jupyterlab-widgets==3.0.0; python_version >= '3.7'
 
-jupyter-server==1.17.1; python_version >= '3.7'
+jupyter-server==1.24.0; python_version == '3.7'
+jupyter-server==2.4.0; python_version >= '3.8'
 
 nbclassic==0.4.7; python_version >= '3.7'
 
@@ -341,12 +345,22 @@ nbconvert==6.5.1; python_version >= '3.7'
 nbformat==4.2.0; python_version == '2.7'
 nbformat==4.2.0; python_version == '3.5'
 nbformat==5.1.3; python_version == '3.6'
-nbformat==5.2.0; python_version >= '3.7'
+nbformat==5.3.0; python_version >= '3.7'
 
 notebook==4.3.1; python_version == '2.7'
 notebook==4.3.1; python_version == '3.5'
 notebook==6.4.10; python_version == '3.6'
 notebook==6.5.4; python_version >= '3.7'
+
+notebook-shim==0.2.0; python_version >= '3.7'
+
+jupyterlab-server==2.22.1; python_version >= '3.8'
+
+jupyterlab==4.0.2; python_version >= '3.8'
+
+jupyterlab-server==2.22.1; python_version >= '3.8'
+
+jupyterlab==4.0.2; python_version >= '3.8'
 
 pyrsistent==0.14.0; python_version == '2.7'
 pyrsistent==0.14.0; python_version >= '3.6'
@@ -374,8 +388,8 @@ pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.10'
 pip-check-reqs==2.4.3; python_version >= '3.11'
 
 # notebook 6.4.10 depends on pyzmq>=17
-pyzmq==17.0.0; python_version <= '3.8'
-pyzmq==23.2.1; python_version >= '3.9'
+pyzmq==17.0.0; python_version <= '3.6'
+pyzmq==24.0.0; python_version >= '3.7'
 
 # Indirect dependencies for develop that need constraints
 
@@ -436,8 +450,9 @@ Jinja2==2.8.1; python_version <= '3.5'
 # Jinja2 version for python 3.6 is 3.0.0 because nbconvert 6.5.1 requirment
 # that changes at python 36
 # Safety issues #39525 affects <2.11.3 and #54679 affects <2.10.1
-Jinja2==3.0.0; python_version >= '3.6'
-jsonschema==2.6.0
+Jinja2==3.0.3; python_version >= '3.6'
+jsonschema==2.6.0; python_version <= '3.6'
+jsonschema==4.17.3; python_version >= '3.7'
 linecache2==1.0.0
 
 # MarkupSafe version depends on nbconvert min version 6.5.1 requirement
@@ -498,8 +513,8 @@ tomli==2.0.1; python_version >= '3.5'
 
 tornado==4.4.2; python_version == '2.7'
 tornado==4.4.2; python_version == '3.5'
-# ipykernel 4.5.2 depends on tornado>=4.0 notebook 6.4.10 depends on tornado>=6.1
-tornado==6.1; python_version >= '3.6'
+tornado==6.1; python_version == '3.6'
+tornado==6.2; python_version >= '3.7'
 
 tqdm==4.14
 traceback2==1.4.0
@@ -510,7 +525,7 @@ traceback2==1.4.0
 traitlets==4.3.1; python_version == '2.7'
 traitlets==4.3.1; python_version == '3.5'
 traitlets==4.3.1; python_version == '3.6'
-traitlets==5.1.0; python_version >= '3.7'
+traitlets==5.6.0; python_version >= '3.7'
 
 typing==3.10.0.0; python_version == '2.7'
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ six>=1.16.0; python_version >= '3.10'
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to
 #   remove ImportWarning in six
 requests>=2.22.0; python_version == '2.7'
-requests>=2.22.0; python_version >= '3.5' and python_version <= '3.9'
-requests>=2.25.0; python_version >= '3.10'
+requests>=2.22.0;python_version >= '3.5' and python_version <= '3.6'
+requests>=2.28.0; python_version >= '3.7'
 # yamlloader 1.1.0 gets istalled by mistake on py27+34 on Ubuntu when using setup.py install. See issue #2745.
 yamlloader>=0.5.5,<1.0.0; python_version <= '3.5'
 yamlloader>=0.5.5; python_version >= '3.6'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,9 +13,9 @@
 
 
 # Unit test (imports into testcases):
-packaging>=19.0; python_version <= '3.6'
-packaging>=21.0; python_version >= '3.7'
-funcsigs>=1.0.2; python_version < '3.3'
+packaging>=19.0; python_version == '3.6'
+packaging>=21.3; python_version >= '3.7'
+funcsigs>=1.0.2; python_version == '2.7'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 # pytest==6.0.0 causes pylint to report "not-callable" issues
@@ -36,7 +36,8 @@ colorama>=0.4.5; python_version >= '3.5'
 easy-vault>=0.7.0
 easy-server>=0.8.0
 pytest-easy-server>=0.8.0
-jsonschema>=2.6.0,!=4.0.0
+jsonschema>=2.6.0,!=4.0.0; python_version <= '3.6'
+jsonschema>=4.17.3; python_version >= '3.7'
 
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0


### PR DESCRIPTION
Rolls back PR #3027 into 1.6.2.