### PR TITLE
Fix a number of cases of new pylint test failure.

### DIFF
--- a/pywbem/_mof_compiler.py
+++ b/pywbem/_mof_compiler.py
@@ -1860,6 +1860,8 @@ def p_instanceDeclaration(p):
             elif 'EmbeddedObject' in cprop.qualifiers:
                 allowed_types = (CIMInstance,)
                 embedded_object_type = "object"
+            else:
+                allowed_types = ()
 
             if embedded_object_type:
                 if pval:

--- a/tests/manualtest/run_enum_performance.py
+++ b/tests/manualtest/run_enum_performance.py
@@ -427,6 +427,7 @@ Examples:
     elif re.match(r"^[a-zA-Z0-9]+://", args.server) is not None:
         argparser.error('Invalid scheme on server argument.'
                         ' Use "http" or "https"')
+        url = None
 
     else:
         url = f'https://{args.server}'

--- a/tests/manualtest/run_enum_performancesimple.py
+++ b/tests/manualtest/run_enum_performancesimple.py
@@ -468,6 +468,7 @@ Examples:
     elif re.match(r"^[a-zA-Z0-9]+://", args.server) is not None:
         argparser.error('Invalid scheme on server argument.'
                         ' Use "http" or "https"')
+        url = None
 
     else:
         url = f'https://{args.server}'

--- a/tests/manualtest/run_operationtimeouts.py
+++ b/tests/manualtest/run_operationtimeouts.py
@@ -79,6 +79,7 @@ class ClientTest(unittest.TestCase):
         # pylint: disable=global-variable-not-assigned,global-statement
         global args  # pylint: disable=invalid-name
 
+        # pylint: disable=possibly-used-before-assignment
         self.host = args['host']  # pylint: disable=used-before-assignment
         self.port = args['port']
         self.verbose = args['verbose']

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -1649,6 +1649,10 @@ def test_subscriptionmanager(testcase, submgr_id, connection_attrs,
                              remove_destinations]
             submgr.remove_destinations(server_id, removal_paths)
             result = len(added_destinations) - len(remove_destinations)
+        else:
+            result = 0
+            assert f"Remove_destination: {type(remove_destinations)} invalid."
+        # pylint: disable=possibly-used-before-assignment
         assert len(submgr.get_all_destinations(server_id)) == result
 
     if remove_filters is not None:

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -190,10 +190,16 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
     # Setup the ObjectStore
     xxx_repo = InMemoryObjectStore(*init_args)
 
+    # cls_kwargs rqd if inst_kwargs defined
+    if inst_kwargs:
+        assert cls_kwargs is not None
+
     if cls_kwargs:
         cls = CIMClass(**cls_kwargs)
     if inst_kwargs:
         inst = CIMInstance(**inst_kwargs)
+        # pylint: disable=possibly-used-before-assignment
+        # Ignore case where cls not defined.
         inst.path = CIMInstanceName.from_instance(
             cls, inst, namespace=namespace, host='me', strict=True)
     if qual_kwargs:

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -3471,7 +3471,7 @@ class TestClassOperations:
         """
 
         # Verify test valid in that class exists in repo
-
+        exp_class = None
         for cl_ in tst_classes:
             if cl_.classname.lower() == cln.lower():
                 exp_class = cl_
@@ -9202,7 +9202,6 @@ class Method1UserProvider(MethodProvider):
         if methodname.lower() in ['method1', 'staticmethod1']:
 
             if params:
-
                 # Consider InputParam1 a required parameter if params exist.
                 if "InputParam1" not in params:
                     raise CIMError(
@@ -9307,6 +9306,7 @@ class Method1UserProvider(MethodProvider):
                             'OutputParam1', 'string', value='returnvalue'),
                     ]
             else:
+                return_value = 0
                 out_params = None
 
             if val == 'outparam_invalid2_valueerror':


### PR DESCRIPTION
Fix several cases where pylint reports possibly-used-before-assignment because a variable was not defined in all if/else if statements but used after the if ... sequnce.

Marked as rollback needed since this will appear in pylint run against earlier tag