### PR TITLE
Added tests for Python 3.13.0-rc.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,20 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
-            \"package_level\": [ \"minimum\", \"latest\" ] \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13.0-rc.1\" ], \
+            \"package_level\": [ \"minimum\", \"latest\" ], \
+            \"exclude\": [ \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"latest\" \
+              } \
+            ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
@@ -65,6 +77,16 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.8\", \
                 \"package_level\": \"minimum\" \
@@ -77,6 +99,16 @@ jobs:
               { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -7,4 +7,4 @@
 pip>=23.3
 setuptools>=70.0.0
 setuptools-scm>=8.1.0
-wheel>=0.38.1
+wheel>=0.41.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -51,7 +51,7 @@ sphinxcontrib-serializinghtml>=1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml>=1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport>=1.2.4
 autodocsumm>=0.2.12
-Babel>=2.9.1
+Babel>=2.11.0
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -175,8 +175,8 @@ pip-check-reqs>=2.4.3,!=2.5.0; python_version <= '3.11'
 pip-check-reqs>=2.5.1; python_version >= '3.12'
 
 # notebook 6.4.10 depends on pyzmq>=17
-pyzmq>=24.0.0; python_version <= '3.11'
-pyzmq>=25.1.1; python_version >= '3.12'
+# pyzmq 26.1.0 added wheel archives for Python 3.13
+pyzmq>=26.1.0
 
 # bleach is used by nbconvert and readme-renderer
 bleach>=3.3.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -60,7 +60,17 @@ Released: not yet
 * Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
   with Python 3.9-3.11, by running it without login shell.
 
+* Increased minimum version of PyYAML to 6.0.2, to fix an install error for
+  Python 3.13 on Windows. (related to issue #3225)
+
 **Enhancements:**
+
+* Added support for Python 3.13. (issue #3225)
+
+* Added testing on Python 3.13.0-rc.1. Testing on Windows needed to be excluded
+  for that Python version due to an install issue with pywin32. That install
+  issue affects only development and test of pywbem, but not its installation
+  by users. (issues #3225, #3230)
 
 * Development: Migrated from setup.py to pyproject.toml since that is the
   recommended direction for Python packages. The make targets have not changed

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -19,6 +19,9 @@ pytest==4.6.0; python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
 testfixtures==6.9.0
 colorama==0.4.5
+# FormEncode is used for xml comparisons in unit test
+# TODO: Re-enable FormEncode once the fix for https://github.com/formencode/formencode/issues/181 has been released.
+# FormEncode==2.x.x
 
 # Easy-server packages
 easy-vault==0.7.0
@@ -44,14 +47,13 @@ tzdata==2024.1; sys_platform == 'win32'
 # Unit test (indirect dependencies):
 pluggy==0.13.0
 decorator==4.0.11
-# FormEncode is used for xml comparisons in unit test
-FormEncode==2.0.0
 
 # Lxml
 lxml==4.6.2; python_version <= '3.9'
 lxml==4.6.4; python_version == '3.10'
 lxml==4.9.2; python_version == '3.11'
-lxml==4.9.3; python_version >= '3.12'
+lxml==4.9.3; python_version == '3.12'
+lxml==5.3.0; python_version >= '3.13'
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==6.5.0
@@ -112,7 +114,7 @@ sphinxcontrib-serializinghtml==1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport==1.2.4
 autodocsumm==0.2.12
-Babel==2.10.0
+Babel==2.11.0
 
 # PyLint (no imports, invoked via pylint script):
 pylint==2.13.0; python_version <= '3.10'
@@ -196,8 +198,8 @@ pip-check-reqs==2.4.3; python_version <= '3.11'
 pip-check-reqs==2.5.1; python_version >= '3.12'
 
 # notebook 6.4.10 depends on pyzmq>=17
-pyzmq==24.0.0; python_version <= '3.11'
-pyzmq==25.1.1; python_version >= '3.12'
+# pyzmq 26.1.0 added wheel archives for Python 3.13
+pyzmq==26.1.0
 
 # bleach is used by nbconvert and readme-renderer
 bleach==3.3.0
@@ -231,7 +233,7 @@ asttokens==2.0.4
 attrs==22.2.0
 backcall==0.2.0
 beautifulsoup4==4.10.0
-cffi==1.16.0
+cffi==1.17.0
 # Click used by easy-vault (8.0.2) and safety (7.1.1).
 Click==8.0.2
 clint==0.5.1

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -13,13 +13,13 @@
 pip==23.3
 setuptools==70.0.0
 setuptools-scm==8.1.0
-wheel==0.38.1
+wheel==0.41.3
 
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
 ply==3.10
-PyYAML==5.3.1
+PyYAML==6.0.2
 # requests version 2.32.0 required by safety issue 71064 (2.32.0, 2.32.1 yanked)
 requests==2.32.2
 yamlloader==0.5.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8"
 dynamic = ["version", "dependencies", "optional-dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,12 @@
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
 ply>=3.10
-PyYAML>=5.3.1
+# PyYAML is also pulled in by dparse and python-coveralls
+# PyYAML 6.0 has wheel archives for Python 3.6 - 3.11
+# PyYAML 6.0.0 fails install since Cython 3 was released, see issue
+#   https://github.com/yaml/pyyaml/issues/724.
+# PyYAML 6.0.2 provides wheel archives for Python 3.13 on Windows
+PyYAML>=6.0.2
 # requests 2.22.0 removed the pinning of urllib3 to <1.25.0
 # requests 2.25.0 tolerates urllib3 1.26.5 which is needed on Python 3.10 to remove ImportWarning in six
 # requests 2.32.2 safety issue 71064 requires requests ver >=2.32.0 (2.32.0, 2.32.1 yanked)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -27,6 +27,10 @@ pytest>=6.2.5,<8.0; python_version >= '3.10'
 testfixtures>=6.9.0
 # pylint>=2.15 requires colorama>=0.4.5
 colorama>=0.4.5
+# FormEncode is used for xml comparisons in unit test
+# TODO: Re-enable FormEncode once the fix for https://github.com/formencode/formencode/issues/181 has been released.
+# FormEncode>=2.x.x
+FormEncode @ git+https://github.com/formencode/formencode.git@main
 
 # Easy-server packages
 easy-vault>=0.7.0
@@ -55,9 +59,6 @@ pluggy>=0.13.0
 
 decorator>=4.0.11
 
-# FormEncode is used for xml comparisons in unit test
-FormEncode>=2.0.0
-
 # Lxml
 # lxml>=5.0 fails installing on macOS 14 with Python 3.8, see https://bugs.launchpad.net/lxml/+bug/2063945
 # lxml 4.9.2 addresses changes in Python 3.11
@@ -68,6 +69,7 @@ lxml>=4.6.2; python_version == '3.9'
 lxml>=4.6.4; python_version == '3.10'
 lxml>=4.9.2; python_version == '3.11'
 lxml>=4.9.3; python_version == '3.12'
+lxml>=5.3.0; python_version >= '3.13'
 
 virtualenv>=20.15.0; python_version <= '3.11'  # requires six<2,>=1.12.0
 virtualenv>=20.23.0; python_version >= '3.12'

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
     py310
     py311
     py312
+    py313
     win64_py38_32
     win64_py38_64
     win64_py39_32
@@ -28,11 +29,14 @@ envlist =
     win64_py311_64
     win64_py312_32
     win64_py312_64
+    win64_py313_32
+    win64_py313_64
     cygwin64_py38
     cygwin64_py39
     cygwin64_py310
     cygwin64_py311
     cygwin64_py312
+    cygwin64_py313
 
 # For Appveyor, missing interpreters should fail. For local use, you may
 # want to allow to skip missing interpreters.
@@ -104,6 +108,10 @@ basepython = python3.11
 platform = linux2|darwin
 basepython = python3.12
 
+[testenv:py313]
+platform = linux2|darwin
+basepython = python3.13
+
 # Note: The basepython file paths for the win64* tox environments are set for
 #       Appveyor CI.
 
@@ -147,6 +155,14 @@ basepython = C:\Python312\python.exe
 platform = win32
 basepython = C:\Python312-x64\python.exe
 
+[testenv:win64_py313_32]
+platform = win32
+basepython = C:\Python313\python.exe
+
+[testenv:win64_py313_64]
+platform = win32
+basepython = C:\Python313-x64\python.exe
+
 # Note: The 32-bit versions of CygWin do not work and have been removed from
 # appveyor.yml and tox.ini:
 # - On Python 3.6 and upwards, Tox returns success but does not do anything.
@@ -170,3 +186,7 @@ basepython = python3.11
 [testenv:cygwin64_py312]
 platform = cygwin
 basepython = python3.12
+
+[testenv:cygwin64_py313]
+platform = cygwin
+basepython = python3.13


### PR DESCRIPTION
For details, see the commit message.

Specific review points:
* Workaround for FormEncode installation issue (see commit message)
* Workaround for pywin32 installation issue (see commit message)

Note, this PR uses RC1 of Python 3.13.0. Issue #3228 will upgrade this to the GA version of 3.13.0.