### PR TITLE
Send error response when indication queue is full

### DIFF
--- a/changes/3315.feature.rst
+++ b/changes/3315.feature.rst
@@ -1,0 +1,4 @@
+Listener: Improved the handling of the listener queue full condition by
+sending back an error response to the sender and continuing the listener
+and callback threads. Changed default maximum size of indication queue from
+0 to 5000.

--- a/changes/3315.fix.rst
+++ b/changes/3315.fix.rst
@@ -1,0 +1,3 @@
+Listener: Changed methods :meth:`pywbem.WBEMListener.ind_delivery_queue_empty`
+and :meth:`pywbem.WBEMListener.queue_size` to check for existence of the
+indication queue and to return `None` if it does not exist.

--- a/pywbem/_exceptions.py
+++ b/pywbem/_exceptions.py
@@ -774,11 +774,11 @@ class ListenerPromptError(ListenerError):
 
 class ListenerQueueFullError(ListenerError):
     """
-    This exception indicates that the listener received indication queue has
-    reached the maximum count of indications defined in the listener
-    creation max_queue_size parameter.
+    Starting with pywbem 1.8.0, this exception indicated that the indication
+    delivery queue has reached its maximum size. Starting with pywbem 1.9.0,
+    this exception is no longer raised.
 
-    *New in pywbem 1.8.*
+    *New in pywbem 1.8; No longer used starting with pywbem 1.9.0*
 
     Derived from :exc:`~pywbem.ListenerError`.
     """


### PR DESCRIPTION
The PR is ready for review.

I have tested the queue full behavior with the `examples/listen.py` script for running the listener, updated as per PR #3330, and with the `examples/send_indication.sh` script for sending the indications.