### PR TITLE
Ks/fix pip missing reqs

### DIFF
--- a/changes/noissue.12.fix.rst
+++ b/changes/noissue.12.fix.rst
@@ -1,0 +1,3 @@
+Development: Fix issues with minimum-constraints-develop.txt that were causing
+failure of make check_reqs because the package Levenshtein required by
+safety and Sphinx. See PR 3253 for details.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -87,6 +87,9 @@ more-itertools==4.0.0
 # Safety CI by pyup.io
 safety==3.1.0
 safety-schemas==0.0.2
+# The following used by safety
+Levenshtein==0.25.1
+
 # TODO: Change to dparse 0.6.4 once released
 dparse==0.6.4b0
 ruamel.yaml==0.17.21


### PR DESCRIPTION
Fail pywbem tests check_reqs.

Add Levenstein package and python-Levenstein to minimum-constraints-develop.txt to fix issue with the make check_reqs command failing during build.

(pywbem313) kschopmeyer@penny:~/gitpywbems/gitpywbem/pywbem313/pywbem(ks/fix-pip-missing-reqs)$ ack roman *.txt
(pywbem313) kschopmeyer@penny:~/gitpywbems/gitpywbem/pywbem313/pywbem(ks/fix-pip-missing-reqs)$ make check_reqs
Makefile: Checking missing dependencies of the package
pip-missing-reqs pywbem --requirements-file=requirements.txt
pip-missing-reqs pywbem --requirements-file=minimum-constraints-install.txt
Makefile: Done checking missing dependencies of the package
Makefile: Checking missing dependencies of some development packages
cat minimum-constraints-develop.txt minimum-constraints-install.txt >minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/pytest --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/coverage --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/coveralls --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/flake8 --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/pylint --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/safety --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/sphinx --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/notebook --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/jupyter_console --requirements-file=minimum-constraints-all.txt.tmp
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/ipywidgets --requirements-file=minimum-constraints-all.txt.tmp
/home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/ipywidgets/widgets/tests/test_traits.py:61: SyntaxWarning: invalid escape sequence '\.'
  'var(--my-color-\.)', # CSS variable with escaped characters
pip-missing-reqs /home/kschopmeyer/virtualenvs/pywbem313/lib/python3.13/site-packages/towncrier --requirements-file=minimum-constraints-all.txt.tmp
rm -f minimum-constraints-all.txt.tmp
Makefile: Done checking missing dependencies of some development packages
Makefile: check_reqs done.
(pywbem313) kschopmeyer@penny:~/gitpywbems/gitpywbem/pywbem313/pywbem(ks/fix-pip-missing-reqs)$ make check_reqs

