### PR TITLE
1.7: Circumvented issue with installing pywinpty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,26 +113,6 @@ jobs:
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.7\", \
-                \"package_level\": \"latest\" \
               } \
             ] \
           }" >> $GITHUB_OUTPUT; \
@@ -187,11 +167,6 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.10\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,16 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
@@ -92,6 +102,16 @@ jobs:
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -145,12 +165,12 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               }, \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -359,9 +359,14 @@ bleach>=3.3.0; python_version == '2.7'
 bleach>=3.3.0; python_version >= '3.6'
 
 # pywinpty is used by terminado <- notebook <- jupyter
-# pywinpty does not declare supported Pyrthon versions and 1.0 has removed support for py27.
+# pywinpty does not declare supported Python versions and 1.0 has removed support for py27.
+# pywinpty 2.0.14 has an issue with latest maturin on Python 3.8, see https://github.com/andfoy/pywinpty/issues/486
+# pywinpty <2.0.14 has the above issue on Python 3.13
 pywinpty>=0.5; os_name == "nt" and python_version <= '3.6'
-pywinpty>=2.0.3; os_name == "nt" and python_version >= '3.7'
+pywinpty>=2.0.10; os_name == "nt" and python_version == '3.7'
+pywinpty>=2.0.12,!=2.0.14; os_name == "nt" and python_version == '3.8'
+pywinpty>=2.0.12; os_name == "nt" and python_version >= '3.9' and python_version <= '3.12'
+pywinpty>=2.0.14; os_name == "nt" and python_version >= '3.13'
 
 # This version caused by notebook 6.4.10 depends on terminado>=0.8.3
 # terminado 0.10.0 requires pywinpty>=1.1.0, see issue there

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,9 @@ Released: not yet
 * Development: Circumvented an issue when installing certain versions of pywinpty
   with latest version of maturin on certain Python versions.
 
+* Circumvented an issue with yamlloader on Python 3.6 by excluding yamlloader
+  1.5.0.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,6 +52,9 @@ Released: not yet
   ubuntu-20.04 image because the ubuntu-latest image was upgraded to
   Ubuntu 24.04 which no longer supports Python 3.7.
 
+* Test: Removed tests on GitHub Actions on Python 3.6 and 3.7 on MacOS, because
+  the macos-12 image that still supported these Python versions is now rejected.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -41,6 +41,9 @@ Released: not yet
 * Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
   with Python 3.9-3.11, by running it without login shell.
 
+* Development: Circumvented an issue when installing certain versions of pywinpty
+  with latest version of maturin on certain Python versions.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,10 @@ Released: not yet
 
 **Cleanup:**
 
+* Test: Changed tests on Github Actions on Python 3.7 on Ubuntu to use the
+  ubuntu-20.04 image because the ubuntu-latest image was upgraded to
+  Ubuntu 24.04 which no longer supports Python 3.7.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -307,7 +307,9 @@ bleach==3.3.0; python_version >= '3.6'
 
 # pywinpty is used by terminado <- notebook <- jupyter
 pywinpty==0.5; os_name == "nt" and python_version <= '3.6'
-pywinpty==2.0.3; os_name == "nt" and python_version >= '3.7'
+pywinpty==2.0.10; os_name == "nt" and python_version == '3.7'
+pywinpty==2.0.12; os_name == "nt" and python_version >= '3.8' and python_version <= '3.12'
+pywinpty==2.0.14; os_name == "nt" and python_version >= '3.13'
 
 # This version caused by notebook 6.4.10 depends on terminado>=0.8.3
 terminado==0.6; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,9 +28,10 @@ requests>=2.26.0; python_version == '3.6'
 requests>=2.31.0; python_version == '3.7'
 requests>=2.32.2; python_version >= '3.8'
 # yamlloader 1.1.0 gets istalled by mistake on py27+34 on Ubuntu when using setup.py install. See issue #2745.
+# yamlloader 1.5.0 installs on Python 3.6 but uses constructs from Python >=3.7.
 yamlloader>=0.5.5,<1.0.0; python_version == '2.7'
-yamlloader>=0.5.5; python_version >= '3.6'
-
+yamlloader>=0.5.5,<1.5.0; python_version == '3.6'
+yamlloader>=0.5.5; python_version >= '3.7'
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)
 


### PR DESCRIPTION
Rolls back PR #3245 into 1.7.3, plus the following fixes specific to the stable branch and its older set of supported Python versions:
* Changed Ubuntu image for Python 3.7 tests on Ubuntu.
* Removed Python 3.6/3.7 tests on MacOS.
* Circumvented issue with yamlloader on Python 3.6.