### PR TITLE
1.6: Fixed install of ipywidget on Python 2.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -177,8 +177,11 @@ ipykernel>=6.2.0; python_version >= '3.7'
 ipython_genutils>=0.1.0
 
 # Safety issue 50463 affected ipywidgets < 8.0.0
-ipywidgets>=5.2.2; python_version == '2.7'
-ipywidgets>=5.2.2; python_version >= '3.5' and python_version <= '3.6'
+# ipywidget 7.8.0 claims support for py27 but does not install,
+#   see https://github.com/jupyter-widgets/ipywidgets/issues/3825
+ipywidgets>=5.2.2,<7.8.0; python_version == '2.7'
+ipywidgets>=5.2.2,<7.8.0; python_version == '3.5'
+ipywidgets>=5.2.2; python_version == '3.6'
 ipywidgets>=8.0.0; python_version >= '3.7'
 
 jupyter_console>=5.0.0,<6.0.0; python_version == '2.7'


### PR DESCRIPTION
Rolls back PR #3039 into 1.6.2.