### PR TITLE
Cleaned up WBEMListener indication queue terminology

### DIFF
--- a/changes/3315.fix.rst
+++ b/changes/3315.fix.rst
@@ -1,3 +1,3 @@
-Listener: Changed methods :meth:`pywbem.WBEMListener.ind_delivery_queue_empty`
-and :meth:`pywbem.WBEMListener.queue_size` to check for existence of the
-indication queue and to return `None` if it does not exist.
+Listener: Changed WBEMListener methods ``ind_delivery_queue_empty()`` and
+``queue_size()`` to check for existence of the indication queue and to return
+`None` if it does not exist.

--- a/changes/3332.fix.1.rst
+++ b/changes/3332.fix.1.rst
@@ -1,0 +1,6 @@
+Aligned the names of two :class:`pywbem.WBEMListener` methods for more
+consistency. These methods were added in pywbem version 1.8.0, and we consider
+this a fix:
+
+  * Renamed ``ind_delivery_queue_empty()`` to :meth:`pywbem.WBEMListener.ind_queue_empty`.
+  * Renamed ``queue_size()`` to :meth:`pywbem.WBEMListener.ind_queue_size`.

--- a/changes/3332.fix.2.rst
+++ b/changes/3332.fix.2.rst
@@ -1,0 +1,10 @@
+Listener: Made the following internal attributes and methods of the
+:class:`pywbem.WBEMListener` class private in order to ensure that they are not
+accessed or called by users:
+
+  * ``ind_delivery_queue`` attribute
+  * ``stop_indication_delivery()``
+  * ``stop_servers()``
+  * ``deliver_indications_forever()``
+  * ``handle_indication()``
+  * ``deliver_indication_to_callbacks()``

--- a/tests/unittest/pywbem/test_indicationlistener.py
+++ b/tests/unittest/pywbem/test_indicationlistener.py
@@ -923,8 +923,8 @@ def test_WBEMListener_send_indications(
         for i in range(queue_empty_retries):
             sleep(0.2)   # sleep 200 ms to allow callbacks to execute
             if listener.ind_queue_exists():
-                qsize = listener.queue_size()
-                empty = listener.ind_delivery_queue_empty()
+                qsize = listener.ind_queue_size()
+                empty = listener.ind_queue_empty()
             else:
                 qsize = None
                 empty = None
@@ -936,7 +936,7 @@ def test_WBEMListener_send_indications(
                 break
 
             LOGGER.debug("Waiting, %s still in queue.",
-                         listener.ind_delivery_queue.qsize())
+                         listener.ind_queue_size())
 
         assert empty is None or empty is True, \
             f"Test failed in wait for indications loop. rcv_count=" \


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* Renames of WBEMListener methods introduced in version 1.8.0.
* Making internal WBEMListener attributes and methods private.
* The `start()` method should not be called when the listener is already running. Currently we neither reject nor tolerate that, but leave it to the user.