### PR TITLE
Omitted pywbem/_vendor subtree from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ relative_files = True
 omit =
     pywbem/mofparsetab.py
     pywbem/moflextab.py
+    pywbem/_vendor/*
 
 [report]
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ moflog*.txt
 test_recorder.yaml
 pylint_done
 /blah.yaml
-.coverage*
+.coverage
 /coverage_html/
 *.py,cover
 cprofilerstats*.profile

--- a/changes/noissue.vendorcov.cleanup.rst
+++ b/changes/noissue.vendorcov.cleanup.rst
@@ -1,0 +1,1 @@
+Test: Omitted pywbem/_vendor subtree from coverage.

--- a/changes/noissue.vendorcov.fix.rst
+++ b/changes/noissue.vendorcov.fix.rst
@@ -1,0 +1,1 @@
+Test: Fixed that .coveragerc was omitted from git.


### PR DESCRIPTION
No review needed.