### PR TITLE
Update documentation on listener host parameter.

### DIFF
--- a/examples/listen.py
+++ b/examples/listen.py
@@ -106,7 +106,7 @@ def _main():
 WBEM listener started on host %s (HTTP port: %s, HTTPS port: %s).
 The host parameter may be:
 
-  * a specific host name or host IP address on the computer - only  
+  * a specific host name or host IP address on the computer; only  
     indications addressed to that host will be accepted:
   * a wildcard address (0.0.0.0 (IPV4) or ;; (IPV6))) - the listener will accept
     indications addressed to any network address on the host system.

--- a/examples/listen.py
+++ b/examples/listen.py
@@ -104,6 +104,15 @@ def _main():
 
     banner = """
 WBEM listener started on host %s (HTTP port: %s, HTTPS port: %s).
+The host parameter may be:
+
+  * a specific host name or host IP address on the computer - only  
+    indications addressed to that host will be accepted:
+  * a wildcard address (0.0.0.0 (IPV4) or ;; (IPV6))) - the listener will accept
+    indications addressed to any network address on the host system.
+  * The empty string ( "" ) - the listener will accept indications addressed to
+    any network address on the host system.
+
 This Python console displays any indications received by this listener as
 logger outputs (Level=INFO) to the console by default.
 

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -27,7 +27,6 @@ Examples
 The following example creates and runs a listener::
 
     import logging
-    from socket import getfqdn
     from pywbem import WBEMListener
 
     def process_indication(indication, host):
@@ -45,7 +44,9 @@ The following example creates and runs a listener::
 
         certkeyfile = 'listener.pem'
 
-        listener = WBEMListener(host=getfqdn(),
+        # Set host name to wildcard host address to recieve indications on
+        # any network address defined for this system.
+        listener = WBEMListener(host="",
                                 http_port=5990,
                                 https_port=5991,
                                 certfile=certkeyfile,
@@ -725,13 +726,16 @@ class WBEMListener(object):
             that IP address (or to any IP address on the network interface
             containing that address) depending on the OS.
 
-            Setting the host parameter to an empty string (i.e. "") defines a
-            listener that binds to all configured network interfaces on the
-            local machine. Binding to IPV4 or IPV6 network interfaces can be
-            defined with the IP addresses "0.0.0.0" for IPV4 or "::" for IPV6.
+            Network wildcard addressing enables receiving indications from
+            all IP addresses on the system by binding the listener to certain
+            special addresses. The IPV4 wildcard IP address is "0.0.0.0"
+            and the IPV6 wild card IP address is "::".
+
+            Setting the host parameter to an empty string (i.e. "") is
+            equivalent to using at least the IPV4 wildcard address.
 
           http_port (:term:`string` or :term:`integer`):
-            HTTP port at which this listener can be reached. Note that at
+            HTTP port at which this listener can be reached. At
             least one port (HTTP or HTTPS) must be set. Both the http and
             https ports can be set.
 


### PR DESCRIPTION
Update documentation on listener host parameter.  No code changes in this PR.

Clarify the possible values for the host (i.e. the bind address)

NOTE: Fails without PR #3060 and PR#3059

Modify the example since getfqdn() may well return localhost which is only useful if the indication sender is in the same system as the listener and also show example of wildcard bind address.