### PR TITLE
1.6: Fixed new Pylint issue for unused variable 'exp_result'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,8 @@ Released: not yet
 * Fix new Feb 2024 safety issues, GitPython, Jinja2, JupyterLab. Added to
   safety ignore and fixed in requirements files.
 
+* Fixed new Pylint issue for unused variable 'exp_result'. (issue #3113)
+
 **Enhancements:**
 
 * Split safety run out of "check" make target ino a separate "safety" make target

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -1200,10 +1200,10 @@ def result_tuple(value, tc_name):
     if "query_result_class" in value:
         # This appears to be an issue with pylint itself ver 2.13.0
         # pylint: disable=unused-variable
-        result = namedtuple("exp_result", ["instances", "eos", "context",
-                                           "query_result_class"])
+        result = namedtuple("result", ["instances", "eos", "context",
+                                       "query_result_class"])
     else:
-        result = namedtuple("exp_result", ["instances", "eos", "context"])
+        result = namedtuple("result", ["instances", "eos", "context"])
 
     # either path or instances should be in value
     if "instances" in value:


### PR DESCRIPTION
Rolls back PR #3117 into 1.6.3.