### PR TITLE
1.7: Fixed safety issued and missing dependencies

### DIFF
--- a/.safety-policy-all.yml
+++ b/.safety-policy-all.yml
@@ -187,6 +187,10 @@ security:
             reason: Fixed zipp version 3.19.1 requires Python>=3.8 and is used there
         73456:
             reason: Fixed virtualenv version 20.26.6 is only used on Python>=3.12 to avoid other changes
+        74439:
+            reason: Fixed tornado version 6.4.2 requires Python>=3.8 and is used there
+        74735:
+            reason: Fixed jinja2 version 3.1.5 requires Python>=3.7 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -61,6 +61,8 @@ security:
             reason: Fixed requests version 2.32.2 requires Python>=3.8 and is used there
         72236:
             reason: Fixed setuptools version 70.0.0 requires Python>=3.8 and is used there
+        75180:
+            reason: Fixed pip version 25.0 requires Python>=3.8 and is used there
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -312,7 +312,7 @@ pywin32>=306; sys_platform == 'win32' and python_version >= '3.10'
 tornado>=4.4.2,<5.0; python_version == '2.7'
 tornado>=6.1; python_version == '3.6'
 tornado>=6.2; python_version == '3.7'
-tornado>=6.4.1; python_version >= '3.8'
+tornado>=6.4.2; python_version >= '3.8'
 
 # Table output formatter used by the manual performance tests to display
 # timing results

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,10 @@ Released: not yet
 * Circumvented an issue with yamlloader on Python 3.6 by excluding yamlloader
   1.5.0.
 
+* Development: Fix issues with minimum-constraints-develop.txt that were causing
+  failure of make check_reqs because the package Levenshtein required by
+  safety and Sphinx. See PR 3253 for details.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,7 +25,7 @@ Released: not yet
 
 **Bug fixes:**
 
-* Fixed safety issues up to 2024-11-30.
+* Fixed safety issues up to 2025-03-01.
 
 * Fixed new issues reported by Pylint 3.2 and 3.3.
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -20,7 +20,8 @@
 # * pip 22.0 dropped support for Python 3.6.
 pip==19.3.1; python_version == '2.7'
 pip==21.3.1; python_version == '3.6'
-pip==23.3; python_version >= '3.7'
+pip==23.3; python_version == '3.7'
+pip==25.0; python_version >= '3.8'
 
 # setuptools 41.5.0 fixes build errors with Visual C++ 14.0 on Windows
 # setuptools 41.5.1 fixes a py27 regression introduced by 41.5.0.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -100,6 +100,8 @@ more-itertools==4.0.0
 # Safety is run only on Python >=3.7
 safety==3.0.1; python_version >= '3.7'
 safety-schemas==0.0.1; python_version >= '3.7'
+# The following used by safety
+Levenshtein==0.25.1
 # TODO: Change to dparse 0.6.4 once released
 dparse==0.6.4b0; python_version >= '3.7'
 ruamel.yaml==0.17.21; python_version >= '3.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -135,6 +135,7 @@ sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport==1.2.4; python_version >= '3.8'
 autodocsumm==0.2.12; python_version >= '3.8'
 Babel==2.10.0; python_version >= '3.8'
+roman-numerals-py==1.0.0; python_version >= '3.9'
 
 # PyLint (no imports, invoked via pylint script):
 # Not installed below Python 3.6
@@ -276,7 +277,7 @@ pywin32==306; sys_platform == 'win32' and python_version >= '3.10'
 tornado==4.4.2; python_version == '2.7'
 tornado==6.1; python_version == '3.6'
 tornado==6.2; python_version == '3.7'
-tornado==6.4.1; python_version >= '3.8'
+tornado==6.4.2; python_version >= '3.8'
 
 # Table output formatter used by the manual performance tests to display
 # timing results
@@ -404,6 +405,7 @@ matplotlib-inline==0.1.3; python_version >= '3.6'
 mistune==0.8.1; python_version <= '3.7'
 mistune==2.0.3; python_version >= '3.8'
 nest-asyncio==1.5.4; python_version >= '3.6'
+nltk==3.9
 pandocfilters==1.4.1
 parso==0.7.0; python_version >= '3.6'
 pathlib2==2.3.7.post1


### PR DESCRIPTION
Rolls back PRs #3253 and #3256 into 1.7.