### PR TITLE
Add capability for listener to define a case where the received indication queue is full.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -80,6 +80,9 @@ Released: not yet
 * Development: Changed release process to use a GitHub Actions workflow.
   (issue #3128)
 
+* Add argument to set maximum limit on WBEMListener indication queue. (issue
+  #3168)
+
 **Cleanup:**
 
 * Eliminated a warning about about ambiguity of the package list when building

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -28,7 +28,8 @@ __all__ = ['Error', 'ConnectionError', 'AuthError', 'HTTPError', 'TimeoutError',
            'ProtocolVersionError', 'CIMXMLParseError', 'XMLParseError',
            'HeaderParseError', 'CIMError', 'ModelError',
            'ListenerError', 'ListenerCertificateError',
-           'ListenerPortError', 'ListenerPromptError']
+           'ListenerPortError', 'ListenerPromptError',
+           'ListenerQueueFullError']
 
 
 class _RequestExceptionMixin:
@@ -765,6 +766,19 @@ class ListenerPromptError(ListenerError):
     key file of the pywbem listener was interrupted or ended.
 
     *New in pywbem 1.3.*
+
+    Derived from :exc:`~pywbem.ListenerError`.
+    """
+    pass
+
+
+class ListenerQueueFullError(ListenerError):
+    """
+    This exception indicates that the listener received indication queue has
+    reached the maximum count of indications defined in the listener
+    creation max_queue_size parameter.
+
+    *New in pywbem 1.8.*
 
     Derived from :exc:`~pywbem.ListenerError`.
     """


### PR DESCRIPTION
Defines a new exception and exception handling so that user can define a queue full argument on listener initialization and the listener will create the exception and pass it to main thread  if the received indication queue reaches this limit.  If this condition occurs, the whole listener is effectively stopped and must be recreated because we have stopped receiving indications from the wbem server

* Defines an argument on the indication listener init  (max_ind_queue_size) that will define the QUEUE_FULL condition if the number of indications in the listener  indication queue exceeds that limit. This is an optional exception and is only enabled when a listener init argument defines a integer that represents the maximum number of integers allowed in the queue.

* Adds an exception definition for indications received indication queue full and adds code to generate that exception and pass it back from the indication receive thread to the listener main thread.

Since causing this exception interrupts the indication flow (the queue will accept no more indications until the count is reduced, this normally means that the whole listener has failed except for callbacks to process indications in the queue. The indication that was to go into the queue is dropped, and the response to this indication is a code representing failure for this indication.

Adds tests for received indication full condition

Modified some of the function documentation.