### PR TITLE
Fix TODO-OLD-PYTHON flagged changes for python 3.8.

### DIFF
--- a/docs/mof_compiler.help.txt
+++ b/docs/mof_compiler.help.txt
@@ -91,4 +91,4 @@ General options:
                                    (Default=all)
 
 Example: mof_compiler CIM_Schema_2.45.mof -s https://localhost -n root/cimv2
--u sheldon -p p42
+-u sheldon -p 42

--- a/pywbem/_cim_http.py
+++ b/pywbem/_cim_http.py
@@ -319,10 +319,6 @@ def pywbem_urllib3_exception(exc, conn):
         if m:
             exc_name = m.group(1)
             exc_message = m.group(2)
-            if exc_message.endswith(','):
-                # TODO-OLDPYTHON: Rework
-                # Python <3.6 represents it as tuple with trailing comma
-                exc_message = exc_message.rstrip(',')
             if exc_message.startswith('"'):
                 exc_message = exc_message.strip('"')
             elif exc_message.startswith("'"):

--- a/pywbem/_cim_obj.py
+++ b/pywbem/_cim_obj.py
@@ -217,7 +217,7 @@ from .config import SEND_VALUE_NULL
 from . import config
 from ._cim_types import _CIMComparisonMixin, type_from_name, cimtype, \
     atomic_to_cim_xml, CIMType, CIMDateTime, number_types, CIMInt, \
-    CIMFloat, _Longint, Char16, SlottedPickleMixin
+    CIMFloat, Char16, SlottedPickleMixin
 from ._nocasedict import NocaseDict
 from ._utils import _ensure_unicode, _ensure_bool, \
     _hash_name, _hash_item, _hash_dict, _format, _integerValue_to_int, \
@@ -2209,7 +2209,7 @@ class CIMInstanceName(_CIMComparisonMixin, SlottedPickleMixin):
                 # IEE-754 floating point numbers between decimal and binary
                 # without loss.
                 ret.append(repr(value))
-            elif isinstance(value, (CIMInt, int, _Longint)):
+            elif isinstance(value, (CIMInt, int)):
                 # intNN
                 ret.append(str(value))
             elif isinstance(value, CIMInstanceName):

--- a/pywbem/_recorder.py
+++ b/pywbem/_recorder.py
@@ -41,8 +41,6 @@ __all__ = ['BaseOperationRecorder', 'TestClientRecorder',
            'LogOperationRecorder',
            'OpArgs', 'OpResult', 'HttpRequest', 'HttpResponse']
 
-# pylint: disable=invalid-name
-_Longint = int
 
 OpArgsTuple = namedtuple("OpArgsTuple", ["method", "args"])
 
@@ -582,9 +580,8 @@ class LogOperationRecorder(BaseOperationRecorder):
         if self.enabled and self.api_detail_level is not None and \
                 self.apilogger.isEnabledFor(logging.DEBUG):
 
-            # Order kwargs.  Note that this is done automatically starting
-            # with python 3.6
-            # TODO-OLDPYTHON: Rework
+            # Order kwargs.
+            # Sort required to pass tests. Ordering issue without this sort.
             kwstr = ', '.join([(f'{key}={kwargs[key]!r}')
                                for key in sorted(kwargs.keys())])
 
@@ -994,16 +991,8 @@ class TestClientRecorder(BaseOperationRecorder):
             # bool is a subclass of int in Python.
             return obj
         if isinstance(obj, CIMInt):
-            # TODO-OLDPYTHON: Resolve
-            # CIMInt is _Longint and therefore may exceed the value range of
-            # int in Python 2. Therefore, we convert it to _Longint.
-            return _Longint(obj)
+            return int(obj)
         if isinstance(obj, int):
-            # TODO-OLDPYTHON: Resolve
-            # This case must be after CIMInt, because CIMInt is _Longint and
-            # would match a long value in Python 2.
-            # We don't convert int to _Longint, because the value
-            # fits into the provided type, and there is no need to convert it.
             return obj
         if isinstance(obj, CIMFloat):
             return float(obj)

