### PR TITLE
Fix issue where listener startup failure can cause extra exceptions.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fix issue where pywbemlistener that fails startup can cause thread
+  exception. See issue #3157
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
see commit message for description.

This fixes issue #3157 where the failure of the http server in pywbemcli startup causes the subprocess to hang because the callback thread was already created and was not shutdown .

rollback to 1.7.1 required.

NOTE: I assume that this also means that we should pull pywbem 1.7.0 in favor of 1.7.1.