### PR TITLE
Test of build package versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
+            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
               { \
@@ -79,7 +79,7 @@ jobs:
         else \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"3.11\" ], \
+            \"python-version\": [ \"3.12\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
@@ -157,6 +157,11 @@ jobs:
               { \
                 \"os\": \"windows-latest\", \
                 \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.12\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -207,6 +207,13 @@ security:
             reason: jupyterlab  issue in version 4.03, requires < 4.0.11 python >= 3.8
         64588:
             reason: jupyterlab  issue in version 4.03, requires < 4.0.11 python >= 3.8
+        65212:
+            reason: Fixed cryptography version <=42.0.2 requires Python>=3.8
+        65182:
+            reason: Notebook; Issue affects ver >=7.0.0,<=7.0.6, requires Python>=3.8
+        65183:
+            reason: Notebook; Issue affects ver >=7.0.0,<=7.0.6, requires Python>=3.8
+
 
 
     # Continue with exit code 0 when vulnerabilities are found.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@
 # FUTURE: Remove  wheel < 1.0 For details, see
 #       https://github.com/pypa/build/issues/750. Circumvention for now is
 #       to pin build to <1.0. See issue #3112
-build>=0.5.1, <1.0
+build>=0.5.1, <1.1.0
 
 # Cythonize
 Cython>=0.29.33

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -261,7 +261,8 @@ nbformat>=5.9.0; python_version >= '3.8'
 notebook>=4.3.1,<6.1.0; python_version == '2.7'
 notebook>=6.4.10; python_version == '3.6'
 notebook>=6.5.4; python_version == '3.7'
-notebook>=7.0.2; python_version >= '3.8'
+notebook>=7.0.7; python_version >= '3.8'
+
 
 # notebook-shim 0.1.0 removed support for Python 3.6
 # latest 3.10: notebook_shim 0.2.3
@@ -369,7 +370,7 @@ terminado>=0.8.3,<0.10.0; python_version >= '3.6'
 anyio>=3.1.0; python_version >= '3.7'
 cryptography>=3.3; python_version == '2.7'
 cryptography>=3.4.7; python_version == '3.6'
-cryptography>=41.0.6; python_version >= '3.7'
+cryptography>=42.0.2; python_version >= '3.7'
 distlib>=0.3.4
 filelock>=3.0.0
 # gitdb2 4.0.2 requires gitdb>=4.0.1 for installation, see https://github.com/gitpython-developers/gitdb/issues/86

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,11 +12,11 @@
 # Direct dependencies:
 
 # Build distribution archive
-# TODO: Remove dependency to wheel in setup.py, because build 1.1.0 removed
-#       wheel. Wheel does not provide a public API. For details, see
+# Version 1.1.0 pulled after release
+# FUTURE: Remove  wheel < 1.0 For details, see
 #       https://github.com/pypa/build/issues/750. Circumvention for now is
-#       to pin build to <1.1.0.
-build>=0.5.1,<1.1.0
+#       to pin build to <1.0. See issue #3112
+build>=0.5.1, <1.0
 
 # Cythonize
 Cython>=0.29.33
@@ -84,24 +84,24 @@ Babel>=2.9.1; python_version >= '3.8'
 # Pylint 2.7-2.9 had issue https://github.com/PyCQA/pylint/issues/4118 (issues #2672, #2673)
 # Pylint 2.14 / astroid 2.11 support wrapt 1.14 which is required for Python 3.11
 # Pylint 2.15 / astroid 2.12 is needed to circumvent issue https://github.com/PyCQA/pylint/issues/7972 on Python 3.11
-pylint>=2.10.0; python_version >= '3.6' and python_version <= '3.10'
-pylint>=2.15.0; python_version >= '3.11'
-astroid>=2.7.2; python_version >= '3.6' and python_version <= '3.10'
-astroid>=2.12.4; python_version >= '3.11'
-
+# Pylint 3.0.1 / astroid 3.0.1 python 3.12
 # astroid 2.13.0 uses typing-extensions on Python<3.11 but misses to require it on 3.10. See https://github.com/PyCQA/astroid/issues/1942
-# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
-# typing-extensions 4.0.0 removed support for Python < 3.6
-typing-extensions>=3.10.0; python_version == '2.7'
-typing-extensions>=4.0.0; python_version >= '3.6' and python_version <= '3.10'
+pylint>=2.13.0,<2.14.0; python_version == '3.6'
+pylint>=2.13.0; python_version >= '3.7' and python_version <= '3.10'
+pylint>=2.15.0; python_version == '3.11'
+pylint>=3.0.3; python_version >= '3.12'
+astroid>=2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid>=2.12.4; python_version == '3.11'
+astroid>=3.0.2; python_version >= '3.12'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 # lazy-object-proxy is used by astroid
 lazy-object-proxy>=1.4.3; python_version >= '3.6'
-# wrapt 1.13.0 started depending on MS Visual C++ 9.0 on Python 2.7 on Windows,
-#   which is not available by default on GitHub Actions
-# wrapt 1.14.0 started supporting Python 3.11 by accomodating the removed inspect.formatargspec
-wrapt>=1.12; python_version >= '3.6' and python_version <= '3.10'
+wrapt>=1.11.2; python_version >= '3.5' and python_version <= '3.10'
 wrapt>=1.14; python_version >= '3.11'
+# platformdirs is used by pylint starting with its 2.10
+platformdirs>=2.2.0; python_version == '3.6'
+platformdirs>=2.5.0; python_version >= '3.7' and python_version <= '3.11'
+platformdirs>=3.2.0; python_version >= '3.12'
 # isort 5.0.0 removed support for py27,py35
 # isort 4.2.8 fixes a pylint issue with false positive on import order of ssl on Windows
 # isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
@@ -109,28 +109,29 @@ isort>=4.3.8
 # Pylint 2.14 uses tomlkit>=0.10.1 and requires py>=3.7
 tomlkit>=0.10.1; python_version >= '3.7'
 # dill is used by pylint >=2.13
-dill>=0.2; python_version >= '3.6' and python_version <= '3.10'
+dill>=0.3.4; python_version >= '3.6' and python_version <= '3.10'
 dill>=0.3.6; python_version >= '3.11'
-# platformdirs is used by pylint starting with its 2.10
-platformdirs>=2.2.0; python_version == '3.6'
-platformdirs>=2.5.0; python_version >= '3.7'
+
+# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
+# typing-extensions 4.0.0 removed support for Python < 3.6
+typing-extensions>=3.10.0; python_version == '2.7'
+typing-extensions>=4.0.0; python_version >= '3.6' and python_version <= '3.10'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 4.0.0 fixes an AttributeError on Python 3.10.
 # flake8 4.0.0 pins importlib-metadata to <4.3 on Python <3.8. This causes
 #   version conflicts with Sphinx>=4.4.0 and virtualenv>=20.0.35
 flake8>=3.8.0,<4.0.0; python_version == '2.7'
-flake8>=3.8.0,<4.0.0; python_version >= '3.6' and python_version <= '3.7'
-flake8>=3.8.0; python_version >= '3.8' and python_version <= '3.9'
-flake8>=4.0.0; python_version >= '3.10'
-mccabe>=0.6.0; python_version == '2.7'
-mccabe>=0.6.0; python_version >= '3.6'
+flake8>=3.8.0; python_version >= '3.6' and python_version <= '3.9'
+flake8>=5.0.0; python_version >= '3.10'
+mccabe>=0.6.0; python_version <= '3.9'
+mccabe>=0.7.0; python_version >= '3.10'
 pycodestyle>=2.6.0,<2.8.0; python_version == '2.7'
-pycodestyle>=2.6.0; python_version >= '3.6' and python_version <= '3.9'
-pycodestyle>=2.8.0; python_version >= '3.10'
+pycodestyle>=2.6.0; python_version >= '3.5' and python_version <= '3.9'
+pycodestyle>=2.9.0; python_version >= '3.10'
 pyflakes>=2.2.0,<2.4.0; python_version == '2.7'
-pyflakes>=2.2.0; python_version >= '3.6' and python_version <= '3.9'
-pyflakes>=2.4.0; python_version >= '3.10'
+pyflakes>=2.2.0; python_version >= '3.5' and python_version <= '3.9'
+pyflakes>=2.5.0; python_version >= '3.10'
 entrypoints>=0.3.0
 functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
@@ -320,8 +321,10 @@ tornado>=6.3.3; python_version >= '3.8'
 tabulate >= 0.8.3
 
 # Performance profiling tools
-pyinstrument >=3.0.1
-pyinstrument-cext>=0.2.2  # from pyinstrument
+pyinstrument>=3.0.1; python_version <= '3.11'
+pyinstrument-cext>=0.2.2; python_version <= '3.11'  # from pyinstrument
+pyinstrument>=4.5.3; python_version >= '3.12'    # pyinstrument-cext integrated
+
 # psutil on PyPy needs to be <=5.6.3 to avoid an installation error,
 #   see https://github.com/giampaolo/psutil/issues/1659.
 # psutil on macos 11.6 needs to be >=5.8.0 to have support for the compiler.
@@ -340,10 +343,13 @@ pipdeptree>=2.2.0
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
 pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.7'
-pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs>=2.5.1; python_version >= '3.12'
 
-pyzmq>=17.0.0; python_version <= '3.6'
-pyzmq>=24.0.0; python_version >= '3.7'
+# notebook 6.4.10 depends on pyzmq>=17
+pyzmq==17.0.0; python_version <= '3.6'
+pyzmq>=24.0.0; python_version >= '3.7' and python_version <= '3.11'
+pyzmq>=25.1.1; python_version >= '3.12'
 
 # Indirect dependencies are not specified in this file unless constraints are needed.
 
@@ -371,7 +377,8 @@ anyio>=3.1.0; python_version >= '3.7'
 cryptography>=3.3; python_version == '2.7'
 cryptography>=3.4.7; python_version == '3.6'
 cryptography>=42.0.2; python_version >= '3.7'
-distlib>=0.3.4
+distlib>=0.3.4; python_version <= '3.11'
+distlib>=0.3.7; python_version >= '3.12'
 filelock>=3.0.0
 # gitdb2 4.0.2 requires gitdb>=4.0.1 for installation, see https://github.com/gitpython-developers/gitdb/issues/86
 gitdb2>=2.0.6,<4.0; python_version == '2.7'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@
 # FUTURE: Remove  wheel < 1.0 For details, see
 #       https://github.com/pypa/build/issues/750. Circumvention for now is
 #       to pin build to <1.0. See issue #3112
-build>=0.5.1, <1.1.0
+build>=0.5.1, <=1.0
 
 # Cythonize
 Cython>=0.29.33

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,6 +82,10 @@ Released: not yet
 
 * Fixed new Pylint issue for unused variable 'exp_result'. (issue #3113)
 
+* Test: Fixed issue in test_recorder.py where format of OrderDict repl output
+  changed with python 3.12 (see issue #3097)
+
+
 **Enhancements:**
 
 * The 'pywbem.ValueMapping' class now allows controlling what should happen
@@ -132,8 +136,15 @@ Released: not yet
 * Fix issue in pywbem_mock._base_provider where __repr__ had invalid parameter
   (see issue #3036)
 
-* Fix new Feb 2024 safety issues, GitPython, Jinja2, JupyterLab. Added to
+* Fix new feb 2024 safety issues, GitPython, Jinja2, JupyterLab. Added to
   safety ignore and fixed in requirements files.
+
+* Extend support to Python  version 3.12 (see issue #3098). This includes
+  changes to package version requirements in requirements.txt,
+  dev-requirements.txt, minimum_constraints.txt
+
+* Add ignore for gitpython new safety issue 2024-2.
+
 
 **Known issues:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -91,7 +91,6 @@ setuptools==66.1.0; python_version >= '3.12'
 wheel==0.36.2; python_version <= '3.6'
 wheel==0.38.1; python_version >= '3.7'
 
-
 # Direct dependencies for installation (must be consistent with requirements.txt)
 
 mock==2.0.0; python_version == '2.7'
@@ -108,8 +107,9 @@ yamlloader==0.5.5
 nocaselist==1.0.3
 nocasedict==1.0.1
 
-
+#
 # Indirect dependencies for installation (not in requirements.txt)
+#
 
 certifi==2019.11.28; python_version == '2.7'
 certifi==2023.07.22; python_version >= '3.6'
@@ -156,9 +156,8 @@ testfixtures==6.9.0; python_version == '2.7'
 testfixtures==6.9.0; python_version >= '3.6'
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.5; python_version >= '3.6'
-# Using 0.22 caused failure where at least argcompete requires 0.23
-importlib-metadata==0.23; python_version <= '3.7'
-importlib-metadata==4.8.3; python_version >= '3.8'
+importlib-metadata==2.1.3; python_version <= '3.6'
+importlib-metadata==4.8.3; python_version >= '3.7'
 
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
@@ -174,7 +173,9 @@ easy-server==0.8.0
 pytest-easy-server==0.8.0
 
 # Virtualenv
-virtualenv==20.0.35
+
+virtualenv==20.15.0; python_version <= '3.11'  # requires six<2,>=1.12.0
+virtualenv==20.23.0; python_version >= '3.12'
 
 # Unit test (indirect dependencies):
 pluggy==0.7.1; python_version == '2.7'
@@ -189,8 +190,8 @@ FormEncode==2.0.0; python_version >= '3.6'
 lxml==4.6.2; python_version == '2.7'
 lxml==4.6.2; python_version >= '3.6' and python_version <= '3.9'
 lxml==4.6.4; python_version == '3.10'
-lxml==4.9.2; python_version >= '3.11'
-
+lxml==4.9.2; python_version == '3.11'
+lxml==4.9.3; python_version >= '3.12'
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==5.0
 pytest-cov==2.7.0
@@ -231,34 +232,46 @@ autodocsumm==0.2.12; python_version >= '3.8'
 Babel==2.10.0; python_version >= '3.8'
 
 # PyLint (no imports, invoked via pylint script):
-pylint==2.10.0; python_version >= '3.6' and python_version <= '3.10'
-pylint==2.15.0; python_version >= '3.11'
-astroid==2.7.2; python_version >= '3.6' and python_version <= '3.10'
-astroid==2.12.4; python_version >= '3.11'
-
-# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
-# typing-extensions 4.0.0 removed support for Python < 3.6
-typing-extensions==3.10.0; python_version == '2.7'
-typing-extensions==4.0.0; python_version >= '3.6' and python_version <= '3.10'
+# Not installed below Python 3.6
+pylint==2.13.0; python_version >= '3.6' and python_version <= '3.10'
+pylint==2.15.0; python_version == '3.11'
+pylint==3.0.3; python_version >= '3.12'
+astroid==2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid==2.12.4; python_version == '3.11'
+astroid==3.0.2; python_version >= '3.12'
 typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 lazy-object-proxy==1.4.3; python_version >= '3.6'
 wrapt==1.12; python_version >= '3.6' and python_version <= '3.10'
 wrapt==1.14; python_version >= '3.11'
+platformdirs==2.2.0; python_version == '3.6'
+platformdirs==2.5.0; python_version >= '3.7' and python_version <= '3.11'
+platformdirs==3.2.0; python_version >= '3.12'
 isort==4.3.8
 tomlkit==0.10.1; python_version >= '3.7'
-dill==0.2; python_version >= '3.6' and python_version <= '3.10'
-dill==0.3.6; python_version >= '3.11'
-platformdirs==2.2.0; python_version == '3.6'
-platformdirs==2.5.0; python_version >= '3.7'
+dill==0.3.4; python_version >= '3.6' and python_version <= '3.10'
+dill==0.3.7; python_version >= '3.11'
+
+# rich 13.3.5 requires typing-extensions>=4.0.0,<5.0
+# typing-extensions 4.0.0 removed support for Python < 3.6
+typing-extensions==3.10.0; python_version == '2.7'
+typing-extensions==4.0.0; python_version >= '3.6'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
-flake8==3.8.0; python_version <= '3.9'
-flake8==4.0.0; python_version >= '3.10'
-mccabe==0.6.0
+flake8==3.8.0,<4.0.0; python_version == '2.7'
+flake8==3.8.0; python_version >= '3.6' and python_version <= '3.9'
+flake8==5.0.0; python_version >= '3.10'
+# pylint 2.10.0 depends on mccabe<0.7 and >=0.6 (python 3.6 - 3.10)
+# pylint 2.15.0 depends on mccabe >=0.6,<0.8 (python 3.11)
+#               astroid>=2.12.4,<=2.14.0-dev0
+# pylint 3.0.1 depends on mccabe >=0.6,<0.8
+# flake8 3.8.0 depends on mccabe<0.7 and >=0.6
+# flake8 5.0.0 depends on mccabe >=0.7.0,<0.8.0
+mccabe==0.6.0; python_version <= '3.9'
+mccabe==0.7.0; python_version >= '3.10'
 pycodestyle==2.6.0; python_version <= '3.9'
-pycodestyle==2.8.0; python_version >= '3.10'
+pycodestyle==2.9.0; python_version >= '3.10'
 pyflakes==2.2.0; python_version <= '3.9'
-pyflakes==2.4.0; python_version >= '3.10'
+pyflakes==2.5.0; python_version >= '3.10'
 entrypoints==0.3.0
 functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
@@ -359,19 +372,25 @@ pywin32==303; sys_platform == 'win32' and python_version >= '3.10'
 tabulate==0.8.3
 
 # Performance profiling tools
-pyinstrument==3.0.1
-pyinstrument-cext==0.2.2  # from pyinstrument
+pyinstrument==3.0.1; python_version <= '3.11'
+pyinstrument-cext==0.2.2; python_version <= '3.11'  # from pyinstrument
+pyinstrument==4.5.3; python_version >= '3.12'  # pyinstrument-cext integrated
+
 psutil==5.9.0; sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'
 psutil==5.6.0; sys_platform != 'cygwin' and platform_python_implementation == 'PyPy'
 
 # Package dependency management tools
 pipdeptree==2.2.0
 pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
-pip-check-reqs==2.4.3; python_version >= '3.8'
+# Prev version pip-check-reqs==2.4.3; python_version >= '3.8'
+pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs==2.4.3; python_version >= '3.8' and python_version <= '3.11'
+pip-check-reqs==2.5.1; python_version >= '3.12'
 
 # notebook 6.4.10 depends on pyzmq>=17
 pyzmq==17.0.0; python_version <= '3.6'
-pyzmq==24.0.0; python_version >= '3.7'
+pyzmq==24.0.0; python_version >= '3.7' and python_version <= '3.11'
+pyzmq==25.1.1; python_version >= '3.12'
 
 # Indirect dependencies for develop that need constraints
 
@@ -410,10 +429,15 @@ contextlib2==0.6.0.post1; python_version == '2.7'
 dataclasses==0.8; python_version == '3.6'  # used by safety 2.3.1 and argon-cffi
 debugpy==1.5.1; python_version >= '3.6'
 defusedxml==0.7.1
-distlib==0.3.4
+
+distlib==0.3.4; python_version <= '3.11'
+distlib==0.3.7; python_version >= '3.12'
 docopt==0.6.1
 enum34==1.1.10; python_version == '2.7'
-filelock==3.0.0
+# previous version filelock==3.0.0
+filelock==3.2.0; python_version <= "3.11"
+filelock==3.11.0; python_version >= "3.12"
+
 # Safety issue #52510 affected <=0.18.2
 future==0.18.3
 futures==3.3.0; python_version == '2.7'
@@ -500,7 +524,8 @@ terminado==0.6; python_version == '2.7'
 terminado==0.8.3; python_version >= '3.6'
 testpath==0.3
 toml==0.10.0
-tomli==2.0.1; python_version >= '3.6'
+tomli==1.1.0; python_version == '3.6'
+tomli==2.0.1; python_version >= '3.7'
 
 tornado==4.4.2; python_version == '2.7'
 tornado==6.1; python_version == '3.6'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -130,7 +130,8 @@ urllib3==1.26.18; python_version >= '3.7'
 # From easy-vault:
 cryptography==3.3; python_version == '2.7'
 cryptography==3.4.7; python_version == '3.6'
-cryptography==41.0.6; python_version >= '3.7'
+# minimum version 42.0.2, safety issue Mar 24
+cryptography==42.0.2; python_version >= '3.7'
 keyring==18.0.0
 
 
@@ -311,7 +312,8 @@ jupyterlab-widgets==1.0.2; python_version == '3.6'
 jupyterlab-widgets==3.0.3; python_version >= '3.7'
 
 jupyter-server>=1.24.0; python_version == '3.7'
-jupyter-server>=2.4.0; python_version >= '3.8'
+# Safety issue with noteboook.
+jupyter-server==2.7.2; python_version >= '3.8'
 
 nbclassic==1.0.0; python_version >= '3.7'
 
@@ -332,7 +334,7 @@ nbformat==5.9.0; python_version >= '3.8'
 notebook==4.3.1; python_version == '2.7'
 notebook==6.4.10; python_version == '3.6'
 notebook==6.5.4; python_version == '3.7'
-notebook==7.0.2; python_version >= '3.8'
+notebook==7.0.7; python_version >= '3.8'
 
 notebook-shim==0.2.3; python_version >= '3.7'
 

--- a/setup.py
+++ b/setup.py
@@ -320,6 +320,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Systems Administration',
     ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,9 +22,11 @@ funcsigs>=1.0.2; python_version == '2.7'
 # pytest>=6.0.0 causes pylint to report "abstract-method" issues
 # For both, see https://github.com/pytest-dev/pytest/issues/7591
 pytest>=4.3.1,<5.0.0; python_version == '2.7'
-pytest>=4.3.1,!=6.0; python_version == '3.6'
-pytest>=4.4.0,!=6.0; python_version >= '3.7' and python_version <= '3.9'
-pytest>=6.2.5; python_version >= '3.10'
+# Max pytest version < 8.0 because of issue with Deprecated warnings in
+# pytest 8.0.x.
+pytest>=4.3.1,!=6.0,<8.0; python_version == '3.6'
+pytest>=4.4.0,!=6.0,<8.0; python_version >= '3.7' and python_version <= '3.9'
+pytest>=6.2.5,<8.0; python_version >= '3.10'
 testfixtures>=6.9.0; python_version == '2.7'
 testfixtures>=6.9.0; python_version >= '3.6'
 # pylint>=2.15 requires colorama>=0.4.5
@@ -74,12 +76,15 @@ FormEncode>=2.0.0; python_version >= '3.6'
 # lxml 4.6.1 addressed safety issue 38892
 # lxml 4.6.2 addressed safety issue 39194
 # lxml 4.6.3 addressed safety issue 40072
-# lxml 4.9.2 addresses changes in Python 3.11 and 3.12
+# lxml 4.9.2 addresses changes in Python 3.11
+# lxml 4.9.3 python 3.12
 lxml>=4.6.2; python_version == '2.7'
 lxml>=4.6.2; python_version >= '3.6' and python_version <= '3.9'
 lxml>=4.6.4; python_version == '3.10'
-lxml>=4.9.2; python_version >= '3.11'
+lxml>=4.9.2; python_version == '3.11'
+lxml>=4.9.3; python_version == '3.12'
 
-# Virtualenv
-# virtualenv 20.0.35 is required by build
-virtualenv>=20.0.35
+
+virtualenv>=16.1.0,!=20.0.19,!=20.0.32; python_version <= '3.7'
+virtualenv>=20.15.0; python_version >= '3.8' and python_version <= '3.11'  # requires six<2,>=1.12.0
+virtualenv>=20.23.0; python_version >= '3.12'

--- a/tests/functiontest/conftest.py
+++ b/tests/functiontest/conftest.py
@@ -1198,8 +1198,6 @@ def result_tuple(value, tc_name):
     # test for both paths and instances.
     objs = None
     if "query_result_class" in value:
-        # This appears to be an issue with pylint itself ver 2.13.0
-        # pylint: disable=unused-variable
         result = namedtuple("result", ["instances", "eos", "context",
                                        "query_result_class"])
     else:

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -2641,16 +2641,32 @@ class Test_LOR_PywbemArgsResults(BaseLogOperationRecorderTests):
         self.test_recorder.stage_pywbem_result((return_val, params),
                                                None)
 
-        result_req = (
-            "Request:test_id InvokeMethod("
-            "MethodName='Blah', "
-            "ObjectName={!r}, "
-            "Params=OrderedDict(["
-            "('StringParam', 'Spotty'), "
-            "('Uint8', Uint8(cimtype='uint8', minvalue=0, maxvalue=255, 1)), "
-            "('Sint8', Sint8(cimtype='sint8', minvalue=-128, maxvalue=127, 2))"
-            "]))".
-            format(instancename))
+        if sys.version_info[0:2] >= (3, 12):  # fix issue #3097
+            result_req = (
+                "Request:test_id InvokeMethod("
+                "MethodName='Blah', "
+                "ObjectName={!r}, "
+                "Params=OrderedDict("
+                "{{'StringParam': 'Spotty', "
+                "'Uint8': Uint8(cimtype='uint8', minvalue=0, "
+                "maxvalue=255, 1), "
+                "'Sint8': Sint8(cimtype='sint8', minvalue=-128, "
+                "maxvalue=127, 2)"
+                "}}))".
+                format(instancename))
+        else:
+            result_req = (
+                "Request:test_id InvokeMethod("
+                "MethodName='Blah', "
+                "ObjectName={!r}, "
+                "Params=OrderedDict(["
+                "('StringParam', 'Spotty'), "
+                "('Uint8', Uint8(cimtype='uint8', minvalue=0, "
+                "maxvalue=255, 1)), "
+                "('Sint8', Sint8(cimtype='sint8', minvalue=-128, "
+                "maxvalue=127, 2))"
+                "]))".
+                format(instancename))
 
         result_ret = "Return:test_id InvokeMethod(tuple )"
 


### PR DESCRIPTION
  _**This was test only. Delete. Do not merge to master.**
This is just a test branch to help understand what the issues are with the build package.

1 First test.  Set the build package to < 1.1.0.  That resulted in failures in windows tests ( listener tests fail with apparently corrupted indications.  This is inconsistent with what we saw earlier in the 3.12 testing where the latest versions of ubuntu also failed but in the run build step with issues about wheels. 

2 second test. Using build pkg <= 1.0