### PR TITLE
Added support for running ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,13 +19,5 @@ exclude =
 # Globally disabled flake8 issues:
 # * W504 (line break after binary operator) is issued since 10/2018 in situations
 #   that are ok (e.g. within brackets).
-# * E402 (module level import not at top of file) is quite daunting since we
-#   are using conditional imports for py2/py3 in a number of places.
-# * F811 () flake8 reports this on the use of pytest fixtures. Flake8 3.7
-#   changed the place where the corresponding noqa statement needed to be
-#   placed such that there is no place anymore that works with versions before
-#   and after.
 ignore =
-    W504,
-#    E402,
-    F811
+   W504,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,12 @@ jobs:
         RUN_TYPE: ${{ steps.set-run-type.outputs.result }}
       run: |
         make check
+    - name: Run ruff
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+        RUN_TYPE: ${{ steps.set-run-type.outputs.result }}
+      run: |
+        make ruff
     - name: Run pylint
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}

--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,7 @@ help:
 	@echo "  build      - Build the source and wheel distribution archives in: $(dist_dir)"
 	@echo "  builddoc   - Build documentation in: $(doc_build_dir)"
 	@echo "  check      - Run Flake8 on sources"
+	@echo "  ruff       - Run Ruff (an alternate lint tool) on sources"
 	@echo "  pylint     - Run PyLint on sources"
 	@echo "  installtest - Run install tests"
 	@echo "  safety     - Run Safety for install and all"
@@ -564,6 +565,10 @@ builddoc: html
 check: $(done_dir)/flake8_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: Target $@ done."
 
+.PHONY: ruff
+ruff: $(done_dir)/ruff_$(pymn)_$(PACKAGE_LEVEL).done
+	@echo "Makefile: Target $@ done."
+
 .PHONY: pylint
 pylint: $(done_dir)/pylint_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: Target $@ done."
@@ -577,7 +582,7 @@ todo: $(done_dir)/todo_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: Target $@ done."
 
 .PHONY: all
-all: install develop check_reqs build builddoc check pylint installtest test leaktest resourcetest perftest
+all: install develop check_reqs build builddoc check ruff pylint installtest test leaktest resourcetest perftest
 	@echo "Makefile: Target $@ done."
 
 .PHONY: clobber
