### PR TITLE
Fixed incorrect package version in build; Increased pipdeptree version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,9 +711,9 @@ AUTHORS.md: _always
 	echo "" >>AUTHORS.md.tmp
 	echo "Sorted list of authors derived from git commit history:" >>AUTHORS.md.tmp
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "git shortlog --summary --email HEAD | cut -f 2 | sort >>AUTHORS.md.tmp"
+	bash -c "git shortlog --summary --email HEAD | cut -f 2 | sort >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
+	bash -c "if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; rm AUTHORS.md.tmp; fi"
 
 .PHONY: clobber
 clobber: clean
@@ -877,13 +877,15 @@ $(sdist_file): pyproject.toml MANIFEST.in $(dist_dependent_files) $(moftab_files
 	@echo "Makefile: Creating the source distribution archive: $(sdist_file)"
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) -m build --sdist --outdir $(dist_dir) .
+	$(PYTHON_CMD) -m build --no-isolation --sdist --outdir $(dist_dir) .
+	bash -c "ls -l $(sdist_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done creating the source distribution archive: $(sdist_file)"
 
 $(bdist_file) $(version_file): pyproject.toml $(dist_dependent_files) $(moftab_files) $(done_dir)/vendor_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: Creating the normal wheel distribution archive: $(bdist_file)"
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal .
+	$(PYTHON_CMD) -m build --no-isolation --wheel --outdir $(dist_dir) -C--universal .
+	bash -c "ls -l $(bdist_file) $(version_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done creating the normal wheel distribution archive: $(bdist_file)"
 
 $(bdistc_file): setup.py pyproject.toml $(dist_dependent_files) $(moftab_files) $(done_dir)/vendor_$(pymn)_$(PACKAGE_LEVEL).done

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -6,5 +6,5 @@
 
 pip>=25.0
 setuptools>=70.0.0
-setuptools-scm>=8.1.0
+setuptools-scm>=9.2.0
 wheel>=0.41.3

--- a/changes/noissue.14.fix.rst
+++ b/changes/noissue.14.fix.rst
@@ -1,0 +1,5 @@
+Dev: Fixed issue where the package version used for distribution archive file
+names were generated inconsistently between setuptools_scm (used in Makefile)
+and the 'build' module, by using no build isolation ('--no-isolation' option
+of the 'build' module) and increasing the minimum version of 'setuptools-scm'
+to 9.2.0, which fixes a number of version related issues.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -163,7 +163,7 @@ pyinstrument-cext>=0.2.2; python_version <= '3.11'  # from pyinstrument
 pyinstrument>=4.7.2; python_version >= '3.12'    # pyinstrument-cext integrated
 
 # Package dependency management tools
-pipdeptree>=2.2.0
+pipdeptree>=2.24.0
 # pip-check-reqs 2.3.2 is needed to have proper support for pip>=21.3 and below.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -19,7 +19,7 @@ incremental==22.10.0
 click-default-group==1.2.4
 
 # Unit test (imports into testcases):
-packaging==22.0
+packaging==24.1
 pytest==4.6.0; python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
 testfixtures==6.9.0
@@ -190,7 +190,7 @@ pyinstrument-cext==0.2.2; python_version <= '3.11'  # from pyinstrument
 pyinstrument==4.7.2; python_version >= '3.12'  # pyinstrument-cext integrated
 
 # Package dependency management tools
-pipdeptree==2.2.0
+pipdeptree==2.24.0
 pip-check-reqs==2.4.3; python_version <= '3.11'
 pip-check-reqs==2.5.1; python_version >= '3.12'
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -12,7 +12,7 @@
 
 pip==25.0
 setuptools==70.0.0
-setuptools-scm==8.1.0
+setuptools-scm==9.2.0
 wheel==0.41.3
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [build-system]
 requires = [
     "setuptools>=70.0.0",
-    "setuptools-scm>=8.1.0",
+    "setuptools-scm>=9.2.0",
     "wheel>=0.38.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,7 +15,7 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 
 # Unit test (imports into testcases):
-packaging>=21.3
+packaging>=24.1
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 # pytest==6.0.0 causes pylint to report "not-callable" issues
 # pytest>=6.0.0 causes pylint to report "abstract-method" issues


### PR DESCRIPTION
For details, see the commit message.
No review needed.
A rollback to 1.7 is not needed, because that version still uses setup.py.