### PR TITLE
1.7: Test: In test_recorder.py avoid a new AssertionError by testfixtures 8.3.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,8 +33,8 @@ Released: not yet
   macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
   and 3.7.
 
-* Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError that
-  is raised in test_recorder.py.
+* Test: In test_recorder.py, changed code to avoid a new AssertionError raised
+  by testfixtures 8.3.0.
 
 **Enhancements:**
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -29,12 +29,7 @@ pytest>=4.3.1,<5.0.0; python_version == '2.7'
 pytest>=4.3.1,!=6.0,<8.0; python_version == '3.6'
 pytest>=4.4.0,!=6.0,<8.0; python_version >= '3.7' and python_version <= '3.9'
 pytest>=6.2.5,<8.0; python_version >= '3.10'
-# TODO: testfixtures 8.3.0 introduced a new check that causes AssertionError to
-#       be raised in test_recorder.py.
-#       Issue https://github.com/simplistix/testfixtures/issues/200 describes
-#       the issue. To circumvent the issue, 8.3.0 is excluded for now.
-#       Find a permanent solution.
-testfixtures>=6.9.0,!=8.3.0
+testfixtures>=6.9.0
 # pylint>=2.15 requires colorama>=0.4.5
 colorama>=0.3.9,<0.4.0; python_version == '2.7'
 colorama>=0.4.5; python_version >= '3.6'

--- a/tests/unittest/pywbem/test_recorder.py
+++ b/tests/unittest/pywbem/test_recorder.py
@@ -1640,13 +1640,12 @@ class BaseLogOperationRecorderTests(object):
         """
         Setup that is run before each test method.
         """
-        # Shut down any existing logger and reset WBEMConnection and
-        # reset WBEMConnection class attributes
-        # pylint: disable=protected-access
-        WBEMConnection._reset_logging_config()
-        logging.shutdown()
+        # Reset WBEMConnection logging.
         # NOTE We do not clean up handlers or logger names already defined.
         #      That should not affect the tests.
+
+        # pylint: disable=protected-access
+        WBEMConnection._reset_logging_config()
 
     def recorder_setup(self, detail_level=None):
         """


### PR DESCRIPTION
Rolls back PR #3198 into 1.7.3.
No additional review needed.