--- a/pywbem_mock/_baserepository.py
+++ b/pywbem_mock/_baserepository.py
@@ -50,20 +50,6 @@ from abc import abstractmethod
 __all__ = ['BaseObjectStore', 'BaseRepository']
 
 
-def compatibleabstractproperty(func):
-    """
-    TODO-OLDPYTHON: Resolve
-    Python 2 and python 3 differ in decorator for abstract property.
-    in python 3 (gt 3.3) it is:
-        @property
-        @abstractproperty
-    in python 2
-        @abstractproperty
-    """
-
-    return property(abstractmethod(func))
-
-
 class BaseObjectStore:
     """
     An abstract class that defines the APIs for the methods of an object store
@@ -271,7 +257,8 @@ class BaseRepository:
        CIM objects of a single CIM type by namespace in the repository.
     """
 
-    @compatibleabstractproperty
+    @property
+    @abstractmethod
     def namespaces(self):
         """
         :term:`NocaseList` of :term:`string`:

--- a/tests/functiontest/README.md
+++ b/tests/functiontest/README.md
@@ -311,5 +311,5 @@ Elements in `http_response` element
 
 * `data`:
   The CIM-XML payload in the HTTP response handed back to the PyWBEM
-  client. The CIm-XML is handed back as resulting from the specified
+  client. The CIM-XML is handed back as resulting from the specified
   YAML, including any whitespace.

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -25,7 +25,6 @@ from pywbem import CIMInstance, CIMInstanceName, CIMClass, CIMClassName, \
     Sint32, Sint64, Real32, Real64, Char16, CIMDateTime, \
     MinutesFromUTC, __version__, MissingKeybindingsWarning  # noqa: E402
 from pywbem._nocasedict import NocaseDict  # noqa: E402
-from pywbem._cim_types import _Longint  # noqa: E402
 from pywbem._cim_obj import mofstr  # noqa: E402
 from pywbem._utils import _format  # noqa: E402
 from pywbem import cimvalue  # noqa: E402
@@ -8857,9 +8856,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
     # * kwargs: Keyword arguments for the test function:
     #   * cls_props: Dict of input properties for CIMClass.
     #   * inst_prop_vals: Dict of property values for the instance.
-    #     Is specified as OrderedDict to avoid UserWarning about unordered items
-    #     in py<3.7.
-    #     TODO-OLDPYTHON: Rework
+    #     Order required in this dict so limited to py>=3.7.
     #   * kwargs: Dict of input args to from_class method
     #   * exp_props: Expected properties in created instance as a dictionary
     # * exp_exc_types: Expected exception type(s), or None.
@@ -8872,7 +8869,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         " passes (returns instance that matches exp_props",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3))]),
             kwargs={},
@@ -8886,7 +8883,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "to lower case in test",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('id', 'inst_id'), ('str', 'str_val'),
                  ('u32', Uint32(3))]),
             kwargs={'include_path': True},
@@ -8900,7 +8897,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "property_values is a case independent dictionary.",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('id', 'inst_id'), ('str', 'str_val'),
                  ('u32', Uint32(3))]),
             kwargs={'include_path': True},
@@ -8914,7 +8911,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         " passes (returns instance that matches exp_props",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP, REF_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3)),
                  ('REF', CIMInstanceName('CIM_Foo',
@@ -8940,7 +8937,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "inc_null_prop=True passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val')]),
             kwargs={'include_missing_properties': True},
             exp_props={'ID': 'inst_id', 'STR': 'str_val',
@@ -8952,7 +8949,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Verify 2 props defined in instance inc_nul_prop=True passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val')]),
             kwargs={'include_missing_properties': True},
             exp_props={'ID': 'inst_id', 'STR': 'str_val',
@@ -8964,7 +8961,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Verify 2 props defined in instance inc_null_prop=False passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val')]),
             kwargs={'include_missing_properties': False},
             exp_props={'ID': 'inst_id', 'STR': 'str_val'},
@@ -8978,7 +8975,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "passes.",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3))]),
             kwargs={'include_path': True},
@@ -8991,7 +8988,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Verify Class with 3 properties, params: include_path=False passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3))]),
             kwargs={'include_path': False},
@@ -9007,7 +9004,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'blah'), ('U32', None)]),
             kwargs={'include_path': False},
             exp_props={'ID': 'inst_id', 'STR': "blah",
@@ -9021,7 +9018,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Verify class with one property. include_class_origin=True passes",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict([('ID', 'inst_id')]),
+            inst_prop_vals=dict([('ID', 'inst_id')]),
             kwargs={'include_path': False, 'include_class_origin': True,
                     'include_missing_properties': False},
             exp_props={'ID': CIMProperty('ID', 'inst_id', type='string',
@@ -9034,7 +9031,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "creates new instance with path",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3))]),
             kwargs={'include_path': True},
@@ -9048,7 +9045,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "include_missing_properties=False fails.",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('STR', 'str_val'), ('U32', Uint32(99999))]),
             kwargs={'include_path': True,
                     'include_missing_properties': False},
@@ -9062,7 +9059,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "test fails, key propety value None",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('STR', 'str_val'), ('U32', Uint32(99999))]),
             kwargs={'include_path': True},
             exp_props={'ID': 'inst_id', 'STR': 'str_val',
@@ -9074,7 +9071,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Instance with property in instance but not in class fails",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'), ('U32', Uint32(3)),
                  ('BLAH', Uint64(9))]),
             kwargs={},
@@ -9087,7 +9084,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Instance with property type different than class fails",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'), ('U32', 'blah')]),
             kwargs={},
             exp_props={'ID': 'inst_id', 'STR': 'str_val',
@@ -9099,7 +9096,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Class with with valid array property passes test",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP, ARR_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'), ('U32', Uint32(3)),
                  ('A32', [Uint32(3), Uint32(9999)])]),
             kwargs={},
@@ -9112,7 +9109,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Class with with array property but non-array in instance fails",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP, ARR_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'), ('U32', Uint32(3)),
                  ('A32', Uint32(3))]),
             kwargs={},
@@ -9125,7 +9122,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Same properties in instance and class. Default params with namespace",
         dict(
             cls_props=(ID_PROP, STR_PROP, INT_PROP),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'),
                  ('U32', Uint32(3))]),
             kwargs={'namespace': 'root/blah', 'include_path': True},
@@ -9141,7 +9138,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "include_missing_properties not set. No properties set in instance",
         dict(
             cls_props=(ID_PROP_D, STR_PROP_D, INT_PROP_D),
-            inst_prop_vals=OrderedDict(),
+            inst_prop_vals=dict(),
             kwargs={'include_path': True,
                     'include_missing_properties': False},
             exp_props={'ID': 'cls_id', 'STR': 'cls_str', 'U32': Uint32(4)},
@@ -9153,7 +9150,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "include_missing_properties is set",
         dict(
             cls_props=(ID_PROP_D, STR_PROP_D, INT_PROP_D),
-            inst_prop_vals=OrderedDict(),
+            inst_prop_vals=dict(),
             kwargs={'include_path': True,
                     'include_missing_properties': True},
             exp_props={'ID': 'cls_id', 'STR': 'cls_str', 'U32': Uint32(4)},
@@ -9164,7 +9161,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Class default props. All props in instance. ",
         dict(
             cls_props=(ID_PROP_D, STR_PROP_D, INT_PROP_D),
-            inst_prop_vals=OrderedDict(
+            inst_prop_vals=dict(
                 [('ID', 'inst_id'), ('STR', 'str_val'), ('U32', Uint32(3)),
                  ('A32', Uint32(3))]),
             kwargs={'include_path': True,
@@ -9178,7 +9175,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
         "Verify no input properties via empty dict",
         dict(
             cls_props=(ID_PROP_D, STR_PROP_D, INT_PROP_D),
-            inst_prop_vals=OrderedDict(),
+            inst_prop_vals=dict(),
             kwargs={'include_path': False,
                     'include_missing_properties': False},
             exp_props={},
@@ -11583,7 +11580,7 @@ TESTCASES_CIMPROPERTY_INIT = [
         "(raises ValueError instead of TypeError since 0.12)",
         dict(
             init_args=[],
-            init_kwargs=dict(name='FooProp', value=[_Longint(1)]),
+            init_kwargs=dict(name='FooProp', value=[1]),
             exp_attrs=None
         ),
         ValueError, None, True

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -9323,9 +9323,9 @@ class TestInvokeMethod:
     Test invoking extrinsic methods in FakedWBEMConnection
     """
 
