### PR TITLE
Add end2end test for operation timeout.

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -183,7 +183,8 @@ security:
             reason: GitPython, Python 2.7, 3.6. fixed version 3.1.33 requires Python>=3.7
         60841:
             reason: GitPython, Python 2.7, 3.6. fixed version 3.1.35 requires Python>=3.7
-
+        61601:
+            reason: Fixed urllib3 version 1.26.17 requires Python>=3.6 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -58,6 +58,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Addressed safety issues up to 2023-11-05.
+
 * Fixed a doc build issue with Sphinx 6.x (issue #2983) and addressed
   some of the Sphinx warnings during doc build.
 
@@ -67,8 +69,6 @@ Released: not yet
   setup-python, by using the Docker container python:2.7.18-buster instead.
 
 * Fixed missing dependencies in minimum-constraints.txt.
-
-* Fixed safety issues as of 2023-08-21 and 2023-08-27 and 2023-09-10.
 
 * dev: Fixed UnboundLocalError for membername in Sphinx autodoc.
 
@@ -97,6 +97,9 @@ Released: not yet
   to the urllib3 exceptions API that occurred in urllib3 version 2.0.0 and
   keep the capability to handle the urllib3 exceptions API prior to versiion
   2.0. (see issue #3006)
+
+* Add end2end tests for operation timeout. (see issue #2181)
+
 
 **Cleanup:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -115,14 +115,13 @@ certifi==2023.07.22; python_version >= '3.6'
 chardet==3.0.2; python_version <= '3.9'
 charset-normalizer==2.0.0; python_version >= '3.10'
 # urllib3 >= 2.0.0 minimum python == '3.7'
-urllib3==1.25.9; python_version == '2.7'
-urllib3==1.25.9; python_version == '3.6'
 # TODO issue #3006. Update the following to include urllib3 version 2
 # for python version >= 3.7 when issue #3006 resolved.
 # TODO issue #3006. Update the following to include urllib3 version 2 for
 # python >= python 3.7 when issue resolved.
-urllib3==1.25.9; python_version >= '3.7' and python_version <= '3.9'
-urllib3==1.26.5; python_version >= '3.10'
+urllib3==1.26.17,<2.0.0; python_version == '2.7'
+urllib3==1.26.17,<2.0.0; python_version == '3.6'
+urllib3==1.26.17; python_version >= '3.7'
 
 # funcsigs; is covered in direct deps for develop, from mock
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,10 +44,9 @@ nocasedict>=1.0.1
 # urllib3 needs to be pinned to <1.25 for requests <2.22.0
 # urllib3 1.26.5 vendors six 1.16.0 which is needed on Python 3.10 to remove ImportWarning
 # urllib3 2.0 requires py>=3.7
-urllib3>=1.25.9,<2.0.0; python_version == '2.7'
-urllib3>=1.25.9,<2.0.0; python_version == '3.6'
-urllib3>=1.25.9; python_version >= '3.7' and python_version <= '3.9'
-urllib3>=1.26.5; python_version >= '3.10'
+urllib3>=1.26.17,<2.0.0; python_version == '2.7'
+urllib3>=1.26.17,<2.0.0; python_version == '3.6'
+urllib3>=1.26.17; python_version >= '3.7'
 
 # setuptools 61.0.0 breaks "setup.py install", see https://github.com/pypa/setuptools/issues/3198
 setuptools!=61.0.0; python_version >= '3.7'

--- a/tests/end2endtest/test_operation_timeouts.py
+++ b/tests/end2endtest/test_operation_timeouts.py
@@ -1,0 +1,171 @@
+"""
+End2end tests of operation timeout from a test class in the
+OpenPegasus WBEM server.
+
+"""
+
+from __future__ import absolute_import, print_function
+
+import re
+
+import datetime
+
+from .utils.pytest_extensions import skip_if_unsupported_capability
+
+# Note: The wbem_connection fixture uses the es_server fixture, and
+# due to the way py.test searches for fixtures, it also must be imported.
+# pylint: disable=unused-import,wrong-import-order, relative-beyond-top-level
+from .utils.pytest_extensions import wbem_connection  # noqa: F401
+from pytest_easy_server import es_server  # noqa: F401
+from .utils.pytest_extensions import default_namespace  # noqa: F401
+# pylint: enable=unused-import,wrong-import-order, relative-beyond-top-level
+
+# pylint: disable=wrong-import-position, wrong-import-order, invalid-name
+# pylint: disable=relative-beyond-top-level, disable=redefined-builtin
+from ..utils import import_installed
+
+pywbem = import_installed('pywbem')
+from pywbem import Uint32, CIMError, ConnectionError, CIMClassName, \
+    TimeoutError  # noqa: E402 pylint: disable=redefined-builtin
+# pylint: enable=relative-beyond-top-level, enable=redefined-buitin
+# pylint: enable=wrong-import-position, wrong-import-order, invalid-name
+
+# Identity of the OpenPegasus namespace, class, and method that implements
+# the delayed response. NOTE: This is only available on OpenPegasus version
+# 2.15+ available from github.
+NAMESPACE = 'test/testprovider'
+TESTCLASS = 'Test_CLITestProviderClass'
+TESTMETHOD = 'delayedMethodResponse'
+
+
+class ElapsedTimer(object):
+    """
+        Set up elapsed time timer. Calculates time between initiation
+        and access.
+    """
+
+    def __init__(self):
+        """ Initiate the object with current time"""
+        self.start_time = datetime.datetime.now()
+
+    def reset(self):
+        """ Reset the start time for the timer"""
+        self.start_time = datetime.datetime.now()
+
+    def elapsed_ms(self):
+        """ Get the elapsed time in milliseconds. returns floating
+            point representation of elapsed time in seconds.
+        """
+        dt = datetime.datetime.now() - self.start_time
+        return ((dt.days * 24 * 3600) + dt.seconds) * 1000 + \
+            dt.microseconds / 1000.0
+
+    def elapsed_sec(self):
+        """ get the elapsed time in seconds. Returns floating
+            point representation of time in seconds
+        """
+        return self.elapsed_ms() / 1000
+
+
+def run_timeout_test(conn, timeout, response_delay, timeout_exp):
+    """
+    Test a single timeout, expected response_delay and timeout_exp boolean
+    Tests for correct response type (good response if the delay is
+    less than the timeout and timeout exception if the delay is greater
+    than the timeout.
+    """
+    opttimer = ElapsedTimer()
+    conn.timeout = timeout
+    try:
+        # Confirm server working with a simple request.
+        conn.GetClass('CIM_ManagedElement')
+        assert conn.timeout == timeout
+        class_path = CIMClassName(TESTCLASS, namespace=NAMESPACE)
+        result = conn.InvokeMethod(TESTMETHOD, class_path,
+                                   [('delayInSeconds', Uint32(response_delay))])
+
+        assert result[0] == Uint32(0)
+        assert result[1]['delayInSeconds'] == response_delay
+
+        execution_time = opttimer.elapsed_sec()
+
+        assert not timeout_exp, 'Timeout expected but not rcvd., Fail: ' \
+            'url={}, conn.timeout={}, timeout={}, response delay exp={}, '  \
+            'execution time={}'.format(conn.url, conn.timeout, timeout,
+                                       response_delay, execution_time)
+
+    # ConnectionError exception: If this does not include in the response
+    # message the text string, "Read timed out" the test fails.
+    # If it does include that string the timeout is processed. See issue # 3075
+    # Timeout returns this message text:
+    # "HTTPConnectionPool(host='localhost', port=15988): Read timed out. "
+    # #(read timeout=4)"
+    except ConnectionError as ce:
+        execution_time = opttimer.elapsed_sec()
+
+        if re.search(r'^HTTPS?ConnectionPool(.*)Read timed out. (.*)$',
+                     ce.args[0]):
+            time_diff = abs(execution_time - timeout)
+            assert timeout_exp, 'Timeout not expected: url={}, ' \
+                'conn.timeout={}, ' \
+                'timeout={}, response_delay_exp={}, execution time={}'. \
+                format(conn.url, conn.timeout, timeout, response_delay,
+                       execution_time)
+            assert time_diff <= 1, 'Timeout Time - response delay diff to ' \
+                'great, Failed: url={}, timeout={}, response delay exp={}, ' \
+                'execution time={} exp - act diff={}, exception={}'. \
+                format(conn.url, timeout, response_delay, execution_time,
+                       time_diff, ce)
+
+        else:
+            assert False, 'ConnectionError Fail: url={}, conn.timeout={}, '  \
+                'timeout={}, response_delay={}, execution time={}, '  \
+                'exception={}'. \
+                format(conn.url, conn.timeout, timeout, response_delay,
+                       execution_time, ce)
+
+    # This exception tests against expected result. It terminates the
+    # test if the timeout is not expected or time difference between
+    # response delay and timeout is too great.
+    except TimeoutError as te:
+        execution_time = opttimer.elapsed_sec()
+        time_diff = abs(execution_time - timeout)
+        assert timeout_exp, 'Timeout not expected: url={}, ' \
+            'conn.timeout={}, ' \
+            'timeout={}, response_delay_exp={}, execution time={}'. \
+            format(conn.url, conn.timeout, timeout, response_delay,
+                   execution_time)
+        assert time_diff <= 1, 'Timeout Time - response delay diff to great, ' \
+            'Failed: url={}, timeout={}, response delay exp={}, ' \
+            'execution time={} exp - act diff={}, exception={}'. \
+            format(conn.url, timeout, response_delay, execution_time,
+                   time_diff, te)
+
+    # Any CIMError
+    except CIMError as ce:
+        execution_time = opttimer.elapsed_sec()
+        time_diff = abs(execution_time - timeout)
+        assert not timeout_exp, 'CIMError exception: url={}, ' \
+            'conn.timeout={}, timeout={}, response_delay_exp={}, ' \
+            'execution time={} exception={}'. \
+            format(conn.url, conn.timeout, timeout, response_delay,
+                   execution_time, ce)
+
+
+def test_timeouts(wbem_connection):  # pylint: disable=redefined-outer-name
+    """
+    Test indication subscription to a container and reception of indications
+    from the container.
+    """
+    skip_if_unsupported_capability(wbem_connection, 'interop')
+
+    # Table of tests. Each entry is:
+    #    timeout (sec), response_delay(sec), bool(time_out_expected flag)
+    timeout_tests = [{'timeout': 8,
+                      'response_delay': 4,
+                      'timeout_exp': False},
+                     {'timeout': 4,
+                      'response_delay': 8,
+                      'timeout_exp': True}, ]
+    for kwargs in timeout_tests:
+        run_timeout_test(wbem_connection, **kwargs)


### PR DESCRIPTION
Adds a test that uses a provider in OpenPegasus to delay the response to an invoke method to test for operation timeout in the end2end tests.