### PR TITLE
Changed exc to TypeError for disable parm of disable_pull_operations()

### DIFF
--- a/changes/noissue.mocktypeerror.incompatible.rst
+++ b/changes/noissue.mocktypeerror.incompatible.rst
@@ -1,0 +1,4 @@
+Changed the exception type from ValueError to TypeError that is raised
+for an invalid type of the 'disable' parameter in
+pywbem_mock.FakedWBEMConnection.disable_pull_operations() and
+pywbem_mock.MainProvider.disable_pull_operations().

--- a/pywbem_mock/_mainprovider.py
+++ b/pywbem_mock/_mainprovider.py
@@ -186,7 +186,7 @@ class MainProvider(ResolverMixin, BaseProvider):
             # pylint: disable=attribute-defined-outside-init
             self._disable_pull_operations = disable
         else:
-            raise ValueError(
+            raise TypeError(
                 _format('Invalid type for disable_pull_operations: {0!A}, '
                         'must be a boolean', disable))
 

--- a/pywbem_mock/_wbemconnection_mock.py
+++ b/pywbem_mock/_wbemconnection_mock.py
@@ -327,15 +327,14 @@ class FakedWBEMConnection(WBEMConnection):
         # Attribute will always be boolean
         if disable is None:
             disable = False
-        if isinstance(disable, bool):
-            # pylint: disable=attribute-defined-outside-init
-            self._disable_pull_operations = disable
-            # modify the parameter in the mainprovider
-            self._mainprovider.disable_pull_operations = disable
-        else:
-            raise ValueError(
+        if not isinstance(disable, bool):
+            raise TypeError(
                 _format('Invalid type for disable_pull_operations: {0!A}, '
                         'must be a boolean', disable))
+        # pylint: disable=attribute-defined-outside-init
+        self._disable_pull_operations = disable
+        # modify the parameter in the mainprovider
+        self._mainprovider.disable_pull_operations = disable
 
     def __str__(self):
         return _format(

--- a/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
+++ b/tests/unittest/pywbem_mock/test_wbemconnection_mock.py
@@ -991,7 +991,7 @@ class TestFakedWBEMConnection:
         "disable, exp_exec", [[False, None],
                               [None, None],
                               [True, None],
-                              [1, ValueError]])
+                              [1, TypeError]])
     @log_entry_exit
     def test_disable_pull(self, tst_classeswqualifiers, tst_instances,
                           set_on_init, disable, exp_exec):


### PR DESCRIPTION
For details, see the commit message.
This addresses an issue reported by the new ruff version.