### PR TITLE
Eliminate build warning about ambiguous package list

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Eliminated a warning about about ambiguity of the package list when building
+  the wheel distribution archive.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,9 @@ setup_options = dict(
     version=package_version,
     packages=[
         'pywbem',
+        'pywbem._vendor',
+        'pywbem._vendor.nocasedict',
+        'pywbem._vendor.nocaselist',
         'pywbem_mock'
     ],
     include_package_data=True,  # Includes MANIFEST.in files into sdist (only)


### PR DESCRIPTION
No review needed.