### PR TITLE
Fixed error detection when preparing LICENSE files for vendorized packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,8 +560,8 @@ $(done_dir)/vendor_$(pymn)_$(PACKAGE_LEVEL).done: vendorize.toml Makefile
 	@echo "Makefile: Vendoring nocasedict and nocaselist"
 	bash -c "cd $(vendor_dir); rm -rf *"
 	python-vendorize
-	bash -c "cd $(vendor_dir); cp $(nocasedict_dist_dir)/LICENSE nocasedict/; rm -rf $(nocasedict_dist_dir)"
-	bash -c "cd $(vendor_dir); cp $(nocaselist_dist_dir)/LICENSE nocaselist/; rm -rf $(nocaselist_dist_dir)"
+	bash -c "cd $(vendor_dir) && cp $(nocasedict_dist_dir)/LICENSE nocasedict/ && rm -rf $(nocasedict_dist_dir)"
+	bash -c "cd $(vendor_dir) && cp $(nocaselist_dist_dir)/LICENSE nocaselist/ && rm -rf $(nocaselist_dist_dir)"
 	@echo "Makefile: Done vendoring nocasedict and nocaselist"
 	echo "done" >$@
 

--- a/changes/noissue.75.fix.rst
+++ b/changes/noissue.75.fix.rst
@@ -1,0 +1,1 @@
+Dev: Fixed error detection when preparing LICENSE files for vendorized packages.


### PR DESCRIPTION
No review needed.