### PR TITLE
1.8: Migrated to using pytest log control for tests

### DIFF
--- a/changes/noissue.79.feature.rst
+++ b/changes/noissue.79.feature.rst
@@ -1,0 +1,2 @@
+Test: Migrated to using pytest log control for tests, as documented in
+docs/development.rst.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -210,6 +210,38 @@ active, as long as the Python `tox` package is installed in it:
     $ tox -e py27                      # Run tests on Python 2.7
 
 
+
+.. _`Logging during tests`:
+
+Logging during tests
+--------------------
+
+Most unit tests perform entry and exit logging for the test functions at the DEBUG
+log level. Some unit tests perform additional logging during the test function,
+typically also at the DEBUG level. The Python logger used for this is named after
+the test module.
+
+Most functions of pywbem perform logging as well, to the pywbem-specific Python
+loggers. See :ref:`Pywbem logging overview` for details.
+
+The tests that are driven by pytest (e.g. ``make test``, ``make end2end``)
+can use pytest file logging to control the log level for all these loggers and
+the destination to a log file.
+
+The defaults for pytest file logging are defined in the file ``pytest.ini``.
+These defaults can be overridden in the command line using pytest options as
+documented in the ``pytest.ini`` file:
+
+.. literalinclude:: ../pytest.ini
+   :language: ini
+
+For example:
+
+.. code-block:: bash
+
+    $ TESTOPTS='--log-file-level=DEBUG --log-file=myfile.log' make test
+
+
 .. _`Testing from the source archives on Pypi or GitHub`:
 
 Testing from the source archives on Pypi or GitHub

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,17 @@
+# Config file for pytest
+
+[pytest]
+
+# Defaults for pytest logging to a log file.
+
+# Override option: --log-file-level
+# Valid symbolic values: DEBUG,INFO,WARNING,ERROR,CRITICAL
+# To disable logging, set to a numeric value larger than 50 (=CRITICAL)
+log_file_level = WARNING
+
+# Override option: --log-file
+log_file = pytest.log
+
+# No need to override these
+log_file_format = %(asctime)s %(thread)s %(levelname)s %(name)s: %(message)s
+log_file_date_format = %Y-%m-%d %H:%M:%S

--- a/tests/unittest/pywbem/test_cim_http.py
+++ b/tests/unittest/pywbem/test_cim_http.py
@@ -8,7 +8,7 @@ import requests
 import urllib3
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -590,6 +590,7 @@ TESTCASES_PARSE_URL = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_PARSE_URL)
 @simplified_test_function
+@log_entry_exit
 def test_parse_url(
         testcase, func_kwargs, exp_scheme, exp_hostport, exp_url):
     """
@@ -856,6 +857,7 @@ TESTCASES_PYWBEM_REQUESTS_EXCEPTION = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_PYWBEM_REQUESTS_EXCEPTION)
 @simplified_test_function
+@log_entry_exit
 def test_pywbem_requests_exception(
         testcase, func_kwargs, exp_exc_type, exp_pattern):
     """
@@ -967,6 +969,7 @@ TESTCASES_MAX_REPR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MAX_REPR)
 @simplified_test_function
+@log_entry_exit
 def test_max_repr(testcase, func_kwargs, exp_repr):
     """
     Test function for _cim_http.max_repr()
@@ -1078,6 +1081,7 @@ TESTCASES_GET_CIMOBJECT_HEADER = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_GET_CIMOBJECT_HEADER)
 @simplified_test_function
+@log_entry_exit
 def test_get_cimobject_header(testcase, obj, exp_result):
     """
     Test function for _cim_http.get_cimobject_header()

--- a/tests/unittest/pywbem/test_cim_obj.py
+++ b/tests/unittest/pywbem/test_cim_obj.py
@@ -14,7 +14,7 @@ import pytest
 from packaging.version import parse as parse_version
 
 from ..utils.validate import validate_cim_xml_obj
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -237,6 +237,7 @@ TESTCASES_DICT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_DICT)
 @simplified_test_function
+@log_entry_exit
 def test_dict(testcase, obj, exp_dict):
     # pylint: disable=unused-argument
     """
@@ -457,6 +458,7 @@ def test_dict(testcase, obj, exp_dict):
          CIMQualifierDeclaration('Bar', 'string')),
     ]
 )
+@log_entry_exit
 def test_object_comparison(objects, func_name):
     """
     Test function for comparison operators of CIM objects.
@@ -1093,6 +1095,7 @@ TESTCASES_CIMINSTANCENAME_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMInstanceName.__init__()
@@ -1174,6 +1177,7 @@ TESTCASES_KEYBINDING_CONFIG = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_KEYBINDING_CONFIG)
 @simplified_test_function
+@log_entry_exit
 def test_keybinding_config_option(
         testcase, init_args, ignore_flag, init_kwargs, exp_attrs):
     """
@@ -1266,6 +1270,7 @@ TESTCASES_CIMINSTANCENAME_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_copy(testcase, obj_kwargs):
     """
     Test function for CIMInstanceName.copy()
@@ -1705,6 +1710,7 @@ TESTCASES_CIMINSTANCENAME_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -1736,6 +1742,7 @@ def test_CIMInstanceName_setattr(
         assert value == exp_value
 
 
+@log_entry_exit
 def test_CIMInstanceName_eq_keybindings_order():
     """
     Test that two CIMInstanceName objects compare equal if their key
@@ -2144,6 +2151,7 @@ TESTCASES_CIMINSTANCENAME_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMInstanceName.__hash__().
@@ -2170,6 +2178,7 @@ def test_CIMInstanceName_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_HASH_EQ + TESTCASES_CIMINSTANCENAME_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMInstanceName.__eq__().
@@ -2242,6 +2251,7 @@ TESTCASES_CIMINSTANCENAME_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMINSTANCENAME_REPR)
+@log_entry_exit
 def test_CIMInstanceName_repr(obj):
     """
     Test function for CIMInstanceName.__repr__() / repr()
@@ -3422,6 +3432,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMInstanceName.tocimxml().
@@ -3443,6 +3454,7 @@ def test_CIMInstanceName_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMInstanceName.tocimxmlstr().
@@ -3465,6 +3477,7 @@ def test_CIMInstanceName_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -3493,6 +3506,7 @@ def test_CIMInstanceName_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -3571,6 +3585,7 @@ TESTCASES_CIMINSTANCENAME_TOCIMXML_SPECIAL_KB = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TOCIMXML_SPECIAL_KB)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_tocimxml_special_kb(
         testcase, obj, kb_name, kb_value, exp_xml_str):
     """
@@ -4494,6 +4509,7 @@ TESTCASES_CIMINSTANCENAME_FROM_WBEM_URI = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_FROM_WBEM_URI)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_from_wbem_uri(testcase, uri, exp_attrs):
     """
     Test function for CIMInstanceName.from_wbem_uri()
@@ -4778,6 +4794,7 @@ TESTCASES_CIMINSTANCENAME_FROM_INSTANCE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_FROM_INSTANCE)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_from_instance(
         testcase, cls_kwargs, inst_kwargs, exp_attrs, namespace, host, strict):
     # pylint: disable=unused-argument
@@ -5564,6 +5581,7 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TO_WBEM_URI)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_to_wbem_uri(testcase, obj, kwargs, exp_uri):
     """
     Test function for CIMInstanceName.to_wbem_uri()
@@ -5628,6 +5646,7 @@ TESTCASES_CIMINSTANCENAME_TO_WBEM_URI_SPECIAL_KB = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_TO_WBEM_URI_SPECIAL_KB)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_to_wbem_uri_special_kb(
         testcase, obj, kb_name, kb_value, exp_uri):
     """
@@ -5708,6 +5727,7 @@ TESTCASES_CIMINSTANCENAME_STR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCENAME_STR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstanceName_str(testcase, obj, exp_uri):
     """
     Test function for CIMInstanceName.__str__()
@@ -6487,6 +6507,7 @@ TESTCASES_CIMINSTANCE_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMInstance.__init__()
@@ -6597,6 +6618,7 @@ TESTCASES_CIMINSTANCE_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_copy(testcase, obj_kwargs):
     """
     Test function for CIMInstance.copy()
@@ -6997,6 +7019,7 @@ TESTCASES_CIMINSTANCE_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -7129,6 +7152,7 @@ TESTCASES_CIMINSTANCE_UPDATE_PROPERTY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_UPDATE_PROPERTY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_update_property(
         testcase, obj_kwargs, prop_name, new_value, exp_attrs):
     """
@@ -7406,6 +7430,7 @@ TESTCASES_CIMINSTANCE_UPDATE_EXISTING = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_UPDATE_EXISTING)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_update_existing(
         testcase, obj_kwargs, func_args, func_kwargs, exp_attrs):
     """
@@ -7918,6 +7943,7 @@ TESTCASES_CIMINSTANCE_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMInstance.__hash__().
@@ -7944,6 +7970,7 @@ def test_CIMInstance_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_HASH_EQ + TESTCASES_CIMINSTANCE_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMInstance.__eq__().
@@ -7996,6 +8023,7 @@ TESTCASES_CIMINSTANCE_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMINSTANCE_STR_REPR)
+@log_entry_exit
 def test_CIMInstance_str(obj):
     """
     Test function for CIMInstance.__str__() / str()
@@ -8016,6 +8044,7 @@ def test_CIMInstance_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMINSTANCE_STR_REPR)
+@log_entry_exit
 def test_CIMInstance_repr(obj):
     """
     Test function for CIMInstance.__repr__() / repr()
@@ -8405,6 +8434,7 @@ TESTCASES_CIMINSTANCE_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMInstance.tocimxml().
@@ -8426,6 +8456,7 @@ def test_CIMInstance_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMInstance.tocimxmlstr().
@@ -8448,6 +8479,7 @@ def test_CIMInstance_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -8476,6 +8508,7 @@ def test_CIMInstance_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -8804,6 +8837,7 @@ instance of C1 {
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMInstance.tomof().
@@ -9211,6 +9245,7 @@ TESTCASES_CIMINSTANCE_FROMCLASS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMINSTANCE_FROMCLASS)
 @simplified_test_function
+@log_entry_exit
 def test_CIMInstance_from_class(testcase, cls_props, inst_prop_vals, kwargs,
                                 exp_props):
     """
@@ -11592,6 +11627,7 @@ TESTCASES_CIMPROPERTY_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMProperty.__init__()
@@ -11859,6 +11895,7 @@ TESTCASES_CIMPROPERTY_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_copy(testcase, obj_kwargs):
     """
     Test function for CIMProperty.copy()
@@ -14168,6 +14205,7 @@ TESTCASES_CIMPROPERTY_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -14762,6 +14800,7 @@ TESTCASES_CIMPROPERTY_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMProperty.__hash__().
@@ -14788,6 +14827,7 @@ def test_CIMProperty_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_HASH_EQ + TESTCASES_CIMPROPERTY_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMProperty.__eq__().
@@ -14864,6 +14904,7 @@ TESTCASES_CIMPROPERTY_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMPROPERTY_STR_REPR)
+@log_entry_exit
 def test_CIMProperty_str(obj):
     """
     Test function for CIMProperty.__str__() / str()
@@ -14896,6 +14937,7 @@ def test_CIMProperty_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMPROPERTY_STR_REPR)
+@log_entry_exit
 def test_CIMProperty_repr(obj):
     """
     Test function for CIMProperty.__repr__() / repr()
@@ -17455,6 +17497,7 @@ TESTCASES_CIMPROPERTY_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMProperty.tocimxml().
@@ -17476,6 +17519,7 @@ def test_CIMProperty_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMProperty.tocimxmlstr().
@@ -17498,6 +17542,7 @@ def test_CIMProperty_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -17526,6 +17571,7 @@ def test_CIMProperty_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -18145,6 +18191,7 @@ TESTCASES_CIMPROPERTY_TOMOF = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPROPERTY_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMProperty_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMProperty.tomof().
@@ -18161,6 +18208,7 @@ def test_CIMProperty_tomof(testcase, obj, kwargs, exp_mof):
     assert mof == exp_mof
 
 
+@log_entry_exit
 def test_CIMProperty_tomof_special1():
     """
     Special test CIMProperty.tomof(): Datetime value with string type
@@ -18181,6 +18229,7 @@ def test_CIMProperty_tomof_special1():
         obj.tomof(is_instance=False)
 
 
+@log_entry_exit
 def test_CIMProperty_tomof_special2():
     """
     Special test CIMProperty.tomof(): Plain float value
@@ -18640,6 +18689,7 @@ TESTCASES_CIMQUALIFIER_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMQualifier.__init__()
@@ -18738,6 +18788,7 @@ TESTCASES_CIMQUALIFIER_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_copy(testcase, obj_kwargs):
     """
     Test function for CIMQualifier.copy()
@@ -19794,6 +19845,7 @@ TESTCASES_CIMQUALIFIER_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -20087,6 +20139,7 @@ TESTCASES_CIMQUALIFIER_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMQualifier.__hash__().
@@ -20113,6 +20166,7 @@ def test_CIMQualifier_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_HASH_EQ + TESTCASES_CIMQUALIFIER_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMQualifier.__eq__().
@@ -20154,6 +20208,7 @@ TESTCASES_CIMQUALIFIER_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMQUALIFIER_STR_REPR)
+@log_entry_exit
 def test_CIMQualifier_str(obj):
     """
     Test function for CIMQualifier.__str__() / str()
@@ -20177,6 +20232,7 @@ def test_CIMQualifier_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMQUALIFIER_STR_REPR)
+@log_entry_exit
 def test_CIMQualifier_repr(obj):
     """
     Test function for CIMQualifier.__repr__() / repr()
@@ -22572,6 +22628,7 @@ TESTCASES_CIMQUALIFIER_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMQualifier.tocimxml().
@@ -22593,6 +22650,7 @@ def test_CIMQualifier_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMQualifier.tocimxmlstr().
@@ -22615,6 +22673,7 @@ def test_CIMQualifier_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -22643,6 +22702,7 @@ def test_CIMQualifier_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -23068,6 +23128,7 @@ TESTCASES_CIMQUALIFIER_TOMOF = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIER_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifier_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMQualifier.tomof().
@@ -23255,6 +23316,7 @@ TESTCASES_CIMCLASSNAME_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMClassName.__init__()
@@ -23334,6 +23396,7 @@ TESTCASES_CIMCLASSNAME_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_copy(testcase, obj_kwargs):
     """
     Test function for CIMClassName.copy()
@@ -23478,6 +23541,7 @@ TESTCASES_CIMCLASSNAME_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -23705,6 +23769,7 @@ TESTCASES_CIMCLASSNAME_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMClassName.__hash__().
@@ -23731,6 +23796,7 @@ def test_CIMClassName_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_HASH_EQ + TESTCASES_CIMCLASSNAME_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMClassName.__eq__().
@@ -23796,6 +23862,7 @@ TESTCASES_CIMCLASSNAME_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMCLASSNAME_REPR)
+@log_entry_exit
 def test_CIMClassName_repr(obj):
     """
     Test function for CIMClassName.__repr__() / repr()
@@ -24067,6 +24134,7 @@ TESTCASES_CIMCLASSNAME_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMClassName.tocimxml().
@@ -24088,6 +24156,7 @@ def test_CIMClassName_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMClassName.tocimxmlstr().
@@ -24110,6 +24179,7 @@ def test_CIMClassName_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -24138,6 +24208,7 @@ def test_CIMClassName_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -24469,6 +24540,7 @@ TESTCASES_CIMCLASSNAME_FROM_WBEM_URI = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_FROM_WBEM_URI)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_from_wbem_uri(testcase, uri, exp_attrs):
     """
     Test function for CIMClassName.from_wbem_uri()
@@ -24785,6 +24857,7 @@ TESTCASES_CIMCLASSNAME_TO_WBEM_URI = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_TO_WBEM_URI)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_to_wbem_uri(testcase, obj, kwargs, exp_uri):
     """
     Test function for CIMClassName.to_wbem_uri()
@@ -24854,6 +24927,7 @@ TESTCASES_CIMCLASSNAME_STR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASSNAME_STR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClassName_str(testcase, obj, exp_uri):
     """
     Test function for CIMClassName.__str__()
@@ -25424,6 +25498,7 @@ TESTCASES_CIMCLASS_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMClass.__init__()
@@ -25596,6 +25671,7 @@ TESTCASES_CIMCLASS_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_copy(testcase, obj_kwargs):
     """
     Test function for CIMClass.copy()
@@ -26173,6 +26249,7 @@ TESTCASES_CIMCLASS_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -26682,6 +26759,7 @@ TESTCASES_CIMCLASS_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMClass.__hash__().
@@ -26708,6 +26786,7 @@ def test_CIMClass_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_HASH_EQ + TESTCASES_CIMCLASS_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMClass.__eq__().
@@ -26760,6 +26839,7 @@ TESTCASES_CIMCLASS_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMCLASS_STR_REPR)
+@log_entry_exit
 def test_CIMClass_str(obj):
     """
     Test function for CIMClass.__str__() / str()
@@ -26777,6 +26857,7 @@ def test_CIMClass_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMCLASS_STR_REPR)
+@log_entry_exit
 def test_CIMClass_repr(obj):
     """
     Test function for CIMClass.__repr__() / repr()
@@ -27004,6 +27085,7 @@ TESTCASES_CIMCLASS_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMClass.tocimxml().
@@ -27025,6 +27107,7 @@ def test_CIMClass_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMClass.tocimxmlstr().
@@ -27047,6 +27130,7 @@ def test_CIMClass_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -27075,6 +27159,7 @@ def test_CIMClass_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -27299,6 +27384,7 @@ class C1 {
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMCLASS_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMClass_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMClass.tomof().
@@ -27807,6 +27893,7 @@ TESTCASES_CIMMETHOD_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMMethod.__init__()
@@ -27911,6 +27998,7 @@ TESTCASES_CIMMETHOD_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_copy(testcase, obj_kwargs):
     """
     Test function for CIMMethod.copy()