-    INVOKEMETHOD1_TESTCASES = [
+    INVOKEMETHOD_TESTCASES = [
 
-        # Testcases for test_invokemethod1(), with list items as follows:
+        # Testcases for test_invokemethod(), with list items as follows:
         #
         # desc: Description of testcase
         # inputs: Dictionary of input parameters for
@@ -9774,9 +9774,9 @@ class TestInvokeMethod:
         "ns", INITIAL_NAMESPACES + [None])
     @pytest.mark.parametrize(
         "desc, inputs, exp_result, exp_exc, condition",
-        INVOKEMETHOD1_TESTCASES)
-    def test_invokemethod1(self, conn, tst_instances_mof, ns, desc, inputs,
-                           exp_result, exp_exc, condition):
+        INVOKEMETHOD_TESTCASES)
+    def test_invokemethod(self, conn, tst_instances_mof, ns, desc, inputs,
+                          exp_result, exp_exc, condition):
         # pylint: disable=no-self-use,unused-argument
         """
         Test extrinsic method invocation through the

--- a/tests/unittest/utils/pytest_extensions.py
+++ b/tests/unittest/utils/pytest_extensions.py
@@ -6,29 +6,11 @@ Extensions for pytest module.
 import functools
 import warnings
 from collections import namedtuple
-from inspect import Signature, Parameter
+from inspect import signature
 
 import pytest
 
 __all__ = ['simplified_test_function', 'ignore_warnings', 'expect_warnings']
-
-
-# TODO-OLDPYTHON: Rework this.
-# Pytest determines the signature of the test function by unpacking any
-# wrapped functions (this is the default of the signature() function it
-# uses. We correct this behavior by setting the __signature__ attribute of
-# the wrapper function to its correct signature. To do that, we cannot use
-# signature() because its follow_wrapped parameter was introduced only in
-# Python 3.5. Instead, we build the signature manually.
-TESTFUNC_SIGNATURE = Signature(
-    parameters=[
-        Parameter('desc', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('kwargs', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('exp_exc_types', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('exp_warn_types', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('condition', Parameter.POSITIONAL_OR_KEYWORD),
-    ]
-)
 
 
 def simplified_test_function(test_func):
@@ -184,8 +166,8 @@ def simplified_test_function(test_func):
                         raise AssertionError(msg)
         return ret
 
-    # Needed because the decorator is signature-changin
-    wrapper_func.__signature__ = TESTFUNC_SIGNATURE
+    # Needed because the decorator is signature-changing
+    wrapper_func.__signature__ = signature(wrapper_func)
 
     return functools.update_wrapper(wrapper_func, test_func)
 


### PR DESCRIPTION
Fix a number of issues documented as TODO-OLD-PYTHON.

See commit message for details.

**DISCUSSION:** There is one TODO-PYTHON still in the code, the use of x key in dictionary in the CIMInt code and used in functiontests to supply Uint32 data to the InvokeMethod function tests.  I would like the change for that issue to be considered separately, I want to think that one out more but the others are ready for review.