### PR TITLE
Set the pywbem listener threads to daemon=False.

### DIFF
--- a/changes/3135.cleanup.rst
+++ b/changes/3135.cleanup.rst
@@ -1,0 +1,3 @@
+Change the startup mode of the listener threads from daemon=True
+to daemon=False.  This insures that the threads are stopped when the listener
+is closed or fails.

--- a/pywbem/_listener.py
+++ b/pywbem/_listener.py
@@ -1200,7 +1200,7 @@ class WBEMListener:
             target=self.deliver_indications_forever,
             args=(self.ind_delivery_queue,),
             name='Callback',
-            daemon=True)
+            daemon=False)
 
         self.callback_thread.start()
         self.logger.info("Callback thread started max_queue=%s",
@@ -1230,7 +1230,7 @@ class WBEMListener:
                 server.listener = self
                 thread = ServerThread(target=server.serve_forever,
                                       name='http',
-                                      daemon=True)
+                                      daemon=False)
                 # Insure thread is stopped on main thread exit
                 self._http_server = server
                 self._http_thread = thread
@@ -1326,7 +1326,7 @@ class WBEMListener:
 
                 thread = ServerThread(target=server.serve_forever,
                                       name="https",
-                                      daemon=True)
+                                      daemon=False)
 
                 self._https_server = server
                 self._https_thread = thread
@@ -1478,7 +1478,7 @@ class WBEMListener:
                 "Rcvd indication queue full. ListenerQueueFullError Exception, "
                 "queue_size = #%s", self.queue_size)
             new_exc = ListenerQueueFullError(
-                "Listener indiation delivery queue full, "
+                "Listener indication delivery queue full, "
                 f"queue_size = {self.queue_size}. Closing listener.")
             new_exc.__cause__ = None
             raise new_exc  # ListenerQueueFullError


### PR DESCRIPTION
This forces the threads to be closed by the join statements for each thread (and the processing of all received indications by the callback thread) before closing the WBEMListener object.

No listener should ever exist after the WBEMListener object is closed