@@ -28514,6 +28602,7 @@ TESTCASES_CIMMETHOD_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -28881,6 +28970,7 @@ TESTCASES_CIMMETHOD_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMMethod.__hash__().
@@ -28907,6 +28997,7 @@ def test_CIMMethod_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_HASH_EQ + TESTCASES_CIMMETHOD_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMMethod.__eq__().
@@ -28952,6 +29043,7 @@ TESTCASES_CIMMETHOD_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMMETHOD_STR_REPR)
+@log_entry_exit
 def test_CIMMethod_str(obj):
     """
     Test function for CIMMethod.__str__() / str()
@@ -28972,6 +29064,7 @@ def test_CIMMethod_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMMETHOD_STR_REPR)
+@log_entry_exit
 def test_CIMMethod_repr(obj):
     """
     Test function for CIMMethod.__repr__() / repr()
@@ -29246,6 +29339,7 @@ TESTCASES_CIMMETHOD_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMMethod.tocimxml().
@@ -29267,6 +29361,7 @@ def test_CIMMethod_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMMethod.tocimxmlstr().
@@ -29289,6 +29384,7 @@ def test_CIMMethod_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_tocimxmlstr_indent_int(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMMethod.tocimxmlstr() with indent as integer.
@@ -29316,6 +29412,7 @@ def test_CIMMethod_tocimxmlstr_indent_int(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_tocimxmlstr_indent_str(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMMethod.tocimxmlstr() with indent as string.
@@ -29623,6 +29720,7 @@ TESTCASES_CIMMETHOD_TOMOF = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMMETHOD_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMMethod_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMMethod.tomof().
@@ -30427,6 +30525,7 @@ TESTCASES_CIMPARAMETER_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for CIMParameter.__init__()
@@ -30658,6 +30757,7 @@ TESTCASES_CIMPARAMETER_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_copy(testcase, obj_kwargs):
     """
     Test function for CIMParameter.copy()
@@ -32901,6 +33001,7 @@ TESTCASES_CIMPARAMETER_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -33223,6 +33324,7 @@ TESTCASES_CIMPARAMETER_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMParameter.__hash__().
@@ -33249,6 +33351,7 @@ def test_CIMParameter_hash(testcase, obj1, obj2, exp_equal):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_HASH_EQ + TESTCASES_CIMPARAMETER_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMParameter.__eq__().
@@ -33295,6 +33398,7 @@ TESTCASES_CIMPARAMETER_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMPARAMETER_STR_REPR)
+@log_entry_exit
 def test_CIMParameter_str(obj):
     """
     Test function for CIMParameter.__str__() / str()
@@ -33321,6 +33425,7 @@ def test_CIMParameter_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMPARAMETER_STR_REPR)
+@log_entry_exit
 def test_CIMParameter_repr(obj):
     """
     Test function for CIMParameter.__repr__() / repr()
@@ -36484,6 +36589,7 @@ TESTCASES_CIMPARAMETER_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMParameter.tocimxml().
@@ -36505,6 +36611,7 @@ def test_CIMParameter_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMParameter.tocimxmlstr().
@@ -36527,6 +36634,7 @@ def test_CIMParameter_tocimxmlstr(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -36555,6 +36663,7 @@ def test_CIMParameter_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -36960,6 +37069,7 @@ TESTCASES_CIMPARAMETER_TOMOF = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMPARAMETER_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMParameter_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMParameter.tomof().
@@ -37610,6 +37720,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_init(
         testcase, init_args, init_kwargs, exp_attrs):
     """
@@ -37746,6 +37857,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_COPY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_COPY)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_copy(testcase, obj_kwargs):
     """
     Test function for CIMQualifierDeclaration.copy()
@@ -40035,6 +40147,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_SETATTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_SETATTR)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_setattr(
         testcase, obj_kwargs, item, new_value, exp_attrs):
     """
@@ -40424,6 +40537,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_EQ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_HASH_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_hash(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMQualifierDeclaration.__hash__().
@@ -40451,6 +40565,7 @@ def test_CIMQualifierDeclaration_hash(testcase, obj1, obj2, exp_equal):
     TESTCASES_CIMQUALIFIERDECLARATION_HASH_EQ +
     TESTCASES_CIMQUALIFIERDECLARATION_EQ)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_eq(testcase, obj1, obj2, exp_equal):
     """
     Test function for CIMQualifierDeclaration.__eq__().
@@ -40500,6 +40615,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_STR_REPR = [
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMQUALIFIERDECLARATION_STR_REPR)
+@log_entry_exit
 def test_CIMQualifierDeclaration_str(obj):
     """
     Test function for CIMQualifierDeclaration.__str__() / str()
@@ -40526,6 +40642,7 @@ def test_CIMQualifierDeclaration_str(obj):
 @pytest.mark.parametrize(
     "obj",
     TESTCASES_CIMQUALIFIERDECLARATION_STR_REPR)
+@log_entry_exit
 def test_CIMQualifierDeclaration_repr(obj):
     """
     Test function for CIMQualifierDeclaration.__repr__() / repr()
@@ -43247,6 +43364,7 @@ TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_tocimxml(testcase, obj, kwargs, exp_xml_str):
     """
     Test function for CIMQualifierDeclaration.tocimxml().
@@ -43268,6 +43386,7 @@ def test_CIMQualifierDeclaration_tocimxml(testcase, obj, kwargs, exp_xml_str):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_tocimxmlstr(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -43291,6 +43410,7 @@ def test_CIMQualifierDeclaration_tocimxmlstr(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_tocimxmlstr_indent_int(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -43320,6 +43440,7 @@ def test_CIMQualifierDeclaration_tocimxmlstr_indent_int(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_TOCIMXML)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_tocimxmlstr_indent_str(
         testcase, obj, kwargs, exp_xml_str):
     """
@@ -43795,6 +43916,7 @@ Qualifier Q1 : string,
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMQUALIFIERDECLARATION_TOMOF)
 @simplified_test_function
+@log_entry_exit
 def test_CIMQualifierDeclaration_tomof(testcase, obj, kwargs, exp_mof):
     """
     Test function for CIMQualifierDeclaration.tomof().
@@ -44843,6 +44965,7 @@ TESTCASES_CIMVALUE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMVALUE)
 @simplified_test_function
+@log_entry_exit
 def test_cimvalue(testcase, args, kwargs, exp_obj):
     """
     Test function for cimvalue()
@@ -45907,6 +46030,7 @@ TESTCASES_MOFSTR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MOFSTR)
 @simplified_test_function
+@log_entry_exit
 def test_mofstr(testcase, args, kwargs, exp_result):
     """
     Test function for mofstr()

--- a/tests/unittest/pywbem/test_cim_operations.py
+++ b/tests/unittest/pywbem/test_cim_operations.py
@@ -12,7 +12,7 @@ import pytest
 
 from ...utils import skip_if_moftab_regenerated
 from ..utils.dmtf_mof_schema_def import install_test_dmtf_schema
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 from ..utils.unittest_extensions import assert_copy
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
@@ -284,6 +284,7 @@ class TestCreateConnection:
     @pytest.mark.parametrize(
         'desc, files, init_kwargs, exp_attrs, exp_exc, exp_exc_regex',
         TESTCASES_INIT_WBEMCONNECTION)
+    @log_entry_exit
     def test_init(self, desc, files, init_kwargs, exp_attrs, exp_exc,
                   exp_exc_regex):
         # pylint: disable=no-self-use,unused-argument
@@ -335,6 +336,7 @@ class TestCreateConnection:
             ('last_request_len', 7),
             ('last_reply_len', 7),
         ])
+    @log_entry_exit
     def test_attrs_readonly(self, attr_name, value):
         # pylint: disable=no-self-use
         """
@@ -359,12 +361,14 @@ class TestCreateConnection:
             (dict(default_namespace=DEFAULT_NAMESPACE), DEFAULT_NAMESPACE),
             (dict(default_namespace='blah'), 'blah'),
         ])
+    @log_entry_exit
     def test_init_default_namespace(self, kwargs, exp_default_namespace):
         # pylint: disable=no-self-use
         """Test creation of wbem connection with default_namespace values"""
         conn = WBEMConnection('http://localhost', ('name', 'pw'), **kwargs)
         assert conn.default_namespace == exp_default_namespace
 
+    @log_entry_exit
     def test_namespace_slashes_init(self):  # pylint: disable=no-self-use
         """Test stripping of leading and trailing slashes in default namespace
         of wbem connection when initializing"""
@@ -372,6 +376,7 @@ class TestCreateConnection:
                               default_namespace='//root/blah//')
         assert conn.default_namespace == 'root/blah'
 
+    @log_entry_exit
     def test_namespace_slashes_set(self):  # pylint: disable=no-self-use
         """Test stripping of leading and trailing slashes in default namespace
         of wbem connection when setting the attribute"""
@@ -380,6 +385,7 @@ class TestCreateConnection:
         conn.default_namespace = '//root/blah//'
         assert conn.default_namespace == 'root/blah'
 
+    @log_entry_exit
     def test_add_operation_recorder(self):  # pylint: disable=no-self-use
         """Test addition of an operation recorder"""
         conn = WBEMConnection('http://localhost')
@@ -387,6 +393,7 @@ class TestCreateConnection:
         # pylint: disable=protected-access
         assert len(conn._operation_recorders) == 1
 
+    @log_entry_exit
     def test_add_operation_recorders(self):  # pylint: disable=no-self-use
         """Test addition of multiple operation recorders"""
         conn = WBEMConnection('http://localhost')
@@ -399,6 +406,7 @@ class TestCreateConnection:
         tcr_file.close()
         os.remove(tcr_fn)
 
+    @log_entry_exit
     def test_add_same_twice(self):  # pylint: disable=no-self-use
         """
         Test addition of same recorder twice. This not allowed so
@@ -412,6 +420,7 @@ class TestCreateConnection:
         with pytest.raises(ValueError):
             conn.add_operation_recorder(LogOperationRecorder('fake_conn_id'))
 
+    @log_entry_exit
     def test_stats_enabled(self):  # pylint: disable=no-self-use
         """
         Test the property stats_enabled setter
@@ -423,6 +432,7 @@ class TestCreateConnection:
         conn.stats_enabled = False
         assert conn.stats_enabled is False
 
+    @log_entry_exit
     def test_operation_recorder_enabled(self):  # pylint: disable=no-self-use
         """
         Test the property operation_recorder enabled setter
@@ -435,6 +445,7 @@ class TestCreateConnection:
         conn.operation_recorder_enabled = True
         assert conn.operation_recorder_enabled is True
 
+    @log_entry_exit
     def test_close(self):  # pylint: disable=no-self-use
         """
         Test closing a connection once.
@@ -444,6 +455,7 @@ class TestCreateConnection:
         conn.close()
         assert conn.session is None
 
+    @log_entry_exit
     def test_close_twice(self):  # pylint: disable=no-self-use
         """
         Test closing a connection twice.
@@ -456,6 +468,7 @@ class TestCreateConnection:
             exc = exc_info.value
             assert re.match(r'is closed', str(exc))
 
+    @log_entry_exit
     def test_close_imethod(self):  # pylint: disable=no-self-use
         """
         Test closing a connection and invoking an intrinsic operation.
@@ -468,6 +481,7 @@ class TestCreateConnection:
             exc = exc_info.value
             assert re.match(r'is closed', str(exc))
 
+    @log_entry_exit
     def test_close_method(self):  # pylint: disable=no-self-use
         """
         Test closing a connection and invoking a CIM method.
@@ -480,6 +494,7 @@ class TestCreateConnection:
             exc = exc_info.value
             assert re.match(r'is closed', str(exc))
 
+    @log_entry_exit
     def test_close_export(self):  # pylint: disable=no-self-use
         """
         Test closing a connection and invoking an export operation.
@@ -493,6 +508,7 @@ class TestCreateConnection:
             exc = exc_info.value
             assert re.match(r'is closed', str(exc))
 
+    @log_entry_exit
     def test_context_manager(self):  # pylint: disable=no-self-use
         """
         Test the use of WBEMConnection as a context manager.
@@ -504,6 +520,7 @@ class TestCreateConnection:
         assert conn.session is None
 
 
+@log_entry_exit
 def test_conn_set_timeout():
     """
     Test setting the 'timeout' property of WBEMConnection.
@@ -532,6 +549,7 @@ class TestGetRsltParams:
             [None, 'False', None, ParseError],  # no value in ec and eos False
         ]
     )
+    @log_entry_exit
     def test_with_params(self, irval, ec, eos, eos_exp, exctype_exp):
         # pylint: disable=no-self-use,protected-access
         """
@@ -560,6 +578,7 @@ class TestGetRsltParams:
             ecs = None if eos_exp is True else (ec, 'root/blah')
             assert result == (irval, eos_exp, ecs)
 
+    @log_entry_exit
     def test_missing(self):
         # pylint: disable=no-self-use
         """
@@ -694,6 +713,7 @@ TESTCASES_IS_SUBCLASS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_IS_SUBCLASS)
 @simplified_test_function
+@log_entry_exit
 def test_is_subclass(testcase, init_args, exp_attrs):
     # pylint: disable=unused-argument
     """
@@ -1002,6 +1022,7 @@ TESTCASES_REQUEST_INVALID_PARAMS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REQUEST_INVALID_PARAMS)
 @simplified_test_function
+@log_entry_exit
 def test_request_invalid_params(testcase, init_kwargs, method, args, kwargs):
     """Execute the defined method expecting exception"""
 
@@ -1044,6 +1065,7 @@ def test_request_invalid_params(testcase, init_kwargs, method, args, kwargs):
     assert testcase.exp_exc_types is None
 
 
+@log_entry_exit
 def test_close():
     """
     Test WBEMConnection.close().
@@ -1217,6 +1239,7 @@ TESTCASES_COPY_WBEMCONNECTION = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_COPY_WBEMCONNECTION)
 @simplified_test_function
+@log_entry_exit
 def test_copy_conn(
         testcase, files, init_kwargs, set_debug, add_recorder, enable_recorder,
         enable_statistics, perform_operation):
@@ -1400,6 +1423,7 @@ class TestConnectionError:  # pylint: disable=too-few-public-methods
     @pytest.mark.parametrize(
         'desc, init_kwargs, exp_exc, exp_exc_regex',
         TESTCASES_WBEMCONNECTION_ERROR)
+    @log_entry_exit
     def test_init(self, desc, init_kwargs, exp_exc, exp_exc_regex):
         # pylint: disable=no-self-use,unused-argument
         """

--- a/tests/unittest/pywbem/test_cim_types.py
+++ b/tests/unittest/pywbem/test_cim_types.py
@@ -13,7 +13,7 @@ except ImportError:
     from backports import zoneinfo
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -71,17 +71,20 @@ def char16_init_tuple(request):
     return request.param
 
 
+@log_entry_exit
 def test_char16_class_attrs_class():  # pylint: disable=invalid-name
     """Test class attrs via class level"""
     assert Char16.cimtype == 'char16'
 
 
+@log_entry_exit
 def test_char16_class_attrs_inst():
     """Test class attrs via instance level"""
     obj = Char16('foo')
     assert obj.cimtype == 'char16'
 
 
+@log_entry_exit
 def test_char16_inheritance():
     """Test inheritance"""
     obj = Char16('foo')
@@ -89,6 +92,7 @@ def test_char16_inheritance():
     assert isinstance(obj, CIMType)
 
 
+@log_entry_exit
 def test_char16_init(char16_init_tuple):
     """Test initialization from all input types using
        char16_init_tuple pytest.fixture.
@@ -106,6 +110,7 @@ def test_char16_init(char16_init_tuple):
         assert obj is not in_str
 
 
+@log_entry_exit
 def test_char16_repr(char16_init_tuple):
     """
     Test repr(CIMDateTime) from all input types using
@@ -124,6 +129,7 @@ def test_char16_repr(char16_init_tuple):
     repr(obj)
 
 
