### PR TITLE
1.7: Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -375,7 +375,6 @@ jobs:
     - name: Send coverage result to coveralls.io
       # no coverage in py27 container because no test is run
       if: matrix.python-version != '2.7'
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
 * Test: Excluded testfixtures 8.3.0 to circumvent a new AssertionError that
   is raised in test_recorder.py.
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #3219 into 1.7.3.