### PR TITLE
Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,7 +261,6 @@ jobs:
       run: |
         make end2endtest
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -55,6 +55,9 @@ Released: not yet
 * Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError that
   is raised in test_recorder.py.
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell.
+
 **Enhancements:**
 
 * Development: Migrated from setup.py to pyproject.toml since that is the


### PR DESCRIPTION
For the attempt to debug this, see PR https://github.com/zhmcclient/python-zhmcclient/pull/1663.
I opened an issue against the actions/setup-python repo: https://github.com/actions/setup-python/issues/942
This PR fixes the issue permanently (without dependency on a resolution of the issue above).

If you have an idea why the login shell was specified for invoking coveralls, please comment on that during your review.