+@log_entry_exit
 def test_char16_str(char16_init_tuple):
     """
     Test str(CIMDateTime) from all input types using
@@ -173,6 +179,7 @@ def integer_tuple(request):
     return request.param
 
 
+@log_entry_exit
 def test_integer_class_attrs_class(integer_tuple):
     """Test class attrs via class level"""
     # pylint: disable=redefined-outer-name
@@ -182,6 +189,7 @@ def test_integer_class_attrs_class(integer_tuple):
     assert obj_type.maxvalue == exp_maxvalue
 
 
+@log_entry_exit
 def test_integer_class_attrs_inst(integer_tuple):
     """Test class attrs via instance level"""
     # pylint: disable=redefined-outer-name
@@ -192,6 +200,7 @@ def test_integer_class_attrs_inst(integer_tuple):
     assert obj.maxvalue == exp_maxvalue
 
 
+@log_entry_exit
 def test_integer_inheritance(integer_tuple):
     """Test inheritance"""
     # pylint: disable=redefined-outer-name
@@ -203,6 +212,7 @@ def test_integer_inheritance(integer_tuple):
     assert not isinstance(obj, CIMFloat)
 
 
+@log_entry_exit
 def test_integer_init_int(integer_tuple):
     """Test initialization from integer value"""
     # pylint: disable=redefined-outer-name
@@ -211,6 +221,7 @@ def test_integer_init_int(integer_tuple):
     assert obj == 42
 
 
+@log_entry_exit
 def test_integer_init_str(integer_tuple):
     """Test initialization from string value"""
     # pylint: disable=redefined-outer-name
@@ -219,6 +230,7 @@ def test_integer_init_str(integer_tuple):
     assert obj == 42
 
 
+@log_entry_exit
 def test_integer_init_str_base10(integer_tuple):
     """Test initialization from string value with base 10"""
     # pylint: disable=redefined-outer-name
@@ -227,6 +239,7 @@ def test_integer_init_str_base10(integer_tuple):
     assert obj == 42
 
 
+@log_entry_exit
 def test_integer_init_str_base16(integer_tuple):
     """Test initialization from string value with base 16"""
     # pylint: disable=redefined-outer-name
@@ -235,6 +248,7 @@ def test_integer_init_str_base16(integer_tuple):
     assert obj == 42
 
 
+@log_entry_exit
 def test_integer_init_minimum(integer_tuple):
     """Test initialization from integer value at minimum"""
     # pylint: disable=redefined-outer-name
@@ -244,6 +258,7 @@ def test_integer_init_minimum(integer_tuple):
     assert obj == exp_minvalue
 
 
+@log_entry_exit
 def test_integer_init_maximum(integer_tuple):
     """Test initialization from integer value at maximum"""
     # pylint: disable=redefined-outer-name
@@ -253,6 +268,7 @@ def test_integer_init_maximum(integer_tuple):
     assert obj == exp_maxvalue
 
 
+@log_entry_exit
 def test_integer_init_too_low(integer_tuple):
     """Test initialization from integer value below minimum"""
     # pylint: disable=redefined-outer-name
@@ -266,6 +282,7 @@ def test_integer_init_too_low(integer_tuple):
         raise AssertionError("ValueError was not raised.")
 
 
+@log_entry_exit
 def test_integer_init_too_high(integer_tuple):
     """Test initialization from integer value above maximum"""
     # pylint: disable=redefined-outer-name
@@ -300,6 +317,7 @@ def real_tuple(request):
     return request.param
 
 
+@log_entry_exit
 def test_real_class_attrs_class(real_tuple):
     """Test class attrs via class level using real_tuple fixture"""
     # pylint: disable=redefined-outer-name
@@ -307,6 +325,7 @@ def test_real_class_attrs_class(real_tuple):
     assert obj_type.cimtype == exp_cimtype
 
 
+@log_entry_exit
 def test_real_class_attrs_inst(real_tuple):
     """Test class attrs via instance level using real_tuple fixture"""
     # pylint: disable=redefined-outer-name
@@ -315,6 +334,7 @@ def test_real_class_attrs_inst(real_tuple):
     assert obj.cimtype == exp_cimtype
 
 
+@log_entry_exit
 def test_real_inheritance(real_tuple):
     """Test inheritance  using real_tuple fixture"""
     # pylint: disable=redefined-outer-name
@@ -326,6 +346,7 @@ def test_real_inheritance(real_tuple):
     assert not isinstance(obj, CIMInt)
 
 
+@log_entry_exit
 def test_real_init_float(real_tuple):
     """Test initialization from floating point value"""
     # pylint: disable=redefined-outer-name
@@ -334,6 +355,7 @@ def test_real_init_float(real_tuple):
     assert obj == 42.0
 
 
+@log_entry_exit
 def test_real_init_str(real_tuple):
     """Test initialization from string value using real_tuple fixture"""
     # pylint: disable=redefined-outer-name
@@ -366,6 +388,7 @@ def number_str_repr_tuple(request):
     return request.param
 
 
+@log_entry_exit
 def test_number_str(number_str_repr_tuple):
     # pylint: disable=redefined-outer-name
     """Test __str__() for a number"""
@@ -378,6 +401,7 @@ def test_number_str(number_str_repr_tuple):
     assert act_str == exp_str
 
 
+@log_entry_exit
 def test_number_repr(number_str_repr_tuple):
     # pylint: disable=redefined-outer-name
     """Test __repr__() for a number"""
@@ -824,17 +848,20 @@ def datetime_init_tuple(request):
     return request.param
 
 
+@log_entry_exit
 def test_datetime_class_attrs_class():  # pylint: disable=invalid-name
     """Test class attrs via class level"""
     assert CIMDateTime.cimtype == 'datetime'
 
 
+@log_entry_exit
 def test_datetime_class_attrs_inst():
     """Test class attrs via instance level"""
     obj = CIMDateTime('00000000000000.000000:000')
     assert obj.cimtype == 'datetime'
 
 
+@log_entry_exit
 def test_datetime_inheritance():
     """Test inheritance"""
     obj = CIMDateTime('00000000000000.000000:000')
@@ -844,6 +871,7 @@ def test_datetime_inheritance():
     assert not isinstance(obj, CIMInt)
 
 
+@log_entry_exit
 def test_datetime_init(datetime_init_tuple):
     """Test initialization from all input types using
        datetime_init_tuple pytest.fixture.
@@ -871,6 +899,7 @@ def test_datetime_init(datetime_init_tuple):
         assert str(obj) == exp_str
 
 
+@log_entry_exit
 def test_datetime_repr(datetime_init_tuple):
     """
     Test repr(CIMDateTime) from all input types using
@@ -889,6 +918,7 @@ def test_datetime_repr(datetime_init_tuple):
     repr(obj)
 
 
+@log_entry_exit
 def test_datetime_str(datetime_init_tuple):
     """
     Test str(CIMDateTime) from all input types using
@@ -971,6 +1001,7 @@ TESTCASES_MINUTESFROMUTC_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MINUTESFROMUTC_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_MinutesFromUTC_init(testcase, args, kwargs, exp_offset):
     """
     Test function for MinutesFromUTC.__init__().
@@ -1039,6 +1070,7 @@ TESTCASES_MINUTESFROMUTC_UTCOFFSET = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MINUTESFROMUTC_UTCOFFSET)
 @simplified_test_function
+@log_entry_exit
 def test_MinutesFromUTC_utcoffset(testcase, offset, dt, exp_utc_offset):
     """
     Test function for MinutesFromUTC.utcoffset().
@@ -1105,6 +1137,7 @@ TESTCASES_MINUTESFROMUTC_DST = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MINUTESFROMUTC_DST)
 @simplified_test_function
+@log_entry_exit
 def test_MinutesFromUTC_dst(testcase, offset, dt, exp_dst_offset):
     """
     Test function for MinutesFromUTC.dst().
@@ -1241,6 +1274,7 @@ TESTCASES_MINUTESFROMUTC_TZNAME = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MINUTESFROMUTC_TZNAME)
 @simplified_test_function
+@log_entry_exit
 def test_MinutesFromUTC_tzname(testcase, offset, dt, exp_tzname):
     """
     Test function for MinutesFromUTC.tzname().
@@ -1479,6 +1513,7 @@ TESTCASES_CIMTYPE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIMTYPE)
 @simplified_test_function
+@log_entry_exit
 def test_cimtype(testcase, obj, exp_type_name):
     """
     Test function for cimtype().
@@ -1659,6 +1694,7 @@ TESTCASES_TYPE_FROM_NAME = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_TYPE_FROM_NAME)
 @simplified_test_function
+@log_entry_exit
 def test_type_from_name(testcase, type_name, exp_type_obj):
     """
     Test function for type_from_name().

--- a/tests/unittest/pywbem/test_cim_xml.py
+++ b/tests/unittest/pywbem/test_cim_xml.py
@@ -8,7 +8,7 @@ import pytest
 
 from ..utils.validate import validate_cim_xml, CIMXMLValidationError, \
     assert_xml_equal, DTD_VERSION
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -4237,6 +4237,7 @@ TESTCASES_CIM_XML_NODE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CIM_XML_NODE)
 @simplified_test_function
+@log_entry_exit
 def test_cim_xml_node(testcase, xml_node, exp_xml_str_list, **kwargs):
     # pylint: disable=unused-argument
     """

--- a/tests/unittest/pywbem/test_exceptions.py
+++ b/tests/unittest/pywbem/test_exceptions.py
@@ -6,6 +6,8 @@ Test _exceptions module.
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: disable=redefined-builtin
 from ...utils import import_installed
@@ -206,6 +208,7 @@ def response_data_info(request):
     return request.param
 
 
+@log_entry_exit
 def test_message_init(
         message_exception_info, message_arg, conn_info, request_data_info,
         response_data_info):
@@ -263,6 +266,7 @@ def httperror_args(request):
     return request.param
 
 
+@log_entry_exit
 def test_httperror(
         httperror_args, conn_info, request_data_info, response_data_info):
     # pylint: disable=redefined-outer-name
@@ -369,6 +373,7 @@ def error_instances(request):
     return request.param
 
 
+@log_entry_exit
 def test_cimerror_1(status_tuple, conn_info):
     # pylint: disable=redefined-outer-name
     """
@@ -400,6 +405,7 @@ def test_cimerror_1(status_tuple, conn_info):
     _assert_subscription(exc)
 
 
+@log_entry_exit
 def test_cimerror_2(status_tuple, conn_info):
     # pylint: disable=redefined-outer-name
     """
@@ -430,6 +436,7 @@ def test_cimerror_2(status_tuple, conn_info):
     _assert_subscription(exc)
 
 
+@log_entry_exit
 def test_cimerror_3(status_tuple, error_instances, conn_info):
     # pylint: disable=redefined-outer-name
     """
@@ -485,6 +492,7 @@ def parseerror_args(request):
     return request.param
 
 
+@log_entry_exit
 def test_parseerror(parseerror_class, parseerror_args, conn_info):
     # pylint: disable=redefined-outer-name
     """

--- a/tests/unittest/pywbem/test_itermethods.py
+++ b/tests/unittest/pywbem/test_itermethods.py
@@ -23,6 +23,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
@@ -130,6 +132,7 @@ class TestIterEnumerateInstances:
     @pytest.mark.parametrize(
         "pl", [None, 'pl1', ['pl1', 'pl2']]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_insts, ns,
             cim_classname, result_no_host_ns, di, iq, lo, ico, pl):
@@ -199,6 +202,7 @@ class TestIterEnumerateInstances:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -247,6 +251,7 @@ class TestIterEnumerateInstances:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_insts, ns,
                                     lo, di, iq, ico, pl,
                                     fl, fq, ot, coe, moc):
@@ -313,6 +318,7 @@ class TestIterEnumerateInstances:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_insts, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -360,6 +366,7 @@ class TestIterEnumerateInstances:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_insts, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -430,6 +437,7 @@ class TestIterEnumerateInstances:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -456,6 +464,7 @@ class TestIterEnumerateInstances:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -500,6 +509,7 @@ class TestIterEnumerateInstancePaths:
     @pytest.mark.parametrize(
         "result_no_host_ns", [False, True]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_paths, ns,
             cim_classname, result_no_host_ns):
@@ -559,6 +569,7 @@ class TestIterEnumerateInstancePaths:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -599,6 +610,7 @@ class TestIterEnumerateInstancePaths:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, tst_paths, ns, fl, fq, ot,
                                     coe, moc, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -656,6 +668,7 @@ class TestIterEnumerateInstancePaths:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_paths, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -705,6 +718,7 @@ class TestIterEnumerateInstancePaths:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_paths, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -775,6 +789,7 @@ class TestIterEnumerateInstancePaths:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_paths, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -801,6 +816,7 @@ class TestIterEnumerateInstancePaths:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_paths, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -864,6 +880,7 @@ class TestIterReferenceInstances:
     @pytest.mark.parametrize(
         "pl", [None, 'pl1', ['pl1', 'pl2']]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_insts, ns,
             rc, ro, iq, ico, pl,):
@@ -914,6 +931,7 @@ class TestIterReferenceInstances:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -970,6 +988,7 @@ class TestIterReferenceInstances:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_insts, ns,
                                     rc, ro, iq, ico, pl, fl, fq, ot, coe,
                                     moc):
@@ -1035,6 +1054,7 @@ class TestIterReferenceInstances:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_insts, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1083,6 +1103,7 @@ class TestIterReferenceInstances:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_insts, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -1153,6 +1174,7 @@ class TestIterReferenceInstances:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1179,6 +1201,7 @@ class TestIterReferenceInstances:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1234,6 +1257,7 @@ class TestIterReferenceInstancePaths:
                    ['RRole', None],
                    ['RRole', 'CIM_Blah']]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_insts, ns, rc, ro):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -1277,6 +1301,7 @@ class TestIterReferenceInstancePaths:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1325,6 +1350,7 @@ class TestIterReferenceInstancePaths:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_paths, ns,
                                     rc, ro, fl, fq, ot, coe, moc):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -1384,6 +1410,7 @@ class TestIterReferenceInstancePaths:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_paths, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1432,6 +1459,7 @@ class TestIterReferenceInstancePaths:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_paths, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -1502,6 +1530,7 @@ class TestIterReferenceInstancePaths:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1528,6 +1557,7 @@ class TestIterReferenceInstancePaths:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1591,6 +1621,7 @@ class TestIterAssociatorInstances:
     @pytest.mark.parametrize(
         "pl", [None, 'pl1', ['pl1', 'pl2']]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_insts, ns,
             rc, ro, ac, rr, iq, ico, pl):
@@ -1645,6 +1676,7 @@ class TestIterAssociatorInstances:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1701,6 +1733,7 @@ class TestIterAssociatorInstances:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_insts, ns,
                                     rc, ro, rr, ac, iq, ico, pl, fl, fq, ot,
                                     coe, moc):
@@ -1770,6 +1803,7 @@ class TestIterAssociatorInstances:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_insts, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1818,6 +1852,7 @@ class TestIterAssociatorInstances:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_insts, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -1888,6 +1923,7 @@ class TestIterAssociatorInstances:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1914,6 +1950,7 @@ class TestIterAssociatorInstances:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -1969,6 +2006,7 @@ class TestIterAssociatorInstancePaths:
                            ['RRole', None, 'ARole', None],
                            ['RRole', 'CIM_Blah', 'ARole', 'AssocClass']]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_paths, ns, rc, ro, rr, ac):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2016,6 +2054,7 @@ class TestIterAssociatorInstancePaths:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_paths):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2064,6 +2103,7 @@ class TestIterAssociatorInstancePaths:
         "ot, coe, moc", [[None, None, 100],
                          [10, False, 100]]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_paths, ns,
                                     rc, ro, rr, ac, fl, fq, ot, coe, moc):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2127,6 +2167,7 @@ class TestIterAssociatorInstancePaths:
     @pytest.mark.parametrize(
         "use_pull_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_paths, use_pull_param):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2175,6 +2216,7 @@ class TestIterAssociatorInstancePaths:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_paths, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2245,6 +2287,7 @@ class TestIterAssociatorInstancePaths:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_paths, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2271,6 +2314,7 @@ class TestIterAssociatorInstancePaths:
             [dict(ContinueOnError=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_paths, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2312,6 +2356,7 @@ class TestIterQueryInstances:
     @pytest.mark.parametrize(
         "ql, query", [(None, None), ('CQL', 'SELECT from *')]
     )
+    @log_entry_exit
     def test_trad_operation_success(
             self, use_pull_param, pull_status, tst_insts, ns, ql, query):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2351,6 +2396,7 @@ class TestIterQueryInstances:
     @pytest.mark.parametrize(
         "pull_status", [CIM_ERR_NOT_SUPPORTED, CIM_ERR_FAILED]
     )
+    @log_entry_exit
     def test_operation_fail(self, pull_status, tst_insts):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2395,6 +2441,7 @@ class TestIterQueryInstances:
     @pytest.mark.parametrize(
         "rqrc_param", [None, True]
     )
+    @log_entry_exit
     def test_open_operation_success(self, use_pull_param, tst_insts, ns,
                                     ql, query, ot, coe, moc, rqrc_param,
                                     tst_class):
@@ -2463,6 +2510,7 @@ class TestIterQueryInstances:
     @pytest.mark.parametrize(
         "rqrc_param", [None, True]
     )
+    @log_entry_exit
     def test_pull_operation_success(self, tst_insts, use_pull_param,
                                     rqrc_param):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2538,6 +2586,7 @@ class TestIterQueryInstances:
     @pytest.mark.parametrize(
         "close_after", [0, 1, 2]
     )
+    @log_entry_exit
     def test_closed_operation_success(self, tst_insts, use_pull_param,
                                       max_obj_count, close_after):
         # pylint: disable=no-self-use,redefined-outer-name
@@ -2606,6 +2655,7 @@ class TestIterQueryInstances:
             [dict(MaxObjectCount='bla'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_open_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """
@@ -2634,6 +2684,7 @@ class TestIterQueryInstances:
             [dict(ReturnQueryResultClass=True), ValueError()],
         ]
     )
+    @log_entry_exit
     def test_trad_invalid_params(self, tst_insts, kwargs, exp_exc):
         # pylint: disable=no-self-use,redefined-outer-name
         """

--- a/tests/unittest/pywbem/test_mof_compiler.py
+++ b/tests/unittest/pywbem/test_mof_compiler.py
@@ -14,7 +14,7 @@ from ...utils import skip_if_moftab_regenerated
 from ..utils.unittest_extensions import CIMObjectMixin
 from ..utils.dmtf_mof_schema_def import install_test_dmtf_schema, \
     TOTAL_QUALIFIERS, TOTAL_CLASSES
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -118,6 +118,7 @@ class MOFTest(unittest.TestCase):
 class Test_MOFCompiler_init(unittest.TestCase):
     """Test the MOFCompiler initialization"""
 
+    @log_entry_exit
     def test_handle_repo_connection(self):
         """Test init with a handle that is a MOFWBEMConnection"""
 
@@ -127,6 +128,7 @@ class Test_MOFCompiler_init(unittest.TestCase):
 
         self.assertIs(mofcomp.handle, handle)
 
+    @log_entry_exit
     def test_handle_wbem_connection(self):
         """Test init with a handle that is a WBEMConnection"""
 
@@ -136,6 +138,7 @@ class Test_MOFCompiler_init(unittest.TestCase):
 
         self.assertIsInstance(mofcomp.handle, FakedWBEMConnection)
 
+    @log_entry_exit
     def test_handle_invalid(self):
         """Test init with a handle that is an invalid type"""
 
@@ -150,6 +153,7 @@ class TestInstancesUnicode(MOFTest):
     Test compile of an instance with Unicode characters in string properties
     """
 
+    @log_entry_exit
     def test_instance_unicode_literal(self):
         """
         Test compile of string property with literal Unicode characters
@@ -186,6 +190,7 @@ class TestInstancesUnicode(MOFTest):
 
         self.assertEqual(uprop, exp_uprop)
 
+    @log_entry_exit
     def test_instance_unicode_escape(self):
         """
         Test compile of string property with MOF escaped Unicode characters
@@ -222,6 +227,7 @@ class TestInstancesUnicode(MOFTest):
 
         self.assertEqual(uprop, exp_uprop)
 
+    @log_entry_exit
     def test_instance_unicode_escape_fail1(self):
         """
         Test compile of string property with Unicode escape with no hex chars
@@ -247,6 +253,7 @@ class TestInstancesUnicode(MOFTest):
 class TestFlavors(MOFTest):
     """Test for the various combinations of valid and invalid flavors"""
 
+    @log_entry_exit
     def test_valid_flavors(self):
         """Valid flavor combinations compile"""
 
@@ -267,6 +274,7 @@ class TestFlavors(MOFTest):
             "Flavor(EnableOverride, Restricted, Translatable);\n"
         self.mofcomp.compile_string(mof_str, NAME_SPACE)
 
+    @log_entry_exit
     def test_valid_flavor2(self):
         """Test for case independence of flavor keywords"""
 
@@ -280,6 +288,7 @@ class TestFlavors(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_conflicting_flavors1(self):
         """Conflicting flavors should cause exception"""
 
@@ -293,6 +302,7 @@ class TestFlavors(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_conflicting_flavors2(self):
         """Conflicting flavors should cause exception"""
 
@@ -306,6 +316,7 @@ class TestFlavors(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_invalid_flavor1(self):
         """Invalid flavor should cause exception"""
 
@@ -319,6 +330,7 @@ class TestFlavors(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_invalid_flavor2(self):
         """Invalid flavor should cause exception"""
 
@@ -336,6 +348,7 @@ class TestFlavors(MOFTest):
 class TestRemove(MOFTest):
     """Test rollback using test.mof"""
 
+    @log_entry_exit
     def test_remove(self):
         """
         Test create mof and rollback using mocker as remote repository
