### PR TITLE
Increased version of safety to 3.6.2 to simplify its dependencies

### DIFF
--- a/changes/noissue.111.fix.rst
+++ b/changes/noissue.111.fix.rst
@@ -1,0 +1,1 @@
+Dev: Increased version of safety to 3.6.2 to simplify its dependencies.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,10 +25,9 @@ coveralls>=3.3.0
 more-itertools>=4.0.0
 
 # Safety CI by pyup.io
-# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
-# safety 3.4.0 started using httpx and tenacity
+# safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.4.0
+safety>=3.6.1
 safety-schemas>=0.0.14
 dparse>=0.6.4
 ruamel.yaml>=0.17.21
@@ -37,14 +36,12 @@ Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
 pydantic_core>=2.20.0
-# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
-typer>=0.12.1,<0.17.0
-typer-cli>=0.12.1,<0.17.0
-typer-slim>=0.12.1,<0.17.0
-# safety 3.4.0 depends on psutil~=6.1.0
-psutil~=6.1.0
-# safety 3.4.0 requires filelock~=3.16.1
-filelock~=3.16.1
+#safety 3.6.1 depends on typer>=0.16.0
+typer>=0.16.0
+typer-cli>=0.16.0
+typer-slim>=0.16.0
+psutil>=6.1.0
+filelock>=3.16.1
 
 # Tox
 tox>=2.5.0

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -84,7 +84,7 @@ vendorize==0.3.0
 more-itertools==4.0.0
 
 # Safety CI by pyup.io
-safety==3.4.0
+safety==3.6.1
 safety-schemas==0.0.14
 dparse==0.6.4
 ruamel.yaml==0.17.21
@@ -93,9 +93,9 @@ Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
 pydantic_core==2.20.0
-typer==0.12.1
-typer-cli==0.12.1
-typer-slim==0.12.1
+typer==0.16.0
+typer-cli==0.16.0
+typer-slim==0.16.0
 psutil==6.1.0
 filelock==3.16.1
 
@@ -254,7 +254,7 @@ MarkupSafe==3.0.0; python_version >= '3.13'
 matplotlib-inline==0.1.3
 mistune==2.0.3
 nest-asyncio==1.5.4
-nltk==3.9
+nltk==3.9.1
 pandocfilters==1.4.1
 parso==0.7.0
 pathlib2==2.3.7.post1


### PR DESCRIPTION
No review needed.