### PR TITLE
1.6: Fixed dependency issue with safety 3.0.0 by pinning it

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,15 +30,21 @@ more-itertools>=4.0.0; python_version >= '3.6'
 
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
+# Safety 3.0.0 requires exact versions of authlib==1.2.0 and jwt==1.3.1.
+#   (see issue https://github.com/pyupio/safety/issues/496)
+#   TODO: Unpin safety<3.0.0 once the exact version issue is resolved.
 safety>=1.8.7,<1.9.0; python_version == '2.7'
 safety>=1.9.0; python_version == '3.5'
-safety>=2.2.0; python_version >= '3.6'
+safety>=2.2.0,!=2.3.5,<3.0.0; python_version >= '3.6'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.5.1; python_version == '3.5'
 # ver 0.6.2 min requirement by safety 2.2.0
 dparse>=0.6.2; python_version >= '3.6'
+ruamel-yaml>=0.13.6; python_version == '2.7'
+ruamel.yaml>=0.17.21,<0.17.22; python_version == '3.6'
+ruamel.yaml>=0.17.21; python_version >= '3.7'
 
 # Tox
 tox>=2.5.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,8 @@ Released: not yet
 
 * Disable cyclic-import pylint warning.
 
+* Development: Fixed dependency issue with safety 3.0.0 by pinning it.
+
 **Enhancements:**
 
 * Split safety run out of "check" make target ino a separate "safety" make target


### PR DESCRIPTION
Rolls back PR #3103 into 1.6.3.