### PR TITLE
Add documentation in the update of urllib3 (part 2)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,28 @@ Released: not yet
 * Installation of this package using "setup.py" is no longer supported.
   Use "pip" instead.
 
+* Update to support urllib3 package version 2.0+ (for python versions 3.7+)
+  which limits the SSL library implementations (ex. OpenSSL, libreSSL)
+  and only OpenSSL versions >= 1.1.1 (TLS minimum version 1.2). If an older
+  OpenSSL or incompatible SSL library is used, the import of urllib3  will
+  cause an import error. When the server TLS versions allowed by the server are
+  not compatible with the pywbem client an exception like the following may
+  occur:
+
+    SSLError(1, '[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol . . .)
+
+    or
+
+    NotOpenSSLWarning: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the
+           'ssl' module is compiled with 'LibreSSL 2.8.3'
+
+  Also, the default set of cyphers available has changed to use the list of
+  ciphers configured by the system rather than ciphers defined by urllib3.
+  See issue #1302 and the pywbem documentation
+  `trouble shooting section <https://pywbem.readthedocs.io/en/stable/appendix.html#troubleshooting>`_
+  for more information.
+
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/docs/client/objects.rst
+++ b/docs/client/objects.rst
@@ -1,8 +1,11 @@
 
+
 .. _`CIM objects`:
 
 CIM objects
 -----------
+
+.. index:: pair: CIM Objects; libraries
 
 .. automodule:: pywbem._cim_obj
 

--- a/docs/client/operations.rst
+++ b/docs/client/operations.rst
@@ -6,6 +6,8 @@ WBEM operations
 
 .. automodule:: pywbem._cim_operations
 
+..index: pair: libraries; WBEMConnection library
+
 WBEMConnection
 ^^^^^^^^^^^^^^
 

--- a/docs/client/types.rst
+++ b/docs/client/types.rst
@@ -4,6 +4,8 @@
 CIM data types
 --------------
 
+.. index:: pair: CIM data types; libraries
+
 .. automodule:: pywbem._cim_types
 
 .. autoclass:: pywbem.CIMType

--- a/docs/client/valuemappings.rst
+++ b/docs/client/valuemappings.rst
@@ -4,6 +4,8 @@
 Mapping between ValueMap and Values qualifiers
 ----------------------------------------------
 
+.. index:: pair: CIM Objects; ValueMap
+
 .. automodule:: pywbem._valuemapping
 
 .. autoclass:: pywbem.ValueMapping

--- a/docs/indication.rst
+++ b/docs/indication.rst
@@ -17,6 +17,8 @@ subscriptions for indications on a WBEM server.
 
 .. _`WBEMListener`:
 
+.. index: pair: WBEMListener, indications
+
 WBEMListener
 ^^^^^^^^^^^^
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -7,6 +7,24 @@ Introduction
 .. contents:: Chapter Contents
    :depth: 2
 
+Pywbem is a python implementation of the APIs defined by the DTMF WBEM Standards
+specifications.
+
+This document provides information on:
+* pywbem  :ref:`Functionality`,
+* pywbem :ref:`Installation`,
+* pywbem libraries including:
+
+  * pywbem Python API definitions
+  * Examples of the use of these Python APIs.
+
+..index:: single; examples
+Examples of the APIs are contained throughout this document (see examples in
+the document index), in a set of Jupyter notebooks :ref:`Tutorial`, and in the:
+`pywbem repository examples directory (``pywbem/examples``) at
+<https://github.com/pywbem/pywbem/tree/master/examples/>`_ that is available in
+the pywbem github project and available when pywbem is cloned.
+
 
 .. _`Functionality`:
 
@@ -25,6 +43,9 @@ The blue components are not part of the pywbem or pywbemtools packages.
 The pywbem components all run on the client side and communicate with a remote
 WBEM server using the standard CIM operations over HTTP (CIM-XML) protocol
 defined in the DMTF standards :term:`DSP0200` and :term:`DSP0201`.
+
+.. index:: pair: pywbem; libraries
+.. index:: pair: pywbem; APIs
 
 Pywbem provides the following Python APIs:
 

--- a/docs/mockwbemserver.rst
+++ b/docs/mockwbemserver.rst
@@ -10,6 +10,8 @@ Mock WBEM server
 Overview
 --------
 
+.. index:: single: Mock WBEM Server
+
 The 'pywbem_mock' module of pywbem provides a *mock WBEM server* that
 enables using the pywbem client library without a real WBEM server.
 This is useful for testing the pywbem client library itself as well
@@ -61,6 +63,9 @@ the operations of a real WBEM server.
 CIM classes, instances and qualifier types to its CIM repository by providing
 them as :term:`CIM objects <CIM object>`, or by compiling MOF.
 See :ref:`Building a mocked CIM repository` for details.
+
+.. index:: pair: examples; mock WBEM server setup
+.. index:: pair: mock WBEM server; setup
 
 The following example demonstrates setting up a mock WBEM server, adding
 several CIM objects defined in a MOF string to its CIM repository, and
@@ -212,6 +217,8 @@ Diagram of flow of requests operations through mocker
 
 WBEM operations of a mock WBEM server
 -------------------------------------
+
+.. index:: pair: Mock WBEM Server; WBEM Operations
 
 The :class:`pywbem_mock.FakedWBEMConnection` class supports the same WBEM
 operations that are supported by the :class:`pywbem.WBEMConnection` class and
@@ -610,6 +617,9 @@ schema version 2.49.0 into the CIM repository along with all of the qualifier
 types defined by the DMTF CIM schema and any dependent classes
 (superclasses, etc.).
 
+.. index: pair: examples, mock define qualifier types
+.. index: pair: examples, mock define classes
+
 .. code-block:: python
 
     import pywbem
@@ -641,6 +651,9 @@ types defined by the DMTF CIM schema and any dependent classes
 
 Example: Set up qualifier types and classes from MOF
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index: pair: examples, mock define qualifier types from MOF
+.. index: pair: examples, mock define classes from MOF
 
 This example creates a mock WBEM server and sets up its CIM repository with
 qualifier types and classes that are defined in a MOF string.
@@ -745,6 +758,8 @@ Here is the output from displaying the CIM repository in the example above:
 Example: Set up instances from single CIM objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. index: pair: examples, mock define CIM instances
+
 Based on the CIM repository content of the previous example, this example
 adds two class instances and one association instance from their CIM objects
 using the :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects` method.
@@ -844,7 +859,7 @@ DMTF CIM schema download support
 .. _`In-memory CIM repository classes`:
 
 In-memory CIM repository classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pywbem_mock._inmemoryrepository
 
@@ -964,8 +979,13 @@ Creating user-defined providers
 
 A user-defined provider can be created as follows:
 
+.. index:: pair: examples; instance write provider
+
 1. Define a subclass of the superclass listed in the table above, with the
    methods and attributes listed below.
+
+   .. index:: pair: examples; create instance write provider
+
 
    Example for an instance write provider:
 
@@ -1021,6 +1041,8 @@ A user-defined provider can be created as follows:
       provider class default to implementations in the superclass.
       See `Python operation methods in user-defined providers`_ for details.
 
+      .. index:: pair: examples; instance write provider CreateInstance
+
       Example for an ``CreateInstance`` method of an instance write provider
       that just calls superclass method to perform the work (and that could
       therefore be omitted):
@@ -1055,6 +1077,8 @@ A user-defined provider can be created as follows:
    This specifies the CIM namespaces for which the user-defined provider will
    be active. These namespaces must already exist in the CIM repository
    if the mock WBEM server.
+
+   .. index:: pair: examples; register user-defined provider
 
    .. code-block:: python
 

--- a/docs/notebooks/pywbemmock.ipynb
+++ b/docs/notebooks/pywbemmock.ipynb
@@ -38,7 +38,7 @@
     "The pywbem client includes a package (`pywbem_mock`) to mock a WBEM server and allow the pywbem client to \n",
     "execute WBEM operations against this fake WBEM server.\n",
     "\n",
-    "This notebook contains examples of creating and using a simple repository and creating and using more complex repositories usingthe DMTF released Schema MOF files.\n",
+    "This notebook contains examples of creating and using a simple repository and creating and using more complex repositories using the DMTF released Schema MOF files.\n",
     "\n",
     "For more detailed information on the package and its APIs see the pywbem client documentation on \n",
     "[read-the-docs](https://pywbem.readthedocs.io/en/stable/mocksupport.html) which includes both an overview and API descriptions for the `pywbem_mock` package of pywbem."

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -4,6 +4,10 @@
 WBEM server library
 ===================
 
+.. index: pair: WBEM server library; indications
+.. index: pair: WBEM server library; indication subscriptions
+.. index: pair: libraries; WBEM Server library
+
 .. automodule:: pywbem._server
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -8,6 +8,8 @@ This section contains a few short tutorials about using pywbem. It is intended
 to be enough to get people up and going who already know a bit about WBEM and
 CIM.
 
+.. index:: pair: examples; Jupyter Notebooks
+
 The tutorials in this section are
 `Jupyter Notebooks <https://jupyter-notebook-beginner-guide.readthedocs.io/>`_,
 and are shown using the online
@@ -43,7 +45,7 @@ For the following topics, tutorials are not yet available:
 * ExecQuery
 * Association Operations
 * Class Operations
-* Qualifier Operations
+* Qualifier Declaration Operations
 * WBEMListener
 
 Executing code in the tutorials

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -10,6 +10,9 @@ They are all implemented as pure-Python scripts.
 These commands are installed into the Python script directory and should
 therefore automatically be available in the command search path.
 
+..index:: pair; MOF, compiler
+..index:: single; MOF compiler
+
 The following commands are provided:
 
 * :ref:`mof_compiler`
@@ -22,6 +25,7 @@ interactive command line environment. It is recommended to use the
 ``pywbemcli`` command from the
 `pywbemtools package on Pypi <https://pypi.org/project/pywbemtools/>`_
 as a replacement.
+
 
 
 .. _`mof_compiler`:


### PR DESCRIPTION
The inclusion of urllib3 verson 2.0+ can cause SSL incompatibility issue because it sets the minimum TLS version to 1.2 where it was previously TLS 1.1 or less and also limits the allowable SSL libraries to OpenSSL and possibly libreSSL.

This change updates the changes.rst document to describe the possible issues and also updates the troubleshooting section to provide details on the possible issues and corrections.

Adds index entries for SSL and OpenSSL.