### PR TITLE
pylint cyclic import issue.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -86,6 +86,8 @@ Released: not yet
 * Update dev-requirements.txt, minimum-constraings.txt, .safety_policy.json for
   new safety issues with GitPython and add ruamel-yaml.
 
+* Disable cyclic-import pylint warning.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pylintrc
+++ b/pylintrc
@@ -192,6 +192,7 @@ disable=I0011, bad-option-value,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
         signature-differs, raise-missing-from, super-with-arguments,
         redundant-u-string-prefix, consider-using-f-string,
+        cyclic-import,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/manualtest/run_operationtimeouts.py
+++ b/tests/manualtest/run_operationtimeouts.py
@@ -80,9 +80,9 @@ class ClientTest(unittest.TestCase):
         """Create a connection."""
 
         # pylint: disable=global-variable-not-assigned,global-statement
-        global args                 # pylint: disable=invalid-name
+        global args  # pylint: disable=invalid-name
 
-        self.host = args['host']
+        self.host = args['host']  # pylint: disable=used-before-assignment
         self.port = args['port']
         self.verbose = args['verbose']
         self.debug = args['debug']


### PR DESCRIPTION
Disable cyclic-import issue.

NOTE: Fails without PR #3059

A new issue popped up, cyclic-import with a number of warnings issued,
apparently when the new version of pylint (3.00) was released.

The following messages were produced by make pylint today:

```

mof_compiler:1:0: R0401: Cyclic import (pywbem._cim_obj ->
pywbem._cim_types) (cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._server ->
pywbem._cim_operations -> pywbem._recorder -> pywbem._logging)
(cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._mof_compiler
-> pywbem._cim_operations -> pywbem._recorder -> pywbem._logging)
(cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._logging)
(cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._recorder ->
pywbem._logging) (cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._server ->
pywbem._cim_operations -> pywbem._logging) (cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem -> pywbem._cim_operations
-> pywbem._recorder -> pywbem._logging) (cyclic-import)
mof_compiler:1:0: R0401: Cyclic import (pywbem ->
pywbem._subscription_manager -> pywbem._server -> pywbem._cim_operations
-> pywbem._recorder -> pywbem._logging) (cyclic-import)

```

I do not see these as cyclic-import issues but as reimporting components
used in different modules.
