### PR TITLE
Fixed new Pylint issue for unused variable 'exp_result'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -80,6 +80,8 @@ Released: not yet
 * Test: Fixed issues resulting from removal of support for pytest.warns(None)
   in pytest version 8. (issue #3114)
 
+* Fixed new Pylint issue for unused variable 'exp_result'. (issue #3113)
+
 **Enhancements:**
 
 * The 'pywbem.ValueMapping' class now allows controlling what should happen

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -1200,10 +1200,10 @@ def result_tuple(value, tc_name):
     if "query_result_class" in value:
         # This appears to be an issue with pylint itself ver 2.13.0
         # pylint: disable=unused-variable
-        result = namedtuple("exp_result", ["instances", "eos", "context",
-                                           "query_result_class"])
+        result = namedtuple("result", ["instances", "eos", "context",
+                                       "query_result_class"])
     else:
-        result = namedtuple("exp_result", ["instances", "eos", "context"])
+        result = namedtuple("result", ["instances", "eos", "context"])
 
     # either path or instances should be in value
     if "instances" in value:


### PR DESCRIPTION
This PR fixes only the error reported in issue #3113, but not the warning.