### PR TITLE
Add fixes for new safety issues, 17 Mar 24.

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -202,11 +202,25 @@ security:
         63687:
             reason: GitPython, Python 2.7, 3.6. fixed version 3.1.35 requires Python>=3.7
         64227:
-            reason: Jinja2, ver 3.1.3 fixes scripting vulnerability, requires Python>=3.7
+            reason: Jinja2, ver 3.1.3 fixes scripting vulnerability, requires Python >= 3.7
         64587:
-            reason: jupyterlab  issue in version 4.03, requires < 4.0.11 python >= 3.8
+            reason: jupyterlab issue in version 4.03, requires < 4.0.11 python >= 3.8
         64588:
-            reason: jupyterlab  issue in version 4.03, requires < 4.0.11 python >= 3.8
+            reason: jupyterlab issue in version 4.03, requires < 4.0.11 python >= 3.8
+        65212:
+            reason: cryptography, Fixed  version 42.0.2 requires Python >= 3.7 and used there
+        65182:
+            reason: notebook, Fixed version 7.1.0, requires Python >= 3.8 and used there
+        65183:
+            reason: notebook, Fixed  version 7.0.7, requires Python >= 3.8 and used there
+        65278:
+            reason: crypography, Fixed version 42.0.1 requires Python >=3.7 and used there
+        65358:
+            reason: Jupyter-Server, Fixed version 2.11.2 requires Python >= 3.8 and used there
+        65029:
+            reason: Jupyter-Server, Fixed version 2.7.2 requires Python >= 3.8 and used there
+
+
 
 
     # Continue with exit code 0 when vulnerabilities are found.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -220,7 +220,8 @@ jupyterlab-widgets>=3.0.3; python_version >= '3.7'
 # jupyter-server 2.25.0 removed support for Python 3.7
 # latest 3.10: jupyter_server 2.12.4
 jupyter-server>=1.24.0; python_version == '3.7'
-jupyter-server>=2.4.0; python_version >= '3.8'
+# safety issue requires jupyter_server >=2.11.2 2204-3-17
+jupyter-server>=2.11.2; python_version >= '3.8'
 
 # latest 3.10: jupyter-events                0.9.0
 # latest 3.10: jupyter-lsp                   2.2.1
@@ -262,7 +263,8 @@ nbformat>=5.9.0; python_version >= '3.8'
 notebook>=4.3.1,<6.1.0; python_version == '2.7'
 notebook>=6.4.10; python_version == '3.6'
 notebook>=6.5.4; python_version == '3.7'
-notebook>=7.0.2; python_version >= '3.8'
+# safety issue sets new minimum 7.1.0 2025-3-17
+notebook>=7.1.0; python_version >= '3.8'
 
 # notebook-shim 0.1.0 removed support for Python 3.6
 # latest 3.10: notebook_shim 0.2.3
@@ -275,7 +277,8 @@ jupyterlab-server>=2.22.1,<3; python_version >= '3.8'
 # jupyterlab 4.0.0 removed support for Python 3.7
 # latest 3.10: jupyterlab 4.0.10
 # safety vulnerability #64588, #64587 jupyterlab < 4.0.11
-jupyterlab>=4.0.11,<5; python_version >= '3.8'
+# notebook 7.1.0 depends on jupyterlab<4.2 and >=4.1.1
+jupyterlab>=4.1.1,<5; python_version >= '3.8'
 
 pyrsistent>=0.14.0,<0.16.0; python_version == '2.7'
 pyrsistent>=0.14.0; python_version == '3.6'
@@ -375,10 +378,11 @@ terminado>=0.8.3,<0.10.0; python_version >= '3.6'
 anyio>=3.1.0; python_version >= '3.7'
 cryptography>=3.3; python_version == '2.7'
 cryptography>=3.4.7; python_version == '3.6'
-cryptography>=41.0.6; python_version >= '3.7'
+cryptography>=42.0.2; python_version >= '3.7'
 
 distlib>=0.3.4; python_version <= '3.11'
 distlib>=0.3.7; python_version >= '3.12'
