### PR TITLE
Bumped bleach from 3.3.0 to 6.3.0/6.4.0 on Python==3.9/>=3.10

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -217,7 +217,9 @@ asttokens==2.0.4
 attrs==22.2.0
 backcall==0.2.0
 beautifulsoup4==4.10.0
-bleach==3.3.0
+# bleach is used by nbconvert (Jupyter notebook)
+bleach==6.2.0; python_version == '3.9'
+bleach==6.4.0; python_version >= '3.10'
 cffi==2.0.0
 Click==8.0.2
 clint==0.5.1


### PR DESCRIPTION
No review needed.