### PR TITLE
Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,9 @@ Released: not yet
   macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
   and 3.7.
 
+* Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError that
+  is raised in test_recorder.py.
+
 **Enhancements:**
 
 * Development: Migrated from setup.py to pyproject.toml since that is the

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -24,7 +24,12 @@ packaging>=21.3
 # pytest-cov 4.0.0 depends on pytest>=4.6
 pytest>=4.6.0,!=6.0,<8.0; python_version <= '3.9'
 pytest>=6.2.5,<8.0; python_version >= '3.10'
-testfixtures>=6.9.0
+# TODO: testfixtures 8.3.0 introduced a new check that causes AssertionError to
+#       be raised in test_recorder.py.
+#       Issue https://github.com/simplistix/testfixtures/issues/200 describes
+#       the issue. To circumvent the issue, 8.3.0 is excluded for now.
+#       Find a permanent solution.
+testfixtures>=6.9.0,!=8.3.0
 # pylint>=2.15 requires colorama>=0.4.5
 colorama>=0.4.5
 


### PR DESCRIPTION
This is a circumvention for the issue.
Issue https://github.com/pywbem/pywbem/issues/3198 is for the final solution and links to the details of the issue.