### PR TITLE
1.7: Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,9 @@ Released: not yet
   macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
   and 3.7.
 
+* Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError that
+  is raised in test_recorder.py.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -24,8 +24,7 @@ pytest==4.3.1; python_version == '2.7'
 pytest==4.3.1; python_version == '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
-testfixtures==6.9.0; python_version == '2.7'
-testfixtures==6.9.0; python_version >= '3.6'
+testfixtures==6.9.0
 colorama==0.3.9; python_version == '2.7'
 colorama==0.4.5; python_version >= '3.6'
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -28,8 +28,12 @@ pytest>=4.3.1,<5.0.0; python_version == '2.7'
 pytest>=4.3.1,!=6.0,<8.0; python_version == '3.6'
 pytest>=4.4.0,!=6.0,<8.0; python_version >= '3.7' and python_version <= '3.9'
 pytest>=6.2.5,<8.0; python_version >= '3.10'
-testfixtures>=6.9.0; python_version == '2.7'
-testfixtures>=6.9.0; python_version >= '3.6'
+# TODO: testfixtures 8.3.0 introduced a new check that causes AssertionError to
+#       be raised in test_recorder.py.
+#       Issue https://github.com/simplistix/testfixtures/issues/200 describes
+#       the issue. To circumvent the issue, 8.3.0 is excluded for now.
+#       Find a permanent solution.
+testfixtures>=6.9.0,!=8.3.0
 # pylint>=2.15 requires colorama>=0.4.5
 colorama>=0.3.9,<0.4.0; python_version == '2.7'
 colorama>=0.4.5; python_version >= '3.6'


### PR DESCRIPTION
Rolls back PR #3199 into 1.7.3.