### PR TITLE
1.9: Mitigated ruff issues by pinning ruff to <0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -909,7 +909,7 @@ $(done_dir)/flake8_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn)_$(
 	echo "done" >$@
 	@echo "Makefile: Done running Flake8"
 
-$(done_dir)/ruff_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(py_src_files) $(py_test_files)
+$(done_dir)/ruff_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(py_src_files) $(py_test_files)
 	@echo "Makefile: Running Ruff"
 	-$(call RM_FUNC,$@)
 	ruff --version

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -92,7 +92,7 @@ pyflakes>=3.2.0
 entrypoints>=0.3.0
 
 # Ruff checker
-ruff>=0.3.5
+ruff>=0.3.5,<0.16.0
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
 # Note: The packages for Jupyter Notebook are prone to causing endless pip backtracking when


### PR DESCRIPTION
No review needed.