### PR TITLE
Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -309,8 +309,9 @@ pipdeptree>=2.2.0
 #   on Python 2.7.
 # pip-check-reqs 2.3.2 is needed to have proper support for pip>=21.3 and below.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
-pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.10'
-pip-check-reqs>=2.4.3; python_version >= '3.11'
+# pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
+pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'
 
 pyzmq>=17.0.0; python_version <= '3.6'
 pyzmq>=24.0.0; python_version >= '3.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,8 @@ Released: not yet
 
 * dev: Fixed UnboundLocalError for membername in Sphinx autodoc.
 
+* Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0.
+
 **Enhancements:**
 
 * The 'pywbem.ValueMapping' class now allows controlling what should happen

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -361,8 +361,8 @@ psutil==5.6.0; sys_platform != 'cygwin' and platform_python_implementation == 'P
 
 # Package dependency management tools
 pipdeptree==2.2.0
-pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.10'
-pip-check-reqs==2.4.3; python_version >= '3.11'
+pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs==2.4.3; python_version >= '3.8'
 
 # notebook 6.4.10 depends on pyzmq>=17
 pyzmq==17.0.0; python_version <= '3.6'


### PR DESCRIPTION
No review needed.