### PR TITLE
1.6: Test: Upgraded GitHub Actions plugins to use node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,19 +240,19 @@ jobs:
     - name: Set up caching for local Docker image cache directory
       # GitHub Actions has Docker only on Ubuntu
       if: startsWith(matrix.os, 'ubuntu-')
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.DOCKER_CACHE_DIR }}
         key: docker-cache-{hash}
         restore-keys: |
           docker-cache-
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ ! ( matrix.python-version == '2.7' ) }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,8 @@ Released: not yet
 
 * Development: Fixed dependency issue with safety 3.0.0 by pinning it.
 
+* Test: Upgraded GitHub Actions plugins to use node.js 20.
+
 **Enhancements:**
 
 * Split safety run out of "check" make target ino a separate "safety" make target


### PR DESCRIPTION
Rolls back PR #3105 into 1.6.3.