### PR TITLE
1.6: Fixed dependency issue with importlib-metadata on py38+39

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -163,7 +163,8 @@ colorama==0.3.9; python_version == '2.7'
 colorama==0.4.5; python_version >= '3.5'
 # Using 0.22 caused failure where at least argcompete requires 0.23
 importlib-metadata==0.23; python_version <= '3.7'
-importlib-metadata==1.1.0; python_version >= '3.8'
+importlib-metadata==4.8.3; python_version >= '3.8'
+
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
 requests-mock==1.6.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -47,7 +47,7 @@ yagot>=0.5.0
 #  Issue with importlib-metadata 5.0.0
 importlib-metadata>=0.22,<5.0.0; python_version < '3.7'
 importlib-metadata>=0.22,<5.0.0; python_version == '3.7'
-importlib-metadata>=1.1.0; python_version >= '3.8'
+importlib-metadata>=4.8.3; python_version >= '3.8'
 
 # pytz before 2019.1 fails on Python 3.10 because it uses collections.Mapping
 pytz>=2016.10; python_version <= '3.9'


### PR DESCRIPTION
Rolls back PR #3033 into 1.6.2.