### PR TITLE
Update requirements to use urllib3 version 2 (Part 1).

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -71,6 +71,11 @@ Released: not yet
 * Split safety run out of "check" make target ino a separate "safety" make target
   and moved its run to the end of the test workflow.
 
+* Update handling of request exceptions in CIM_http.py to account for changes
+  to the urllib3 exceptions API that occurred in urllib3 version 2.0.0 and
+  keep the capability to handle the urllib3 exceptions API prior to versiion
+  2.0. (see issue #3006)
+
 **Cleanup:**
 
 * Replaced the safety_ignore_opts in Makefile that is used as the basis for

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,10 +46,8 @@ nocasedict>=1.0.1
 # urllib3 2.0 requires py>=3.7
 urllib3>=1.25.9,<2.0.0; python_version == '2.7'
 urllib3>=1.25.9,<2.0.0; python_version == '3.6'
-# TODO: Following limits use of urllib3<= 2.0 until issues about this upgrade
-# resolved. Issue #3006 failed to update urllib3 to version 2.0.0 for python >= '3.7'
-urllib3>=1.25.9,<2.0.0; python_version >= '3.7' and python_version <= '3.9'
-urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
+urllib3>=1.25.9; python_version >= '3.7' and python_version <= '3.9'
+urllib3>=1.26.5; python_version >= '3.10'
 
 # setuptools 61.0.0 breaks "setup.py install", see https://github.com/pypa/setuptools/issues/3198
 setuptools!=61.0.0; python_version >= '3.7'

--- a/tests/unittest/pywbem/test_cim_http.py
+++ b/tests/unittest/pywbem/test_cim_http.py
@@ -29,6 +29,9 @@ DEFAULT_SCHEME = 'http'
 # Keep in sync with same value in _cim_http.py
 HTTP_CONNECT_TIMEOUT = 9.99
 
+URLLIB3_VERSION = tuple(map(int, urllib3.__version__.split('.')[0:3]))
+URLLIB3V2 = URLLIB3_VERSION >= (2, 0, 0)
+
 TESTCASES_PARSE_URL = [
 
     # Testcases for _cim_http.parse_url()
@@ -623,9 +626,12 @@ def test_parse_url(
 
 
 DUMMY_CONN_USING_HTTPS = pywbem.WBEMConnection('https://dummy')
-DUMMY_CONN_USING_HTTP = pywbem.WBEMConnection('http://dummy')
+DUMMY_CONN_USING_HTTP = pywbem.WBEMConnection(url='http://dummy')
 DUMMY_POOL = urllib3.connectionpool.HTTPConnectionPool('dummy')
 
+# Argument for NewConnectionError which changes first parameter from
+# urllib3 version 1.x to urllib3 version 2.0 (from pool to host).
+NEW_CONN_ERR_PARM1 = DUMMY_CONN_USING_HTTP if URLLIB3V2 else DUMMY_POOL
 
 TESTCASES_PYWBEM_REQUESTS_EXCEPTION = [
 
@@ -833,12 +839,12 @@ TESTCASES_PYWBEM_REQUESTS_EXCEPTION = [
                         pool=DUMMY_POOL,
                         url='http://dummy',
                         reason=urllib3.exceptions.NewConnectionError(
-                            pool=DUMMY_POOL,
+                            NEW_CONN_ERR_PARM1,
                             message="bla"))),
                 conn=DUMMY_CONN_USING_HTTP,
             ),
             exp_exc_type=pywbem.ConnectionError,
-            exp_pattern="^bla$",
+            exp_pattern="^bla$"
         ),
         None, None, True
     ),

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -1345,3 +1345,81 @@ def test_copy_conn(
         for fname in files:
             os.remove(fname)
         dev_null.close()
+
+
+TESTCASES_WBEMCONNECTION_ERROR = [
+
+    # Test WBEMConnection error
+    # The testcase items are tuples with these items:
+    # * desc: Testcase description
+    # * init_kwargs: dict of init arguments for WBEMConnection
+    # * exp_exc: Type of expected exception, or None
+    # * exp_exc_regex: Regexp for the expected exception message, or None
+
+    (
+        "http connection",
+        dict(
+            url='http://InvalidHostName',
+            creds=None,
+            default_namespace='root/cimv2',
+            x509=None,
+            ca_certs=None,
+            no_verification=False,
+            timeout=5,
+            use_pull_operations=False,
+            stats_enabled=False,
+            proxies=None,
+        ),
+        ConnectionError, None
+    ),
+    (
+        "No optional init parameters, test defaults",
+        dict(
+            url='https://InvalidHostName',
+            creds=None,
+            default_namespace='root/cimv2',
+            x509=None,
+            ca_certs=None,
+            no_verification=False,
+            timeout=5,
+            use_pull_operations=False,
+            stats_enabled=False,
+            proxies=None,
+        ),
+        ConnectionError, None
+    ),
+]
+
+
+class TestConnectionError(object):  # pylint: disable=too-few-public-methods
+    """
+    Test construction of WBEMConnection and error exception when connection
+    is executed with a function that communicates with the server.
+    Only returns the exception message determined by the system since we have
+    not control over these exceptions.
+    """
+
+    @pytest.mark.parametrize(
+        'desc, init_kwargs, exp_exc, exp_exc_regex',
+        TESTCASES_WBEMCONNECTION_ERROR)
+    def test_init(self, desc, init_kwargs, exp_exc, exp_exc_regex):
+        # pylint: disable=no-self-use,unused-argument
+        """
+        Test  WBEMConnection object Exceptions caused by Server connection
+        failure.
+        """
+        exc = None
+        try:
+            assert exp_exc is not None
+            with pytest.raises(exp_exc) as exc_info:
+
+                # The code to be tested
+                conn = WBEMConnection(**init_kwargs)
+                _ = conn.EnumerateClasses()
+
+            exc = exc_info.value
+            exc_msg = str(exc)
+            if exp_exc_regex:
+                assert re.search(exp_exc_regex, exc_msg)
+        finally:
+            assert exc is not None


### PR DESCRIPTION
This pr includes:

1. Update of requirements to allow use of  urllib3 version 2 but modify the code for continued use of urllib3 < 20
2. Update of tests and code to account for interface difference in the utllib3 NewConnectionError class.
3. Adds a single test for failure of a connection to  test_cim_operations.py
4. Modify test_http.py to provided for modified interface of the urllib3 NewConnection exception.

This is only part of the changes for issue #3006, the complete integration of urllib3 version 2.0

It does not close that Issue.  The remaining issues involve any changes
because with urllib3, OpenSSL version 1.1.1 (released 2018) is required.