@@ -397,6 +410,7 @@ class TestRemove(MOFTest):
 class TestAliases(MOFTest):
     """Test of a mof file that contains aliases"""
 
+    @log_entry_exit
     def test_testmof(self):
         """
         Execute test using test.mof file. This compiles the test.mof file
@@ -466,6 +480,7 @@ class TestAliases(MOFTest):
                      inst['Collection'] == collection_path]
         self.assertEqual(len(my_member), 1)
 
+    @log_entry_exit
     def test_ref_alias(self):
         """
         Test for aliases for association classes with reference properties
@@ -551,6 +566,7 @@ class TestAliases(MOFTest):
 class TestSchemaError(MOFTest):
     """Test with errors in the schema"""
 
+    @log_entry_exit
     def test_all(self):
         """Test multiple errors. Each test tries to compile a
            specific mof and should result in a specific error
@@ -608,6 +624,7 @@ class TestSchemaSearch(MOFTest):
        by search attribute. Searches the TEST_DMTF_CIMSCHEMA_MOF_DIR
     """
 
+    @log_entry_exit
     def test_compile_one(self):
         """Test against schema single mof file that is dependent
            on other files in the schema directory
@@ -633,6 +650,7 @@ class TestSchemaSearch(MOFTest):
                              LocalOnly=False, IncludeQualifiers=True)
         self.assertEqual(cele.properties['RequestedState'].type, 'uint16')
 
+    @log_entry_exit
     def test_search_single_string(self):
         """
         Test search_paths with single string as path definition.  Compiles
@@ -661,6 +679,7 @@ class TestSchemaSearch(MOFTest):
         repo.GetClass('CIM_ComputerSystem', namespace=NAME_SPACE,
                       LocalOnly=False, IncludeQualifiers=True)
 
+    @log_entry_exit
     def test_search_None(self):
         """
         Test search_paths with single string as path definition.  Compiles
@@ -696,6 +715,7 @@ class TestParseError(MOFTest):
        a defined error.
     """
 
+    @log_entry_exit
     def test_error01(self):
         """Test missing statement end comment"""
 
@@ -715,6 +735,7 @@ class TestParseError(MOFTest):
             self.assertEqual(pe.context[5][1:5], '^^^^')
             self.assertEqual(pe.context[4][1:5], 'size')
 
+    @log_entry_exit
     def test_error02(self):
         """Test invalid instance def TODO what is error? ks 6/16"""
 
@@ -733,6 +754,7 @@ class TestParseError(MOFTest):
             self.assertEqual(pe.context[5][7:13], '^^^^^^')
             self.assertEqual(pe.context[4][7:13], 'weight')
 
+    @log_entry_exit
     def test_error03(self):
         """Test invalid mof, extra } character"""
 
@@ -751,6 +773,7 @@ class TestParseError(MOFTest):
             self.assertEqual(pe.context[5][53], '^')
             self.assertEqual(pe.context[4][53], '}')
 
+    @log_entry_exit
     def test_error04(self):
         """Test invalid mof, Pragmas with invalid file definitions."""
 
@@ -767,6 +790,7 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.msg, 'Unexpected end of MOF')
 
+    @log_entry_exit
     def test_invalid_scope(self):
         """
         Test for qualifier declaration scope with invalid keyword
@@ -785,6 +809,7 @@ class TestParseError(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_invalid_scope2(self):
         """
         Test for qualifier declaration scope with invalid keyword "qualifier".
@@ -805,6 +830,7 @@ class TestParseError(MOFTest):
         except MOFParseError:
             pass
 
+    @log_entry_exit
     def test_missing_alias(self):
         """
         Test for alias not defined
@@ -853,6 +879,7 @@ class TestParseError(MOFTest):
                 r".* not previously defined",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_missing_superclass(self):
         """
         Test for missing superclass
@@ -872,6 +899,7 @@ class TestParseError(MOFTest):
                 r"Cannot compile class .* superclass",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_dup_instance(self):
         """Test Current behavior where dup instance gets put into repo"""
         mof_str = """
@@ -901,6 +929,7 @@ class TestParseError(MOFTest):
 
         self.mofcomp.compile_string(mof_str, NAME_SPACE)
 
+    @log_entry_exit
     def test_instance_wo_class(self):
         """Test Current behavior for instance without class"""
         mof_str = """
@@ -922,6 +951,7 @@ class TestParseError(MOFTest):
                 r"Cannot compile instance .* class .* not exist",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_dup_qualifiers(self):
         """Test Current behavior where set qualifierbehavior overrides."""
         mof_str = """
@@ -937,6 +967,7 @@ class TestParseError(MOFTest):
 
         self.mofcomp.compile_string(mof_str, NAME_SPACE)
 
+    @log_entry_exit
     def test_missing_namespace_pragma_value_name(self):
         """Test Current behavior where #pragma namespace contains no
            namespace name."""
@@ -954,6 +985,7 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.msg, 'MOF grammar error')
 
+    @log_entry_exit
     def test_missing_namespace_pragma_value(self):
         """Test Current behavior where spragma namespace contains no
            namespace."""
@@ -971,6 +1003,7 @@ class TestParseError(MOFTest):
         except MOFParseError as pe:
             self.assertEqual(pe.msg, 'MOF grammar error')
 
+    @log_entry_exit
     def test_invalid_namespace_pragma_ns(self):
         """Test Current behavior where spragma namespace contains no
            namespace."""
@@ -994,6 +1027,7 @@ class TestPropertyAlternatives(MOFTest):
         Test compile of a class with individual property alternatives
     """
 
+    @log_entry_exit
     def test_array_type(self):
         """ Test compile of class with array property"""
 
@@ -1010,6 +1044,7 @@ class TestPropertyAlternatives(MOFTest):
         self.assertEqual(cl.properties['arrayprop'].is_array, True)
         self.assertEqual(cl.properties['arrayprop'].array_size, None)
 
+    @log_entry_exit
     def test_array_type_w_size(self):
         """ Test compile of class with array property with size"""
 
@@ -1033,6 +1068,7 @@ class TestPropertyAlternatives(MOFTest):
 class TestRefs(MOFTest):
     """Test for valid References in mof"""
 
+    @log_entry_exit
     def test_all(self):
         """Execute test"""
 
@@ -1047,6 +1083,7 @@ class TestRefs(MOFTest):
 class TestInstCompile(CIMObjectMixin, MOFTest):
     """ Test the compile of instances defined with a class"""
 
+    @log_entry_exit
     def test_good_compile(self):
         """Execute test with file containing class and two instances."""
 
@@ -1152,6 +1189,7 @@ class TestInstCompile(CIMObjectMixin, MOFTest):
                 self.fail("Cannot find required instance k1=%s, k2=%s" %
                           (i['k1'], i['k2']))
 
+    @log_entry_exit
     def test_invalid_property(self):
         """Test compile of instance with undeclared property fails"""
 
@@ -1181,6 +1219,7 @@ class TestInstCompile(CIMObjectMixin, MOFTest):
                 r"Cannot compile instance .* property .* not declared",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_dup_property(self):
         """Test compile of instance with duplicated property fails"""
 
@@ -1210,6 +1249,7 @@ class TestInstCompile(CIMObjectMixin, MOFTest):
                 r"Cannot compile instance .* property .* more than once",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_mismatch_property(self):
         """Test compile of instance with duplicated property fails"""
 
@@ -1245,6 +1285,7 @@ class TestInstCompile(CIMObjectMixin, MOFTest):
 class TestTypes(CIMObjectMixin, MOFTest):
     """Test for all CIM data types in a class mof"""
 
+    @log_entry_exit
     def test_all(self):
         """Execute test"""
 
@@ -1359,6 +1400,7 @@ def _build_scope(set_true=None):
 class TestToInstanceFlavor(CIMObjectMixin, MOFTest):
     """ Test variations on use of ToInstance Flavor"""
 
+    @log_entry_exit
     def test_no_toinstance_flavor(self):
         """ Test that this is not attached to tosubclass flavor by
             compiler in qualifier decl or in class creation from that
@@ -1394,6 +1436,7 @@ class TestToInstanceFlavor(CIMObjectMixin, MOFTest):
                                                           tosubclass=True)})
         self.assertEqual(cl, cmp_cl)
 
+    @log_entry_exit
     def test_no_toinstance_flavor2(self):
         """ Test that this is not attached to tosubclass flavor by
             compiler in qualifier decl or in class creation from that
@@ -1450,6 +1493,7 @@ class BaseTestLexer(unittest.TestCase):
         self.lexer = self.mofcomp.lexer
         self.last_error_t = None  # saves 't' arg of t_error()
 
+        @log_entry_exit
         def test_t_error(t):  # pylint: disable=invalid-name
             """Our replacement for t_error() when testing."""
             self.last_error_t = t
@@ -1560,11 +1604,13 @@ class BaseTestLexer(unittest.TestCase):
 class TestLexerSimple(BaseTestLexer):
     """Simple testcases for the lexical analyzer."""
 
+    @log_entry_exit
     def test_empty(self):
         """Test an empty input."""
         skip_if_moftab_regenerated()
         self.run_assert_lexer("", [])
 
+    @log_entry_exit
     def test_simple(self):
         """Test a simple list of tokens."""
         skip_if_moftab_regenerated()
