### PR TITLE
Modify Listener documentation and extend examples.

### DIFF
--- a/examples/listen.py
+++ b/examples/listen.py
@@ -104,6 +104,15 @@ def _main():
 
     banner = """
 WBEM listener started on host %s (HTTP port: %s, HTTPS port: %s).
+The host parameter may be:
+
+  * a specific host name or host IP address on the computer - only  
+    indications addressed to that host will be accepted:
+  * a wildcard address (0.0.0.0 (IPV4) or ;; (IPV6))) - the listener will accept
+    indications addressed to any network address on the host system.
+  * The empty string ( "" ) - the listener will accept indications addressed to
+    any network address on the host system.
+
 This Python console displays any indications received by this listener as
 logger outputs (Level=INFO) to the console by default.
 

--- a/pylintrc
+++ b/pylintrc
@@ -191,7 +191,7 @@ disable=I0011, bad-option-value,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
         signature-differs, raise-missing-from, super-with-arguments,
-        redundant-u-string-prefix, consider-using-f-string,
+        redundant-u-string-prefix, consider-using-f-string, use-dict-literal,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -426,8 +426,8 @@ preferred-modules=
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [REFACTORING]

--- a/pywbem/_cim_operations.py
+++ b/pywbem/_cim_operations.py
@@ -197,6 +197,7 @@ with warnings.catch_warnings():
     else:
         RETRY_METHODS_PARM = 'method_whitelist'
 
+# pylint: disable=use-dict-literal
 RETRY_KWARGS = dict(
     total=HTTP_TOTAL_RETRIES,
     connect=HTTP_CONNECT_RETRIES,

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -45,6 +45,7 @@ The following example creates and runs a listener::
 
         certkeyfile = 'listener.pem'
 
+        # Receive indications only on the IP address returned by getfqdn()
         listener = WBEMListener(host=getfqdn(),
                                 http_port=5990,
                                 https_port=5991,
@@ -230,6 +231,7 @@ def saved_term_attrs():
         term_fd = None
 
     if term_fd is not None:
+        # pylint: disable=use-dict-literal
         count_dict = dict(count=0)  # Must be mutable
         saved_attrs = termios.tcgetattr(term_fd)
         atexit.register(restore_term_attrs, term_fd, saved_attrs, count_dict)
@@ -719,7 +721,12 @@ class WBEMListener(object):
         Parameters:
 
           host (:term:`string`):
-            IP address or host name at which this listener can be reached.
+            IP address or host name at which this listener can be reached. Only
+            indications directed to this IP address will be accepted.
+            The listener can receive indications from any network
+            interface in the host system by using a wildcard address (0.0.0.0
+            (IPv4) or :: (IPv6)) or an empty string ( "" ) to indicate that the
+            wild card address should be used.
 
           http_port (:term:`string` or :term:`integer`):
             HTTP port at which this listener can be reached. Note that at

--- a/pywbem/_server.py
+++ b/pywbem/_server.py
@@ -1113,16 +1113,17 @@ class WBEMServer(object):
                     break
                 # Some other error happened.
                 raise
-            else:
-                # Namespace class is implemented in the current namespace.
-                # Use the returned namespace name, if possible.
-                ns_names = [p.keybindings['name'] for p in inst_paths]
-                ns_dict = NocaseDict(list(zip(ns_names, ns_names)))
-                try:
-                    interop_ns = ns_dict[ns]
-                except KeyError:
-                    interop_ns = ns
-                break
+
+            # Namespace class is implemented in the current namespace.
+            # Use the returned namespace name, if possible.
+            ns_names = [p.keybindings['name'] for p in inst_paths]
+            ns_dict = NocaseDict(list(zip(ns_names, ns_names)))
+            try:
+                interop_ns = ns_dict[ns]
+            except KeyError:
+                interop_ns = ns
+            break
+
         if interop_ns is None:
             # Exhausted the possible namespaces
             raise ModelError(
@@ -1205,10 +1206,11 @@ class WBEMServer(object):
                     continue
                 # Some other error.
                 raise
-            else:
-                # Found a namespace class that is implemented.
-                ns_classname = classname
-                break
+
+            # Found a namespace class that is implemented.
+            ns_classname = classname
+            break
+
         if ns_insts is None:
             # Exhausted the possible class names
             raise ModelError(

--- a/pywbem/_tupleparse.py
+++ b/pywbem/_tupleparse.py
@@ -126,7 +126,7 @@ def kids(tup_tree):
     k = tup_tree[2]
     assert k is not None
     # pylint: disable=unidiomatic-typecheck
-    return [x for x in k if type(x) == tuple]
+    return [x for x in k if type(x) == tuple]  # noqa: E721
 
 
 def pcdata(tup_tree):
@@ -2340,11 +2340,12 @@ class TupleParser(object):
 
           CIMXMLParseError: There is an error in the XML.
         """
