### PR TITLE
Add support for python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
+            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
               { \
@@ -79,7 +79,7 @@ jobs:
         else \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"3.11\" ], \
+            \"python-version\": [ \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
@@ -157,6 +157,11 @@ jobs:
               { \
                 \"os\": \"windows-latest\", \
                 \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.12\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -98,9 +98,11 @@ Babel>=2.10.0; python_version >= '3.6'
 # Pylint 2.14 / astroid 2.11 support wrapt 1.14 which is required for Python 3.11
 # Pylint 2.15 / astroid 2.12 is needed to circumvent issue https://github.com/PyCQA/pylint/issues/7972 on Python 3.11
 pylint>=2.10.0; python_version >= '3.6' and python_version <= '3.10'
-pylint>=2.15.0; python_version >= '3.11'
+pylint>=2.15.0; python_version == '3.11'
+pylint>=3.0.1; python_version >= '3.12'
 astroid>=2.7.2; python_version >= '3.6' and python_version <= '3.10'
-astroid>=2.12.4; python_version >= '3.11'
+astroid>=2.12.4; python_version == '3.11'
+astroid>=3.0.1; python_version >= '3.12'
 
 # astroid 2.13.0 uses typing-extensions on Python<3.11 but misses to require it on 3.10. See https://github.com/PyCQA/astroid/issues/1942
 # rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
@@ -126,21 +128,33 @@ dill>=0.2; python_version >= '3.6' and python_version <= '3.10'
 dill>=0.3.6; python_version >= '3.11'
 # platformdirs is used by pylint starting with its 2.10
 platformdirs>=2.2.0; python_version == '3.6'
-platformdirs>=2.5.0; python_version >= '3.7'
+platformdirs>=2.5.0; python_version >= '3.7' and python_version <= '3.11'
+platformdirs>=3.2.0; python_version >= '3.12'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 4.0.0 fixes an AttributeError on Python 3.10.
 # flake8 4.0.0 pins importlib-metadata to <4.3 on Python <3.8. This causes
 #   version conflicts with Sphinx>=4.4.0 and virtualenv>=20.0.35
-flake8>=3.8.0,<4.0.0; python_version == '2.7'
-flake8>=3.8.0,<4.0.0; python_version >= '3.6' and python_version <= '3.7'
+
+# before pywbem 1.7
+
 flake8>=3.8.0; python_version >= '3.8' and python_version <= '3.9'
-flake8>=4.0.0; python_version >= '3.10'
+##flake8>=4.0.0; python_version >= '3.10'
+##mccabe>=0.6.0; python_version == '2.7'
+##mccabe>=0.6.0; python_version >= '3.6'
+
+# changes for pywbem 1.7
+flake8>=3.8.0; python_version <= '3.9'
+flake8>=5.0.0; python_version >= '3.10'
 mccabe>=0.6.0; python_version == '2.7'
-mccabe>=0.6.0; python_version >= '3.6'
+mccabe>=0.6.0; python_version >= '3.6' and python_version <= '3.9'
+mccabe>=0.7.0; python_version >= '3.10'
+
+# TODO: inconsistend with defs in pywbemtools
 pycodestyle>=2.6.0,<2.8.0; python_version == '2.7'
 pycodestyle>=2.6.0; python_version >= '3.6' and python_version <= '3.9'
-pycodestyle>=2.8.0; python_version >= '3.10'
+pycodestyle>=2.9.0; python_version >= '3.10'
+
 pyflakes>=2.2.0,<2.4.0; python_version == '2.7'
 pyflakes>=2.2.0; python_version >= '3.6' and python_version <= '3.9'
 pyflakes>=2.4.0; python_version >= '3.10'
@@ -351,7 +365,8 @@ pipdeptree>=2.2.0
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
 pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.7'
-pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs>=2.5.1; python_version >= '3.12'
 
 pyzmq>=17.0.0; python_version <= '3.6'
 pyzmq>=24.0.0; python_version >= '3.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -77,6 +77,9 @@ Released: not yet
 
 * Test: Upgraded GitHub Actions plugins to use node.js 20.
 
+* Test: Fixed issue in test_recorder.py where format of OrderDict repl output
+  changed with python 3.12 (see issue #3097)
+
 **Enhancements:**
 
 * The 'pywbem.ValueMapping' class now allows controlling what should happen

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -130,6 +130,8 @@ Released: not yet
 * Fix issue in pywbem_mock._base_provider where __repr__ had invalid parameter
   (see issue #3036)
 
+* Extend support to Python  version 3.12 (see issue #3098)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -155,9 +155,8 @@ testfixtures==6.9.0; python_version == '2.7'
 testfixtures==6.9.0; python_version >= '3.6'
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.5; python_version >= '3.6'
-# Using 0.22 caused failure where at least argcompete requires 0.23
-importlib-metadata==0.23; python_version <= '3.7'
-importlib-metadata==4.8.3; python_version >= '3.8'
+importlib-metadata==2.1.3; python_version <= '3.6'
+importlib-metadata==4.8.3; python_version >= '3.7'
 
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
@@ -173,7 +172,9 @@ easy-server==0.8.0
 pytest-easy-server==0.8.0
 
 # Virtualenv
-virtualenv==20.0.35
+virtualenv==16.1.0; python_version <= '3.7'
+virtualenv==20.15.0; python_version >= '3.8' and python_version <= '3.11'  # requires six<2,>=1.12.0
+virtualenv==20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 pluggy==0.7.1; python_version == '2.7'
@@ -244,9 +245,12 @@ Babel==2.10.0; python_version >= '3.6'
 
 # PyLint (no imports, invoked via pylint script):
 pylint==2.10.0; python_version >= '3.6' and python_version <= '3.10'
-pylint==2.15.0; python_version >= '3.11'
+pylint==2.15.0; python_version == '3.11'
+pylint==3.0.1; python_version >= '3.12'
+
 astroid==2.7.2; python_version >= '3.6' and python_version <= '3.10'
-astroid==2.12.4; python_version >= '3.11'
+astroid==2.12.4; python_version == '3.11'
+astroid==3.0.1; python_version >= '3.12'
 
 # rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
 # typing-extensions 4.0.0 removed support for Python < 3.6
@@ -259,18 +263,25 @@ wrapt==1.14; python_version >= '3.11'
 isort==4.3.8
 tomlkit==0.10.1; python_version >= '3.7'
 dill==0.2; python_version >= '3.6' and python_version <= '3.10'
-dill==0.3.6; python_version >= '3.11'
-platformdirs==2.2.0; python_version == '3.6'
-platformdirs==2.5.0; python_version >= '3.7'
+dill==0.3.7; python_version >= '3.11'
+#platformdirs==2.2.0; python_version == '3.6'
+#platformdirs==2.5.0; python_version >= '3.7'
+platformdirs==2.2.0; python_version >= '3.6' and python_version <= '3.11'
+platformdirs==3.2.0; python_version >= '3.12'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.8.0; python_version <= '3.9'
-flake8==4.0.0; python_version >= '3.10'
-mccabe==0.6.0
+flake8==5.0.0; python_version >= '3.10'
+# From prev versionmccabe==0.6.0
+mccabe==0.6.0; python_version <= '3.9'
+mccabe==0.7.0; python_version >= '3.10'
 pycodestyle==2.6.0; python_version <= '3.9'
-pycodestyle==2.8.0; python_version >= '3.10'
+pycodestyle==2.9.0; python_version >= '3.10'
+
 pyflakes==2.2.0; python_version <= '3.9'
-pyflakes==2.4.0; python_version >= '3.10'
+# From prev version pyflakes==2.4.0; python_version >= '3.10'
+pyflakes==2.5.0; python_version >= '3.10'
+
 entrypoints==0.3.0
 functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
@@ -377,7 +388,10 @@ psutil==5.6.0; sys_platform != 'cygwin' and platform_python_implementation == 'P
 # Package dependency management tools
 pipdeptree==2.2.0
 pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
-pip-check-reqs==2.4.3; python_version >= '3.8'
+# Prev version pip-check-reqs==2.4.3; python_version >= '3.8'
+pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs==2.4.3; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs==2.5.1; python_version >= '3.12'
 
 # notebook 6.4.10 depends on pyzmq>=17
 pyzmq==17.0.0; python_version <= '3.6'
@@ -423,7 +437,10 @@ defusedxml==0.7.1
 distlib==0.3.4
 docopt==0.6.1
 enum34==1.1.10; python_version == '2.7'
-filelock==3.0.0
+# previous version filelock==3.0.0
+filelock==3.2.0; python_version <= "3.11"
+filelock==3.11.0; python_version >= "3.12"
+
 # Safety issue #52510 affected <=0.18.2
 future==0.18.3
 futures==3.3.0; python_version == '2.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -71,7 +71,7 @@
 # * pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
 # * pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
 # * pip 22.0 dropped support for Python 3.6.
-pip==10.0.1; python_version == '2.7'
+pip==19.3.1; python_version == '2.7'
 pip==21.3.1; python_version == '3.6'
 pip==23.3; python_version >= '3.7'
 
@@ -81,13 +81,15 @@ pip==23.3; python_version >= '3.7'
 # setuptools 49.0.0 fixes the comparison of Python versions in requirements that was
 #   based on strings and thus ignored certain requirements on Python 3.10.
 # setuptools safety issue 52495 affects 65.1.1
-setuptools==41.5.1; python_version <= '3.9'
-setuptools==65.2.0; python_version >= '3.10'
+setuptools==41.5.1; python_version == '2.7'
+setuptools==59.6.0; python_version == '3.6'
+setuptools==65.5.1; python_version >= '3.7' and python_version <= '3.11'
+setuptools==66.1.0; python_version >= '3.12'
 
 # wheel 0.36.2 fixes empty and invalid tag issues in archive file name, and supports get_platform() with args
 # wheel 0.38.1 fixes CVE issue 51499, and dropped support for Python <=3.6
-wheel==0.36.2; python_version <= '3.7'
-wheel==0.38.1; python_version >= '3.8'
+wheel==0.36.2; python_version <= '3.6'
+wheel==0.38.1; python_version >= '3.7'
 
 
 # Direct dependencies for installation (must be consistent with requirements.txt)
@@ -179,8 +181,8 @@ pluggy==0.12.0; python_version == '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 decorator==4.0.11
 # FormEncode is used for xml comparisons in unit test
-FormEncode==1.3.1; python_version <= '3.9'
-FormEncode==2.0.0; python_version >= '3.10'
+FormEncode==1.3.1; python_version == '2.7'
+FormEncode==2.0.0; python_version >= '3.6'
 
 # Lxml
 lxml==4.6.2; python_version == '2.7'

--- a/setup.py
+++ b/setup.py
@@ -320,6 +320,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Systems Administration',
     ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -80,6 +80,6 @@ lxml>=4.6.2; python_version >= '3.6' and python_version <= '3.9'
 lxml>=4.6.4; python_version == '3.10'
 lxml>=4.9.2; python_version >= '3.11'
 
-# Virtualenv
-# virtualenv 20.0.35 is required by build
-virtualenv>=20.0.35
+virtualenv>=16.1.0,!=20.0.19,!=20.0.32; python_version <= '3.7'
+virtualenv>=20.15.0; python_version >= '3.8' and python_version <= '3.11'  # requires six<2,>=1.12.0
+virtualenv>=20.23.0; python_version >= '3.12'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -65,8 +65,9 @@ decorator>=4.0.11; python_version >= '3.6'
 backports.statistics>=0.1.0; python_version == '2.7'
 # FormEncode is used for xml comparisons in unit test
 # FormEncode 1.3.1 has no python_requires and fails install on Python 3.10 due to incorrect version checking
-FormEncode>=1.3.1; python_version <= '3.9'
-FormEncode>=2.0.0; python_version >= '3.10'
+# FormEncode 1.3.1 uses the use_2to3 directive, so attempting to install FormEncode<2 on setuptools>=58 breaks
+FormEncode>=1.3.1; python_version == '2.7'
+FormEncode>=2.0.0; python_version >= '3.6'
 
 # Lxml
 # lxml 4.4.3 added Python 3.8 support and exposed it correctly

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -2641,16 +2641,32 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         self.test_recorder.stage_pywbem_result((return_val, params),
                                                None)
 
-        result_req = (
-            "Request:test_id InvokeMethod("
-            "MethodName='Blah', "
-            "ObjectName={!r}, "
-            "Params=OrderedDict(["
-            "('StringParam', 'Spotty'), "
-            "('Uint8', Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 1)), "
-            "('Sint8', Sint8(cimtype='sint8', minvalue=-128, maxvalue=127, 2))"
-            "]))".
-            format(instancename))
+        if sys.version_info[0:2] >= (3, 12):  # fix issue #3097
+            result_req = (
+                "Request:test_id InvokeMethod("
+                "MethodName='Blah', "
+                "ObjectName={!r}, "
+                "Params=OrderedDict("
+                "{'StringParam': 'Spotty', "
+                "'Uint8': Uint8(cimtype='uint8', minvalue=0, "
+                "maxvalue=255, 1), "
+                "'Sint8': Sint8(cimtype='sint8', minvalue=-128, "
+                "maxvalue=127, 2)"
+                "}))".
+                format(instancename))
+        else:
+            result_req = (
+                "Request:test_id InvokeMethod("
+                "MethodName='Blah', "
+                "ObjectName={!r}, "
+                "Params=OrderedDict(["
+                "('StringParam', 'Spotty'), "
+                "('Uint8', Uint8(cimtype='uint8', minvalue=0, "
+                "maxvalue=255, 1)), "
+                "('Sint8', Sint8(cimtype='sint8', minvalue=-128, "
+                "maxvalue=127, 2))"
+                "]))".
+                format(instancename))
 
         result_ret = "Return:test_id InvokeMethod(tuple )"
 

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -2647,12 +2647,12 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
                 "MethodName='Blah', "
                 "ObjectName={!r}, "
                 "Params=OrderedDict("
-                "{'StringParam': 'Spotty', "
+                "{{'StringParam': 'Spotty', "
                 "'Uint8': Uint8(cimtype='uint8', minvalue=0, "
                 "maxvalue=255, 1), "
                 "'Sint8': Sint8(cimtype='sint8', minvalue=-128, "
                 "maxvalue=127, 2)"
-                "}))".
+                "}}))".
                 format(instancename))
         else:
             result_req = (


### PR DESCRIPTION
Make changes to support Python 3.12.

1. Add Python 3.12 to CI test matrix.

2. Add Python 3.12 to list of supported Python versions.