@@ -1575,6 +1621,7 @@ class TestLexerSimple(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_no_ws_delimiter(self):
         """Test that no whitespace is needed to delimit tokens."""
         skip_if_moftab_regenerated()
@@ -1585,6 +1632,7 @@ class TestLexerSimple(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_ignore_space(self):
         """Test that space is ignored, but triggers new token."""
         skip_if_moftab_regenerated()
@@ -1595,6 +1643,7 @@ class TestLexerSimple(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_ignore_cr(self):
         """Test that CR is ignored, but triggers new token."""
         skip_if_moftab_regenerated()
@@ -1605,6 +1654,7 @@ class TestLexerSimple(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_ignore_tab(self):
         """Test that TAB is ignored, but triggers new token."""
         skip_if_moftab_regenerated()
@@ -1615,6 +1665,7 @@ class TestLexerSimple(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_invalid_token(self):
         """Test that an invalid token is recognized as error."""
         skip_if_moftab_regenerated()
@@ -1633,6 +1684,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Decimal numbers
 
+    @log_entry_exit
     def test_decimal_0(self):
         """Test a decimal number 0."""
         skip_if_moftab_regenerated()
@@ -1643,6 +1695,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_plus_0(self):
         """Test a decimal number +0."""
         skip_if_moftab_regenerated()
@@ -1653,6 +1706,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_minus_0(self):
         """Test a decimal number -0."""
         skip_if_moftab_regenerated()
@@ -1663,6 +1717,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_small(self):
         """Test a small decimal number."""
         skip_if_moftab_regenerated()
@@ -1673,6 +1728,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_small_plus(self):
         """Test a small decimal number with +."""
         skip_if_moftab_regenerated()
@@ -1683,6 +1739,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_small_minus(self):
         """Test a small decimal number with -."""
         skip_if_moftab_regenerated()
@@ -1693,6 +1750,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_decimal_long(self):
         """Test a decimal number that is long."""
         skip_if_moftab_regenerated()
@@ -1705,6 +1763,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Binary numbers
 
+    @log_entry_exit
     def test_binary_0b(self):
         """Test a binary number 0b."""
         skip_if_moftab_regenerated()
@@ -1715,6 +1774,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_0B(self):
         # pylint: disable=invalid-name
         """Test a binary number 0B (upper case B)."""
@@ -1726,6 +1786,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_small(self):
         """Test a small binary number."""
         skip_if_moftab_regenerated()
@@ -1736,6 +1797,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_small_plus(self):
         """Test a small binary number with +."""
         skip_if_moftab_regenerated()
@@ -1746,6 +1808,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_small_minus(self):
         """Test a small binary number with -."""
         skip_if_moftab_regenerated()
@@ -1756,6 +1819,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_long(self):
         """Test a binary number that is long."""
         skip_if_moftab_regenerated()
@@ -1766,6 +1830,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_leadingzero(self):
         """Test a binary number with a leading zero."""
         skip_if_moftab_regenerated()
@@ -1776,6 +1841,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_binary_leadingzeros(self):
         """Test a binary number with two leading zeros."""
         skip_if_moftab_regenerated()
@@ -1788,6 +1854,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Octal numbers
 
+    @log_entry_exit
     def test_octal_00(self):
         """Test octal number 00."""
         skip_if_moftab_regenerated()
@@ -1798,6 +1865,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_01(self):
         """Test octal number 01."""
         skip_if_moftab_regenerated()
@@ -1808,6 +1876,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_small(self):
         """Test a small octal number."""
         skip_if_moftab_regenerated()
@@ -1818,6 +1887,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_small_plus(self):
         """Test a small octal number with +."""
         skip_if_moftab_regenerated()
@@ -1828,6 +1898,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_small_minus(self):
         """Test a small octal number with -."""
         skip_if_moftab_regenerated()
@@ -1838,6 +1909,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_long(self):
         """Test an octal number that is long."""
         skip_if_moftab_regenerated()
@@ -1848,6 +1920,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_octal_leadingzeros(self):
         """Test an octal number with two leading zeros."""
         skip_if_moftab_regenerated()
@@ -1860,6 +1933,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Hex numbers
 
+    @log_entry_exit
     def test_hex_0x0(self):
         """Test hex number 0x0."""
         skip_if_moftab_regenerated()
@@ -1870,6 +1944,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_0X0(self):
         # pylint: disable=invalid-name
         """Test hex number 0X0."""
@@ -1881,6 +1956,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_0x1(self):
         """Test hex number 0x1."""
         skip_if_moftab_regenerated()
@@ -1891,6 +1967,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_0x01(self):
         """Test hex number 0x01."""
         skip_if_moftab_regenerated()
@@ -1901,6 +1978,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_small(self):
         """Test a small hex number."""
         skip_if_moftab_regenerated()
@@ -1911,6 +1989,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_small_plus(self):
         """Test a small hex number with +."""
         skip_if_moftab_regenerated()
@@ -1921,6 +2000,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_small_minus(self):
         """Test a small hex number with -."""
         skip_if_moftab_regenerated()
@@ -1931,6 +2011,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_long(self):
         """Test a hex number that is long."""
         skip_if_moftab_regenerated()
@@ -1941,6 +2022,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_hex_leadingzeros(self):
         """Test a hex number with two leading zeros."""
         skip_if_moftab_regenerated()
@@ -1953,6 +2035,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Floating point numbers
 
+    @log_entry_exit
     def test_float_dot0(self):
         """Test a float number '.0'."""
         skip_if_moftab_regenerated()
@@ -1963,6 +2046,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_0dot0(self):
         """Test a float number '0.0'."""
         skip_if_moftab_regenerated()
@@ -1973,6 +2057,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_plus_0dot0(self):
         """Test a float number '+0.0'."""
         skip_if_moftab_regenerated()
@@ -1983,6 +2068,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_minus_0dot0(self):
         """Test a float number '-0.0'."""
         skip_if_moftab_regenerated()
@@ -1993,6 +2079,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_small(self):
         """Test a small float number."""
         skip_if_moftab_regenerated()
@@ -2003,6 +2090,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_small_plus(self):
         """Test a small float number with +."""
         skip_if_moftab_regenerated()
@@ -2013,6 +2101,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_small_minus(self):
         """Test a small float number with -."""
         skip_if_moftab_regenerated()
@@ -2023,6 +2112,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_float_long(self):
         """Test a float number that is long."""
         skip_if_moftab_regenerated()
@@ -2035,6 +2125,7 @@ class TestLexerNumber(BaseTestLexer):
 
     # Errors
 
+    @log_entry_exit
     def test_error_09(self):
         """Test '09' (decimal: no leading zeros; octal: digit out of range)."""
         skip_if_moftab_regenerated()
@@ -2045,6 +2136,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_error_008(self):
         """Test '008' (decimal: no leading zeros; octal: digit out of range)."""
         skip_if_moftab_regenerated()
@@ -2055,6 +2147,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_error_2b(self):
         """Test '2b' (decimal: b means binary; binary: digit out of range)."""
         skip_if_moftab_regenerated()
@@ -2065,6 +2158,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_error_9b(self):
         """Test '9b' (decimal: b means binary; binary: digit out of range)."""
         skip_if_moftab_regenerated()
@@ -2075,6 +2169,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_error_02B(self):
         # pylint: disable=invalid-name
         """Test '02B' (decimal: B means binary; binary: digit out of range;
@@ -2087,6 +2182,7 @@ class TestLexerNumber(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_error_0dot(self):
         """Test '0.' (not a valid float, is parsed as a decimal '0' followed by
         an illegal character '.' which is skipped in t_error()."""
@@ -2103,6 +2199,7 @@ class TestLexerNumber(BaseTestLexer):
 class TestLexerString(BaseTestLexer):
     """Lexer testcases for CIM datatype string."""
 
+    @log_entry_exit
     def test_string_empty(self):
         """Test an empty string."""
         skip_if_moftab_regenerated()
@@ -2112,6 +2209,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_onechar(self):
         """Test a string with one character."""
         skip_if_moftab_regenerated()
@@ -2121,6 +2219,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_long(self):
         """Test a long string with ASCII chars (no backslash or quotes)."""
         skip_if_moftab_regenerated()
@@ -2130,6 +2229,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_one_sq(self):
         """Test a string with a single quote."""
         skip_if_moftab_regenerated()
@@ -2139,6 +2239,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_two_sq(self):
         """Test a string with two single quotes."""
         skip_if_moftab_regenerated()
@@ -2148,6 +2249,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_two_sq_char(self):
         """Test a string with two single quotes and a char."""
         skip_if_moftab_regenerated()
@@ -2157,6 +2259,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_one_dq(self):
         """Test a string with an escaped double quote."""
         skip_if_moftab_regenerated()
@@ -2166,6 +2269,7 @@ class TestLexerString(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_string_two_dq_char(self):
         """Test a string with two escaped double quotes and a char."""
         skip_if_moftab_regenerated()
@@ -2179,6 +2283,7 @@ class TestLexerString(BaseTestLexer):
 class TestLexerChar(BaseTestLexer):
     """Lexer testcases for CIM datatype char16."""
 
+    @log_entry_exit
     def test_char_char(self):
         """Test a char16 with one character."""
         skip_if_moftab_regenerated()
@@ -2188,6 +2293,7 @@ class TestLexerChar(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_char_space(self):
         """Test a char16 with one space."""
         skip_if_moftab_regenerated()
@@ -2197,6 +2303,7 @@ class TestLexerChar(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_char_dquote(self):
         """Test a char16 with a double quote."""
         skip_if_moftab_regenerated()
@@ -2206,6 +2313,7 @@ class TestLexerChar(BaseTestLexer):
         ]
         self.run_assert_lexer(input_data, exp_tokens)
 
+    @log_entry_exit
     def test_char_esquote(self):
         """Test a char16 with an escaped single quote."""
         skip_if_moftab_regenerated()
@@ -2222,6 +2330,7 @@ class TestFullSchema(MOFTest):
         mof file. Tests have numbers to control ordering.
     """
 
+    @log_entry_exit
     def test_mof_schema_roundtrip(self):
         """ Test compile, of the schema, write of a new mof output file
             and recompile of that file
@@ -2327,6 +2436,7 @@ class TestPartialSchema(MOFTest):
         return ('CIM_ManagedElement', 'CIM_WBEMService', 'CIM_Service',
                 'CIM_RegisteredSpecification')
 
+    @log_entry_exit
     def test_build_from_partial_schema(self):
         """
         Build the schema qualifier and class objects in the repository.
@@ -2365,6 +2475,7 @@ class TestPartialSchema(MOFTest):
         for cln in self.expected_dependent_classes():
             self.assertTrue(cln in clsrepo)
 
+    @log_entry_exit
     def test_build_from_schema_string(self):
         """
         Build the schema qualifier and class objects in the repository from
@@ -2393,6 +2504,7 @@ class TestPartialSchema(MOFTest):
         for cln in self.expected_dependent_classes():
             self.assertTrue(cln in clsrepo)
 
+    @log_entry_exit
     def test_compile_class_withref(self):
         """
         Test compile a single class with reference properties that are not
@@ -2416,6 +2528,7 @@ class TestPartialSchema(MOFTest):
         for cln in exp_classes:
             self.assertTrue(cln in clsrepo)
 
+    @log_entry_exit
     def test_compile_classmethod_ref(self):
         """
         Test compile a single class with reference properties that are not
@@ -2444,6 +2557,7 @@ class TestPartialSchema(MOFTest):
         for cln in exp_classes:
             self.assertTrue(cln in clsrepo)
 
+    @log_entry_exit
     def test_compile_class_ref_err(self):
         """
         Test compile a single class with reference properties where the
@@ -2470,6 +2584,7 @@ class TestPartialSchema(MOFTest):
                 r"Cannot compile class .* dependent class .* not exist",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_compile_class_embinst(self):
         """
         Test compile a single class with property and method param containing
@@ -2504,6 +2619,7 @@ class TestPartialSchema(MOFTest):
         for cln in exp_classes:
             self.assertTrue(cln in clsrepo)
 
+    @log_entry_exit
     def test_compile_class_embinst_err(self):
         """
         Test finding class for EmbeddedInstance qualifier where
@@ -2533,6 +2649,7 @@ class TestPartialSchema(MOFTest):
                 r"Cannot compile class .* dependent class .* not exist",
                 pe.msg, re.IGNORECASE)
 
+    @log_entry_exit
     def test_compile_class_circular(self):
         """
         Test compile a class that itself contains a circular reference, in this
@@ -2585,6 +2702,7 @@ class TestFileErrors(MOFTest):
             verbose=False,
             log_func=moflog)
 
+    @log_entry_exit
     def test_file_not_found(self):
         """
             Test for case where compile file does not exist.
@@ -2596,6 +2714,7 @@ class TestFileErrors(MOFTest):
         except OSError:
             pass
 
+    @log_entry_exit
     def test_filedir_not_found(self):
         """
             Test for filename with dir component not found.
@@ -2606,6 +2725,7 @@ class TestFileErrors(MOFTest):
         except OSError:
             pass
 
+    @log_entry_exit
     def test_error_search(self):
         """
             Test for file not found in search path where search path is
@@ -2747,6 +2867,7 @@ class Test_CreateInstanceWithDups(unittest.TestCase):
             if os.path.exists(self.partial_schema_file):
                 os.remove(self.partial_schema_file)
 
+    @log_entry_exit
     def test_nopath(self):
         """
         Test no alias on instance. Result should include path in the repo
@@ -2781,6 +2902,7 @@ class Test_CreateInstanceWithDups(unittest.TestCase):
 class TestNamespacePragma(MOFTest):
     """Test use of the namespace pragma"""
 
+    @log_entry_exit
     def test_single_namespace(self):
         """
         Test that uses namespace pragma. NOTE: This only tests the use
@@ -2824,6 +2946,7 @@ class TestNamespacePragma(MOFTest):
 
         self.assertEqual(len(repo.instances[NAME_SPACE]), 2)
 
+    @log_entry_exit
     def test_invalid_namespace(self):
         """
         Test that uses namespace pragma. NOTE: This only tests the use
@@ -3174,6 +3297,7 @@ TESTCASES_EMBEDDED_OBJECT_PROP_COMPILE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_EMBEDDED_OBJECT_PROP_COMPILE)
 @simplified_test_function
+@log_entry_exit
 def test_embedded_object_property_compile(testcase, iid, pname, pstr, exp_dict):
     # pylint: disable=unused-argument
     """
@@ -3310,6 +3434,7 @@ TESTCASES_ABSTRACT_MOF_INSTANCE_COMPILE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_ABSTRACT_MOF_INSTANCE_COMPILE)
 @simplified_test_function
+@log_entry_exit
 def test_abstract_mof_instance_compile(testcase, instmof, result_inst):
     # pylint: disable=unused-argument
     """

--- a/tests/unittest/pywbem/test_nocasedict.py
+++ b/tests/unittest/pywbem/test_nocasedict.py
@@ -4,7 +4,7 @@ Test the _nocasedict module.
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -68,6 +68,7 @@ TESTCASES_NOCASEDICT_UNNAMEDKEYS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_NOCASEDICT_UNNAMEDKEYS)
 @simplified_test_function
+@log_entry_exit
 def test_NocaseDict_unnamedkeys_getitem(testcase, allow, key):
     """
     Test function for NocaseDict.__getitem__() for unnamed keys
@@ -92,6 +93,7 @@ def test_NocaseDict_unnamedkeys_getitem(testcase, allow, key):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_NOCASEDICT_UNNAMEDKEYS)
 @simplified_test_function
+@log_entry_exit
 def test_NocaseDict_unnamedkeys_setitem(testcase, allow, key):
     """
     Test function for NocaseDict.__setitem__() for unnamed keys
@@ -114,6 +116,7 @@ def test_NocaseDict_unnamedkeys_setitem(testcase, allow, key):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_NOCASEDICT_UNNAMEDKEYS)
 @simplified_test_function
+@log_entry_exit
 def test_NocaseDict_unnamedkeys_delitem(testcase, allow, key):
     """
     Test function for NocaseDict.__delitem__() for unnamed keys
@@ -140,6 +143,7 @@ def test_NocaseDict_unnamedkeys_delitem(testcase, allow, key):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_NOCASEDICT_UNNAMEDKEYS)
 @simplified_test_function
+@log_entry_exit
 def test_NocaseDict_unnamedkeys_contains(testcase, allow, key):
     """
     Test function for NocaseDict.__contains__() for unnamed keys
@@ -164,6 +168,7 @@ def test_NocaseDict_unnamedkeys_contains(testcase, allow, key):
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_NOCASEDICT_UNNAMEDKEYS)
 @simplified_test_function
+@log_entry_exit
 def test_NocaseDict_unnamedkeys_pop(testcase, allow, key):
     """
     Test function for NocaseDict.pop() for unnamed keys

--- a/tests/unittest/pywbem/test_perf_equality.py
+++ b/tests/unittest/pywbem/test_perf_equality.py
@@ -9,6 +9,8 @@ from time import process_time, get_clock_info
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from tests.utils import import_installed
 pywbem = import_installed('pywbem')
@@ -83,6 +85,7 @@ TESTCASES_PERF_EQ = [
 @pytest.mark.parametrize(
     "desc, obj1, obj2",
     TESTCASES_PERF_EQ)
+@log_entry_exit
 def test_perf_eq(desc, obj1, obj2):
     """
     Measure performance of equality tests.

--- a/tests/unittest/pywbem/test_statistics.py
+++ b/tests/unittest/pywbem/test_statistics.py
@@ -9,7 +9,7 @@ import time
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -107,6 +107,7 @@ TESTCASES_STATISTICS_INIT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_STATISTICS_INIT)
 @simplified_test_function
+@log_entry_exit
 def test_Statistics_init(testcase, init_args, init_kwargs, exp_attrs):
     """
     Test function for Statistics.__init__()
@@ -124,6 +125,7 @@ def test_Statistics_init(testcase, init_args, init_kwargs, exp_attrs):
     assert isinstance(statistics.enabled, type(exp_enabled))
 
 
+@log_entry_exit
 def test_Statistics_enable(statistics_enable):
     # pylint: disable=redefined-outer-name
     """
@@ -138,6 +140,7 @@ def test_Statistics_enable(statistics_enable):
     assert statistics.enabled is True
 
 
+@log_entry_exit
 def test_Statistics_disable(statistics_enable):
     # pylint: disable=redefined-outer-name
     """
@@ -211,6 +214,7 @@ TESTCASES_STATISTICS_GET_OP_STATISTIC = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_STATISTICS_GET_OP_STATISTIC)
 @simplified_test_function
+@log_entry_exit
 def test_Statistics_get_op_statistic(
         testcase, init_enable, method_name, exp_snapshot_len,
         exp_op_stats_attrs):
@@ -234,6 +238,7 @@ def test_Statistics_get_op_statistic(
             f"Unexpected op_stats attribute '{attr_name}'"
 
 
+@log_entry_exit
 def test_Statistics_measure_enabled():
     """
     Test measuring time with enabled statistics.
@@ -267,6 +272,7 @@ def test_Statistics_measure_enabled():
     assert stats.max_time == 0
 
 
+@log_entry_exit
 def test_Statistics_measure_disabled_cm():
     """
     Test measuring time with disabled statistics, via context manager.
@@ -283,6 +289,7 @@ def test_Statistics_measure_disabled_cm():
     assert len(stats_list) == 0
 
 
+@log_entry_exit
 def test_Statistics_measure_enabled_cm():
     """
     Test measuring time with enabled statistics, via context manager.
@@ -304,6 +311,7 @@ def test_Statistics_measure_enabled_cm():
     assert stats.count == 1
 
 
+@log_entry_exit
 def test_Statistics_measure_enabled_nested_cm():
     """
     Test measuring time with enabled statistics, via nested context managers.
@@ -332,6 +340,7 @@ def test_Statistics_measure_enabled_nested_cm():
     assert stats.count == inner_count
 
 
+@log_entry_exit
 def test_Statistics_measure_enabled_with_servertime():
     # pylint: disable=invalid-name
     """
@@ -369,6 +378,7 @@ def test_Statistics_measure_enabled_with_servertime():
     assert stats.max_time == 0
 
 
+@log_entry_exit
 def test_Statistics_measure_disabled():
     """
     Test measuring time with disabled statistics.
@@ -392,6 +402,7 @@ def test_Statistics_measure_disabled():
         assert stats.max_time == 0
 
 
+@log_entry_exit
 def test_Statistics_measure_avg():
     """
     Test measuring time with enabled statistics.
@@ -423,6 +434,7 @@ def test_Statistics_measure_avg():
         assert stats.avg_reply_len == 300
 
 
+@log_entry_exit
 def test_Statistics_measure_exception():
     """
     Test measuring time with enabled statistics.
@@ -454,6 +466,7 @@ def test_Statistics_measure_exception():
         assert stats.avg_reply_len == 300
 
 
+@log_entry_exit
 def test_Statistics_snapshot():
     """
     Test that snapshot() takes a stable snapshot.
@@ -484,6 +497,7 @@ def test_Statistics_snapshot():
         assert_time_range(stats.max_time, duration)
 
 
+@log_entry_exit
 def test_Statistics_reset():
     """
     Test resetting statistics.
@@ -517,6 +531,7 @@ def test_Statistics_reset():
     assert not snapshot
 
 
+@log_entry_exit
 def test_Statistics_server_time_suspension():
     """
     Test suspending server time and resetting.
@@ -600,6 +615,7 @@ def test_Statistics_server_time_suspension():
         assert_time_range(stats.max_server_time, server_resp_time)
 
 
+@log_entry_exit
 def test_Statistics_print_statistics():
     """
     Test repr() and formatted() for a small statistics.
@@ -677,6 +693,7 @@ def test_Statistics_print_statistics():
         report)
 
 
+@log_entry_exit
 def test_Statistics_print_stats_svrtime():
     """
     Test repr() and formatted() for a small statistics.

--- a/tests/unittest/pywbem/test_subscriptionmanager.py
+++ b/tests/unittest/pywbem/test_subscriptionmanager.py
@@ -30,7 +30,7 @@ import pytest
 from ...utils import skip_if_moftab_regenerated
 from ..utils.dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
 from ..utils.wbemserver_mock import WbemServerMock
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -313,6 +313,7 @@ class BaseMethodsForTests:
 class TestSubMgrClass(BaseMethodsForTests):
     """Test of subscription manager"""
 
+    @log_entry_exit
     def test_create_owned_subscription(self):
         """
         Test Basic Creation of sub mgr, creation of owned subscription
@@ -403,6 +404,7 @@ class TestSubMgrClass(BaseMethodsForTests):
         # confirm no owned filters, destinations, subscriptions in server
         assert self.get_owned_inst_counts() == (0, 0, 0)
 
+    @log_entry_exit
     def test_create_permanent_subscription(self):
         """
         Test creating permanent filter, destination and filter and determining
@@ -453,6 +455,7 @@ class TestSubMgrClass(BaseMethodsForTests):
                 sub_mgr.remove_filter(server_id, filter_.path)
             assert self.get_submgr_inst_counts(sub_mgr, server_id) == (0, 0, 0)
 
+    @log_entry_exit
     def test_recovery_of_owned_subscriptions(self):
         """
         Test the ability to recover owned subscriptions from the server. Tests
@@ -1495,6 +1498,7 @@ TESTCASES_SUBMGR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_SUBMGR)
 @simplified_test_function
+@log_entry_exit
 def test_subscriptionmanager(testcase, submgr_id, connection_attrs,
                              filter_attrs, dest_attrs, subscription_attrs,
                              remove_destinations, remove_filters,
@@ -1885,6 +1889,7 @@ TESTCASES_SUBMGR_MODIFY = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_SUBMGR_MODIFY)
 @simplified_test_function
+@log_entry_exit
 def test_submgr_modify(testcase, submgr_id, connection_attrs,
                        filter_attrs, dest_attrs, subscription_attrs,
                        modify_filter_attrs, modify_dest_attrs,

--- a/tests/unittest/pywbem/test_tupleparse.py
+++ b/tests/unittest/pywbem/test_tupleparse.py
@@ -5,7 +5,7 @@ Test CIM-XML parsing routines in _tupleparse.py.
 import pytest
 from packaging.version import parse as parse_version
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -586,6 +586,7 @@ TESTCASES_TUPLEPARSE_ROUNDTRIP = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_TUPLEPARSE_ROUNDTRIP)
 @simplified_test_function
+@log_entry_exit
 def test_tupleparse_roundtrip(testcase, obj):
     """
     Test tupleparse parsing based upon roundtrip between CIM objects and their
@@ -15288,6 +15289,7 @@ TESTCASES_TUPLEPARSE_XML = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_TUPLEPARSE_XML)
 @simplified_test_function
+@log_entry_exit
 def test_tupleparse_xml(testcase, xml_str, exp_result):
     """
     Test tupleparse parsing, based upon a CIM-XML string as input.

--- a/tests/unittest/pywbem/test_tupletree.py
+++ b/tests/unittest/pywbem/test_tupletree.py
@@ -8,6 +8,8 @@ import re
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
@@ -485,6 +487,7 @@ class Test_xml_to_tupletree_sax:
         "encoding",
         ['unicode', 'bytes']
     )
+    @log_entry_exit
     def test_xml_to_tupletree_sax(
             self, encoding, desc, xml_string, exp_tupletree, exp_exc_type,
             exp_exc_msg_pattern, condition):
@@ -676,6 +679,7 @@ class Test_get_failing_line:
         "desc, xml_string, exc_msg, exp_result, exp_exc_type, condition",
         testcases
     )
+    @log_entry_exit
     def test_get_failing_line(
             self, desc, xml_string, exc_msg, exp_result, exp_exc_type,
             condition):
@@ -801,6 +805,7 @@ class Test_check_invalid_utf8_sequences:
         "desc, utf8_string, exp_exc_type, condition",
         testcases
     )
+    @log_entry_exit
     def test_check_invalid_utf8_sequences(
             self, desc, utf8_string, exp_exc_type, condition):
         # pylint: disable=no-self-use
@@ -915,6 +920,7 @@ class Test_check_invalid_xml_chars:
         "desc, xml_string, exp_exc_type, condition",
         testcases
     )
+    @log_entry_exit
     def test_check_invalid_xml_chars(
             self, desc, xml_string, exp_exc_type, condition):
         # pylint: disable=no-self-use

--- a/tests/unittest/pywbem/test_units.py
+++ b/tests/unittest/pywbem/test_units.py
@@ -4,7 +4,7 @@ Test functions in _units module
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -168,6 +168,7 @@ TESTCASES_SIUNIT_OBJ = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_SIUNIT_OBJ)
 @simplified_test_function