-
-        if type(val) == list:  # pylint: disable=unidiomatic-typecheck
+        # pylint: disable=unidiomatic-typecheck
+        if type(val) == list:   # noqa: E721
             return [self.parse_embeddedObject(obj) for obj in val]
         if val is None:
             return None
+        # pylint: enable=unidiomatic-typecheck
 
         # Perform the un-embedding (may raise XMLParseError)
         tup_tree = xml_to_tupletree_sax(val, "embedded object", self.conn_id)
@@ -2385,9 +2386,11 @@ class TupleParser(object):
 
         raw_val = raw_val[0]
 
-        if type(raw_val) == list:  # pylint: disable=unidiomatic-typecheck
+        # pylint: disable=unidiomatic-typecheck
+        if type(raw_val) == list:  # noqa: E721
             return [self.unpack_single_value(data, valtype)
                     for data in raw_val]
+        # pylint: enable=unidiomatic-typecheck
 
         return self.unpack_single_value(raw_val, valtype)
 

--- a/pywbem_mock/_utils.py
+++ b/pywbem_mock/_utils.py
@@ -72,9 +72,9 @@ def _uprint(dest, text):
         sys.stdout.write(text)
     elif isinstance(dest, (six.text_type, six.binary_type)):
         if isinstance(text, six.text_type):
-            kw = dict(mode='a', encoding='utf-8')
+            kw = {"mode": 'a', "encoding": 'utf-8'}
         else:
-            kw = dict(mode='ab')
+            kw = {"mode": 'ab'}
         with io.open(dest, **kw) as f:  # pylint: disable=unspecified-encoding
             f.write(text)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,9 +43,9 @@ nocasedict>=1.0.1
 # urllib3 1.25.9 addressed issue 38834 reported by safety
 # urllib3 needs to be pinned to <1.25 for requests <2.22.0
 # urllib3 1.26.5 vendors six 1.16.0 which is needed on Python 3.10 to remove ImportWarning
-urllib3>=1.25.9; python_version == '2.7'
-urllib3>=1.25.9; python_version >= '3.5' and python_version <= '3.9'
-urllib3>=1.26.5; python_version >= '3.10'
+urllib3>=1.25.9,<2.0.0; python_version == '2.7'
+urllib3>=1.25.9,<2.0.0; python_version >= '3.5' and python_version <= '3.9'
+urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
 
 # setuptools 61.0.0 breaks "setup.py install", see https://github.com/pypa/setuptools/issues/3198
 setuptools!=61.0.0; python_version >= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,8 @@ package_version = get_version(os.path.join('pywbem', '_version.py'))
 #   highlight=setup#distutils.core.setup
 # * https://setuptools.readthedocs.io/en/latest/setuptools.html#
 #   new-and-changed-setup-keywords
+
+# pylint: disable=use-dict-literal
 setup_options = dict(
     name='pywbem',
     version=package_version,
@@ -323,6 +325,7 @@ setup_options = dict(
         'Topic :: System :: Systems Administration',
     ]
 )
+# pylint: enable=use-dict-literal
 
 CYTHONIZED = False
 if cythonize and '--cythonized' in sys.argv:
@@ -343,6 +346,7 @@ if CYTHONIZED:
                 src_files,
                 build_dir='build_cythonize',
                 annotate=False,
+                # pylint: disable=use-dict-literal
                 compiler_directives=dict(
                     language_level=str(sys.version_info[0])))
         except CompileError as exc:

--- a/tests/manualtest/run_cim_operations.py
+++ b/tests/manualtest/run_cim_operations.py
@@ -253,11 +253,10 @@ class ClientTest(unittest.TestCase):
                     mofcomp.compile_file(PYWBEM_TEST_MOF_FILE, self.namespace)
                 except Error:
                     return False
-                else:
-                    return True
+                return True
+
             # Error other than NOT_FOUND. Just return False so tests continue
-            else:
-                return False
+            return False
 
     def assertClassNamesValid(self, classnames):
         """

--- a/tests/unittest/pywbem/test_cim_http.py
+++ b/tests/unittest/pywbem/test_cim_http.py
@@ -888,7 +888,8 @@ def test_pywbem_requests_exception(
         "  Expected type: {}\n" \
         "  Actual message: {}\n" \
         "  Expected message pattern: {}\n". \
-        format(type(act_exc), exp_exc_type, act_message, exp_pattern)
+        format(type(act_exc), exp_exc_type, \
+               act_message, exp_pattern)  # noqa=E721
     assert re.search(exp_pattern, act_message), \
         "Unexpected exception message:\n" \
         "  Actual: {}\n" \


### PR DESCRIPTION
Modify the definition of the host parameter of the WBEMListener to define the concept of wild card host.

Modify the documentation of the example to clarify the same thing.

Then a lot of check and pylint issues hit us.

Add new check bypass (for == on type tests)

Modified some code to add ignores for pylint and check

Modified requirements to limit urllib3 max version because of issue in tests with pool parameter and version 2.0

Modified pylintrc to ignore the pylint issue about literal dictionaries.  Note that I changed some but it found a bunch and most did not seem to be in any critical speed path.