### PR TITLE
Update version of OpenPegasus Docker file from 

### DIFF
--- a/changes/noissue.4.cleanup.rst
+++ b/changes/noissue.4.cleanup.rst
@@ -1,0 +1,3 @@
+Change the version of OpenPegasus docker image used in end-end tests to
+match the version in pywbemclitools repository.  This makes some changes
+to the structure of the docker definitions and results in smaller image.

--- a/tests/end2endtest/es_server.yml
+++ b/tests/end2endtest/es_server.yml
@@ -95,7 +95,7 @@ servers:
   pegasus_https:
     description: Local OpenPegasus container with HTTPS port
     user_defined:
-      docker_image: kschopmeyer/openpegasus-server:0.1.2
+      docker_image: kschopmeyer/openpegasus-server:0.1.3
       docker_port_mapping:
         image: 5989
         host: 15989
@@ -109,7 +109,7 @@ servers:
   pegasus_http:
     description: Local OpenPegasus container with HTTP port
     user_defined:
-      docker_image: kschopmeyer/openpegasus-server:0.1.2
+      docker_image: kschopmeyer/openpegasus-server:0.1.3
       docker_port_mapping:
         image: 5988
         host: 15988


### PR DESCRIPTION
Update the version of the OpenPegasus Docker file to match pywbemtool repo.  This version of the Docker file make several changes to the container to:

1. Clean up documentation
2. Add more tools to the build image to enhance testing of this image.
3. Standardize the names of the various makefiles

Note that the pywbemtools repo was updated to this version some time ago.