+@log_entry_exit
 def test_siunit_obj(testcase, in_kwargs, exp_result):
     """
     Test function for siunit_obj().
@@ -590,6 +591,7 @@ TESTCASES_SIUNIT_GENERAL = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_SIUNIT_GENERAL)
 @simplified_test_function
+@log_entry_exit
 def test_siunit_general(testcase, in_kwargs, exp_result):
     """
     Test function for siunit(), that test general behavior.
@@ -752,6 +754,7 @@ TESTCASES_SIUNIT_PUNIT = [
 @pytest.mark.parametrize(
     "punit, exp_result",
     TESTCASES_SIUNIT_PUNIT)
+@log_entry_exit
 def test_siunit_punit(punit, exp_result):
     """
     Test function for siunit(), that test only good cases with PUnit values.
@@ -934,6 +937,7 @@ TESTCASES_SIUNIT_UNITS = [
 @pytest.mark.parametrize(
     "units, exp_result",
     TESTCASES_SIUNIT_UNITS)
+@log_entry_exit
 def test_siunit_units(units, exp_result):
     """
     Test function for siunit(), that test only good cases with Units values.

--- a/tests/unittest/pywbem/test_utils.py
+++ b/tests/unittest/pywbem/test_utils.py
@@ -11,7 +11,7 @@ import random
 import pytest
 
 from ..utils.unichr2 import unichr2
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -223,6 +223,7 @@ TESTCASES_ASCII2 = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_ASCII2)
 @simplified_test_function
+@log_entry_exit
 def test_ascii2(testcase, value, exp_result):
     """
     Test function for _ascii2().
@@ -531,6 +532,7 @@ TESTCASES_FORMAT_FIXED = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_FORMAT_FIXED)
 @simplified_test_function
+@log_entry_exit
 def test_format_fixed(testcase, format_str, format_args, format_kwargs,
                       exp_result):
     """
@@ -567,6 +569,7 @@ def unicode_cp(request):
     return request.param
 
 
+@log_entry_exit
 def test_format_random(unicode_cp):
     # pylint: disable=redefined-outer-name
     """
@@ -849,6 +852,7 @@ TESTCASES_INTEGER_VALUE_TO_INT = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_INTEGER_VALUE_TO_INT)
 @simplified_test_function
+@log_entry_exit
 def test_integerValue_to_int(testcase, value, exp_result):
     """
     Test function for _integerValue_to_int().

--- a/tests/unittest/pywbem/test_valuemapping.py
+++ b/tests/unittest/pywbem/test_valuemapping.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
 pywbem = import_installed('pywbem')
@@ -192,6 +194,7 @@ class Test_ValueMapping:
         assert re.match(".*outside of the set defined by its Values "
                         "qualifier.*", exc_msg) is not None
 
+    @log_entry_exit
     def test_empty(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test empty ValueMapping"""
@@ -204,6 +207,7 @@ class Test_ValueMapping:
         self.assertOutsideValueMap(vm, 0)
         self.assertOutsideValues(vm, 'x')
 
+    @log_entry_exit
     def test_attrs_property(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM property"""
@@ -226,6 +230,7 @@ class Test_ValueMapping:
         assert prop.name == PROPNAME
         assert prop.type == integer_type
 
+    @log_entry_exit
     def test_attrs_method(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM method"""
@@ -248,6 +253,7 @@ class Test_ValueMapping:
         assert meth.name == METHNAME
         assert meth.return_type == integer_type
 
+    @log_entry_exit
     def test_attrs_parameter(self, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test attributes of ValueMapping for a CIM parameter"""
@@ -270,6 +276,7 @@ class Test_ValueMapping:
         assert parm.name == PARMNAME
         assert parm.type == integer_type
 
+    @log_entry_exit
     def test_repr(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test ValueMapping.__repr__()"""
@@ -308,6 +315,7 @@ class Test_ValueMapping:
 
         # We don't check the internal data attributes.
 
+    @log_entry_exit
     def test_invalid_valuemap_format(self, element_kind, server_arg,
                                      integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -325,6 +333,7 @@ class Test_ValueMapping:
                         "ValueMap entry.*",
                         exc_msg) is not None
 
+    @log_entry_exit
     def test_invalid_element_type(self, element_kind, server_arg, is_array):
         # pylint: disable=redefined-outer-name
         """Test invalid type for the element"""
@@ -340,6 +349,7 @@ class Test_ValueMapping:
         assert re.match(".*is not integer-typed.*",
                         exc_msg) is not None
 
+    @log_entry_exit
     def test_invalid_tovalues_type(self, element_kind, server_arg,
                                    integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -358,6 +368,7 @@ class Test_ValueMapping:
         assert re.match(".*is not integer-typed.*",
                         exc_msg) is not None
 
+    @log_entry_exit
     def test_invalid_tobinary_type(self, element_kind, server_arg,
                                    integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -376,6 +387,7 @@ class Test_ValueMapping:
         assert re.match(".*is not string-typed.*",
                         exc_msg) is not None
 
+    @log_entry_exit
     def test_no_values_qualifier(self, element_kind, server_arg, integer_type,
                                  is_array):
         # pylint: disable=redefined-outer-name
@@ -392,6 +404,7 @@ class Test_ValueMapping:
         assert re.match(".*has no Values qualifier defined.*",
                         exc_msg) is not None
 
+    @log_entry_exit
     def test_valuemap_default(self, element_kind, server_arg, integer_type,
                               is_array):
         # pylint: disable=redefined-outer-name
@@ -420,6 +433,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_zero(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 0"""
@@ -442,6 +456,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_one(self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
         """Test valuemap with value 1"""
@@ -465,6 +480,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_tovalues_with_cimtype(self, element_kind, server_arg,
                                    integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -478,6 +494,7 @@ class Test_ValueMapping:
         cimtype = type_from_name(integer_type)
         assert vm.tovalues(cimtype(1)) == 'one'
 
+    @log_entry_exit
     def test_tobinary_with_unicode(self, element_kind, server_arg,
                                    integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -490,6 +507,7 @@ class Test_ValueMapping:
 
         assert vm.tobinary('one') == 1
 
+    @log_entry_exit
     def test_singles(self, element_kind, server_arg, integer_type,
                      is_array):
         # pylint: disable=redefined-outer-name
@@ -519,6 +537,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_singles_ranges(self, element_kind, server_arg, integer_type,
                             is_array):
         # pylint: disable=redefined-outer-name
@@ -556,6 +575,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_unclaimed(self, element_kind, server_arg, integer_type,
                        is_array):
         # pylint: disable=redefined-outer-name
@@ -579,6 +599,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_singles_ranges_unclaimed(self, element_kind, server_arg,
                                       integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -618,6 +639,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_singles_ranges_unclaimed2(self, element_kind, server_arg,
                                        integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -656,6 +678,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_min_max_single(self, element_kind, server_arg, integer_type,
                             is_array):
         # pylint: disable=redefined-outer-name
@@ -695,6 +718,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_min_max_closed_ranges(self, element_kind, server_arg,
                                    integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -738,6 +762,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_min_max_open_range1(self, element_kind, server_arg, integer_type,
                                  is_array):
         # pylint: disable=redefined-outer-name
@@ -786,6 +811,7 @@ class Test_ValueMapping:
             items.append(item)
         assert items == exp_items
 
+    @log_entry_exit
     def test_min_max_open_range2(self, element_kind, server_arg, integer_type,
                                  is_array):
         # pylint: disable=redefined-outer-name
@@ -897,6 +923,7 @@ class Test_ValueMapping:
         "exp_valuemap_list, exp_exc_type, exp_exc_msg_pattern, condition",
         testcases_integer_representations
     )
+    @log_entry_exit
     def test_integer_representations(
             self, desc, integer_type, is_array, values_str_list,
             valuemap_str_list, exp_valuemap_list, exp_exc_type,
@@ -934,6 +961,7 @@ class Test_ValueMapping:
             (1, 2),
         ]
     )
+    @log_entry_exit
     def test_tovalues_multiple_values(
             self, element_value, element_kind, server_arg, integer_type,
             is_array):
@@ -947,6 +975,7 @@ class Test_ValueMapping:
         result = vm.tovalues(element_value)
         assert result == ['one', 'two']
 
+    @log_entry_exit
     def test_tovalues_none(
             self, element_kind, server_arg, integer_type, is_array):
         # pylint: disable=redefined-outer-name
@@ -1020,6 +1049,7 @@ class Test_ValueMapping:
             ),
         ]
     )
+    @log_entry_exit
     def test_tovalues_different_sizes(
             self, valuemap, values, values_default, exp_exc, exp_values,
             element_kind, server_arg, integer_type, is_array):

--- a/tests/unittest/pywbem/test_warnings.py
+++ b/tests/unittest/pywbem/test_warnings.py
@@ -6,6 +6,8 @@ Test _warnings module.
 
 import pytest
 
+from ..utils.pytest_extensions import log_entry_exit
+
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 # pylint: disable=redefined-builtin
 from ...utils import import_installed
@@ -112,6 +114,7 @@ def conn_info(request):
     return request.param
 
 
+@log_entry_exit
 def test_simple(simple_class, simple_args, conn_info):
     # pylint: disable=redefined-outer-name
     """

--- a/tests/unittest/pywbem/test_wbemserverclass.py
+++ b/tests/unittest/pywbem/test_wbemserverclass.py
@@ -29,7 +29,7 @@ import os
 import pytest
 
 from ..utils.wbemserver_mock import WbemServerMock
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -65,6 +65,7 @@ class TestServerClass(BaseMethodsForTests):
     @pytest.mark.parametrize(
         "tst_namespace",
         ['interop', 'root/interop', 'root/PG_Interop'])
+    @log_entry_exit
     def test_wbemserver_basic(self, tst_namespace):
         # pylint: disable=no-self-use
         """
@@ -219,6 +220,7 @@ TESTCASES_CREATE_NAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CREATE_NAMESPACE)
 @simplified_test_function
+@log_entry_exit
 def test_create_namespace(testcase, new_namespace, exp_namespace):
     """
     Test creation of a namespace using approach 2.
@@ -345,6 +347,7 @@ TESTCASES_DELETE_NAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_DELETE_NAMESPACE)
 @simplified_test_function
+@log_entry_exit
 def test_delete_namespace(testcase,
                           namespace, namespace_content, exp_namespace):
     """
@@ -433,6 +436,7 @@ TESTCASES_GET_CENTRAL_INSTANCES = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_GET_CENTRAL_INSTANCES)
 @simplified_test_function
+@log_entry_exit
 def test_get_central_instances(testcase, profile_name, central_class,
                                scoping_class, scoping_path, direction,
                                exp_paths):

--- a/tests/unittest/pywbem_mock/test_complexassoc.py
+++ b/tests/unittest/pywbem_mock/test_complexassoc.py
@@ -30,6 +30,7 @@ import os
 import pytest
 
 from ...utils import skip_if_moftab_regenerated
+from ..utils.pytest_extensions import log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -315,6 +316,7 @@ instance of TST_A3Sub as $A3Sub511 {
          OK],
     ]
 )
+@log_entry_exit
 def test_complexref_classnames(conn, ns, target, ro, rc, mof, exp_rslt,
                                complex_assoc_mof, cond):
     # pylint: disable=redefined-outer-name,invalid-name
@@ -468,6 +470,7 @@ def test_complexref_classnames(conn, ns, target, ro, rc, mof, exp_rslt,
         ),
     ]
 )
+@log_entry_exit
 def test_complexref_instnames(conn, ns, target, ro, rc, mof, exp_rslt,
                               complex_assoc_mof, cond):
     # pylint: disable=redefined-outer-name,invalid-name
@@ -599,6 +602,7 @@ def test_complexref_instnames(conn, ns, target, ro, rc, mof, exp_rslt,
 
     ]
 )
+@log_entry_exit
 def test_complexassoc_classnames(conn, ns, target, ro, rr, ac,
                                  rc, mof, exp_rslt, complex_assoc_mof, cond):
     # pylint: disable=redefined-outer-name,invalid-name
@@ -1131,6 +1135,7 @@ def test_complexassoc_classnames(conn, ns, target, ro, rr, ac,
         ],
     ]
 )
+@log_entry_exit
 def test_complexassoc_instnames(conn, ns, target, ro, rr, ac,
                                 rc, mof, exp_rslt, complex_assoc_mof, cond):
     # pylint: disable=redefined-outer-name,invalid-name

--- a/tests/unittest/pywbem_mock/test_inmemory_repository.py
+++ b/tests/unittest/pywbem_mock/test_inmemory_repository.py
@@ -20,7 +20,7 @@ import pickle
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -179,6 +179,7 @@ TESTCASES_OBJSTORE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_OBJSTORE)
 @simplified_test_function
+@log_entry_exit
 def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
     # pylint: disable=unused-argument
     """
@@ -334,6 +335,7 @@ def test_objectstore(testcase, init_args, cls_kwargs, inst_kwargs, qual_kwargs):
         ('root/def', [], None, None, ValueError()),
     ]
 )
+@log_entry_exit
 def test_add_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
     # pylint: disable=no-self-use
     """
@@ -372,6 +374,7 @@ def test_add_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
         ('root/def', [], None, None, ValueError()),
     ]
 )
+@log_entry_exit
 def test_remove_namespace(default_ns, additional_ns, test_ns, exp_ns, exp_exc):
     # pylint: disable=no-self-use
     """
@@ -438,6 +441,7 @@ TEST_OBJECTS2 = [
         ),
     ],
 )
+@log_entry_exit
 def test_repository_valid_methods(desc, args, condition, capsys):
     """
     This is a test of the various methods of the repository that return
@@ -589,6 +593,7 @@ def test_repository_valid_methods(desc, args, condition, capsys):
         ),
     ],
 )
+@log_entry_exit
 def test_repository_method_errs(desc, args, condition, capsys):
     # pylint: disable=unused-argument
     """
@@ -710,6 +715,7 @@ TESTCASES_REPO_PICKLE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REPO_PICKLE)
 @simplified_test_function
+@log_entry_exit
 def test_InMemoryRepository_pickle(testcase, init_namespace, init_objects):
     """
     Test function for pickling and unpickling InMemoryRepository objects
@@ -854,6 +860,7 @@ TESTCASES_REPO_LOAD = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REPO_LOAD)
 @simplified_test_function
+@log_entry_exit
 def test_InMemoryRepository_load(testcase,
                                  init_namespace1, init_objects1,
                                  init_namespace2, init_objects2):

--- a/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
+++ b/tests/unittest/pywbem_mock/test_multi_ns_assoc.py
@@ -28,7 +28,7 @@ provide a test of the logic of processing these associations.
 import pytest
 
 from ...utils import skip_if_moftab_regenerated
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from pywbem._utils import _format  # noqa: E402
@@ -666,6 +666,7 @@ TESTCASES_MULTI_NAMESPACES = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MULTI_NAMESPACES)
 @simplified_test_function
+@log_entry_exit
 def test_multiple_namespace_assoc(testcase, namespaces, class_mof, inst_mof,
                                   assoc_inst_mof, source_clns, assoc_clns,
                                   delete_ns, exp_rtn):
@@ -895,6 +896,7 @@ TESTCASES_MULTI_NAMESPACES_ERRORS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MULTI_NAMESPACES_ERRORS)
 @simplified_test_function
+@log_entry_exit
 def test_multiple_namespace_assoc_errs(testcase, namespaces, class_mof,
                                        remove_classes, inst_mof,
                                        assoc_inst_mof, assoc_inst_obj,
@@ -1534,6 +1536,7 @@ TESTCASES_MULTI_NAMESPACES_MODIFY_INSTANCE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_MULTI_NAMESPACES_MODIFY_INSTANCE)
 @simplified_test_function
+@log_entry_exit
 def test_multiple_namespace_assoc_modify(testcase, namespaces, class_mof,
                                          inst_mof, assoc_inst_mof, source_clns,
                                          assoc_clns, property_mods, prop_list,

--- a/tests/unittest/pywbem_mock/test_providerdependentregistry.py
+++ b/tests/unittest/pywbem_mock/test_providerdependentregistry.py
@@ -19,7 +19,7 @@ import pickle
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -152,6 +152,7 @@ TESTCASES_REGISTRY_REPR = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REGISTRY_REPR)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderDependentRegistry_repr(testcase, reg_dict):
     """
     Test function for ProviderDependentRegistry.__repr__().
@@ -258,6 +259,7 @@ TESTCASES_REGISTRY_ADD_ITER_DEPENDENTS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REGISTRY_ADD_ITER_DEPENDENTS)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderDependentRegistry_add_dependents(
         testcase, mock_script, dependents, exp_dependents):
     """
@@ -357,6 +359,7 @@ TESTCASES_REGISTRY_LOAD = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REGISTRY_LOAD)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderDependentRegistry_load(testcase, reg_dict1, reg_dict2):
     """
     Test function for ProviderDependentRegistry.load().
@@ -427,6 +430,7 @@ TESTCASES_REGISTRY_PICKLE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_REGISTRY_PICKLE)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderDependentRegistry_pickle(testcase, reg_dict):
     """
     Test function for pickling and unpickling ProviderDependentRegistry objects.

--- a/tests/unittest/pywbem_mock/test_providerregistry.py
+++ b/tests/unittest/pywbem_mock/test_providerregistry.py
@@ -17,7 +17,7 @@ import pickle
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
 from ...utils import import_installed
@@ -240,6 +240,7 @@ TESTCASES_PROVREG_ITERITEMS = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_PROVREG_ITERITEMS)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderRegistry_iteritems(testcase, providers):
     """
     Test function for ProviderRegistry.iteritems().
@@ -328,6 +329,7 @@ TESTCASES_PROVREG_LOAD = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_PROVREG_LOAD)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderRegistry_load(testcase, providers1, providers2):
     """
     Test function for ProviderRegistry.load().
@@ -397,6 +399,7 @@ TESTCASES_PROVREG_PICKLE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_PROVREG_PICKLE)
 @simplified_test_function
+@log_entry_exit
 def test_ProviderRegistry_pickle(testcase, providers):
     """
     Test function for pickling and unpickling ProviderRegistry objects.

--- a/tests/unittest/pywbem_mock/test_system_providers.py
+++ b/tests/unittest/pywbem_mock/test_system_providers.py
@@ -26,7 +26,7 @@ import os
 
 import pytest
 
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 from ..utils.dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
 from ...utils import skip_if_moftab_regenerated
 
@@ -90,6 +90,7 @@ def inst_from_classname(conn, class_name, namespace=None,
         include_path=include_path)
 
 
+@log_entry_exit
 def test_interop_namespace_names():
     """
     Test the method interop_namespace_names. This is a single test
