### PR TITLE
1.7: Fixed Python 3.6/3.7 on macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,26 @@ jobs:
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
               } \
             ], \
             \"include\": [ \
@@ -72,6 +92,26 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-12\", \
+                \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               } \
             ] \
@@ -130,8 +170,13 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"macos-latest\", \
+                \"os\": \"macos-12\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* For Python 3.6 and 3.7, changed macos-latest back to macos-12 because
+  macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
+  and 3.7.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -88,7 +88,11 @@ FormEncode>=2.0.0; python_version >= '3.6'
 # lxml 4.9.2 addresses changes in Python 3.11
 # lxml 4.9.3 python 3.12
 lxml>=4.6.2; python_version == '2.7'
-lxml>=4.6.2; python_version >= '3.6' and python_version <= '3.9'
+lxml>=4.6.2; python_version >= '3.6' and python_version <= '3.7'
+# lxml>=5.0 fails installing on macOS 14 with Python 3.8, see https://bugs.launchpad.net/lxml/+bug/2063945
+lxml>=4.6.2,<5.0; python_version == '3.8' and sys_platform == 'darwin'
+lxml>=4.6.2; python_version == '3.8' and sys_platform != 'darwin'
+lxml>=4.6.2; python_version == '3.9'
 lxml>=4.6.4; python_version == '3.10'
 lxml>=4.9.2; python_version == '3.11'
 lxml>=4.9.3; python_version == '3.12'


### PR DESCRIPTION
Rolls back PR #3171 into 1.7.3.