### PR TITLE
1.6: Update .safety_policy, dev-ramts, minimum_constraints.txt files.

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -179,6 +179,13 @@ security:
             reason: Fixed cryptography version 41.0.3 requires Python>=3.7 and is used there
         60225:
             reason: Fixed cryptography version 41.0.3 requires Python>=3.7 and is used there
+        60350:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.32 requires Python>=3.7
+        60789:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.33 requires Python>=3.7
+        60841:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.35 requires Python>=3.7
+
 
 
     # Continue with exit code 0 when vulnerabilities are found.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -65,9 +65,10 @@ sphinx-git>=10.1.1
 # GitPython version 3.0.0 and newer does not support Python 2.7
 # GitPython version 3.1.24 requires Python >=3.7
 # GitPython version 3.1.27 fixes safety issue #52518
+# GitPython version 3.1.35 fixes safety issue #60350, #60789 #60841
 GitPython>=2.1.1,<3.0.0; python_version == '2.7'
 GitPython>=2.1.1; python_version >= '3.5' and python_version <= '3.6'
-GitPython>=3.1.27; python_version >= '3.7'
+GitPython>=3.1.35; python_version >= '3.7'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
 # rich 13.3.5 depends on pygments>=2.13.0,<3.0.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,9 @@ Released: not yet
 
 * Fixed safety issues from 2023-08-27.
 
+* Update dev-requirements.txt, minimum-constraings.txt, .safety_policy.json for
+  new safety issues with GitPython and add ruamel-yaml.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -232,7 +232,7 @@ docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
 GitPython==2.1.1; python_version == '2.7'
 GitPython==2.1.1; python_version >= '3.5' and python_version <= '3.6'
-GitPython==3.1.27; python_version >= '3.7'
+GitPython==3.1.35; python_version >= '3.7'
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 sphinxcontrib-applehelp==1.0.2; python_version >= '3.5'
@@ -534,6 +534,11 @@ traitlets==4.3.1; python_version == '2.7'
 traitlets==4.3.1; python_version == '3.5'
 traitlets==4.3.1; python_version == '3.6'
 traitlets==5.6.0; python_version >= '3.7'
+
+ruamel-yaml==0.13.6; python_version == '2.7'
+#safety 2.2.0 depends on ruamel.yaml>=0.17.21
+ruamel-yaml==0.17.21; python_version == '3.6'
+ruamel-yaml==0.17.21; python_version >= '3.7'
 
 typing==3.10.0.0; python_version == '2.7'
 wcwidth==0.1.7


### PR DESCRIPTION
Rolls back PR #3058 into 1.6.3