### PR TITLE
Fix issue with losing indications sent by OpenPegasus

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -119,6 +119,11 @@ Released: not yet
   This reduces the burden of fixing safety issues that affect only development
   packages.
 
+* Document the issue and possible corrections for the pywbem listener possibly
+  losing indications.  Modifies the indication tests in the examples directory
+  to give better visibility and control of what these examples are doing.
+  See the documentation troubleshooting section. See issue #3022.
+
 **Cleanup:**
 
 * Replaced the safety_ignore_opts in Makefile that is used as the basis for

--- a/examples/listen.py
+++ b/examples/listen.py
@@ -3,6 +3,10 @@
 ''' Test listener. When started this code creates a WBEMListener on the
     address/ports defined by the input parameters.  This listener
     displays any indications received as log entries.
+
+    It does not validate the MESSAGE_ID or SEQUENCE_NUMBER of incoming
+    indications. Therefore, it does not know if any indications are missing
+    from a sequence.
 '''
 
 import sys as _sys
@@ -106,7 +110,7 @@ def _main():
 WBEM listener started on host %s (HTTP port: %s, HTTPS port: %s).
 The host parameter may be:
 
-  * a specific host name or host IP address on the computer; only  
+  * a specific host name or host IP address on the computer; only
     indications addressed to that host will be accepted:
   * a wildcard address (0.0.0.0 (IPV4) or ;; (IPV6))) - the listener will accept
     indications addressed to any network address on the host system.

--- a/examples/listen.py
+++ b/examples/listen.py
@@ -3,10 +3,6 @@
 ''' Test listener. When started this code creates a WBEMListener on the
     address/ports defined by the input parameters.  This listener
     displays any indications received as log entries.
-
-    It does not validate the MESSAGE_ID or SEQUENCE_NUMBER of incoming
-    indications. Therefore, it does not know if any indications are missing
-    from a sequence.
 '''
 
 import sys as _sys

--- a/examples/pegasusindicationtest.py
+++ b/examples/pegasusindicationtest.py
@@ -270,8 +270,9 @@ class RunIndicationTest(object):
 
     def indication_consumer(self, indication, host):
         """
-        Consume a single indication. This is a callback and may be on another
-        thead. It is called each time an indication is received.
+        Consume a single indication. This is a callback and is on another
+        thread from the script thread. It is called each time an indication
+        is received.
         """
         self.received_indications.append(indication)
         # Count received indications and save received time.
@@ -402,9 +403,14 @@ class RunIndicationTest(object):
                 if self.last_indication_time:
                     stalled_time = datetime.datetime.now() - \
                         self.last_indication_time
-                else:
+                elif self.indication_start_time:
                     stalled_time = datetime.datetime.now() - \
                         self.indication_start_time
+
+                else:
+                    self.indication_starttime = datetime.datetime.now()
+                    stalled_time = datetime.datetime.now() - \
+                        datetime.datetime.now()
 
                 if stall_ctr > 5:
                     if self.last_indication_time:

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -145,6 +145,7 @@ import threading
 import atexit
 import getpass
 <<<<<<< HEAD
+<<<<<<< HEAD
 # Python 2.7 uses name Queue
 try:
     import queue
@@ -153,6 +154,8 @@ except ImportError:
 =======
 import queue
 >>>>>>> e37bdcf4 (Fix issue with example/pegasusindicationtest.py. (#3079))
+=======
+>>>>>>> 735da1d2 (Document the timeout issue between listener and WBEM server.)
 try:
     import termios
 except ImportError:
@@ -189,12 +192,6 @@ SUPPORTED_DTD_VERSION_PATTERN = r'2\.\d+'
 SUPPORTED_DTD_VERSION_STR = '2.x'
 SUPPORTED_PROTOCOL_VERSION_PATTERN = r'1\.\d+'
 SUPPORTED_PROTOCOL_VERSION_STR = '1.x'
-
-
-# NOTE: This is a test flag while making modifications to use a queue between
-# the reception of indications and the indication consumer.  When False,
-# the queue path is used.
-DIRECT_DELIVER_INDICATIONS =True
 
 # Pattern for findall() for header values that are a list of tokens with
 # quality values (see RFC2616). The pattern does not verify conformance
@@ -521,6 +518,7 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                             "but {0!A}", indication_inst))
                 return
 <<<<<<< HEAD
