### PR TITLE
Fix python syntax error in example and refactor example.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -251,6 +251,8 @@ Released: 2022-10-12
   (i.e. CIMInstanceName). Now issues a warning and ignores the host value since
   pywbem_mock does not handle cross-host associations. (see issue #2920)
 
+* Fixed python syntax issue in example/pegasus_indication_test.py
+
 **Enhancements:**
 
 * Added support for the new 'CIM_WBEMServerNamespace' class used in the


### PR DESCRIPTION
Fixed python syntax error in examples/pegasus_indication_test.py code and issue with logging.

In addition this PR:

1. Cleans up use of logs both for logging the client api calls and for logging the reception of indications.
2. Restructures some of the code be more readable.
3. Modifies some of the argument help to clarify usage.
4. Error exit if test fails.

I have tested this significantly since it is the basis for trying to figure out why there is a communication issue with OpenPegasus where we do not receive all requested indications.  

There are no real functional changes. 

You do not have to review this code if you do not want to since there are a lot of minor changes and moving code around.  After-all to everybody else it is just an example of creating subscriptions and getting indications.