### PR TITLE
1.6: Safety issues; Pinned lxml<4.9.4 on py35/win/latest; Added py36/win/latest to normal tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,11 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
                 \"python-version\": \"3.10\", \
                 \"package_level\": \"minimum\" \
               }, \

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -193,6 +193,12 @@ security:
             reason: Fixed tornado version 6.3.3 requires Python>=3.8 and is used there
         62044:
             reason: Fixed pip version 23.3 requires Python>=3.7 and is used there
+        62451:
+            reason: Fixed cryptography version 41.0.4 requires Python>=3.7 and is used there
+        62452:
+            reason: Fixed cryptography version 41.0.5 requires Python>=3.7 and is used there
+        62556:
+            reason: Fixed cryptography version 41.0.6 requires Python>=3.7 and is used there
 
 
     # Continue with exit code 0 when vulnerabilities are found.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -365,7 +365,7 @@ anyio>=3.1.0; python_version >= '3.7'
 cryptography>=3.3; python_version == '2.7'
 cryptography>=3.2.1; python_version == '3.5'
 cryptography>=3.4.7; python_version == '3.6'
-cryptography>=41.0.2; python_version >= '3.7'
+cryptography>=41.0.6; python_version >= '3.7'
 distlib>=0.3.4
 filelock>=3.0.0
 # gitdb2 4.0.2 requires gitdb>=4.0.1 for installation, see https://github.com/gitpython-developers/gitdb/issues/86

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,7 +25,7 @@ Released: not yet
 
 **Bug fixes:**
 
-* Addressed safety issues up to 2023-11-26.
+* Addressed safety issues up to 2024-01-03.
 
 * Update dev-requirements.txt, minimum-constraings.txt, .safety_policy.json for
   new safety issues with GitPython and add ruamel-yaml.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -136,7 +136,7 @@ urllib3==1.26.18; python_version >= '3.7'
 cryptography==3.3; python_version == '2.7'
 cryptography==3.2.1; python_version == '3.5'
 cryptography==3.4.7; python_version == '3.6'
-cryptography==41.0.2; python_version >= '3.7'
+cryptography==41.0.6; python_version >= '3.7'
 keyring==18.0.0
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -76,7 +76,9 @@ FormEncode>=2.0.0; python_version >= '3.10'
 # lxml 4.6.3 addressed safety issue 40072
 # lxml 4.9.2 addresses changes in Python 3.11 and 3.12
 lxml>=4.6.2; python_version == '2.7'
-lxml>=4.6.2; python_version >= '3.5' and python_version <= '3.9'
+lxml>=4.6.2; python_version == '3.5' and sys_platform != "win32"
+lxml>=4.6.2,<4.9.4; python_version == '3.5' and sys_platform == "win32"
+lxml>=4.6.2; python_version >= '3.6' and python_version <= '3.9'
 lxml>=4.6.4; python_version == '3.10'
 lxml>=4.9.2; python_version >= '3.11'
 


### PR DESCRIPTION
Rolls back PR #3090 into 1.6.3.

In addition, pins lxml to <4.9.4 to mitigate install failure on Python 3.5 on Windows. For the lxml install failure, created issue https://bugs.launchpad.net/lxml/+bug/2047927

In addition, added Python 3.6 / Windows / latest to normal tests to ensure the lxml install failure does not show up there.

No review needed.