+
 filelock>=3.0.0
 # gitdb2 4.0.2 requires gitdb>=4.0.1 for installation, see https://github.com/gitpython-developers/gitdb/issues/86
 gitdb2>=2.0.6,<4.0; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -85,6 +85,8 @@ Released: not yet
 * Test: Fixed issue in test_recorder.py where format of OrderDict repl output
   changed with python 3.12 (see issue #3097)
 
+* Updated safety issues to 2024-3-17. Includes issues for: GitPython, Jinja2,
+  Jupyter notebook. Adds to .safety-policy.yml and fixes in requirements files.
 
 **Enhancements:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -130,7 +130,8 @@ urllib3==1.26.18; python_version >= '3.7'
 # From easy-vault:
 cryptography==3.3; python_version == '2.7'
 cryptography==3.4.7; python_version == '3.6'
-cryptography==41.0.6; python_version >= '3.7'
+# minimum version 42.0.2, safety issue 2024-3-17
+cryptography==42.0.2; python_version >= '3.7'
 keyring==18.0.0
 
 
@@ -323,8 +324,9 @@ jupyterlab-widgets==0.6.5; python_version == '2.7'
 jupyterlab-widgets==1.0.2; python_version == '3.6'
 jupyterlab-widgets==3.0.3; python_version >= '3.7'
 
-jupyter-server>=1.24.0; python_version == '3.7'
-jupyter-server>=2.4.0; python_version >= '3.8'
+jupyter-server==1.24.0; python_version == '3.7'
+# Safety issue requires 2.11.2. 2024-3-17
+jupyter-server==2.11.2; python_version >= '3.8'
 
 nbclassic==1.0.0; python_version >= '3.7'
 
@@ -345,14 +347,16 @@ nbformat==5.9.0; python_version >= '3.8'
 notebook==4.3.1; python_version == '2.7'
 notebook==6.4.10; python_version == '3.6'
 notebook==6.5.4; python_version == '3.7'
-notebook==7.0.2; python_version >= '3.8'
+# safety issue sets new minimum 7.1.0 17  2024-3-17
+notebook==7.1.0; python_version >= '3.8'
 
 notebook-shim==0.2.3; python_version >= '3.7'
 
 jupyterlab-server==2.22.1; python_version >= '3.8'
 
 # safety vulnerability #64588, #64587 with jupyterlab < 4.0.11
-jupyterlab==4.0.11; python_version >= '3.8'
+# notebook 7.1.0 depends on jupyterlab<4.2 and >=4.1.1
+jupyterlab==4.1.1; python_version >= '3.8'
 
 pyrsistent==0.14.0; python_version == '2.7'
 pyrsistent==0.14.0; python_version == '3.6'
@@ -410,7 +414,8 @@ argon2-cffi-bindings==21.2.0; python_version >= '3.6'
 args==0.1.0
 asttokens==2.0.4; python_version >= '3.6'
 atomicwrites==1.4.0; python_version == '2.7'
-attrs==19.2.0; python_version >= '3.6'
+attrs==19.2.0; python_version <= '3.5'
+attrs==22.2.0; python_version >= '3.6'
 backcall==0.2.0; python_version >= '3.6'
 backports-abc==0.5; python_version == '2.7'
 backports.functools-lru-cache==1.6.4; python_version == '2.7'
@@ -466,7 +471,9 @@ Jinja2==3.0.3; python_version == '3.6'
 Jinja2==3.1.3; python_version >= '3.7'
 
 jsonschema==2.6.0; python_version <= '3.6'
-jsonschema==4.17.3; python_version >= '3.7'
+jsonschema==4.17.3; python_version == '3.7'
+# jsonschema v 4.18.0 required by jupyter-events 0.9.1
+jsonschema==4.18.0; python_version >= '3.8'
 linecache2==1.0.0
 
 # MarkupSafe version depends on nbconvert min version 6.5.1 requirement

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -38,7 +38,9 @@ easy-vault>=0.7.0
 easy-server>=0.8.0
 pytest-easy-server>=0.8.0
 jsonschema>=2.6.0,!=4.0.0; python_version <= '3.6'
-jsonschema>=4.17.3; python_version >= '3.7'
+jsonschema>=4.17.3; python_version == '3.7'
+# jsonschema v 4.18.0 required by jupyter-events 0.9.1
+jsonschema>=4.18.0; python_version >= '3.8'
 
 requests-mock>=1.6.0
 requests-toolbelt>=0.8.0


### PR DESCRIPTION
Modified safety policy dev-requirements, and minimum constraints for new issues with:

1. cryptograpy - New minimum 42.0.2 for python > 3.7
2. Jupyter Notebook - New Minimum 7.07 Python > 3.8
3. jupyter-server - recommendation of minim version from Notebook safety issue.

The new safety issues are as follows:

 -> Vulnerability ID: 65183 Affected spec: >=7.0.0,<=7.0.6 ADVISORY: CVE-2024-22420 describes a vulnerability in Jupyter Notebook, where user interaction with a malicious notebook or Markdown file
enables an attacker to access and act with the same permissions as the user.
The flaw lies in the table of contents plugin. Jupyter Notebook v7.0.7
includes a patch for this issue. Users can manually disable the plugin as a
   workaround.
https://github.com/jupyterlab/jupyterlab/security/advisories/GHSA-4m77-cmpx-
   vjc4
   CVE-2024-22420
   For more information, please visit
   https://data.safetycli.com/v/65183/f17

   NOTES:
     New minimum version: 7.0.7
     7.0.2 python 3.8, 3.11
    7.0.7, first version with documented python 3.12 support. However, there is not version 7.0.7 so next version is 7.1.0. Previously the classiifier was python 3:;

-> Vulnerability found in notebook version 7.0.2
   Vulnerability ID: 65182
   Affected spec: >=7.0.0,<=7.0.6
   ADVISORY: CVE-2024-22421 is a vulnerability in Jupyter Notebook where
clicking a malicious link could expose Authorization and XSRFToken tokens to
third parties in older jupyter-server versions. Patched versions include
notebook above 7.0.7. Users are advised to upgrade jupyter-server to version
2.7.2 or newer, which includes a fix for a redirect vulnerability. No other
workaround has been identified.
https://github.com/jupyterlab/jupyterlab/secu
   rity/advisories/GHSA-44cc-43rp-5947
   CVE-2024-22421
   For more information, please visit
   https://data.safetycli.com/v/65182/f17

   Note: NEW MINIMUM 7.0.7. However, there is no 7.0.7. Next released version is 7.1.1.  Also proposes jupyter-server >= 2.7.2

-> Vulnerability found in cryptography version 41.0.6
   Vulnerability ID: 65212
   Affected spec: >=35.0.0,<42.0.2
   ADVISORY: Versions of Cryptograph starting from 35.0.0 are
   susceptible to a security flaw in the POLY1305 MAC algorithm on PowerPC CPUs,
   which allows an attacker to disrupt the application's state. This disruption
   might result in false calculations or cause a denial of service. The
   vulnerability's exploitation hinges on the attacker's ability to alter the
   algorithm's application and the dependency of the software on non-volatile
   XMM registers.https://github.com/pyca/cryptography/commit/89d0d56fb104ac4e0e6
   db63d78fc22b8c53d27e9
   CVE-2023-6129
   For more information, please visit
   https://data.safetycli.com/v/65212/f17

   NOTES:
     New minimum version: 42.0.2
     Minimum for Python 3.12 support:

-> Vulnerability found in cryptography version 3.4.7
   Vulnerability ID: 65278
   Affected spec: <42.0.0
   ADVISORY: A flaw was found in the python-cryptography package. This
   issue may allow a remote attacker to decrypt captured messages in TLS servers
   that use RSA key exchanges, which may lead to exposure of confidential or
   sensitive data. See CVE-2023-50782.
   CVE-2023-50782
   For more information, please visit
   https://data.safetycli.com/v/65278/f17