+<<<<<<< HEAD
             # server.listener created in WBEMListener.start function
             self.server.listener.handle_indication(indication_inst,
                                                    self.client_address[0])
@@ -533,6 +531,11 @@ class ListenerRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.server.listener.queue_indication(indication_inst,
                                                       self.client_address[0])
 >>>>>>> e37bdcf4 (Fix issue with example/pegasusindicationtest.py. (#3079))
+=======
+            # server.listener created in WBEMListener.start function
+            self.server.listener.deliver_indication(indication_inst,
+                                                    self.client_address[0])
+>>>>>>> 735da1d2 (Document the timeout issue between listener and WBEM server.)
 
             self.send_success_response(msgid, methodname)
 
@@ -766,6 +769,13 @@ class WBEMListener(object):
     The listener must be stopped in order to free the TCP/IP port it listens
     on. Using this class as a context manager ensures that the listener is
     stopped when leaving the context manager scope.
+
+    The listener validates the syntax of the received CIM instance but does not
+    validate the values of received the MESSAGE_ID or SEQUENCE_NUMBER of
+    incoming indications. Therefore, it does not know if any indications are
+    missing from a sequence. The callback function must do any such
+    processing., etc. that confirms if indications are in the proper sequence
+    and none were lost.
     """
 
     def __init__(self, host, http_port=None, https_port=None,
@@ -869,6 +879,7 @@ class WBEMListener(object):
         self._callbacks = []  # Registered callback functions
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         # Set up callback queue and callback thread.
         self.rcvd_indication_queue = queue.Queue()
         self.callback_thread = StoppableThread(
@@ -885,6 +896,8 @@ class WBEMListener(object):
         self.delivery_running = True
 >>>>>>> e37bdcf4 (Fix issue with example/pegasusindicationtest.py. (#3079))
 
+=======
+>>>>>>> 735da1d2 (Document the timeout issue between listener and WBEM server.)
     def __str__(self):
         """
         Return a representation of the :class:`~pywbem.WBEMListener` object
@@ -1063,6 +1076,7 @@ class WBEMListener(object):
           :exc:`py:IOError`: Other error (Python 2.7 only)
         """
 <<<<<<< HEAD
+<<<<<<< HEAD
         # Start delivery queue
         self.callback_thread.start()
         self.logger.info("Callback queue thread started")
@@ -1071,6 +1085,8 @@ class WBEMListener(object):
         if not DIRECT_DELIVER_INDICATIONS:
             self.delivery_thread.start()
 >>>>>>> e37bdcf4 (Fix issue with example/pegasusindicationtest.py. (#3079))
+=======
+>>>>>>> 735da1d2 (Document the timeout issue between listener and WBEM server.)
 
         if self._http_port:
             if not self._http_server:
@@ -1227,6 +1243,7 @@ class WBEMListener(object):
             self.logger.info("Stopped threaded Queue")
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         self.logger.info("Stopping queued delivery")
         self.callback_thread.stop()
         self.logger.info("Joining queued delivery")
@@ -1260,6 +1277,8 @@ class WBEMListener(object):
             except queue.Empty:
                 pass
 
+=======
+>>>>>>> 735da1d2 (Document the timeout issue between listener and WBEM server.)
     def deliver_indication(self, indication, host):
 >>>>>>> e37bdcf4 (Fix issue with example/pegasusindicationtest.py. (#3079))
         """

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -649,6 +649,10 @@ def test_WBEMListener_send_indications(send_count):
     can receive large numbers of indications without duplicates or dropping
     indications.
 
+    The test generates the indications itself and does not depend on a
+    WBEM Server.  Tests in tests/end2end test with indications from
+    a WBEM server.
+
     It does not validate all of the possible xml options on indications.
 
     Creates the listener, starts the listener, creates the indication XML and


### PR DESCRIPTION
This PR was prepared to document the open issued in issue #3022., losing indications.
2. It does not fix the issue where occasionally the passing of indications from the server to pywbem listener client fails to deliver and puts the indications into a queue to be delivered after a delay determined by the server. Note that the issue itself is caused by conflicts between the tests and retry timers in OpenPegaus, not indications actually being lost.
This PR documents those issues in the documentation troubleshooting
4. Makes changes to the examples directories to help with tracking down the lost indications issue.

Read issue #3022 for more detailed information on the issue with finding the lost indications problem.

‘replaced by pr #3084. Same changes but the other one fixes last minute code rebase conflict 