@@ -781,6 +786,22 @@ $(done_dir)/flake8_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(
 	flake8 --statistics --config=$(flake8_rc_file) --filename='*' $(py_src_files) $(py_test_files)
 	echo "done" >$@
 	@echo "Makefile: Done running Flake8"
+
+$(done_dir)/ruff_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(py_src_files) $(py_test_files)
+ifeq ($(python_mn_version),2.7)
+	@echo "Makefile: Warning: Skipping Ruff on Python $(python_version)" >&2
+else
+ifeq ($(python_mn_version),3.6)
+	@echo "Makefile: Warning: Skipping Ruff on Python $(python_version)" >&2
+else
+	@echo "Makefile: Running Ruff"
+	-$(call RM_FUNC,$@)
+	ruff --version
+	ruff check --unsafe-fixes $(py_src_files) $(py_test_files)
+	echo "done" >$@
+	@echo "Makefile: Done running Ruff"
+endif
+endif
 
 $(done_dir)/safety_all_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done Makefile $(safety_all_policy_file) minimum-constraints.txt minimum-constraints-install.txt
 ifeq ($(python_m_version),2)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -132,6 +132,9 @@ pyflakes>=2.5.0; python_version >= '3.10'
 entrypoints>=0.3.0
 functools32>=3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
+# Ruff checker
+ruff>=0.3.5; python_version >= '3.7'
+
 # Twine (no imports, invoked via twine script):
 # twine 2.0.0 removed support for Python < 3.6
 twine>=1.8.1,<2.0.0; python_version == '2.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -167,6 +167,9 @@ pyflakes==2.5.0; python_version >= '3.10'
 entrypoints==0.3.0
 functools32==3.2.3.post2; python_version == '2.7'  # technically: python_version < '3.2'
 
+# Ruff checker
+ruff==0.3.5; python_version >= '3.7'
+
 # Twine (no imports, invoked via twine script):
 twine==1.8.1; python_version == '2.7'
 twine==3.0.0; python_version >= '3.6'

--- a/tests/end2endtest/test_indications.py
+++ b/tests/end2endtest/test_indications.py
@@ -42,7 +42,8 @@ from pywbem import WBEMServer, WBEMListener, CIMClassName, \
 # pylint: enable=wrong-import-position, wrong-import-order, invalid-name
 
 
-def test_indications(wbem_connection):  # pylint: disable=redefined-outer-name
+def test_indications(wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test indication subscription to a container and reception of indications
     from the container.

--- a/tests/end2endtest/test_operation_timeouts.py
+++ b/tests/end2endtest/test_operation_timeouts.py
@@ -152,7 +152,8 @@ def run_timeout_test(conn, timeout, response_delay, timeout_exp):
                    execution_time, ce)
 
 
-def test_timeouts(wbem_connection):  # pylint: disable=redefined-outer-name
+def test_timeouts(wbem_connection):  # noqa: F811
+    # pylint: disable=redefined-outer-name
     """
     Test indication subscription to a container and reception of indications
     from the container.

--- a/tests/end2endtest/utils/pytest_extensions.py
+++ b/tests/end2endtest/utils/pytest_extensions.py
@@ -223,7 +223,7 @@ def supports_capability(conn, cap_name):
 @pytest.fixture(
     scope='function'
 )
-def wbem_connection(request, es_server):
+def wbem_connection(request, es_server):  # noqa: F811
     # pylint: disable=redefined-outer-name, unused-argument
     """
     Fixture representing a WBEMConnection object to use for the end2end tests.

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -1594,7 +1594,7 @@ def to_dict(mapping, dict_type):
     that are mappings, recursively.
     """
     assert isinstance(mapping, Mapping)
-    if not type(mapping) is dict_type:  # pylint: disable=unidiomatic-typecheck
+    if type(mapping) is not dict_type:  # pylint: disable=unidiomatic-typecheck
         mapping = dict(mapping)
     for k, v in mapping.items():
         if isinstance(v, Mapping):

--- a/tests/unittest/pywbem_mock/test_complexassoc.py
+++ b/tests/unittest/pywbem_mock/test_complexassoc.py
@@ -555,28 +555,28 @@ def test_complexref_instnames(conn, ns, target, ro, rc, mof, exp_rslt,
         # pylint: disable=line-too-long
         ['TST_EP', None, None, None, None, None, ['TST_EP', 'TST_LD'], OK],
         ['TST_EP', None, 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],
-        ['TST_EP', 'Initiator', None, None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: 501
-        ['TST_EP', 'Initiator', 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: 501
+        ['TST_EP', 'Initiator', None, None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: E501
+        ['TST_EP', 'Initiator', 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: E501
         ['TST_EP', None, 'TST_A3', 'Target', None, None, ['TST_EP'], OK],
         ['TST_EP', 'Initiator', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],
         ['TST_EP', None, 'TST_A3', 'Target', 'TST_LD', None, [], OK],
         ['TST_EP', 'Initiator', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],
         ['TST_EP', 'Initiator', 'TST_A3', 'Target', 'TST_LD', None, [], OK],
-        ['TST_EP', 'Initiator', 'TST_A3', 'LogicalUnit', 'TST_LD', None, ['TST_LD'], OK],  # noqa: 501
+        ['TST_EP', 'Initiator', 'TST_A3', 'LogicalUnit', 'TST_LD', None, ['TST_LD'], OK],  # noqa: E501
         # test for case indepence on all parameters
-        ['tst_ep', 'INITIATOR', 'tst_a3', 'LOGICALUNIT', 'tst_ld', None, ['TST_LD'], OK],  # noqa: 501
+        ['tst_ep', 'INITIATOR', 'tst_a3', 'LOGICALUNIT', 'tst_ld', None, ['TST_LD'], OK],  # noqa: E501
 
         # test source TST_EP and Target as role
         ['TST_EP', None, None, None, None, None, ['TST_EP', 'TST_LD'], OK],
         ['TST_EP', None, 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],
         ['TST_EP', 'Target', None, None, None, None, ['TST_EP', 'TST_LD'], OK],
-        ['TST_EP', 'Target', 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: 501
+        ['TST_EP', 'Target', 'TST_A3', None, None, None, ['TST_EP', 'TST_LD'], OK],  # noqa: E501
         ['TST_EP', None, 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],
         ['TST_EP', 'Target', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],
         ['TST_EP', None, 'TST_A3', 'Initiator', 'TST_LD', None, [], OK],
         ['TST_EP', 'Target', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],
         ['TST_EP', 'Target', 'TST_A3', 'Initiator', 'TST_LD', None, [], OK],
-        ['TST_EP', 'Target', 'TST_A3', 'LogicalUnit', 'TST_LD', None, ['TST_LD'], OK],  # noqa: 501
+        ['TST_EP', 'Target', 'TST_A3', 'LogicalUnit', 'TST_LD', None, ['TST_LD'], OK],  # noqa: E501
 
         # Test source TST_LD, Initiator as ResultRole
         # TODO 4 Failures. PEG Returns TST_EP only. Mock ACT TST_EP and TST_LD
@@ -586,17 +586,17 @@ def test_complexref_instnames(conn, ns, target, ro, rc, mof, exp_rslt,
         ['TST_LD', 'LogicalUnit', 'TST_A3', None, None, None, ['TST_EP'], OK],
         ['TST_LD', None, 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],
         # TODO: did we miss this option with all params in tests above
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_EP', None, ['TST_EP'], OK],  # noqa: 501
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],  # noqa: 501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_EP', None, ['TST_EP'], OK],  # noqa: E501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],  # noqa: E501
         ['TST_LD', None, 'TST_A3', 'Initiator', 'TST_LD', None, [], OK],
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],  # noqa: 501
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_EP', None, ['TST_EP'], OK],  # noqa: 501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', None, None, ['TST_EP'], OK],  # noqa: E501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_EP', None, ['TST_EP'], OK],  # noqa: E501
 
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_LD', None, [], OK],  # noqa: 501
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],  # noqa: 501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Initiator', 'TST_LD', None, [], OK],  # noqa: E501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],  # noqa: E501
         ['TST_LD', None, 'TST_A3', 'Target', 'TST_LD', None, [], OK],
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],  # noqa: 501
-        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', 'TST_EP', None, ['TST_EP'], OK],  # noqa: 501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', None, None, ['TST_EP'], OK],  # noqa: E501
+        ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', 'TST_EP', None, ['TST_EP'], OK],  # noqa: E501
         ['TST_LD', 'LogicalUnit', 'TST_A3', 'Target', 'TST_LD', None, [], OK],
         # pylint: enable=line-too-long
 


### PR DESCRIPTION
The Python "ruff" package is used, and is run on Python >=3.7.
For details, see the commit message and issue #3144.