@@ -127,6 +128,7 @@ TESTCASES_IS_INTEROP_NAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_IS_INTEROP_NAMESPACE)
 @simplified_test_function
+@log_entry_exit
 def test_is_interop_namespace(testcase, ns, exp_rtn):
     # pylint: disable=unused-argument
     """
@@ -182,6 +184,7 @@ TESTCASES_FIND_INTEROP_NAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_FIND_INTEROP_NAMESPACE)
 @simplified_test_function
+@log_entry_exit
 def test_find_interop_namespace(testcase, deflt, nss, exp_ns):
     # pylint: disable=unused-argument
     """
@@ -253,6 +256,7 @@ TESTCASES_INSTALL_NAMESPACE_PROVIDER = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_INSTALL_NAMESPACE_PROVIDER)
 @simplified_test_function
+@log_entry_exit
 def test_install_namespace_provider(testcase, default_ns, ns):
     """
     Test installation of the namespace provider
@@ -374,6 +378,7 @@ TESTCASES_ADD_NAMESPACE_NAMESPACE_PROVIDER = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_ADD_NAMESPACE_NAMESPACE_PROVIDER)
 @simplified_test_function
+@log_entry_exit
 def test_add_namespace_namespace_provider(testcase, initial_ns, interop_ns,
                                           final_ns, total_exp_ns):
     """
@@ -498,6 +503,7 @@ TESTCASES_ADD_CIMNAMESPACE_WITH_CREATENAMESPACE = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_ADD_CIMNAMESPACE_WITH_CREATENAMESPACE)
 @simplified_test_function
+@log_entry_exit
 def test_add_cimnamespace_with_createnamespace(testcase, initial_ns, final_ns,
                                                total_exp_ns):
     """

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -42,7 +42,7 @@ from testfixtures import OutputCapture
 from ...utils import skip_if_moftab_regenerated
 from ..utils.dmtf_mof_schema_def import TOTAL_QUALIFIERS, TOTAL_CLASSES, \
     install_test_dmtf_schema, DMTF_TEST_SCHEMA_VER
-from ..utils.pytest_extensions import simplified_test_function
+from ..utils.pytest_extensions import simplified_test_function, log_entry_exit
 from ..utils.unittest_extensions import assert_copy
 
 # pylint: disable=wrong-import-position, wrong-import-order, invalid-name
@@ -955,6 +955,7 @@ class TestFakedWBEMConnection:
         "set_on_init", [False, True])
     @pytest.mark.parametrize(
         "delay", [.5, 1])
+    @log_entry_exit
     def test_response_delay(self, tst_qualifiers, tst_class, set_on_init,
                             delay):
         # pylint: disable=no-self-use
@@ -991,6 +992,7 @@ class TestFakedWBEMConnection:
                               [None, None],
                               [True, None],
                               [1, ValueError]])
+    @log_entry_exit
     def test_disable_pull(self, tst_classeswqualifiers, tst_instances,
                           set_on_init, disable, exp_exec):
         # pylint: disable=no-self-use
@@ -1076,6 +1078,7 @@ class TestFakedWBEMConnection:
                 conn.OpenAssociatorInstancePaths(path)
                 conn.OpenQueryInstances('DMTF:FQL', "SELECT * FROM CIM_Foo")
 
+    @log_entry_exit
     def test_repr(self):
         # pylint: disable=no-self-use
         """ Test output of repr"""
@@ -1085,6 +1088,7 @@ class TestFakedWBEMConnection:
         repr_ = f'{conn!r}'
         assert repr_.startswith('FakedWBEMConnection(response_delay=3,')
 
+    @log_entry_exit
     def test_attr(self):
         # pylint: disable=no-self-use
         """
@@ -1101,6 +1105,7 @@ class TestFakedWBEMConnection:
         assert conn.default_namespace == DEFAULT_NAMESPACE
         assert conn.operation_recorder_enabled is False
 
+    @log_entry_exit
     def test_userdefined_url(self):
         # pylint: disable=no-self-use
         """
@@ -1117,6 +1122,7 @@ class TestFakedWBEMConnection:
         assert conn.default_namespace == DEFAULT_NAMESPACE
         assert conn.operation_recorder_enabled is False
 
+    @log_entry_exit
     def test_multiple_urls(self):
         # pylint: disable=no-self-use
         """
@@ -1159,6 +1165,7 @@ class TestRepoMethods:
             ['CIM_FooX', False],
         ]
     )
+    @log_entry_exit
     def test_class_exists(self, conn, tst_classeswqualifiers, tst_classes_mof,
                           ns, mof, cln, exp_rslt):
         # pylint: disable=no-self-use
@@ -1198,6 +1205,7 @@ class TestRepoMethods:
             ['CIM_Foo_sub', False, ['CIM_Foo_sub_sub']],
         ]
     )
+    @log_entry_exit
     def test_get_subclassnames(self, conn, tst_classeswqualifiers,
                                tst_classes_mof, ns, mof, cln, di, exp_clns):
         # pylint: disable=no-self-use
@@ -1234,6 +1242,7 @@ class TestRepoMethods:
             ['CIM_Foo_sub_sub', ['CIM_Foo', 'CIM_Foo_sub']],
         ]
     )
+    @log_entry_exit
     def test_get_superclass_names(self, conn, tst_classeswqualifiers,
                                   tst_classes_mof, ns, mof, cln, exp_cln):
         # pylint: disable=no-self-use
@@ -1283,6 +1292,7 @@ class TestRepoMethods:
             ['cim_foo_sub', True, True, False, ['cimfoo_sub'], ['cimfoo_sub']],
         ]
     )
+    @log_entry_exit
     def test_get_class(self, conn, tst_classeswqualifiers, tst_classes_mof,
                        ns, mof, cln, lo, iq, ico, pl, exp_pl):
         # pylint: disable=no-self-use
@@ -1410,6 +1420,7 @@ class TestRepoMethods:
              CIMError(CIM_ERR_NOT_FOUND)],
         ]
     )
+    @log_entry_exit
     def test_get_instance_internal(self, conn, tst_classeswqualifiers,
                                    tst_instances, tst_instances_mof, ns, mof,
                                    cln, key, lo, iq, ico, pl, exp_pl, exp_exc):
@@ -1526,6 +1537,7 @@ class TestRepoMethods:
             ['CIM_Foo_sub', 'CIM_Foo_sub99', False],
         ]
     )
+    @log_entry_exit
     def test_get_bare_instance(self, conn, tst_classeswqualifiersandinsts,
                                tst_instances_mof, ns, mof, cln, inst_id,
                                exp_ok):
@@ -1557,6 +1569,7 @@ class TestRepoMethods:
             assert inst is None
 
     @pytest.mark.skip(reason="Used only to display repo so not real test.")
+    @log_entry_exit
     def test_disp_repo_tostdout(self, conn, tst_instances_mof):
         # pylint: disable=no-self-use
         """
@@ -1594,6 +1607,7 @@ class TestRepoMethods:
         tst_file = os.path.join(TEST_DIR, tst_file_name)
         conn.display_repository(dest=tst_file)
 
+    @log_entry_exit
     def test_display_repository(self, conn, tst_instances_mof, capsys):
         # pylint: disable=no-self-use
         """
@@ -1661,6 +1675,7 @@ class TestRepoMethods:
         assert "Namespace 'root/cimv2': contains 5 Classes" in result
         assert "Namespace 'root/cimv2': contains 12 Instances" in result
 
+    @log_entry_exit
     def test_display_repo_tofile(self, conn, tst_instances_mof):
         # pylint: disable=no-self-use
         """
@@ -1700,6 +1715,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_addcimobject(self, conn, tst_classeswqualifiers, tst_instances,
                           tst_insts_big, tst_classes, ns):
         # pylint: disable=no-self-use
@@ -1739,6 +1755,7 @@ class TestRepoMethods:
             ],
         ]
     )
+    @log_entry_exit
     def test_addcimobject_err(self, conn, tst_classeswqualifiers, tst_instances,
                               ns,
                               tst_objs, exp_exec, condition):
@@ -1764,6 +1781,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_addcimobject_duperr(self, conn, tst_classeswqualifiers,
                                  tst_instances, ns):
         # pylint: disable=no-self-use
@@ -1777,6 +1795,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_addcimobject_err1(self, conn, tst_classeswqualifiers, ns):
         # pylint: disable=no-self-use
         """Test error if class with no superclass"""
@@ -1789,6 +1808,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_qualifiers(self, conn, tst_qualifiers_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -1827,6 +1847,7 @@ class TestRepoMethods:
             ('root/def', [], None, None, ValueError()),
         ]
     )
+    @log_entry_exit
     def test_add_namespace(self, default_ns, additional_ns, in_ns, exp_ns,
                            exp_exc):
         # pylint: disable=no-self-use
@@ -1872,6 +1893,7 @@ class TestRepoMethods:
             ('root/def', [], None, None, ValueError()),
         ]
     )
+    @log_entry_exit
     def test_remove_namespace(self, default_ns, additional_ns, in_ns, exp_ns,
                               exp_exc):
         # pylint: disable=no-self-use
@@ -1899,6 +1921,7 @@ class TestRepoMethods:
             if isinstance(exp_exc, CIMError):
                 assert exc.status_code == exp_exc.status_code
 
+    @log_entry_exit
     def test_unicode(self, conn):
         # pylint: disable=no-self-use
         """
@@ -1940,6 +1963,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_mult(self, conn, ns):
         # pylint: disable=no-self-use
         """
@@ -2038,6 +2062,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_classes(self, conn, tst_classes_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -2064,6 +2089,7 @@ class TestRepoMethods:
         assert len(cls) == 5
         assert set(clns) == {cl_.classname for cl_ in cls}
 
+    @log_entry_exit
     def test_compile_classes_multiple_ns(self, conn, tst_classes_mof):
         # pylint: disable=no-self-use
         """
@@ -2103,6 +2129,7 @@ class TestRepoMethods:
         assert clns == conn.EnumerateClassNames(namespace=ns,
                                                 DeepInheritance=True)
 
+    @log_entry_exit
     def test_compile_classes_nspragma(self, conn, tst_classes_mof):
         # pylint: disable=no-self-use
         """
@@ -2144,6 +2171,7 @@ class TestRepoMethods:
         assert clns == conn.EnumerateClassNames(namespace=ns,
                                                 DeepInheritance=True)
 
+    @log_entry_exit
     def test_compile_classes_nspragma_2(self, conn, tst_classes_mof):
         # pylint: disable=no-self-use
         """
@@ -2188,6 +2216,7 @@ class TestRepoMethods:
         assert clns == conn.EnumerateClassNames(namespace=ns,
                                                 DeepInheritance=True)
 
+    @log_entry_exit
     def test_compile_classes_nspragma_err1(self, conn, tst_classes_mof):
         # pylint: disable=no-self-use
         """
@@ -2212,6 +2241,7 @@ class TestRepoMethods:
         except MOFParseError:
             return
 
+    @log_entry_exit
     def test_compile_classes_nspragma_err2(self, conn, tst_classes_mof):
         # pylint: disable=no-self-use
         """
@@ -2237,6 +2267,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_instances(self, conn, tst_classes_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -2277,6 +2308,7 @@ class TestRepoMethods:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_assoc_mof(self, conn, tst_assoc_mof,
                                tst_person_instance_names, ns):
         # pylint: disable=no-self-use
@@ -2331,6 +2363,7 @@ class TestRepoMethods:
             inst = conn.GetInstance(inst_name)
             assert inst == insts_dict[inst.path]
 
+    @log_entry_exit
     def test_compile_complete_dmtf_schema(self, conn):
         # pylint: disable=no-self-use
         """
@@ -2519,6 +2552,7 @@ class TestRepoMethods:
              OK],
         ]
     )
+    @log_entry_exit
     def test_compile_schema_classes(self, conn, desc, classnames,
                                     extra_exp_classnames, exp_class, condition):
         # pylint: disable=no-self-use,unused-argument
@@ -2558,6 +2592,7 @@ class TestRepoMethods:
                                    LocalOnly=False)
             assert get_cl == exp_class
 
+    @log_entry_exit
     def test_compile_part_schema_multiple_ns(self, conn):
         # pylint: disable=no-self-use
         """
@@ -2612,6 +2647,7 @@ class TestRepoMethods:
         cls_rtn3.path = None
         assert cls_rtn3 == cls_rtn1
 
+    @log_entry_exit
     def test_compile_err(self, conn):
         # pylint: disable=no-self-use
         """
@@ -2635,6 +2671,7 @@ class TestRepoMethods:
     @pytest.mark.skip(reason="Fails because does not allow dup")
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_instances_dup(self, conn, tst_classes_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -2797,6 +2834,7 @@ class TestUserDefinedProviders:
              ValueError(), OK],
         ]
     )
+    @log_entry_exit
     def test_register_provider(self, conn, tst_classeswqualifiersandinsts,
                                ns, desc, inputs, exp_exc, condition):
         # pylint: disable=no-self-use,unused-argument
@@ -2942,6 +2980,7 @@ class TestUserDefinedProviders:
              True, OK],
         ]
     )
+    @log_entry_exit
     def test_get_registered_provider(
             self, conn, tst_classeswqualifiers, tst_instances, ns, desc, inputs,
             get_ns, get_cln, get_pt, exp_rslt, condition):
@@ -3068,6 +3107,7 @@ class TestUserDefinedProviders:
 
         ]
     )
+    @log_entry_exit
     def test_display_registered_providers(
             self, conn, tst_classeswqualifiersandinsts, capsys,
             desc, inputs, output, condition):
@@ -3116,6 +3156,7 @@ class TestUserDefinedProviders:
             for ns in nss:
                 assert f"namespace: {ns}" in result
 
+    @log_entry_exit
     def test_user_provider1(self, conn, tst_classeswqualifiers, tst_instances):
         """
         Test execution with a user provider and CreateInstance.
@@ -3187,6 +3228,7 @@ class TestUserDefinedProviders:
         except CIMError as ce:
             assert ce.status_code == CIM_ERR_NOT_FOUND
 
+    @log_entry_exit
     def test_user_provider2(self, conn, tst_classeswqualifiers, tst_instances):
         """
         Test with a single user defined provider using CIM_Foo_sub as the
@@ -3258,6 +3300,7 @@ class TestUserDefinedProviders:
         except CIMError as ce:
             assert ce.status_code == CIM_ERR_NOT_FOUND
 
+    @log_entry_exit
     def test_user_provider3(self, conn, tst_classeswqualifiers, tst_instances):
         """
         Test execution with a user provider that handles all  of the
@@ -3417,6 +3460,7 @@ class TestClassOperations:
             [NOT_DEFAULT_NS, 'CIM_Foo', NOT_DEFAULT_NS, None],
         ]
     )
+    @log_entry_exit
     def test_getclass(self, conn, tst_qualifiers, tst_class, tst_ns, cln,
                       ns, exp_exc):
         # pylint: disable=no-self-use
@@ -3462,6 +3506,7 @@ class TestClassOperations:
             ['CIM_Foo_sub', True, True],
         ]
     )
+    @log_entry_exit
     def test_getclass_iqico(self, conn, tst_classes, tst_classeswqualifiers,
                             ns, cln, iq, ico):
         # pylint: disable=no-self-use
@@ -3531,6 +3576,7 @@ class TestClassOperations:
                                         'InstanceID']],
         ]
     )
+    @log_entry_exit
     def test_getclass_lo(self, conn, tst_qualifiers, tst_classes, ns, cln,
                          lo, exp_pl):
         # pylint: disable=no-self-use
@@ -3586,6 +3632,7 @@ class TestClassOperations:
             [['InstanceID', 'cimfoo_sub'], ['InstanceID', 'cimfoo_sub']]
         ]
     )
+    @log_entry_exit
     def test_getclass_pl(self, conn, tst_classeswqualifiers, ns, pl, exp_pl):
         # pylint: disable=no-self-use
         """
@@ -3633,6 +3680,7 @@ class TestClassOperations:
             ['CIM_Foo_sub', 42, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_enumerateclassnames(self, conn, tst_classeswqualifiers, ns, cln,
                                  di, exp_rslt):
         # pylint: disable=no-self-use
@@ -3740,6 +3788,7 @@ class TestClassOperations:
             ['CIM_Foo_sub', False, 42, [], TypeError()],
         ]
     )
+    @log_entry_exit
     def test_enumerateclasses(self, conn, tst_classes, tst_qualifiers, ns, iq,
                               ico, cln, lo, di, exp_pl, exp_rslt):
         # pylint: disable=no-self-use
@@ -4421,6 +4470,7 @@ class TestClassOperations:
             # namespace if one does not exist
         ],
     )
+    @log_entry_exit
     def test_createclass(self, conn, tst_qualifiers_mof, tst_classes, ns, desc,
                          pre_tst_classes, tst_cls, exp_rslt, exp_exc,
                          condition):
@@ -4684,6 +4734,7 @@ class TestClassOperations:
 
         ],
     )
+    @log_entry_exit
     def test_createclass_mof_er(self, conn, tst_qualifiers_mof,
                                 ns, desc, pre_tst_mof, tst_cls_mof, exp_rslt,
                                 exp_exc, condition):
@@ -5036,6 +5087,7 @@ class TestClassOperations:
              CIMError(CIM_ERR_CLASS_HAS_INSTANCES), OK],  # expect err response
         ],
     )
+    @log_entry_exit
     def test_modifyclass(self, conn, tst_qualifiers_mof, tst_classes,
                          tst_instances, ns, desc, pre_tst_classes, has_insts,
                          tst_cls, exp_rslt, exp_exc, condition):
@@ -5253,6 +5305,7 @@ class TestClassOperations:
             [None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_deleteclass(self, conn, tst_qualifiers, tst_classes, ns, cln,
                          exp_exc):
         # pylint: disable=no-self-use
@@ -5364,6 +5417,7 @@ class TestInstanceOperations:
 
         ]
     )
+    @log_entry_exit
     def test_getinstance(self, conn, tst_classeswqualifiers, tst_instances,
                          tst_ns, iq, ico, pl, inst_cln, inst_id, inst_ns,
                          exp_exc):
@@ -5472,6 +5526,7 @@ class TestInstanceOperations:
             [None, True, True],
         ]
     )
+    @log_entry_exit
     def test_getinstance_opts(self, conn, tst_classeswqualifiers,
                               tst_instances, ns, inst_id, lo, iq, ico):
         # pylint: disable=no-self-use
@@ -5555,6 +5610,7 @@ class TestInstanceOperations:
              ['InstanceID', 'cimfoo_sub']],
         ]
     )
+    @log_entry_exit
     def test_getinstance_pl(self, conn, tst_classeswqualifiers, tst_instances,
                             ns, inst_cln, inst_id, pl, exp_pl):
         # pylint: disable=no-self-use
@@ -5582,6 +5638,7 @@ class TestInstanceOperations:
         "ns", EXPANDED_NAMESPACES + [None])
     @pytest.mark.parametrize(
         "cln", ['cim_foo', 'CIM_Foo', 'cim_foo_sub'])
+    @log_entry_exit
     def test_enumerateinstancenames(self, conn, tst_classeswqualifiers,
                                     tst_instances, ns, cln):
         # pylint: disable=no-self-use
@@ -5648,6 +5705,7 @@ class TestInstanceOperations:
             [DEFAULT_NAMESPACE, 'CIM_Foo', 42, None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_enumerateinstancenames_ns_er(self, conn, tst_classeswqualifiers,
                                           tst_instances, tst_ns, cln, in_ns,
                                           exp_clns, exp_exc):
@@ -5712,6 +5770,7 @@ class TestInstanceOperations:
              ['InstanceID']],
         ]
     )
+    @log_entry_exit
     def test_enumerateinstances(self, conn, tst_classeswqualifiers,
                                 tst_instances, ns, cln, di, exp_clns, exp_pl):
         # pylint: disable=no-self-use
@@ -5819,6 +5878,7 @@ class TestInstanceOperations:
              ['InstanceID', 'cimfoo_sub']],
         ]
     )
+    @log_entry_exit
     def test_enumerateinstances_pl_di(self, conn, tst_classeswqualifiers,
                                       tst_instances, ns, operation, cln, di,
                                       pl, exp_pls):
@@ -5903,6 +5963,7 @@ class TestInstanceOperations:
             ['CIM_Foo', True, ['InstanceID'], ['InstanceID'], 12],
         ]
     )
+    @log_entry_exit
     def test_enumerateinstances_di(self, conn, tst_classeswqualifiers,
                                    tst_instances, ns, operation, cln, di, pl,
                                    exp_pl, exp_num_insts):
@@ -6002,6 +6063,7 @@ class TestInstanceOperations:
             [DEFAULT_NAMESPACE, 'CIM_Foo', 42, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_enumerateinstances_er(self, conn, tst_classeswqualifiers,
                                    tst_instances, tst_ns, cln, in_ns, exp_exc):
         # pylint: disable=no-self-use
@@ -6109,6 +6171,7 @@ class TestInstanceOperations:
             [0, CIMClass('CIM_Foo_sub'), TypeError()],
         ]
     )
+    @log_entry_exit
     def test_createinstance(self, conn, tst_classeswqualifiers, tst_instances,
                             ns, test, new_inst, exp_rslt):
         # pylint: disable=no-self-use
@@ -6190,6 +6253,7 @@ class TestInstanceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_createinstance_dup(self, conn, tst_classeswqualifiers,
                                 tst_instances, ns):
         # pylint: disable=no-self-use
@@ -6218,6 +6282,7 @@ class TestInstanceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_addinstance_abstract(self, conn, ns):
         # pylint: disable=no-self-use
         """
@@ -6275,6 +6340,7 @@ class TestInstanceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_createinstance_abstract(self, conn, ns):
         # pylint: disable=no-self-use
         """
@@ -6329,6 +6395,7 @@ class TestInstanceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_inst_abstract(self, conn, ns):
         # pylint: disable=no-self-use
         """
@@ -6397,6 +6464,7 @@ class TestInstanceOperations:
             ),
         ]
     )
+    @log_entry_exit
     def test_createinstance_namespace(self, conn, tst_pg_namespace_class,
                                       desc, interop_ns, additional_ns, new_ns,
                                       exp_ns, exp_exc):
@@ -6517,6 +6585,7 @@ class TestInstanceOperations:
                  CIMError(CIM_ERR_INVALID_PARAMETER))],
         ]
     )
+    @log_entry_exit
     def test_compile_instances_path(self, conn, tst_assoc_class_mof, ns,
                                     tst_mof, exp_rslt, exp_exc):
         # pylint: disable=no-self-use
@@ -6656,6 +6725,7 @@ class TestInstanceOperations:
              7, [], None, TypeError(), OK],
         ]
     )
+    @log_entry_exit
     def test_modifyinstance(self, conn, tst_classeswqualifiers, tst_instances,
                             desc, ns, sp, nv, pl, exp_rslt, condition):
         # pylint: disable=no-self-use
@@ -6777,6 +6847,7 @@ class TestInstanceOperations:
             [None, 'blah', TypeError()],  # Invalid ClassName
         ]
     )
+    @log_entry_exit
     def test_deleteinstance(self, conn, tst_classeswqualifiers, tst_instances,
                             ns, cln, inst_id, exp_exc):
         # pylint: disable=no-self-use
@@ -6906,6 +6977,7 @@ class TestInstanceOperations:
             ),
         ]
     )
+    @log_entry_exit
     def test_deleteinstance_namespace(
             self, conn, tst_pg_namespace_class, tst_qualifiers,
             desc, interop_ns, additional_objs, new_inst, delete, exp_ns,
@@ -6983,6 +7055,7 @@ class TestPullOperations:
             ['TST_Person', 2, False, None, "Select from *", CIMError],
         ]
     )
+    @log_entry_exit
     def test_openenumerateinstancepaths(self, conn, tst_assoc_mof, ns,
                                         src_class, maxobj, exp_open_eos,
                                         fql, fq, exp_exec):
@@ -7039,6 +7112,7 @@ class TestPullOperations:
             ['TST_Person', 2, False],
         ]
     )
+    @log_entry_exit
     def test_openenumerateinstances(self, conn, tst_assoc_mof, ns,
                                     src_class, maxobj, exp_open_eos):
         # pylint: disable=no-self-use,invalid-name
@@ -7098,6 +7172,7 @@ class TestPullOperations:
             [None, None, None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_openreferenceinstancepaths(self, conn, tst_assoc_mof, ns,
                                         src_inst, ro, rc, exp_rslt):
         # pylint: disable=no-self-use,invalid-name
@@ -7198,6 +7273,7 @@ class TestPullOperations:
             [None, None, None, None, None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_openassociatorinstancepaths(self, conn, tst_assoc_mof, ns,
                                          src_inst, ro, ac, rc, rr, exp_rslt):
         # pylint: disable=no-self-use,invalid-name
@@ -7302,6 +7378,7 @@ class TestPullOperations:
             [None, None, None, None, None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_openassociatorinstances(self, conn, tst_assoc_mof, ns, src_inst,
                                      ro, ac, rc, rr, exp_rslt):
         # pylint: disable=no-self-use,invalid-name
@@ -7422,6 +7499,7 @@ class TestPullOperations:
              TypeError()],
         ]
     )
+    @log_entry_exit
     def test_openqueryinstances(self, conn, tst_assoc_mof, ns,
                                 fql, fq, rqrc, exp_rslt):
         # pylint: disable=no-self-use
@@ -7501,6 +7579,7 @@ class TestPullOperations:
              CIMError(CIM_ERR_INVALID_ENUMERATION_CONTEXT)],
         ]
     )
+    @log_entry_exit
     def test_closeenumeration(self, conn, tst_classeswqualifiers, tst_instances,
                               ns, test, cln, omoc, pmoc, exp_exc):
         # pylint: disable=no-self-use
@@ -7590,6 +7669,7 @@ class TestQualifierOperations:
             [None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_getqualifier(self, conn, ns, qname, exp_exc):
         """
         Test adding a qualifierdecl to the repository and doing a
@@ -7633,6 +7713,7 @@ class TestQualifierOperations:
             CIMError(CIM_ERR_INVALID_NAMESPACE)
         ]
     )
+    @log_entry_exit
     def test_enumeratequalifiers(self, conn, ns, exp_exc):
         """
         Test adding qualifier declarations to the repository and using
@@ -7681,6 +7762,7 @@ class TestQualifierOperations:
             [None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_setqualifier(self, conn, ns, qual, exp_exc):
         # pylint: disable=no-self-use
         """
@@ -7749,6 +7831,7 @@ class TestQualifierOperations:
 
         ]
     )
+    @log_entry_exit
     def test_deletequalifier(self, conn, ns, qname, mof, exp_exc):
         """
         Test  fake DeleteQualifier declaration method. Adds qualifier
@@ -7824,6 +7907,7 @@ class TestReferenceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_compile_assoc_mof(self, conn, tst_assoc_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -7884,6 +7968,7 @@ class TestReferenceOperations:
             [None, 42, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_referencenames_classes(self, conn, tst_assoc_mof, ns, cln, rc, ro,
                                     exp_rslt):
         # pylint: disable=no-self-use
@@ -8017,6 +8102,7 @@ class TestReferenceOperations:
             [None, 42, None, None, None, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_references_classes(self, conn, tst_assoc_mof, ns, cln, rc, ro,
                                 iq, ico, pl, exp_rslt):
         # pylint: disable=no-self-use
@@ -8119,6 +8205,7 @@ class TestReferenceOperations:
             if isinstance(exp_exc, CIMError):
                 assert exc.status_code == exp_exc.status_code
 
+    @log_entry_exit
     def test_reference_instnames_min(self, conn, tst_assoc_mof):
         # pylint: disable=no-self-use
         """
@@ -8199,6 +8286,7 @@ class TestReferenceOperations:
             ['TST_Lineage', None, CIMError(CIM_ERR_INVALID_NAMESPACE, "blah")]
         ]
     )
+    @log_entry_exit
     def test_reference_instnames(self, conn, tst_assoc_mof, ns, targ_iname, rc,
                                  ro, exp_rslt):
         # pylint: disable=no-self-use
@@ -8267,6 +8355,7 @@ class TestReferenceOperations:
 
     @pytest.mark.parametrize(
         "ns", INITIAL_NAMESPACES + [None])
+    @log_entry_exit
     def test_reference_instances_min(self, conn, tst_assoc_mof, ns):
         # pylint: disable=no-self-use
         """
@@ -8352,6 +8441,7 @@ class TestReferenceOperations:
 
         ]
     )
+    @log_entry_exit
     def test_reference_instances_opts(self, conn, tst_assoc_mof, ns,
                                       desc, rc, role, iq, ico, pl, exp_rslt):
         # pylint: disable=no-self-use
@@ -8413,6 +8503,7 @@ class TestReferenceOperations:
             CIMInstanceName('XXX_Blah', keybindings={'InstanceID': 3}),
         ]
     )
+    @log_entry_exit
     def test_reference_source_err(self, conn, tst_assoc_mof, ns, targ_obj):
         # pylint: disable=no-self-use
         """
@@ -8472,6 +8563,7 @@ class TestAssociatorOperations:
             [None, None, None, 42, TypeError()],
         ]
     )
+    @log_entry_exit
     def test_associator_classnames(self, conn, tst_assoc_mof, ns, target_cln,
                                    role, rr, ac, rc, exp_rslt):
         # pylint: disable=no-self-use
@@ -8580,6 +8672,7 @@ class TestAssociatorOperations:
              CIMError(CIM_ERR_INVALID_NAMESPACE, "blah")],
         ]
     )
+    @log_entry_exit
     def test_associator_instnames(self, conn, tst_assoc_mof, ns, targ_iname,
                                   role, rr, ac, rc, exp_rslt):
         # pylint: disable=no-self-use
@@ -8757,6 +8850,7 @@ class TestAssociatorOperations:
         "desc, inst_name, role, ac, rr, rc, iq, ico, pl, exp_rslt",
         TESTCASES_ASSOCIATOR_INSTANCES
     )
+    @log_entry_exit
     def test_associator_instances(
             self, conn, tst_assoc_mof, tst_ns, cln, name_key,
             desc, inst_name, role, rr, ac, rc, iq, ico, pl, exp_rslt):
@@ -8941,6 +9035,7 @@ class TestAssociatorOperations:
              []],
         ]
     )
+    @log_entry_exit
     def test_associator_classes(self, conn, tst_assoc_mof, ns, cln,
                                 desc, role, rr, ac, rc,
                                 iq, ico, pl, exp_rslt):
@@ -9038,6 +9133,7 @@ class TestAssociatorOperations:
             CIMInstanceName('XXX_Blah', keybindings={'InstanceID': 3}),
         ]
     )
+    @log_entry_exit
     def test_associator_target_err(self, conn, tst_assoc_mof, ns, targ_obj):
         # pylint: disable=no-self-use
         """
@@ -9776,6 +9872,7 @@ class TestInvokeMethod:
     @pytest.mark.parametrize(
         "desc, inputs, exp_result, exp_exc, condition",
         INVOKEMETHOD_TESTCASES)
+    @log_entry_exit
     def test_invokemethod(self, conn, tst_instances_mof, ns, desc, inputs,
                           exp_result, exp_exc, condition):
         # pylint: disable=no-self-use,unused-argument
@@ -10022,6 +10119,7 @@ class TestBaseProvider:
     @pytest.mark.parametrize(
         "desc, inputs, exp_result, exp_exc, condition",
         IS_SUBCLASS_TESTCASES)
+    @log_entry_exit
     def test_is_subclass(self, conn, tst_classeswqualifiers, ns, desc, inputs,
                          exp_result, exp_exc, condition):
         # pylint: disable=no-self-use,unused-argument
@@ -10061,7 +10159,7 @@ class TestBaseProvider:
 
 
 @pytest.fixture()
-def test_schema_root_dir():
+def tst_schema_root_dir():
     """
     Fixture defines the test_schema root directory for the schema and also
     removes the directory if it exists at the end of each test.
@@ -10083,6 +10181,7 @@ class TestDMTFCIMSchema:
     first test.
     """
 
+    @log_entry_exit
     def test_current_schema(self):
         # pylint: disable=no-self-use
         """
@@ -10127,7 +10226,8 @@ class TestDMTFCIMSchema:
 
         assert schema_mof == exp_mof
 
-    def test_schema_final_load(self, test_schema_root_dir):
+    @log_entry_exit
+    def test_schema_final_load(self, tst_schema_root_dir):
         # pylint: disable=no-self-use
         """
         Test the DMTFCIMSchema class and its methods to get a schema from the
@@ -10138,11 +10238,11 @@ class TestDMTFCIMSchema:
         if not os.environ.get('TEST_SCHEMA_DOWNLOAD', False):
             pytest.skip("Test run only if TEST_SCHEMA_DOWNLOAD is non-empty.")
 
-        schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, test_schema_root_dir,
+        schema = DMTFCIMSchema(DMTF_TEST_SCHEMA_VER, tst_schema_root_dir,
                                verbose=False)
 
         assert schema.schema_version == DMTF_TEST_SCHEMA_VER
-        assert schema.schema_root_dir == test_schema_root_dir
+        assert schema.schema_root_dir == tst_schema_root_dir
         assert schema.schema_version_str == \
             '{}.{}.{}'.format(*DMTF_TEST_SCHEMA_VER)
         assert os.path.isdir(schema.schema_root_dir)
@@ -10151,7 +10251,7 @@ class TestDMTFCIMSchema:
         assert os.path.isfile(schema.schema_zip_file)
 
         mof_dir = f'mofFinal{schema.schema_version_str}'
-        test_schema_mof_dir = os.path.join(test_schema_root_dir, mof_dir)
+        test_schema_mof_dir = os.path.join(tst_schema_root_dir, mof_dir)
         assert schema.schema_mof_dir == test_schema_mof_dir
 
         assert schema.schema_pragma_file == \
@@ -10160,7 +10260,7 @@ class TestDMTFCIMSchema:
 
         assert repr(schema) == (
             f'DMTFCIMSchema(schema_version={DMTF_TEST_SCHEMA_VER}, '
-            f'schema_root_dir={test_schema_root_dir}, '
+            f'schema_root_dir={tst_schema_root_dir}, '
             f'schema_zip_file={schema.schema_zip_file}, '
             f'schema_mof_dir={schema.schema_mof_dir}, '
             f'schema_pragma_file={schema.schema_pragma_file}, '
@@ -10174,6 +10274,7 @@ class TestDMTFCIMSchema:
 
         assert schema_mof == exp_mof
 
+    @log_entry_exit
     def test_schema_experimental_load(self):
         # pylint: disable=no-self-use
         """
@@ -10209,6 +10310,7 @@ class TestDMTFCIMSchema:
         assert not os.path.isfile(schema.schema_pragma_file)
         assert os.path.isdir(schema.schema_root_dir)
 
+    @log_entry_exit
     def test_second_schema_load(self):
         # pylint: disable=no-self-use
         """
@@ -10265,7 +10367,8 @@ class TestDMTFCIMSchema:
             [(1, 205, 0), ValueError()]
         ]
     )
-    def test_schema_invalid_version(self, test_schema_root_dir, schema_version,
+    @log_entry_exit
+    def test_schema_invalid_version(self, tst_schema_root_dir, schema_version,
                                     exp_exc):
         # pylint: disable=no-self-use
         """
@@ -10276,7 +10379,7 @@ class TestDMTFCIMSchema:
         with pytest.raises(type(exp_exc)):
 
             # The code to be tested
-            DMTFCIMSchema(schema_version, test_schema_root_dir, verbose=VERBOSE)
+            DMTFCIMSchema(schema_version, tst_schema_root_dir, verbose=VERBOSE)
 
     @pytest.mark.parametrize(
         "clns, exp_rslt",
@@ -10305,6 +10408,7 @@ class TestDMTFCIMSchema:
 
         ]
     )
+    @log_entry_exit
     def test_schema_build(self, clns, exp_rslt):
         # pylint: disable=no-self-use
         """
@@ -10371,6 +10475,7 @@ TESTCASES_COPY_FAKEDWBEMCONNECTION = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_COPY_FAKEDWBEMCONNECTION)
 @simplified_test_function
+@log_entry_exit
 def test_copy_fakedconn(
         testcase, init_kwargs, perform_operation):
     """Test FakedWBEMConnection.copy()"""


### PR DESCRIPTION
Rolls back PR #3316 into 1.8.